### PR TITLE
Update io.kotlintest:kotlintest-extensions-spring to 3.2.0

### DIFF
--- a/kotlintest-samples/kotlintest-samples-spring/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-spring/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     compile 'org.springframework:spring-test:4.3.14.RELEASE'
     compile 'org.springframework:spring-context:4.3.14.RELEASE'
     testCompile 'io.kotlintest:kotlintest-runner-junit5:3.2.0'
-    testCompile 'io.kotlintest:kotlintest-extensions-spring:3.1.11'
+    testCompile 'io.kotlintest:kotlintest-extensions-spring:3.2.0'
 }


### PR DESCRIPTION
Updates io.kotlintest:kotlintest-extensions-spring to 3.2.0.

If you'd like to skip this version, you can just close this PR.

If commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.