### PR TITLE
WIP: Feature/634 Extended word spec

### DIFF
--- a/doc/styles.md
+++ b/doc/styles.md
@@ -72,6 +72,26 @@ class MyTests : WordSpec({
 })
 ```
 
+It also supports the keyword `When` allowing to add another level of nesting.
+
+```
+class MyTests : WordSpec({
+    "Hello" When {
+        "asked for length" should {
+            "return 5" {
+                "Hello".length shouldBe 5
+            }
+        }
+        "appended to Bob" should {
+            "return Hello Bob" {
+                "Hello " + "Bob" shouldBe "Hello Bob"
+            }
+        }
+    }
+    
+})
+```
+
 ### Feature Spec
 
 `FeatureSpec` allows you to use `feature` and `scenario`, which will be familar to those who have used [cucumber](http://docs.cucumber.io/gherkin/reference/)

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
@@ -22,7 +22,7 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   }
 
   infix fun String.should(init: suspend WordScope.() -> Unit) =
-          addTestCase("$this should", { this@AbstractWordSpec.WordScope(this).init() }, defaultTestCaseConfig, TestType.Container)
+      addTestCase("$this should", { this@AbstractWordSpec.WordScope(this).init() }, defaultTestCaseConfig, TestType.Container)
 
   infix fun String.When(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
   infix fun String.`when`(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
@@ -35,25 +35,25 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   inner class WordScope(val context: TestContext) {
 
     suspend fun String.config(
-            invocations: Int? = null,
-            enabled: Boolean? = null,
-            timeout: Duration? = null,
-            threads: Int? = null,
-            tags: Set<Tag>? = null,
-            extensions: List<TestCaseExtension>? = null,
-            test: FinalTestContext.() -> Unit) {
+        invocations: Int? = null,
+        enabled: Boolean? = null,
+        timeout: Duration? = null,
+        threads: Int? = null,
+        tags: Set<Tag>? = null,
+        extensions: List<TestCaseExtension>? = null,
+        test: FinalTestContext.() -> Unit) {
       val config = TestCaseConfig(
-              enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
-              invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
-              timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
-              threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
-              tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
-              extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions)
+          enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
+          invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
+          timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
+          threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
+          tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
+          extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions)
       context.registerTestCase(this, this@AbstractWordSpec, { FinalTestContext(this, coroutineContext).test() }, config, TestType.Test)
     }
 
     suspend infix operator fun String.invoke(test: FinalTestContext.() -> Unit) =
-            context.registerTestCase(this, this@AbstractWordSpec, { FinalTestContext(this, coroutineContext).test() }, this@AbstractWordSpec.defaultTestCaseConfig, TestType.Test)
+        context.registerTestCase(this, this@AbstractWordSpec, { FinalTestContext(this, coroutineContext).test() }, this@AbstractWordSpec.defaultTestCaseConfig, TestType.Test)
 
     // we need to override the should method to stop people nesting a should inside a should
     @Deprecated("A should block can only be used at the top level", ReplaceWith("{}"), level = DeprecationLevel.ERROR)
@@ -82,28 +82,28 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
     suspend infix operator fun String.invoke(test: suspend FinalTestContext.() -> Unit) = addInContext(this, test)
 
     suspend fun String.config(
-            invocations: Int? = null,
-            enabled: Boolean? = null,
-            timeout: Duration? = null,
-            threads: Int? = null,
-            tags: Set<Tag>? = null,
-            extensions: List<TestCaseExtension>? = null,
-            test: suspend FinalTestContext.() -> Unit) {
+        invocations: Int? = null,
+        enabled: Boolean? = null,
+        timeout: Duration? = null,
+        threads: Int? = null,
+        tags: Set<Tag>? = null,
+        extensions: List<TestCaseExtension>? = null,
+        test: suspend FinalTestContext.() -> Unit) {
       val config = Pair(this, TestCaseConfig(
-              enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
-              invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
-              timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
-              threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
-              tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
-              extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions))
+          enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
+          invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
+          timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
+          threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
+          tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
+          extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions))
       addInContext(config, test)
     }
 
     private suspend fun addInContext(testConfig: Pair<String, TestCaseConfig>, test: suspend FinalTestContext.() -> Unit) {
       context.registerTestCase(createTestName("Should: ", testConfig.first), thisSpec,
-              { thisSpec.FinalTestContext(this, coroutineContext).test() }, testConfig.second, TestType.Test)
+          { thisSpec.FinalTestContext(this, coroutineContext).test() }, testConfig.second, TestType.Test)
     }
-    
+
   }
 
   @KotlinTestDsl

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
@@ -67,7 +67,7 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
     suspend infix fun String.should(test: suspend ShouldContext.() -> Unit) = addShouldContext(this, test)
 
     private suspend fun addShouldContext(name: String, test: suspend ShouldContext.() -> Unit) {
-      context.registerTestCase(createTestName("When: ", name), thisSpec, { thisSpec.ShouldContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
+      context.registerTestCase(createTestName("When: ", name), thisSpec, { thisSpec.ShouldContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
   }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
@@ -28,7 +28,7 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   infix fun String.`when`(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
 
   private fun addWhenContext(name: String, init: suspend WhenContext.() -> Unit) {
-    addTestCase(name, { thisSpec.WhenContext(this).init() }, defaultTestCaseConfig, TestType.Container)
+    addTestCase("$name when", { thisSpec.WhenContext(this).init() }, defaultTestCaseConfig, TestType.Container)
   }
 
   @KotlinTestDsl
@@ -63,45 +63,11 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   @KotlinTestDsl
   inner class WhenContext(val context: TestContext) {
 
-    suspend infix fun String.Should(test: suspend ShouldContext.() -> Unit) = addShouldContext(this, test)
-    suspend infix fun String.should(test: suspend ShouldContext.() -> Unit) = addShouldContext(this, test)
+    suspend infix fun String.Should(test: suspend WordScope.() -> Unit) = addShouldContext(this, test)
+    suspend infix fun String.should(test: suspend WordScope.() -> Unit) = addShouldContext(this, test)
 
-    private suspend fun addShouldContext(name: String, test: suspend ShouldContext.() -> Unit) {
-      context.registerTestCase(createTestName("When: ", name), thisSpec, { thisSpec.ShouldContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
-    }
-
-  }
-
-  @KotlinTestDsl
-  inner class ShouldContext(val context: TestContext) {
-
-    private suspend fun addInContext(name: String, test: suspend FinalTestContext.() -> Unit) {
-      context.registerTestCase(createTestName("Should: ", name), thisSpec, { thisSpec.FinalTestContext(this, coroutineContext).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
-    }
-
-    suspend infix operator fun String.invoke(test: suspend FinalTestContext.() -> Unit) = addInContext(this, test)
-
-    suspend fun String.config(
-        invocations: Int? = null,
-        enabled: Boolean? = null,
-        timeout: Duration? = null,
-        threads: Int? = null,
-        tags: Set<Tag>? = null,
-        extensions: List<TestCaseExtension>? = null,
-        test: suspend FinalTestContext.() -> Unit) {
-      val config = Pair(this, TestCaseConfig(
-          enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
-          invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
-          timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
-          threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
-          tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
-          extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions))
-      addInContext(config, test)
-    }
-
-    private suspend fun addInContext(testConfig: Pair<String, TestCaseConfig>, test: suspend FinalTestContext.() -> Unit) {
-      context.registerTestCase(createTestName("Should: ", testConfig.first), thisSpec,
-          { thisSpec.FinalTestContext(this, coroutineContext).test() }, testConfig.second, TestType.Test)
+    private suspend fun addShouldContext(name: String, test: suspend WordScope.() -> Unit) {
+      context.registerTestCase("$name should", thisSpec, { thisSpec.WordScope(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Container)
     }
 
   }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
@@ -28,9 +28,10 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   }
 
   infix fun String.should(init: suspend WordScope.() -> Unit) =
-      addTestCase(this + " should", { this@AbstractWordSpec.WordScope(this).init() }, defaultTestCaseConfig, TestType.Container)
+      addTestCase("$this should", { this@AbstractWordSpec.WordScope(this).init() }, defaultTestCaseConfig, TestType.Container)
 
   infix fun String.When(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
+  infix fun String.`when`(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
 
   private fun addWhenContext(name: String, init: suspend WhenContext.() -> Unit) {
     addTestCase(name, { thisSpec.WhenContext(this).init() }, defaultTestCaseConfig, TestType.Container)
@@ -81,10 +82,13 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   inner class ShouldContext(val context: TestContext) {
 
     suspend infix fun String.In(test: suspend InContext.() -> Unit) = addInContext(this, test)
+    suspend infix fun String.`in`(test: suspend InContext.() -> Unit) = addInContext(this, test)
 
     private suspend fun addInContext(name: String, test: suspend InContext.() -> Unit) {
       context.registerTestCase(createTestName("Should: ", name), thisSpec, { thisSpec.InContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
     }
+
+    suspend infix operator fun String.invoke(test: suspend InContext.() -> Unit) = addInContext(this, test)
 
   }
 

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/specs/AbstractWordSpec.kt
@@ -22,7 +22,7 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   }
 
   infix fun String.should(init: suspend WordScope.() -> Unit) =
-      addTestCase("$this should", { this@AbstractWordSpec.WordScope(this).init() }, defaultTestCaseConfig, TestType.Container)
+          addTestCase("$this should", { this@AbstractWordSpec.WordScope(this).init() }, defaultTestCaseConfig, TestType.Container)
 
   infix fun String.When(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
   infix fun String.`when`(init: suspend WhenContext.() -> Unit) = addWhenContext(this, init)
@@ -35,25 +35,25 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   inner class WordScope(val context: TestContext) {
 
     suspend fun String.config(
-        invocations: Int? = null,
-        enabled: Boolean? = null,
-        timeout: Duration? = null,
-        threads: Int? = null,
-        tags: Set<Tag>? = null,
-        extensions: List<TestCaseExtension>? = null,
-        test: FinalTestContext.() -> Unit) {
+            invocations: Int? = null,
+            enabled: Boolean? = null,
+            timeout: Duration? = null,
+            threads: Int? = null,
+            tags: Set<Tag>? = null,
+            extensions: List<TestCaseExtension>? = null,
+            test: FinalTestContext.() -> Unit) {
       val config = TestCaseConfig(
-          enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
-          invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
-          timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
-          threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
-          tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
-          extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions)
+              enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
+              invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
+              timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
+              threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
+              tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
+              extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions)
       context.registerTestCase(this, this@AbstractWordSpec, { FinalTestContext(this, coroutineContext).test() }, config, TestType.Test)
     }
 
     suspend infix operator fun String.invoke(test: FinalTestContext.() -> Unit) =
-        context.registerTestCase(this, this@AbstractWordSpec, { FinalTestContext(this, coroutineContext).test() }, this@AbstractWordSpec.defaultTestCaseConfig, TestType.Test)
+            context.registerTestCase(this, this@AbstractWordSpec, { FinalTestContext(this, coroutineContext).test() }, this@AbstractWordSpec.defaultTestCaseConfig, TestType.Test)
 
     // we need to override the should method to stop people nesting a should inside a should
     @Deprecated("A should block can only be used at the top level", ReplaceWith("{}"), level = DeprecationLevel.ERROR)
@@ -75,64 +75,36 @@ abstract class AbstractWordSpec(body: AbstractWordSpec.() -> Unit = {}) : Abstra
   @KotlinTestDsl
   inner class ShouldContext(val context: TestContext) {
 
-    suspend infix fun String.In(test: suspend InContext.() -> Unit) = addInContext(this, test)
-    suspend infix fun String.`in`(test: suspend InContext.() -> Unit) = addInContext(this, test)
-
-    private suspend fun addInContext(name: String, test: suspend InContext.() -> Unit) {
-      context.registerTestCase(createTestName("Should: ", name), thisSpec, { thisSpec.InContext(this).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
+    private suspend fun addInContext(name: String, test: suspend FinalTestContext.() -> Unit) {
+      context.registerTestCase(createTestName("Should: ", name), thisSpec, { thisSpec.FinalTestContext(this, coroutineContext).test() }, thisSpec.defaultTestCaseConfig, TestType.Test)
     }
 
-    suspend infix operator fun String.invoke(test: suspend InContext.() -> Unit) = addInContext(this, test)
+    suspend infix operator fun String.invoke(test: suspend FinalTestContext.() -> Unit) = addInContext(this, test)
 
-      //TODO: See if repeating so much code can be avoided
-      suspend fun String.config(
-              invocations: Int? = null,
-              enabled: Boolean? = null,
-              timeout: Duration? = null,
-              threads: Int? = null,
-              tags: Set<Tag>? = null,
-              extensions: List<TestCaseExtension>? = null,
-              test: suspend InContext.() -> Unit) {
-          val config = Pair(this,TestCaseConfig(
-                  enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
-                  invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
-                  timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
-                  threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
-                  tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
-                  extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions))
-          addInContext(config, test)
-      }
+    suspend fun String.config(
+            invocations: Int? = null,
+            enabled: Boolean? = null,
+            timeout: Duration? = null,
+            threads: Int? = null,
+            tags: Set<Tag>? = null,
+            extensions: List<TestCaseExtension>? = null,
+            test: suspend FinalTestContext.() -> Unit) {
+      val config = Pair(this, TestCaseConfig(
+              enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
+              invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
+              timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
+              threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
+              tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
+              extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions))
+      addInContext(config, test)
+    }
 
-      fun String.config(
-              invocations: Int? = null,
-              enabled: Boolean? = null,
-              timeout: Duration? = null,
-              threads: Int? = null,
-              tags: Set<Tag>? = null,
-              extensions: List<TestCaseExtension>? = null): Pair<String, TestCaseConfig> {
-          return Pair(this, TestCaseConfig(
-                  enabled ?: this@AbstractWordSpec.defaultTestCaseConfig.enabled,
-                  invocations ?: this@AbstractWordSpec.defaultTestCaseConfig.invocations,
-                  timeout ?: this@AbstractWordSpec.defaultTestCaseConfig.timeout,
-                  threads ?: this@AbstractWordSpec.defaultTestCaseConfig.threads,
-                  tags ?: this@AbstractWordSpec.defaultTestCaseConfig.tags,
-                  extensions ?: this@AbstractWordSpec.defaultTestCaseConfig.extensions))
-      }
-
-      suspend infix fun Pair<String, TestCaseConfig>.In(test: suspend InContext.() -> Unit) = addInContext(this, test)
-
-      suspend infix fun Pair<String, TestCaseConfig>.`in`(test: suspend InContext.() -> Unit) = addInContext(this, test)
-
-      private suspend fun addInContext(testConfig: Pair<String, TestCaseConfig>, test: suspend InContext.() -> Unit) {
-          context.registerTestCase(createTestName("Should: ", testConfig.first), thisSpec,
-                  { thisSpec.InContext(this).test() }, testConfig.second, TestType.Test)
-      }
-
-
+    private suspend fun addInContext(testConfig: Pair<String, TestCaseConfig>, test: suspend FinalTestContext.() -> Unit) {
+      context.registerTestCase(createTestName("Should: ", testConfig.first), thisSpec,
+              { thisSpec.FinalTestContext(this, coroutineContext).test() }, testConfig.second, TestType.Test)
+    }
+    
   }
-
-  @KotlinTestDsl
-  inner class InContext(val context: TestContext)
 
   @KotlinTestDsl
   inner class FinalTestContext(val context: TestContext, coroutineContext: CoroutineContext) : TestContext(coroutineContext) {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecExample.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecExample.kt
@@ -11,5 +11,15 @@ class WordSpecExample : WordSpec() {
       "allow config".config(invocations = 2) {
       }
     }
+
+    "another test" When {
+      "using when" Should {
+        "test something"{
+          // test here
+        }
+        "allow config".config(invocations = 2) {
+        }
+      }
+    }
   }
 }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecTest.kt
@@ -20,15 +20,6 @@ class WordSpecTest : WordSpec() {
 
     "another context" When {
 
-      "using In" Should {
-        "have a test" In {
-          2.shouldBeGreaterThan(1)
-        }
-        "have a test with config".config(invocations = 2) In{
-          2.shouldBeGreaterThan(1)
-        }
-      }
-
       "not using In" Should {
         "have a test" {
           2.shouldBeGreaterThan(1)

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecTest.kt
@@ -20,7 +20,7 @@ class WordSpecTest : WordSpec() {
 
     "another context" When {
 
-      "not using In" Should {
+      "using when" Should {
         "have a test" {
           2.shouldBeGreaterThan(1)
         }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/specs/wordspec/WordSpecTest.kt
@@ -17,5 +17,27 @@ class WordSpecTest : WordSpec() {
 
       }
     }
+
+    "another context" When {
+
+      "using In" Should {
+        "have a test" In {
+          2.shouldBeGreaterThan(1)
+        }
+        "have a test with config".config(invocations = 2) In{
+          2.shouldBeGreaterThan(1)
+        }
+      }
+
+      "not using In" Should {
+        "have a test" {
+          2.shouldBeGreaterThan(1)
+        }
+        "have a test with config".config(invocations = 2) {
+          2.shouldBeGreaterThan(1)
+        }
+      }
+
+    }
   }
 }

--- a/kotlintest-tests/kotlintest-tests-junit-report/src/test/kotlin/com/sksamuel/kotlintest/JUnitXMLReportTest.kt
+++ b/kotlintest-tests/kotlintest-tests-junit-report/src/test/kotlin/com/sksamuel/kotlintest/JUnitXMLReportTest.kt
@@ -40,7 +40,7 @@ class JUnitXMLReportTest : WordSpec() {
       "include top level information" {
         val root = root()
         root.getAttributeValue("name").shouldBe("com.sksamuel.kotlintest.specs.wordspec.WordSpecTest")
-        root.getAttributeValue("tests").shouldBe("3")
+        root.getAttributeValue("tests").shouldBe("5")
         root.getAttributeValue("skipped").shouldBe("0")
         root.getAttributeValue("errors").shouldBe("0")
         root.getAttributeValue("failures").shouldBe("0")


### PR DESCRIPTION
Implementing https://github.com/kotlintest/kotlintest/issues/634

There are still some things to do and test, but I open the pull request to get some feedback before advancing more

In the WordSpecTest it can be seen how it would be used.

Intellij shows it like this:

![image](https://user-images.githubusercontent.com/9098977/52252118-575c5e00-28df-11e9-939e-4dd39f881cf9.png)

I'm not sure if there is any way to avoid repeating so much code in the config function if we want to keep allowing to use "In" or nothing. I'm just learning kotlin, so I don't know if there is some magic feature to do that :laughing: 