### PR TITLE
Update javax.xml.bind:jaxb-api to 2.3.1

### DIFF
--- a/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile 'io.qameta.allure:allure-java-commons:2.6.0'
-    compile 'javax.xml.bind:jaxb-api:2.2.11'
+    compile 'javax.xml.bind:jaxb-api:2.3.1'
     compile 'com.sun.xml.bind:jaxb-core:2.2.11'
     compile 'com.sun.xml.bind:jaxb-impl:2.2.11'
     testCompile project(':kotlintest-runner:kotlintest-runner-junit5')


### PR DESCRIPTION
Updates javax.xml.bind:jaxb-api to 2.3.1.

If you'd like to skip this version, you can just close this PR.

Be well.