### PR TITLE
Update org.springframework:spring-context to 5.1.5-RELEASE

### DIFF
--- a/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile 'org.springframework:spring-test:4.3.14.RELEASE'
-    compile 'org.springframework:spring-context:4.3.14.RELEASE'
+    compile 'org.springframework:spring-context:5.1.5-RELEASE'
     testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
 }
 

--- a/kotlintest-samples/kotlintest-samples-spring/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-spring/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 dependencies {
     compile 'org.springframework:spring-test:4.3.14.RELEASE'
-    compile 'org.springframework:spring-context:4.3.14.RELEASE'
+    compile 'org.springframework:spring-context:5.1.5-RELEASE'
     testCompile 'io.kotlintest:kotlintest-runner-junit5:3.2.1'
     testCompile 'io.kotlintest:kotlintest-extensions-spring:3.2.1'
 }


### PR DESCRIPTION
Updates org.springframework:spring-context to 5.1.5-RELEASE.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.