### PR TITLE
Update com.github.wumpz:diffutils to 3.0

### DIFF
--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect"
     compile 'com.univocity:univocity-parsers:2.7.6'
-    compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
+    compile group: 'com.github.wumpz', name: 'diffutils', version: '3.0'
 }


### PR DESCRIPTION
Updates com.github.wumpz:diffutils to 3.0.

If you'd like to skip this version, you can just close this PR.

Be well.