### PR TITLE
Update org.junit.jupiter:junit-jupiter-engine to 5.4.0

### DIFF
--- a/kotlintest-tests/kotlintest-tests-core/build.gradle
+++ b/kotlintest-tests/kotlintest-tests-core/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"
     testImplementation 'org.mockito:mockito-core:2.24.0'
     // this is here to test that the intellij marker 'dummy' test doesn't appear in intellij
-    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
+    testCompile 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.2'
 }
 


### PR DESCRIPTION
Updates org.junit.jupiter:junit-jupiter-engine to 5.4.0.

If you'd like to skip this version, you can just close this PR, and I won't make another for the same version.

And if commits from elsewhere cause a conflict I'll automatically resolve them unless you make changes yourself.

Cheerio.