### PR TITLE
Update io.ktor:ktor-server-test-host to 1.1.2

### DIFF
--- a/kotlintest-assertions-ktor/build.gradle
+++ b/kotlintest-assertions-ktor/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.ktor_version = '1.1.1'
+    ext.ktor_version = '1.1.2'
 }
 
 repositories {


### PR DESCRIPTION
Updates io.ktor:ktor-server-test-host to 1.1.2.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.