### PR TITLE
Update io.qameta.allure:allure-java-commons to 2.10.0

### DIFF
--- a/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-allure/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
-    compile 'io.qameta.allure:allure-java-commons:2.9.0'
+    compile 'io.qameta.allure:allure-java-commons:2.10.0'
     compile 'javax.xml.bind:jaxb-api:2.3.1'
     compile 'com.sun.xml.bind:jaxb-core:2.3.0.1'
     compile 'com.sun.xml.bind:jaxb-impl:2.3.2'


### PR DESCRIPTION
Updates io.qameta.allure:allure-java-commons to 2.10.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.