### PR TITLE
CollectionMatchers: Lazily evaluate joined string representations

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/CollectionMatchers.kt
@@ -32,11 +32,12 @@ fun <T> containsAll(ts: List<T>): Matcher<Collection<T>> = containAll(ts)
 
 fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 fun <T> containAll(ts: Collection<T>): Matcher<Collection<T>> = object : Matcher<Collection<T>> {
-  override fun test(value: Collection<T>) = Result(
-      ts.all { value.contains(it) },
-      "Collection should contain all of ${ts.joinToString(", ", limit = 10) { stringRepr(it) }}",
-      "Collection should not contain all of ${ts.joinToString(", ", limit = 10) { stringRepr(it) }}"
-  )
+  override fun test(value: Collection<T>): Result {
+    val joinedString by lazy { ts.joinToString(", ", limit = 10) { stringRepr(it) } }
+    val failureMessage by lazy { "Collection should contain all of $joinedString" }
+    val negatedFailureMessage by lazy { "Collection should not contain all of $joinedString" }
+    return Result(ts.all { value.contains(it) }, failureMessage, negatedFailureMessage)
+  }
 }
 
 fun <T> containsInOrder(vararg ts: T): Matcher<Collection<T>?> = containsInOrder(ts.asList())
@@ -74,16 +75,16 @@ fun <T> singleElement(t: T): Matcher<Collection<T>> = object : Matcher<Collectio
 fun <T : Comparable<T>> beSorted(): Matcher<List<T>> = sorted()
 fun <T : Comparable<T>> sorted(): Matcher<List<T>> = object : Matcher<List<T>> {
   override fun test(value: List<T>): Result {
-    val failure = value.withIndex().firstOrNull { (i, it) -> i != value.lastIndex && it > value[i+1] }
-    val snippet = value.joinToString(",", limit = 10)
-    val elementMessage = when (failure) {
+    val failure = value.withIndex().find { (i, it) -> i != value.lastIndex && it > value[i+1] }
+    val elementMessage by lazy {
+      when (failure) {
         null -> ""
         else -> ". Element ${failure.value} at index ${failure.index} was greater than element ${value[failure.index+1]}"
+      }
     }
-    return Result(
-        failure == null,
-        "List [$snippet] should be sorted$elementMessage",
-        "List [$snippet] should not be sorted"
-    )
+    val snippet by lazy { value.joinToString(",", limit = 10) }
+    val failureMessage by lazy { "List [$snippet] should be sorted$elementMessage" }
+    val negatedFailureMessage by lazy { "List [$snippet] should not be sorted" }
+    return Result(failure == null, failureMessage, negatedFailureMessage)
   }
 }


### PR DESCRIPTION
For large data classes calling toString() might actually be quite
expensive, esp. if there are multiple of those in a collection. So even
if limited to 10 elements here, only lazily evaluate the failure message
strings as they are not used at all on success.