### PR TITLE
Update com.fasterxml.jackson.module:jackson-module-kotlin to 2.9.8

### DIFF
--- a/kotlintest-assertions-json/build.gradle
+++ b/kotlintest-assertions-json/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.jackson_version = '2.9.6'
+    ext.jackson_version = '2.9.8'
 }
 
 repositories {


### PR DESCRIPTION
Updates com.fasterxml.jackson.module:jackson-module-kotlin to 2.9.8.

If you'd like to skip this version, you can just close this PR.

Be well.