### PR TITLE
Update com.univocity:univocity-parsers to 2.8.1

### DIFF
--- a/kotlintest-assertions/build.gradle
+++ b/kotlintest-assertions/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-reflect"
-    compile 'com.univocity:univocity-parsers:2.8.0'
+    compile 'com.univocity:univocity-parsers:2.8.1'
     compile group: 'com.github.wumpz', name: 'diffutils', version: '2.2'
 }
 


### PR DESCRIPTION
Updates com.univocity:univocity-parsers to 2.8.1.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.