### PR TITLE
Add cancel of TestCaseExecutor interruption job if test succeeds

### DIFF
--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestEngine.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestEngine.kt
@@ -7,8 +7,6 @@ import io.kotlintest.Spec
 import io.kotlintest.runner.jvm.internal.NamedThreadFactory
 import io.kotlintest.runner.jvm.spec.SpecExecutor
 import org.slf4j.LoggerFactory
-import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -25,9 +23,11 @@ class TestEngine(val classes: List<KClass<out Spec>>,
   // the main executor is used to parallelize the execution of specs
   // inside a spec, tests themselves are executed as coroutines
   private val executor = Executors.newFixedThreadPool(parallelism, NamedThreadFactory("kotlintest-engine-%d"))
-  private val listenerExecutors = ConcurrentLinkedQueue<ExecutorService>()
+
+  // the scheduler executor is used for notifications on when a test case timeout has been reached
   private val scheduler = Executors.newSingleThreadScheduledExecutor()
-  private val specExecutor = SpecExecutor(listener, listenerExecutors, scheduler)
+
+  private val specExecutor = SpecExecutor(listener, scheduler)
 
 
   private fun afterAll() = Try {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/MultipleTestTimeoutTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/MultipleTestTimeoutTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.kotlintest
+
+import io.kotlintest.milliseconds
+import io.kotlintest.specs.FreeSpec
+
+class MultipleTestTimeoutTest : FreeSpec() {
+
+  // The test executor was failing because as it reutilizes some threads from a thread pool.
+  // When using that thread pool, a task to cancel the thread is created, so that the engine can interrupt
+  // a test that is going forever.
+  // However, if the task is not cancelled, it will eventually interrupt the thread when it's running another task
+  // in the thread pool, interrupting a test that hasn't timed out yet, which is undesired.
+
+  init {
+    // 100 millis sleep will "accumulate" between tests. If the context is still shared, one of them will fail
+    // due to timeout.
+    "Test 1".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 2".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 3".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 4".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 5".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 6".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 7".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+  }
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/TestCaseExecutorListenerAfterTimeoutTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/TestCaseExecutorListenerAfterTimeoutTest.kt
@@ -35,13 +35,13 @@ class TestCaseExecutorListenerAfterTimeoutTest : FunSpec() {
 
   init {
 
-    test("tests which block should timeout but still run after listeners").config {
+    test("tests which timeout should still run the 'after test' listeners").config {
       val listenerExecutor = Executors.newSingleThreadExecutor()
       val listener = mock<TestEngineListener> {}
       val executor = TestCaseExecutor(listener, listenerExecutor, scheduler)
 
       val testCase = TestCase(Description.root("wibble"), this@TestCaseExecutorListenerAfterTimeoutTest, {
-        Thread.sleep(100000000L)
+        Thread.sleep(500)
       }, 0, TestType.Test, TestCaseConfig(true, invocations = 1, threads = 1, timeout = 100.milliseconds))
 
       val context = object : TestContext(GlobalScope.coroutineContext) {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/TestCaseExecutorTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/TestCaseExecutorTest.kt
@@ -14,6 +14,7 @@ import io.kotlintest.runner.jvm.TestCaseExecutor
 import io.kotlintest.runner.jvm.TestEngineListener
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
+import io.kotlintest.specs.FreeSpec
 import io.kotlintest.specs.FunSpec
 import kotlinx.coroutines.GlobalScope
 import java.lang.System.currentTimeMillis
@@ -286,6 +287,47 @@ class TestCaseExecutorTest : FunSpec() {
       executor.execute(testCase, context)
 
       then(listener).should().exitTestCase(argThat { description == Description.root("wibble") }, argThat { status == TestStatus.Failure })
+    }
+  }
+}
+
+class MultipleTestTimeoutTest : FreeSpec() {
+
+  // The test executor was failing because as it reutilizes some threads from a thread pool.
+  // When using that thread pool, a task to cancel the thread is created, so that the engine can interrupt
+  // a test that is going forever.
+  // However, if the task is not cancelled, it will eventually interrupt the thread when it's running another task
+  // in the thread pool, interrupting a test that hasn't timed out yet, which is undesired.
+
+  init {
+    // 100 millis sleep will "accumulate" between tests. If the context is still shared, one of them will fail
+    // due to timeout.
+    "Test 1".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 2".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 3".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 4".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 5".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 6".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
+    }
+
+    "Test 7".config(timeout = 300.milliseconds) {
+      Thread.sleep(100)
     }
   }
 }


### PR DESCRIPTION
As it is, the current TestCaseExecutor will by mistake recycle a thread from a threadpool between multiple test executions. That shouldn't be a problem. However, the scheduler will cancel the executor after a timeout has passed, and if another thread is running there, it will be interrupted.

This interruption is undesired, as it had nothing to do with the thread that successfully passed without a timeout.

This commit cancels the interruption job if the test ran successfully, avoiding this issue.

Fixes #588