### PR TITLE
Update io.arrow-kt:arrow-core to 0.8.2

### DIFF
--- a/kotlintest-runner/kotlintest-runner-jvm/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-jvm/build.gradle
@@ -2,6 +2,6 @@ dependencies {
     compile project(':kotlintest-core')
     compile 'io.github.classgraph:classgraph:4.4.12'
     compile 'org.slf4j:slf4j-api:1.7.25'
-    compile 'io.arrow-kt:arrow-core:0.8.1'
+    compile 'io.arrow-kt:arrow-core:0.8.2'
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1'
 }


### PR DESCRIPTION
Updates io.arrow-kt:arrow-core to 0.8.2.

If you'd like to skip this version, you can just close this PR.

Be well.