### PR TITLE
Update io.kotlintest:kotlintest-runner-junit5 to 3.2.1

### DIFF
--- a/kotlintest-samples/kotlintest-samples-gradle/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-gradle/build.gradle
@@ -11,5 +11,5 @@ buildscript {
 }
 
 dependencies {
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.2.0'
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.2.1'
 }

--- a/kotlintest-samples/kotlintest-samples-spring/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-spring/build.gradle
@@ -14,6 +14,6 @@ buildscript {
 dependencies {
     compile 'org.springframework:spring-test:4.3.14.RELEASE'
     compile 'org.springframework:spring-context:4.3.14.RELEASE'
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.2.0'
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.2.1'
     testCompile 'io.kotlintest:kotlintest-extensions-spring:3.2.0'
 }


### PR DESCRIPTION
Updates io.kotlintest:kotlintest-runner-junit5 to 3.2.1.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.