### PR TITLE
Update org.apache.logging.log4j:log4j-slf4j-impl to 2.11.1

### DIFF
--- a/kotlintest-tests/kotlintest-tests-core/build.gradle
+++ b/kotlintest-tests/kotlintest-tests-core/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     testImplementation project(':kotlintest-assertions')
     testImplementation project(':kotlintest-runner:kotlintest-runner-junit5')
     testImplementation project(':kotlintest-assertions-arrow')
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.0'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"
     testImplementation 'org.mockito:mockito-core:2.23.4'
     // this is here to test that the intellij marker 'dummy' test doesn't appear in intellij

--- a/kotlintest-tests/kotlintest-tests-junit-report/build.gradle
+++ b/kotlintest-tests/kotlintest-tests-junit-report/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     testCompile project(':kotlintest-core')
     testCompile project(':kotlintest-assertions')
     testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
-    testCompile 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.0'
+    testCompile 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
     testCompile 'org.jdom:jdom2:2.0.6'
 }
 

--- a/kotlintest-tests/kotlintest-tests-parallelism/build.gradle
+++ b/kotlintest-tests/kotlintest-tests-parallelism/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     testImplementation project(':kotlintest-assertions')
     testImplementation project(':kotlintest-runner:kotlintest-runner-junit5')
     testImplementation project(':kotlintest-assertions-arrow')
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.0'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
 }
 
 test {


### PR DESCRIPTION
Updates org.apache.logging.log4j:log4j-slf4j-impl to 2.11.1.

If you'd like to skip this version, you can just close this PR.

Be well.