### PR TITLE
Implement System Environment Extension

### DIFF
--- a/kotlintest-extensions/src/main/kotlin/io/kotlintest/extensions/system/SystemEnvironmentExtensions.kt
+++ b/kotlintest-extensions/src/main/kotlin/io/kotlintest/extensions/system/SystemEnvironmentExtensions.kt
@@ -1,0 +1,265 @@
+package io.kotlintest.extensions.system
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.extensions.TestListener
+import java.lang.reflect.Field
+
+/**
+ * Overrides System Environment with chosen key and value
+ *
+ * This is a helper function for code that uses Environment Variables. It overrides the specific [key] from [System.getenv]
+ * with the specified [value], only during the execution of [block].
+ *
+ * To do this, this function uses a trick that makes the System Environment editable, and overrides [key]. Any previous
+ * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+ * it will be overridden. If the chosen key is not in the environment, it will be included.
+ *
+ * After the execution of [block], the environment is set to what it was before.
+ *
+ * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+ * already changed, the result is inconsistent, as the System Environment Map is a single map.
+ */
+inline fun <T> withEnvironment(key: String, value: String?, block: () -> T): T {
+  return withEnvironment(key to value, block)
+}
+
+/**
+ * Overrides System Environment with chosen key and value
+ *
+ * This is a helper function for code that uses Environment Variables. It overrides the specific key from [System.getenv]
+ * with the specified value, only during the execution of [block].
+ *
+ * To do this, this function uses a trick that makes the System Environment editable, and overrides the key. Any previous
+ * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+ * it will be overridden. If the chosen key is not in the environment, it will be included.
+ *
+ * After the execution of [block], the environment is set to what it was before.
+ *
+ * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+ * already changed, the result is inconsistent, as the System Environment Map is a single map.
+ */
+inline fun <T> withEnvironment(environment: Pair<String, String?>, block: () -> T): T {
+  return withEnvironment(mapOf(environment), block)
+}
+
+/**
+ * Overrides System Environment with chosen keys and values
+ *
+ * This is a helper function for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+ * with the specified values, only during the execution of [block].
+ *
+ * To do this, this function uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+ * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+ * it will be overridden. If the chosen key is not in the environment, it will be included.
+ *
+ * After the execution of [block], the environment is set to what it was before.
+ *
+ * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+ * already changed, the result is inconsistent, as the System Environment Map is a single map.
+ */
+inline fun <T> withEnvironment(environment: Map<String, String?>, block: () -> T): T {
+  val originalEnvironment = System.getenv().toMap() // Using to map to guarantee it's not modified
+  
+  setEnvironmentMap(originalEnvironment overridenWith environment)
+  
+  try {
+    return block()
+  } finally {
+    setEnvironmentMap(originalEnvironment)
+  }
+}
+
+
+@PublishedApi
+internal infix fun Map<String,String>.overridenWith(map: Map<String, String?>): MutableMap<String, String> {
+  return toMutableMap().apply { putReplacingNulls(map) }
+}
+
+@PublishedApi
+// Implementation inspired from https://github.com/stefanbirkner/system-rule
+internal fun setEnvironmentMap(map: Map<String, String?>) {
+  val envMapOfVariables = getEditableMapOfVariables()
+  val caseInsensitiveEnvironment = getCaseInsensitiveEnvironment()
+  
+  envMapOfVariables.clear()
+  caseInsensitiveEnvironment?.clear()
+  
+  envMapOfVariables.putReplacingNulls(map)
+  caseInsensitiveEnvironment?.putReplacingNulls(map)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun getEditableMapOfVariables(): MutableMap<String, String> {
+  val systemEnv = System.getenv()
+  val classOfMap = systemEnv::class.java
+  
+  return classOfMap.getDeclaredField("m").asAccessible().get(systemEnv) as MutableMap<String, String>
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun getCaseInsensitiveEnvironment(): MutableMap<String, String>? {
+  val processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment")
+  
+  return try {
+    processEnvironmentClass.getDeclaredField("theCaseInsensitiveEnvironment").asAccessible().get(null) as MutableMap<String, String>?
+  } catch (e: NoSuchFieldException) {
+    // Only available in Windows, ok to return null if it's not found
+    null
+  }
+}
+
+private fun  Field.asAccessible(): Field {
+  return apply { isAccessible = true }
+}
+
+private fun MutableMap<String,String>.putReplacingNulls(map: Map<String, String?>) {
+  map.forEach { key, value ->
+    if(value == null) remove(key) else put(key, value)
+  }
+}
+
+abstract class SystemEnvironmentListener(private val environment: Map<String, String>) : TestListener {
+  
+  protected fun changeSystemEnvironment() {
+    originalEnvironment = System.getenv().toMap() // Using to map to guarantee it's not modified
+    setEnvironmentMap(originalEnvironment overridenWith environment)
+  }
+  
+  protected fun resetSystemEnvironment() {
+    setEnvironmentMap(originalEnvironment)
+  }
+  
+  protected companion object {
+     /*
+     Must use a companion object because a new test listener is created every time.
+     When a new one is created, the original environment will be forgotten, and it won't be cleared
+     After the test is executed
+     It's also ok for this to be lateinit, because the first time this extension is used, the original
+     system Environment will be the same forever.
+     */
+    private lateinit var originalEnvironment: Map<String, String>
+  }
+}
+
+/**
+ * Overrides System Environment with chosen keys and values
+ *
+ * This is a Listener for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+ * with the specified values, only during the execution of a test.
+ *
+ * To do this, this listener uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+ * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+ * it will be overridden. If the chosen key is not in the environment, it will be included.
+ *
+ * After the execution of the test, the environment is set to what it was before.
+ *
+ * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+ * already changed, the result is inconsistent, as the System Environment Map is a single map.
+ */
+class SystemEnvironmentTestListener(environment: Map<String, String>) : SystemEnvironmentListener(environment) {
+  
+  /**
+   * Overrides System Environment with chosen keys and values
+   *
+   * This is a Listener for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+   * with the specified values, only during the execution of a test.
+   *
+   * To do this, this listener uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+   * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+   * it will be overridden. If the chosen key is not in the environment, it will be included.
+   *
+   * After the execution of the test, the environment is set to what it was before.
+   *
+   * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+   * already changed, the result is inconsistent, as the System Environment Map is a single map.
+   */
+  constructor(key: String, value: String) : this(key to value)
+  
+  /**
+   * Overrides System Environment with chosen keys and values
+   *
+   * This is a Listener for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+   * with the specified values, only during the execution of a test.
+   *
+   * To do this, this listener uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+   * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+   * it will be overridden. If the chosen key is not in the environment, it will be included.
+   *
+   * After the execution of the test, the environment is set to what it was before.
+   *
+   * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+   * already changed, the result is inconsistent, as the System Environment Map is a single map.
+   */
+  constructor(environment: Pair<String, String>) : this(mapOf(environment))
+  
+  override fun beforeTest(testCase: TestCase) {
+    changeSystemEnvironment()
+  }
+  
+  override fun afterTest(testCase: TestCase, result: TestResult) {
+    resetSystemEnvironment()
+  }
+}
+
+/**
+ * Overrides System Environment with chosen keys and values
+ *
+ * This is a Listener for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+ * with the specified values, during the execution of the project.
+ *
+ * To do this, this listener uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+ * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+ * it will be overridden. If the chosen key is not in the environment, it will be included.
+ *
+ * After the execution of the project, the environment is set to what it was before.
+ *
+ * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+ * already changed, the result is inconsistent, as the System Environment Map is a single map.
+ */
+class SystemEnvironmentProjectListener(environment: Map<String, String>) : SystemEnvironmentListener(environment) {
+  
+  
+  /**
+   * Overrides System Environment with chosen keys and values
+   *
+   * This is a Listener for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+   * with the specified values, during the execution of the project.
+   *
+   * To do this, this listener uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+   * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+   * it will be overridden. If the chosen key is not in the environment, it will be included.
+   *
+   * After the execution of the project, the environment is set to what it was before.
+   *
+   * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+   * already changed, the result is inconsistent, as the System Environment Map is a single map.
+   */
+  constructor(key: String, value: String) : this(key to value)
+  
+  /**
+   * Overrides System Environment with chosen keys and values
+   *
+   * This is a Listener for code that uses Environment Variables. It overrides the specific keys from [System.getenv]
+   * with the specified values, during the execution of the project.
+   *
+   * To do this, this listener uses a trick that makes the System Environment editable, and overrides the keys. Any previous
+   * environment (anything not overridden) will also be in the environment. If the chosen key is in the environment,
+   * it will be overridden. If the chosen key is not in the environment, it will be included.
+   *
+   * After the execution of the project, the environment is set to what it was before.
+   *
+   * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
+   * already changed, the result is inconsistent, as the System Environment Map is a single map.
+   */
+  constructor(environment: Pair<String, String>) : this(mapOf(environment))
+  
+  
+  override fun beforeProject() {
+    changeSystemEnvironment()
+  }
+  
+  override fun afterProject() {
+    resetSystemEnvironment()
+  }
+}

--- a/kotlintest-extensions/src/main/kotlin/io/kotlintest/extensions/system/SystemPropertiesExtension.kt
+++ b/kotlintest-extensions/src/main/kotlin/io/kotlintest/extensions/system/SystemPropertiesExtension.kt
@@ -5,7 +5,7 @@ import io.kotlintest.TestResult
 import io.kotlintest.extensions.TestCaseExtension
 import java.util.*
 
-fun <T> withSystemProperty(key: String, value: String?, thunk: () -> T): T {
+inline fun <T> withSystemProperty(key: String, value: String?, thunk: () -> T): T {
     val previous = System.setProperty(key, value)
     try {
         return thunk()
@@ -17,16 +17,16 @@ fun <T> withSystemProperty(key: String, value: String?, thunk: () -> T): T {
     }
 }
 
-fun <T> withSystemProperties(props: List<Pair<String, String?>>, thunk: () -> T): T {
+inline fun <T> withSystemProperties(props: List<Pair<String, String?>>, thunk: () -> T): T {
     return withSystemProperties(props.toMap(), thunk)
 }
 
-fun <T> withSystemProperties(props: Properties, thunk: () -> T): T {
+inline fun <T> withSystemProperties(props: Properties, thunk: () -> T): T {
     val pairs = props.toList().map { it.first.toString() to it.second?.toString() }
     return withSystemProperties(pairs, thunk)
 }
 
-fun <T> withSystemProperties(props: Map<String, String?>, thunk: () -> T): T {
+inline fun <T> withSystemProperties(props: Map<String, String?>, thunk: () -> T): T {
     val prevs = props.map { it.key to System.setProperty(it.key, it.value) }
     try {
         return thunk()

--- a/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/locale/LocaleExtensionTest.kt
+++ b/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/locale/LocaleExtensionTest.kt
@@ -1,9 +1,10 @@
-package io.kotlintest.extensions.locale
+package com.sksamuel.kt.extensions.locale
 
 import io.kotlintest.Spec
 import io.kotlintest.TestCase
 import io.kotlintest.TestResult
 import io.kotlintest.extensions.TopLevelTest
+import io.kotlintest.extensions.locale.LocaleExtension
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FunSpec
 import java.util.*

--- a/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/locale/TimezoneExtensionTest.kt
+++ b/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/locale/TimezoneExtensionTest.kt
@@ -1,9 +1,10 @@
-package io.kotlintest.extensions.locale
+package com.sksamuel.kt.extensions.locale
 
 import io.kotlintest.Spec
 import io.kotlintest.TestCase
 import io.kotlintest.TestResult
 import io.kotlintest.extensions.TopLevelTest
+import io.kotlintest.extensions.locale.TimezoneExtension
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FunSpec
 import java.time.ZoneId

--- a/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/NoSytemOutOrErrTest.kt
+++ b/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/NoSytemOutOrErrTest.kt
@@ -1,5 +1,9 @@
-package io.kotlintest.extensions.system
+package com.sksamuel.kt.extensions.system
 
+import io.kotlintest.extensions.system.NoSystemErrListener
+import io.kotlintest.extensions.system.NoSystemOutListener
+import io.kotlintest.extensions.system.SystemErrWriteException
+import io.kotlintest.extensions.system.SystemOutWriteException
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 

--- a/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/SystemEnvironmentExtensionTest.kt
+++ b/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/SystemEnvironmentExtensionTest.kt
@@ -1,0 +1,91 @@
+package com.sksamuel.kt.extensions.system
+
+import io.kotlintest.Spec
+import io.kotlintest.extensions.system.SystemEnvironmentTestListener
+import io.kotlintest.extensions.system.withEnvironment
+import io.kotlintest.inspectors.forAll
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.AbstractFreeSpec
+import io.kotlintest.specs.FreeSpec
+import io.kotlintest.specs.ShouldSpec
+
+class SystemEnvironmentExtensionFunctionTest : FreeSpec() {
+  
+  init {
+    "The system environment configured with a custom value" - {
+      "Should contain the custom variable" - {
+        val allResults = executeOnAllSystemEnvironmentOverloads("foo", "bar") {
+          System.getenv("foo") shouldBe "bar"
+          "RETURNED"
+        }
+        
+        allResults.forAll { it shouldBe "RETURNED" }
+      }
+    }
+    
+    "The system environment already with a specified value" - {
+      "Should become null when I set it to null" - {
+        System.getenv("foo") shouldBe null  // Enforcing pre conditions
+        
+        withEnvironment("foo", "booz") {
+          val allResults = executeOnAllSystemEnvironmentOverloads("foo", null) {
+            System.getenv("foo") shouldBe null
+            "RETURNED"
+          }
+  
+          allResults.forAll { it shouldBe "RETURNED" }
+  
+        }
+      }
+    }
+  }
+  
+  override fun afterSpec(spec: Spec) {
+    verifyFooIsUnset()
+  }
+  
+}
+
+private suspend fun AbstractFreeSpec.FreeSpecScope.executeOnAllSystemEnvironmentOverloads(key: String, value: String?, block: suspend () -> String): List<String> {
+  val results = mutableListOf<String>()
+  
+  "String String overload" {
+    results += withEnvironment(key, value) {
+      block()
+    }
+  }
+  
+  "Pair overload" {
+    results += withEnvironment(key to value) { block() }
+  }
+  
+  "Map overload" {
+    results += withEnvironment(mapOf(key to value)) { block() }
+  }
+  
+  return results
+}
+
+class SystemEnvironmentTestListenerTest : ShouldSpec() {
+  
+  override fun listeners() = listOf(SystemEnvironmentTestListener("foo", "bar"))
+  
+  init {
+    should("Get extra extension from environment") {
+      verifyFooIsBar()
+    }
+  }
+  
+  override fun afterSpec(spec: Spec) {
+    // The environment must be reset afterwards
+    verifyFooIsUnset()
+  }
+}
+
+private fun verifyFooIsBar() {
+  System.getenv("foo") shouldBe "bar"
+}
+
+private fun verifyFooIsUnset() {
+  System.getenv("foo") shouldBe null
+}

--- a/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/SystemExitTest.kt
+++ b/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/SystemExitTest.kt
@@ -1,5 +1,7 @@
-package io.kotlintest.extensions.system
+package com.sksamuel.kt.extensions.system
 
+import io.kotlintest.extensions.system.SpecSystemExitListener
+import io.kotlintest.extensions.system.SystemExitException
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec

--- a/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/SystemPropertiesExtensionsTests.kt
+++ b/kotlintest-extensions/src/test/kotlin/com/sksamuel/kt/extensions/system/SystemPropertiesExtensionsTests.kt
@@ -1,11 +1,51 @@
-package io.kotlintest.extensions.system
+package com.sksamuel.kt.extensions.system
 
 import io.kotlintest.*
 import io.kotlintest.extensions.SpecLevelExtension
 import io.kotlintest.extensions.TopLevelTest
+import io.kotlintest.extensions.system.SystemPropertyExtension
+import io.kotlintest.extensions.system.withSystemProperties
+import io.kotlintest.extensions.system.withSystemProperty
+import io.kotlintest.specs.FreeSpec
 import io.kotlintest.specs.FunSpec
 import io.kotlintest.specs.WordSpec
 import java.util.*
+
+class SystemPropertiesSuspendTest : FreeSpec() {
+  
+  init {
+    "The system properties function" - {
+      "Must accept a suspend block" - {
+        
+        val suspendBlock: suspend () -> Unit = {  }
+        
+        "Key Value overload" {
+            withSystemProperty("Key", "Value") {
+              suspendBlock()
+          }
+        }
+  
+        "List of Pair value overload" {
+          withSystemProperties(listOf("Key" to "Value")){
+            suspendBlock()
+          }
+        }
+  
+        "Properties value overload" {
+          withSystemProperties(Properties()) {
+            suspendBlock()
+          }
+        }
+  
+        "Map value overload" {
+          withSystemProperties(mapOf("Key" to "Value")) {
+            suspendBlock()
+          }
+        }
+      }
+    }
+  }
+}
 
 class SystemPropertyFunctionTest : FunSpec({
 
@@ -46,7 +86,7 @@ class SystemPropertyFunctionTest : FunSpec({
     val props = Properties()
     props.setProperty("a", "m")
     props.setProperty("b", "n")
-
+  
     withSystemProperties(props) {
       System.getProperty("a") shouldBe "m"
       System.getProperty("b") shouldBe "n"


### PR DESCRIPTION
This commit implements the System Environment Extensions. With some extension functions and a listener, this commit enables System Environment Override by users, something only possible via reflection.

An special attention is needed to the system environments, as they're susceptible to race conditions. This was specified in the documentations.

This commit also fixes a small issue with SystemProperties extension, in which they wouldn't accept a suspended function. A test for that behavior was added.

This commit also renames the tests package, to stop stacktrace filtering, so that the error is clear whenever one of these tests fail.

Implements #623