### PR TITLE
Update org.mockito:mockito-core to 2.23.4

### DIFF
--- a/kotlintest-runner/kotlintest-runner-junit4/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-junit4/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(':kotlintest-assertions')
     compile project(':kotlintest-runner:kotlintest-runner-jvm')
     compile 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.18.3'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
     testCompile "com.nhaarman:mockito-kotlin:1.6.0"
 }
 


### PR DESCRIPTION
Updates org.mockito:mockito-core to 2.23.4.

If you'd like to skip this version, you can just close this PR.

Be well.