### PR TITLE
Clarify documentation for TestConfig.invocations

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -649,7 +649,7 @@ Test Case Config
 Each test can be configured with various parameters. After the test name, invoke the config function
  passing in the parameters you wish to set. The available parameters are:
 
-* `invocations` - the number of times to run this test. Useful if you have a non-deterministic test and you want to run that particular test a set number of times. Defaults to 1.
+* `invocations` - The number of times to run this test. Useful if you have a non-deterministic test and you want to run that particular test a set number of times to see if it eventually fails. A test will only succeed if all invocations succeed. Defaults to 1.
 * `threads` - Allows the invocation of this test to be parallelized by setting the number of threads. If invocations is 1 (the default) then this parameter will have no effect. Similarly, if you set invocations to a value less than or equal to the number threads, then each invocation will have its own thread.
 * `enabled` - If set to `false` then this test is disabled. Can be useful if a test needs to be temporarily ignored. You can also use this parameter with boolean expressions to run a test only under certain conditions.
 * `timeout` - sets a timeout for this test. If the test has not finished in that time then the test fails. Useful for code that is non-deterministic and might not finish. Timeout is of type `Duration` which can be instantiated like `2.seconds`, `3.minutes` and so on.


### PR DESCRIPTION
Users weren't completely sure of how invocations worked. It was possible to think that you wouldn't need all invocations to pass for a test to succeed.

This commit clarifies in the documentation that for a test to pass, all it's invocations must pass, otherwise it will fail.

Fixes #591