### PR TITLE
Update io.kotlintest:kotlintest-runner-junit5 to 3.1.11

### DIFF
--- a/kotlintest-samples/kotlintest-samples-gradle/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-gradle/build.gradle
@@ -11,5 +11,5 @@ buildscript {
 }
 
 dependencies {
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.0'
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.11'
 }

--- a/kotlintest-samples/kotlintest-samples-spring/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-spring/build.gradle
@@ -14,6 +14,6 @@ buildscript {
 dependencies {
     compile 'org.springframework:spring-test:4.3.14.RELEASE'
     compile 'org.springframework:spring-context:4.3.14.RELEASE'
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.0.2'
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.11'
     testCompile 'io.kotlintest:kotlintest-extensions-spring:3.0.2'
 }


### PR DESCRIPTION
Updates io.kotlintest:kotlintest-runner-junit5 to 3.1.11.

If you'd like to skip this version, you can just close this PR.

Be well.