### PR TITLE
Add nullability matchers with Kotlin Contracts

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -27,6 +27,7 @@ For the extension function style, each function has an equivalent negated versio
 | `obj.shouldBeTypeOf<T>()` | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
 | `obj.shouldBeInstanceOf<T>` | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
+| `obj.shouldBeNull()` | Asserts that a given reference is null.|
 
 | Maps ||
 | -------- | ---- |

--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -3,3 +3,9 @@ dependencies {
     compile 'com.univocity:univocity-parsers:2.7.6'
     compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
 }
+
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs += '-Xuse-experimental=kotlin.Experimental'
+    }
+}

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/types/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/types/matchers.kt
@@ -7,7 +7,10 @@ import io.kotlintest.matchers.beOfType
 import io.kotlintest.matchers.beTheSameInstanceAs
 import io.kotlintest.should
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNot
 import io.kotlintest.shouldNotBe
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 inline fun <reified T : Any> Any?.shouldBeInstanceOf() {
   val matcher = beInstanceOf<T>()
@@ -41,4 +44,103 @@ inline fun <A, reified T : Annotation> haveAnnotation(klass: Class<T>) = object 
     val passed = value.annotations.any { it.annotationClass.qualifiedName == className }
     return Result(passed, "Class $value should contain annotation $className", "Class $value should not contain annotation $className")
   }
+}
+
+
+/**
+ * Verifies that this value is null
+ *
+ * Matcher to verify that a specific value contains a reference to `null`.
+ * Opposite of [shouldNotBeNull]
+ *
+ * Example:
+ *
+ * ```
+ *     val nullable: String? = null
+ *     val nonNull: String? = "NonNull"
+ *
+ *     nullable.shouldBeNull()    // Passes
+ *     nonNull.shouldBeNull()     // Fails
+ *
+ * ```
+ */
+@UseExperimental(ExperimentalContracts::class)
+fun Any?.shouldBeNull() {
+  contract {
+    returns() implies (this@shouldBeNull == null)
+  }
+
+  this should beNull()
+}
+
+/**
+ * Verifies that this is not null
+ *
+ * Matcher to verify that a specific nullable reference is not null.
+ * Opposite of [shouldBeNull]
+ *
+ * Example:
+ *
+ * ```
+ *     val nullable: String? = null
+ *     val nonNull: String? = "NonNull"
+ *
+ *     nonNull.shouldNotBeNull()     // Passes
+ *     nullable.shouldNotBeNull()    // Fails
+ * ```
+ *
+ * Note: This function uses Kotlin Contracts to tell the compiler that this is not null. So after this is used, all subsequent
+ * lines can assume the value is not null without having to cast it. For example:
+ *
+ * ```
+ *
+ *     val nonNull: String? = "NonNull"
+ *
+ *     nonNull.shouldNotBeNull()
+ *     useNonNullString(nonNull)
+ *
+ *
+ *     // Notice how this is a not-nullable reference
+ *     fun useNonNullString(string: String) { }
+ *
+ * ```
+ */
+@UseExperimental(ExperimentalContracts::class)
+fun Any?.shouldNotBeNull() {
+  contract {
+    returns() implies (this@shouldNotBeNull != null)
+  }
+
+  this shouldNot beNull()
+}
+
+
+/**
+ * Matcher that verifies if a reference is null
+ *
+ * Verifies that a given value contains a reference to null or not.
+ *
+ * Example:
+ * ```
+ *     val nullable: String? = null
+ *     val nonNull: String? = "NonNull"
+ *
+ *     nullable should beNull() // Passes
+ *     nonNull should beNull()  // Fails
+ *
+ *     nullable shouldNot beNull() // Fails
+ *     nonNull shouldNot beNull()  // Passes
+ *
+ * ```
+ * @see [shouldBeNull]
+ * @see [shouldNotBeNull]
+ */
+fun beNull() = object : Matcher<Any?> {
+
+  override fun test(value: Any?): Result {
+    val passed = value == null
+
+    return Result(passed, "Expected value to be null, but was not-null.", "Expected value to not be null, but was null.")
+  }
+
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/types/TypeMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/types/TypeMatchersTest.kt
@@ -3,12 +3,23 @@ package com.sksamuel.kotlintest.matchers.types
 import io.kotlintest.matchers.beInstanceOf
 import io.kotlintest.matchers.beOfType
 import io.kotlintest.matchers.beTheSameInstanceAs
-import io.kotlintest.matchers.types.*
+import io.kotlintest.matchers.types.beNull
+import io.kotlintest.matchers.types.haveAnnotation
+import io.kotlintest.matchers.types.shouldBeInstanceOf
+import io.kotlintest.matchers.types.shouldBeNull
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.matchers.types.shouldBeTypeOf
+import io.kotlintest.matchers.types.shouldHaveAnnotation
+import io.kotlintest.matchers.types.shouldNotBeInstanceOf
+import io.kotlintest.matchers.types.shouldNotBeNull
+import io.kotlintest.matchers.types.shouldNotBeTypeOf
 import io.kotlintest.should
+import io.kotlintest.shouldBe
 import io.kotlintest.shouldNot
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
-import java.util.*
+import java.util.ArrayList
+import java.util.LinkedList
 
 @Suppress("UnnecessaryVariable")
 class TypeMatchersTest : WordSpec() {
@@ -120,5 +131,43 @@ class TypeMatchersTest : WordSpec() {
         }
       }
     }
+
+    "beNull" should {
+      val nullString: String? = null
+      val nonNullString: String? = "Foo"
+      "Pass for a null value" {
+        nullString.shouldBeNull()
+        nullString should beNull()
+      }
+
+      "Fail for a non-null value" {
+        shouldThrow<AssertionError> { nonNullString.shouldBeNull() }
+        shouldThrow<AssertionError> { nonNullString should beNull() }
+      }
+    }
+
+    "notBeNull" should {
+      val nullString: String? = null
+      val nonNullString: String? = "Foo"
+
+      "Pass for a non-null value" {
+        nonNullString.shouldNotBeNull()
+        nonNullString shouldNot beNull()
+      }
+
+      "Fail for a null value" {
+        shouldThrow<AssertionError> { nullString.shouldNotBeNull() }
+        shouldThrow<AssertionError> { nullString shouldNot beNull() }
+      }
+
+      "Allow automatic type cast" {
+        fun useString(string: String) {  }
+
+        nonNullString.shouldNotBeNull()
+        useString(nonNullString)
+        nonNullString shouldBe "Foo"
+      }
+    }
   }
+
 }


### PR DESCRIPTION
With Kotlin Contracts it's possible to establish that "If this function passes, X is true". This commit implements nullability type matchers for the `Any?` type, using Contracts to allow non-null inference to users.

This commit didn't implement the same logic for matchers such as `x.shouldBeInstanceOf<Foo>()`, because currently it's impossible to implement this with Kotlin Contracts. https://youtrack.jetbrains.com/issue/KT-28298

Fixes #601