### PR TITLE
[3.3 only] Add documentation for #647

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -120,6 +120,7 @@ For the extension function style, each function has an equivalent negated versio
 | `list.shouldHaveElementAt(index, element)` | Asserts that this list contains the given element at the given position. |
 | `list.shouldStartWith(lst)` | Asserts that this list starts with the elements of the given list, in order. |
 | `list.shouldEndWith(lst)` | Asserts that this list ends with the elements of the given list, in order. |
+| `value.shouldBeOneOf(collection)` | Asserts that a specific instance is contained in a collection. |
 
 | URIs ||
 | -------- | ---- |


### PR DESCRIPTION
Pull request #647 introduced the matcher `shouldBeOneOf`. This matcher is going to be introduced in a future version of KotlinTest, and with it, the documentation must be current.

This wasn't added as part of #647 because we didn't want documentation to include a matcher not existent yet.

Part of #616