### PR TITLE
Update com.sun.xml.bind:jaxb-impl to 2.3.2

### DIFF
--- a/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile 'io.qameta.allure:allure-java-commons:2.6.0'
     compile 'javax.xml.bind:jaxb-api:2.2.11'
     compile 'com.sun.xml.bind:jaxb-core:2.2.11'
-    compile 'com.sun.xml.bind:jaxb-impl:2.2.11'
+    compile 'com.sun.xml.bind:jaxb-impl:2.3.2'
     testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
     testRuntime 'log4j:log4j:1.2.17'
     testRuntime 'org.slf4j:slf4j-log4j12:1.7.25'


### PR DESCRIPTION
Updates com.sun.xml.bind:jaxb-impl to 2.3.2.

If you'd like to skip this version, you can just close this PR.

Be well.