### PR TITLE
Update com.nhaarman:mockito-kotlin to 1.6.0

### DIFF
--- a/kotlintest-runner/kotlintest-runner-junit4/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-junit4/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     compile project(':kotlintest-runner:kotlintest-runner-jvm')
     compile 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.18.3'
-    testCompile "com.nhaarman:mockito-kotlin:1.5.0"
+    testCompile "com.nhaarman:mockito-kotlin:1.6.0"
 }
 
 test {


### PR DESCRIPTION
Updates com.nhaarman:mockito-kotlin to 1.6.0.

If you'd like to skip this version, you can just close this PR.

Be well.