### PR TITLE
Implement System Security Manager Extensions

### DIFF
--- a/kotlintest-extensions/src/main/kotlin/io/kotlintest/extensions/system/SecurityManagerExtensions.kt
+++ b/kotlintest-extensions/src/main/kotlin/io/kotlintest/extensions/system/SecurityManagerExtensions.kt
@@ -1,0 +1,93 @@
+package io.kotlintest.extensions.system
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.extensions.TestListener
+
+/**
+ * Replaces System Security Manager with [securityManager]
+ *
+ * This function replaces the System Security Manager with the specified [securityManager], executes [block] and then
+ * returns the original manager to its place. This will also happen if the original manager is null.
+ *
+ * **Attention**: This code is subject to race conditions. As Java's System Manager is only one per JVM, this code
+ * will replace it. However, all other tests are going to use it if tests are running in parallel.
+ */
+inline fun <reified T> withSecurityManager(securityManager: SecurityManager?, block: () -> T): T {
+  val originalSecurityManager = System.getSecurityManager()
+  
+  System.setSecurityManager(securityManager)
+  
+  try {
+    return block()
+  } finally {
+    System.setSecurityManager(originalSecurityManager)
+  }
+}
+
+
+abstract class SecurityManagerListener(
+        protected val securityManager: SecurityManager?
+) : TestListener {
+  
+  private val originalSecurityManager = System.getSecurityManager()
+  
+  protected fun changeSecurityManager() {
+    System.setSecurityManager(securityManager)
+  }
+  
+  protected fun resetSecurityManager() {
+    System.setSecurityManager(originalSecurityManager)
+  }
+  
+}
+
+/**
+ * Overrides System Security Manager with specified [securityManager]
+ *
+ * This is a Listener for code that uses the System Security Manager. It replaces the System Security Manager with the
+ * desired [securityManager].
+ *
+ * After the execution of the test, the System Security Manager is set to what it was before. This will also happen if
+ * the original manager is null.
+ *
+ * **Attention**: This code is subject to race conditions. As Java's System Manager is only one per JVM, this code
+ * will replace it. However, all other tests are going to use it if tests are running in parallel.
+ */
+class SecurityManagerTestListener(
+        securityManager: SecurityManager?
+) : SecurityManagerListener(securityManager) {
+  
+  override fun beforeTest(testCase: TestCase) {
+    changeSecurityManager()
+  }
+  
+  override fun afterTest(testCase: TestCase, result: TestResult) {
+    resetSecurityManager()
+  }
+}
+
+/**
+ * Overrides System Security Manager with specified [securityManager]
+ *
+ * This is a Listener for code that uses the System Security Manager. It replaces the System Security Manager with the
+ * desired [securityManager].
+ *
+ * After the execution of the project, the System Security Manager is set to what it was before. This will also happen if
+ * the original manager is null.
+ *
+ * **Attention**: This code is subject to race conditions. As Java's System Manager is only one per JVM, this code
+ * will replace it. However, all other tests are going to use it if tests are running in parallel.
+ */
+class SecurityManagerProjectListener(
+        securityManager: SecurityManager?
+) : SecurityManagerListener(securityManager) {
+  
+  override fun beforeProject() {
+    changeSecurityManager()
+  }
+  
+  override fun afterProject() {
+    resetSecurityManager()
+  }
+}

--- a/kotlintest-extensions/src/test/kotlin/io/kotlintest/extensions/system/SecurityManagerExtensionsTests.kt
+++ b/kotlintest-extensions/src/test/kotlin/io/kotlintest/extensions/system/SecurityManagerExtensionsTests.kt
@@ -1,0 +1,73 @@
+package io.kotlintest.extensions.system
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.matchers.types.shouldBeSameInstanceAs
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import java.security.Permission
+
+class SecurityManagerExtensionFunctionTests : StringSpec() {
+  
+  init {
+    "Should reset the security manager after execution" {
+      val originalSecurityManager = System.getSecurityManager()
+      
+      withSecurityManager(MySecurityManager) {  }
+      
+      System.getSecurityManager() shouldBeSameInstanceAs originalSecurityManager
+    }
+  
+    "Should reset the security manager even if there's an exception" {
+      val originalSecurityManager = System.getSecurityManager()
+      
+      fun throwException(): Unit = throw RuntimeException() // Must be Unit. Nothing can't be used as reified
+      
+      try {
+        withSecurityManager(MySecurityManager) { throwException() }
+      } catch(_: Exception) {  }
+      
+      System.getSecurityManager() shouldBeSameInstanceAs originalSecurityManager
+    }
+    
+    "Should use custom security manager during execution" {
+      withSecurityManager(MySecurityManager) {
+        System.getSecurityManager() shouldBe MySecurityManager
+      }
+    }
+    
+    "Should allow for suspend functions to be called" {
+  
+      @Suppress("RedundantSuspendModifier")
+      suspend fun foo() {  }
+  
+      withSecurityManager(MySecurityManager) { foo() }
+    }
+  }
+}
+
+class SecurityManagerTestListenerTest : StringSpec() {
+  
+  init {
+    "Should use custom security manager" {
+      System.getSecurityManager() shouldBe MySecurityManager
+    }
+  }
+  
+  private var originalSecurityManager: SecurityManager? = null
+  
+  override fun beforeTest(testCase: TestCase) {
+    originalSecurityManager = System.getSecurityManager()
+  }
+  
+  override fun afterTest(testCase: TestCase, result: TestResult) {
+    // Should reset to system default
+    System.getSecurityManager() shouldBe originalSecurityManager
+  }
+  
+  override fun listeners() = listOf(SecurityManagerTestListener(MySecurityManager))
+}
+
+private object MySecurityManager : SecurityManager() {
+  override fun checkPermission(perm: Permission?) { /* Throw nothing */ }
+}


### PR DESCRIPTION
This commit implements the System Security Manager Extensions.

A special attention is needed to the System Security Manager, as it's only one for the JVM, it's susceptible to race conditions. This was specified in the documentation.

Implements #624