### PR TITLE
Update org.mockito:mockito-core to 2.24.0

### DIFF
--- a/kotlintest-runner/kotlintest-runner-junit4/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-junit4/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     compile project(':kotlintest-assertions')
     compile project(':kotlintest-runner:kotlintest-runner-jvm')
     compile 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     testCompile "com.nhaarman:mockito-kotlin:1.6.0"
 }
 

--- a/kotlintest-tests/kotlintest-tests-core/build.gradle
+++ b/kotlintest-tests/kotlintest-tests-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     testImplementation project(':kotlintest-assertions-arrow')
     testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.1'
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     // this is here to test that the intellij marker 'dummy' test doesn't appear in intellij
     testCompile 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.2'


### PR DESCRIPTION
Updates org.mockito:mockito-core to 2.24.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.