### PR TITLE
Update io.github.classgraph:classgraph to 4.6.16

### DIFF
--- a/kotlintest-runner/kotlintest-runner-jvm/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-jvm/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile project(':kotlintest-core')
-    compile 'io.github.classgraph:classgraph:4.4.12'
+    compile 'io.github.classgraph:classgraph:4.6.16'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'io.arrow-kt:arrow-core:0.8.1'
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1'


### PR DESCRIPTION
Updates io.github.classgraph:classgraph to 4.6.16.

If you'd like to skip this version, you can just close this PR.

Be well.