### PR TITLE
Implement shouldNotThrow matchers

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/AnyThrowableHandling.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/AnyThrowableHandling.kt
@@ -16,6 +16,23 @@ package io.kotlintest
 inline fun shouldThrowAnyUnit(block: () -> Unit) = shouldThrowAny(block)
 
 /**
+ * Verifies that a block of code does NOT throw any [Throwable]
+ *
+ * Use function to wrap a block of code that you want to make sure doesn't throw any [Throwable],
+ * where using [shouldNotThrowAny] can't be used for any reason, such as an assignment of a variable (assignments are
+ * statements, therefore has no return value).
+ *
+ * Note that executing this code is no different to executing [block] itself, as any uncaught exception will
+ * be propagated up anyways.
+ *
+ * @see [shouldNotThrowAny]
+ * @see [shouldNotThrowExactlyUnit]
+ * @see [shouldNotThrowUnit]
+ *
+ */
+inline fun shouldNotThrowAnyUnit(block: () -> Unit) = shouldNotThrowAny(block)
+
+/**
  * Verifies that a block of code throws any [Throwable]
  *
  * Use function to wrap a block of code that you want to verify that throws any kind of [Throwable].
@@ -45,4 +62,33 @@ inline fun shouldThrowAny(block: () -> Any?): Throwable {
   } catch (e: Throwable) { e }
 
   return thrownException ?: throw Failures.failure("Expected a throwable, but nothing was thrown.")
+}
+
+
+/**
+ * Verifies that a block of code does NOT throw any [Throwable]
+ *
+ * Use function to wrap a block of code that you want to make sure doesn't throw any [Throwable].
+ *
+ * Note that executing this code is no different to executing [block] itself, as any uncaught exception will
+ * be propagated up anyways.
+ *
+ * **Attention to assignment operations:**
+ *
+ * When doing an assignment to a variable, the code won't compile, because an assignment is not of type [Any], as required
+ * by [block]. If you need to test that an assignment doesn't throw a [Throwable], use [shouldNotThrowAnyUnit] or it's
+ * variations.
+ *
+ * @see [shouldNotThrowAnyUnit]
+ * @see [shouldNotThrowExactly]
+ * @see [shouldNotThrow]
+ *
+ */
+inline fun shouldNotThrowAny(block: () -> Unit) {
+  val thrownException = try {
+    block()
+    return
+  } catch (e: Throwable) { e }
+
+  throw Failures.failure("No exception expected, but a ${thrownException::class.simpleName} was thrown.", thrownException)
 }


### PR DESCRIPTION
This commit implements `shouldNotThrow`, `shouldNotThrowExactly` and `shouldNotThrowAny` matchers, with their `Unit` variations.

Effectively, for the user, it doesn't make a difference on calling this and calling the code directly, but this may be better for communicating intent explicitly.

These matchers won't let an uncaught failure to be silently caught. Any uncaught exception will still be propagated upwards, however, if it matches the `shouldThrow<T>` T parameter, it will be wrapped around an AssertionError (makes tests Yellow, not Red.).

It's never necessary to use this construct. It would be the same as every java method being `void foo() throws no Exception`, and it usually doesn't make sense to.

Fixes #205