### PR TITLE
Implement expected exception for AnnotationSpec

### DIFF
--- a/kotlintest-core/src/main/kotlin/io/kotlintest/internal/ThrowableUnwrapping.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/internal/ThrowableUnwrapping.kt
@@ -1,0 +1,16 @@
+package io.kotlintest.internal
+
+import java.lang.reflect.InvocationTargetException
+
+/**
+ * In some particular cases, such as AnnotationSpec, a call will be made using Reflection.
+ * When using reflection, any error will be wrapped around a InvocationTargetException, as explained
+ * in https://stackoverflow.com/questions/6020719/what-could-cause-java-lang-reflect-invocationtargetexception
+ * By verifying if this is an InvocationTargetException, we can unwrap it and throw the cause instead
+ */
+fun Throwable.unwrapIfReflectionCall(): Throwable {
+  return when (this) {
+    is InvocationTargetException -> cause ?: this
+    else -> this
+  }
+}

--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestCaseExecutor.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestCaseExecutor.kt
@@ -8,11 +8,11 @@ import io.kotlintest.TestStatus
 import io.kotlintest.extensions.TestCaseExtension
 import io.kotlintest.extensions.TestListener
 import io.kotlintest.internal.isActive
+import io.kotlintest.internal.unwrapIfReflectionCall
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
-import java.lang.reflect.InvocationTargetException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -195,16 +195,4 @@ class TestCaseExecutor(private val listener: TestEngineListener,
     else -> TestResult(TestStatus.Error, error, null, metadata)
   }
 
-  /**
-   * In some particular cases, such as AnnotationSpec, a call will be made using Reflection.
-   * When using reflection, any error will be wrapped around a InvocationTargetException, as explained
-   * in https://stackoverflow.com/questions/6020719/what-could-cause-java-lang-reflect-invocationtargetexception
-   * By verifying if this is an InvocationTargetException, we can unwrap it and throw the cause instead
-   */
-  private fun Throwable.unwrapIfReflectionCall(): Throwable {
-    return when (this) {
-      is InvocationTargetException -> cause ?: this
-      else -> this
-    }
-  }
 }


### PR DESCRIPTION
JUnit's tests can test an exception is thrown by using a parameter in the `@Test` annotation. https://github.com/junit-team/junit4/wiki/exception-testing

Although we support `shouldThrow` and it's variants, we're trying to improve the likelihood of people using KotlinTest instead of JUnit, by making the migration as easy as possible. Because of this objective, this commit implements a parameter in `@Test`, to enable users to configure an expected exception just like JUnit's.

To do this, this commit creates the parameter and annotation processing for it.

To reuse code, this commit moves some internal classes around, to enable `kotlintest-core` module to use some of the classes from `kotlintest-assertions` and `kotlintest-runner-jvm`. This doesn't impact any user, as the moved classes and functions are internal/private.

To test that the new behavior works, this commit uses `SpecLevelExtension` to map specific tests with specific behaviors. It's not very pretty, but it works.

Fixes #527