### PR TITLE
Enables test bang on all specs

### DIFF
--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractBehaviorSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractBehaviorSpec.kt
@@ -19,7 +19,7 @@ abstract class AbstractBehaviorSpec(body: AbstractBehaviorSpec.() -> Unit = {}) 
   fun given(name: String, test: suspend GivenContext.() -> Unit) = addGivenContext(name, test)
 
   private fun addGivenContext(name: String, test: suspend GivenContext.() -> Unit) {
-    addTestCase("Given: $name", { thisSpec.GivenContext(this).test() }, defaultTestCaseConfig, TestType.Container)
+    addTestCase(createTestName("Given: ", name), { thisSpec.GivenContext(this).test() }, defaultTestCaseConfig, TestType.Container)
   }
 
   @KotlinTestDsl
@@ -28,21 +28,21 @@ abstract class AbstractBehaviorSpec(body: AbstractBehaviorSpec.() -> Unit = {}) 
     suspend fun and(name: String, test: suspend GivenAndContext.() -> Unit) = addAndContext(name, test)
 
     private suspend fun addAndContext(name: String, test: suspend GivenAndContext.() -> Unit) {
-      context.registerTestCase("And: $name", thisSpec, { thisSpec.GivenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("And: ", name), thisSpec, { thisSpec.GivenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     suspend fun When(name: String, test: suspend WhenContext.() -> Unit) = addWhenContext(name, test)
     suspend fun `when`(name: String, test: suspend WhenContext.() -> Unit) = addWhenContext(name, test)
 
     private suspend fun addWhenContext(name: String, test: suspend WhenContext.() -> Unit) {
-      context.registerTestCase("When: $name", thisSpec, { thisSpec.WhenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("When: ", name), thisSpec, { thisSpec.WhenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     suspend fun Then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
     suspend fun then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
 
     private suspend fun addThenContext(name: String, test: suspend ThenContext.() -> Unit) {
-      context.registerTestCase("Then: $name", thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("Then: ", name), thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     fun then(name: String) = TestScope(name, context)
@@ -54,21 +54,21 @@ abstract class AbstractBehaviorSpec(body: AbstractBehaviorSpec.() -> Unit = {}) 
     suspend fun and(name: String, test: suspend GivenAndContext.() -> Unit) = addAndContext(name, test)
 
     private suspend fun addAndContext(name: String, test: suspend GivenAndContext.() -> Unit) {
-      context.registerTestCase("And: $name", thisSpec, { thisSpec.GivenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("And: ", name), thisSpec, { thisSpec.GivenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     suspend fun When(name: String, test: suspend WhenContext.() -> Unit) = addWhenContext(name, test)
     suspend fun `when`(name: String, test: suspend WhenContext.() -> Unit) = addWhenContext(name, test)
 
     private suspend fun addWhenContext(name: String, test: suspend WhenContext.() -> Unit) {
-      context.registerTestCase("When: $name", thisSpec, { thisSpec.WhenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("When: ", name), thisSpec, { thisSpec.WhenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     suspend fun Then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
     suspend fun then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
 
     private suspend fun addThenContext(name: String, test: suspend ThenContext.() -> Unit) {
-      context.registerTestCase("Then: $name", thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("Then: ", name), thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     fun then(name: String) = TestScope(name, context)
@@ -80,14 +80,14 @@ abstract class AbstractBehaviorSpec(body: AbstractBehaviorSpec.() -> Unit = {}) 
     suspend fun and(name: String, test: suspend WhenAndContext.() -> Unit) = addAndContext(name, test)
 
     private suspend fun addAndContext(name: String, test: suspend WhenAndContext.() -> Unit) {
-      context.registerTestCase("And: $name", thisSpec, { thisSpec.WhenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("And: ", name), thisSpec, { thisSpec.WhenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     suspend fun Then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
     suspend fun then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
 
     private suspend fun addThenContext(name: String, test: suspend ThenContext.() -> Unit) {
-      context.registerTestCase("Then: $name", thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
+      context.registerTestCase(createTestName("Then: ", name), thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
     }
 
     fun then(name: String) = TestScope(name, context)
@@ -99,14 +99,14 @@ abstract class AbstractBehaviorSpec(body: AbstractBehaviorSpec.() -> Unit = {}) 
     suspend fun and(name: String, test: suspend WhenAndContext.() -> Unit) = addAndContext(name, test)
 
     private suspend fun addAndContext(name: String, test: suspend WhenAndContext.() -> Unit) {
-      context.registerTestCase("And: $name", thisSpec, { thisSpec.WhenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
+      context.registerTestCase(createTestName("And: ", name), thisSpec, { thisSpec.WhenAndContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
     suspend fun Then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
     suspend fun then(name: String, test: suspend ThenContext.() -> Unit) = addThenContext(name, test)
 
     private suspend fun addThenContext(name: String, test: suspend ThenContext.() -> Unit) {
-      context.registerTestCase("Then: $name", thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
+      context.registerTestCase(createTestName("Then: ", name), thisSpec, { thisSpec.ThenContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
     }
 
     fun then(name: String) = TestScope(name, context)

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractDescribeSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractDescribeSpec.kt
@@ -41,13 +41,13 @@ abstract class AbstractDescribeSpec(body: AbstractDescribeSpec.() -> Unit = {}) 
 
     fun it(name: String) = this@AbstractDescribeSpec.TestBuilder(context, "Scenario: $name")
     suspend fun it(name: String, test: suspend TestContext.() -> Unit) =
-        context.registerTestCase("Scenario: $name", this@AbstractDescribeSpec, test, this@AbstractDescribeSpec.defaultTestCaseConfig, TestType.Test)
+        context.registerTestCase(createTestName("Scenario: ", name), this@AbstractDescribeSpec, test, this@AbstractDescribeSpec.defaultTestCaseConfig, TestType.Test)
 
     suspend fun context(name: String, test: suspend DescribeScope.() -> Unit) =
-        context.registerTestCase("Context: $name", this@AbstractDescribeSpec, { this@AbstractDescribeSpec.DescribeScope(this).test() }, this@AbstractDescribeSpec.defaultTestCaseConfig, TestType.Container)
+        context.registerTestCase(createTestName("Context: ", name), this@AbstractDescribeSpec, { this@AbstractDescribeSpec.DescribeScope(this).test() }, this@AbstractDescribeSpec.defaultTestCaseConfig, TestType.Container)
   }
 
   fun describe(name: String, test: suspend DescribeScope.() -> Unit) =
-      addTestCase("Describe: $name", { this@AbstractDescribeSpec.DescribeScope(this).test() }, defaultTestCaseConfig, TestType.Container)
+      addTestCase(createTestName("Describe: ", name), { this@AbstractDescribeSpec.DescribeScope(this).test() }, defaultTestCaseConfig, TestType.Container)
 
 }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractExpectSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractExpectSpec.kt
@@ -39,16 +39,16 @@ abstract class AbstractExpectSpec(body: AbstractExpectSpec.() -> Unit = {}) : Ab
   inner class ExpectScope(val context: TestContext) {
 
     suspend fun context(name: String, test: suspend ExpectScope.() -> Unit) =
-        context.registerTestCase("Expect: $name", this@AbstractExpectSpec, { this@AbstractExpectSpec.ExpectScope(this).test() }, this@AbstractExpectSpec.defaultTestCaseConfig, TestType.Container)
+        context.registerTestCase(createTestName("Context: ", name), this@AbstractExpectSpec, { this@AbstractExpectSpec.ExpectScope(this).test() }, this@AbstractExpectSpec.defaultTestCaseConfig, TestType.Container)
 
     suspend fun expect(name: String, test: suspend TestContext.() -> Unit) =
-        context.registerTestCase("Expect: $name", this@AbstractExpectSpec, test, this@AbstractExpectSpec.defaultTestCaseConfig, TestType.Test)
+        context.registerTestCase(createTestName("Expect: ", name), this@AbstractExpectSpec, test, this@AbstractExpectSpec.defaultTestCaseConfig, TestType.Test)
 
-    fun expect(name: String) = this@AbstractExpectSpec.TestBuilder(context, "Expect: $name")
+    fun expect(name: String) = this@AbstractExpectSpec.TestBuilder(context, createTestName("Expect: ", name))
   }
 
   fun context(name: String, test: suspend ExpectScope.() -> Unit) =
-      addTestCase("Context: $name", { this@AbstractExpectSpec.ExpectScope(this).test() }, defaultTestCaseConfig, TestType.Container)
+      addTestCase(createTestName("Context: ", name), { this@AbstractExpectSpec.ExpectScope(this).test() }, defaultTestCaseConfig, TestType.Container)
 
 
 }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractFeatureSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractFeatureSpec.kt
@@ -35,17 +35,17 @@ abstract class AbstractFeatureSpec(body: AbstractFeatureSpec.() -> Unit = {}) : 
   }
 
   fun feature(name: String, init: suspend FeatureScope.() -> Unit) =
-      addTestCase("Feature: $name", { this@AbstractFeatureSpec.FeatureScope(this).init() }, defaultTestCaseConfig, TestType.Container)
+      addTestCase(createTestName("Feature: ", name), { this@AbstractFeatureSpec.FeatureScope(this).init() }, defaultTestCaseConfig, TestType.Container)
 
   @KotlinTestDsl
   inner class FeatureScope(val context: TestContext) {
 
     suspend fun and(name: String, init: suspend FeatureScope.() -> Unit) =
-        context.registerTestCase("And: $name", this@AbstractFeatureSpec, { this@AbstractFeatureSpec.FeatureScope(this).init() }, this@AbstractFeatureSpec.defaultTestCaseConfig, TestType.Container)
+        context.registerTestCase(createTestName("And: ", name), this@AbstractFeatureSpec, { this@AbstractFeatureSpec.FeatureScope(this).init() }, this@AbstractFeatureSpec.defaultTestCaseConfig, TestType.Container)
 
     suspend fun scenario(name: String, test: suspend TestContext.() -> Unit) =
-        context.registerTestCase("Scenario: $name", this@AbstractFeatureSpec, test, this@AbstractFeatureSpec.defaultTestCaseConfig, TestType.Test)
+        context.registerTestCase(createTestName("Scenario: ", name), this@AbstractFeatureSpec, test, this@AbstractFeatureSpec.defaultTestCaseConfig, TestType.Test)
 
-    fun scenario(name: String) = this@AbstractFeatureSpec.ScenarioBuilder("Scenario: $name", context)
+    fun scenario(name: String) = this@AbstractFeatureSpec.ScenarioBuilder(createTestName("Scenario: ", name), context)
   }
 }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractShouldSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractShouldSpec.kt
@@ -35,9 +35,9 @@ abstract class AbstractShouldSpec(body: AbstractShouldSpec.() -> Unit = {}) : Ab
       addTestCase(this, { this@AbstractShouldSpec.ShouldScope(this).init() }, defaultTestCaseConfig, TestType.Container)
 
   fun should(name: String, test: suspend TestContext.() -> Unit) =
-      addTestCase("should $name", test, defaultTestCaseConfig, TestType.Test)
+      addTestCase(createTestName("should ", name), test, defaultTestCaseConfig, TestType.Test)
 
-  fun should(name: String) = Testbuilder { test, config -> addTestCase("should $name", test, config, TestType.Test) }
+  fun should(name: String) = Testbuilder { test, config -> addTestCase(createTestName("should ", name), test, config, TestType.Test) }
 
   inner class Testbuilder(val register: (suspend TestContext.() -> Unit, TestCaseConfig) -> Unit) {
     fun config(
@@ -66,7 +66,7 @@ abstract class AbstractShouldSpec(body: AbstractShouldSpec.() -> Unit = {}) : Ab
         context.registerTestCase(this, this@AbstractShouldSpec, { this@AbstractShouldSpec.ShouldScope(this).init() }, this@AbstractShouldSpec.defaultTestCaseConfig, TestType.Container)
 
     suspend fun should(name: String, test: suspend TestContext.() -> Unit) =
-        context.registerTestCase("should $name", this@AbstractShouldSpec, test, this@AbstractShouldSpec.defaultTestCaseConfig, TestType.Test)
+        context.registerTestCase(createTestName("should ", name), this@AbstractShouldSpec, test, this@AbstractShouldSpec.defaultTestCaseConfig, TestType.Test)
 
     inner class Testbuilder(val register: suspend (suspend TestContext.() -> Unit, TestCaseConfig) -> Unit) {
       suspend fun config(
@@ -88,6 +88,6 @@ abstract class AbstractShouldSpec(body: AbstractShouldSpec.() -> Unit = {}) : Ab
       }
     }
 
-    suspend fun should(name: String) = Testbuilder { test, config -> context.registerTestCase("should $name", this@AbstractShouldSpec, test, config, TestType.Test) }
+    suspend fun should(name: String) = Testbuilder { test, config -> context.registerTestCase(createTestName("should ", name), this@AbstractShouldSpec, test, config, TestType.Test) }
   }
 }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/TestPrefixes.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/TestPrefixes.kt
@@ -1,0 +1,5 @@
+package io.kotlintest.specs
+
+internal fun createTestName(prefix: String, name: String): String {
+  return if(name.startsWith("!")) "!$prefix${name.drop(1)}" else "$prefix$name"
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/BangHelper.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/BangHelper.kt
@@ -1,0 +1,3 @@
+package com.sksamuel.kotlintest.specs
+
+fun attemptToFail(): Nothing = throw RuntimeException("This shouldn't execute as this test should be ignored!")

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/annotation/AnnotationSpecTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/annotation/AnnotationSpecTest.kt
@@ -30,6 +30,11 @@ class AnnotationSpecTest : AnnotationSpec() {
     count += 1
   }
 
+  @Test
+  fun `!bangedTest`() {
+    throw FooException()  // Test should pass as this should be banged
+  }
+
   @Test(expected = FooException::class)
   fun test3() {
     throw FooException()  // This test should pass!

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/behavior/BehaviorSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/behavior/BehaviorSpecBangTest.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.kotlintest.specs.behavior
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.BehaviorSpec
+
+class BehaviorSpecBangTest : BehaviorSpec() {
+
+  init {
+    Given("!BangedGiven") {
+      attemptToFail()
+    }
+
+    Given("NonBangedGiven") {
+      And("!BangedGivenAnd") {
+        attemptToFail()
+      }
+
+      And("NonBangedGivenAnd") {
+        When("!BangedWhen") {
+          attemptToFail()
+        }
+
+        When("NonBangedWhen") {
+          And("!BangedWhenAnd") {
+            attemptToFail()
+          }
+
+          And("NonBangedWhenAnd") {
+            Then("!BangedThen") {
+              attemptToFail()
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/describe/DescribeSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/describe/DescribeSpecBangTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.kotlintest.specs.describe
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.DescribeSpec
+
+class DescribeSpecBangTest : DescribeSpec() {
+
+  init {
+
+    describe("!BangedDescribe") {
+      attemptToFail()
+    }
+
+    describe("NonBangedDescribe") {
+      it("!BangedIt") {
+        attemptToFail()
+      }
+
+      context("!BangedContext") {
+        attemptToFail()
+      }
+
+      context("NonBangedContext") {
+        it("!BangedIt") {
+          attemptToFail()
+        }
+      }
+    }
+
+  }
+
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/expect/ExpectBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/expect/ExpectBangTest.kt
@@ -1,0 +1,21 @@
+package com.sksamuel.kotlintest.specs.expect
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.ExpectSpec
+
+class ExpectBangTest : ExpectSpec() {
+
+  init {
+    context("!BangedContext") {
+      attemptToFail()
+    }
+
+    context("NonBangedContext") {
+      expect("!BangedExpected") {
+        attemptToFail()
+      }
+    }
+
+  }
+
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/feature/FeatureBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/feature/FeatureBangTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.kotlintest.specs.feature
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.FeatureSpec
+
+class FeatureBangTest : FeatureSpec() {
+
+  init {
+    feature("!BangedFeature") {
+      attemptToFail()
+    }
+
+    feature("NonBangedFeature") {
+      and("!BangedAnd") {
+        attemptToFail()
+      }
+
+      and("NonBangedAnd") {
+        scenario("!BangedScenario") {
+          attemptToFail()
+        }
+      }
+
+      scenario("!BangedScenario") {
+        attemptToFail()
+      }
+    }
+  }
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/freespec/FreeSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/freespec/FreeSpecBangTest.kt
@@ -1,0 +1,20 @@
+package com.sksamuel.kotlintest.specs.freespec
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.FreeSpec
+
+class FreeSpecBangTest : FreeSpec() {
+
+  init {
+    "!BangedOuter" - {
+      attemptToFail()
+    }
+
+    "NonBangedOuter" - {
+      "!BangedInner" {
+        attemptToFail()
+      }
+    }
+  }
+
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/funspec/FunSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/funspec/FunSpecBangTest.kt
@@ -1,0 +1,14 @@
+package com.sksamuel.kotlintest.specs.funspec
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.FunSpec
+
+class FunSpecBangTest : FunSpec() {
+
+  init {
+    test("!BangedTest") {
+      attemptToFail()
+    }
+  }
+
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/shouldspec/ShouldSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/shouldspec/ShouldSpecBangTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.kotlintest.specs.shouldspec
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.ShouldSpec
+
+class ShouldSpecBangTest : ShouldSpec() {
+
+  init {
+    should("!BangedShould") {
+      attemptToFail()
+    }
+
+    "!BangedContext" {
+      attemptToFail()
+    }
+
+    "NonBangedOuter" {
+      "!BangedInner" {
+        attemptToFail()
+      }
+      "NonBangedInner" {
+        should("!BangedShould") {
+          attemptToFail()
+        }
+      }
+    }
+  }
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/stringspec/StringSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/stringspec/StringSpecBangTest.kt
@@ -1,0 +1,14 @@
+package com.sksamuel.kotlintest.specs.stringspec
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.StringSpec
+
+class StringSpecBangTest : StringSpec() {
+
+  init {
+    "!BangedTest" {
+      attemptToFail()
+    }
+  }
+
+}

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecBangTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecBangTest.kt
@@ -1,0 +1,14 @@
+package com.sksamuel.kotlintest.specs.wordspec
+
+import com.sksamuel.kotlintest.specs.attemptToFail
+import io.kotlintest.specs.WordSpec
+
+class WordSpecBangTest : WordSpec() {
+
+  init {
+    "!BangedOuter" should {
+      attemptToFail()
+    }
+  }
+
+}


### PR DESCRIPTION
Before this, some specs couldn't be marked as banged with a `!`. This happened due to the fact that we check for a exclamation mark at the beginning of a test name, such as "Foo" -> "!Foo" would be banged in FreeSpec.

However, some specs such as `BehaviorSpec` wouldn't allow this to work, as `Given("!Foo")` would be turned into `Given: !Foo`. When we checked for the start of the test name, it wouldn't contain `!`, therefore it wouldn't be ignored.

This commit changes all specs that would fall in that scenario, to move an exclamation mark from the beginning of the test chosen name to the beginning of the test final name (Before Given, for example. `Given("!Foo") -> "!Given: Foo"`), fixing this issue.

I chose to do it this way to keep consistent. "Why did this test get ignored?" would be better visualized when `Given` is prefixed with `!`, and not if we edited the bang mechanism to consider only the test name, and not the prefix.

Fixes #605