### PR TITLE
Update org.jetbrains.kotlinx:kotlinx-coroutines-core to 1.1.1

### DIFF
--- a/kotlintest-core/build.gradle
+++ b/kotlintest-core/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     compile project(':kotlintest-assertions')
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile "org.jetbrains.kotlin:kotlin-reflect"
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
 }

--- a/kotlintest-runner/kotlintest-runner-jvm/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-jvm/build.gradle
@@ -3,5 +3,5 @@ dependencies {
     compile 'io.github.classgraph:classgraph:4.6.18'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'io.arrow-kt:arrow-core:0.8.2'
-    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0'
+    compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
 }


### PR DESCRIPTION
Updates org.jetbrains.kotlinx:kotlinx-coroutines-core to 1.1.1.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.