### PR TITLE
Update org.junit.platform:junit-platform-engine to 1.4.0

### DIFF
--- a/kotlintest-runner/kotlintest-runner-junit5/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-junit5/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
     compile project(':kotlintest-runner:kotlintest-runner-jvm')
-    compile 'org.junit.platform:junit-platform-engine:1.3.2'
+    compile 'org.junit.platform:junit-platform-engine:1.4.0'
     compile 'org.junit.platform:junit-platform-suite-api:1.3.2'
     compile 'org.junit.platform:junit-platform-launcher:1.3.2'
 }


### PR DESCRIPTION
Updates org.junit.platform:junit-platform-engine to 1.4.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.