### PR TITLE
Update io.github.classgraph:classgraph to 4.6.32

### DIFF
--- a/kotlintest-runner/kotlintest-runner-jvm/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-jvm/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':kotlintest-core')
     compile project(":kotlintest-extensions")
-    compile 'io.github.classgraph:classgraph:4.6.29'
+    compile 'io.github.classgraph:classgraph:4.6.32'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'io.arrow-kt:arrow-core:0.8.2'
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'


### PR DESCRIPTION
Updates io.github.classgraph:classgraph to 4.6.32.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.