### PR TITLE
Include Kotlin sources and documentation in Maven artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,13 @@ buildscript {
     ext.travisBuildNumber = System.getenv("TRAVIS_BUILD_NUMBER")
     ext.isReleaseVersion = !isTravis
     ext.JUnitPlatformVersion = "1.4.0"
+    ext.dokkaVersion = '0.9.17'
     repositories {
         mavenCentral()
+    }
+    
+    dependencies {
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$dokkaVersion"
     }
 }
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,5 +1,5 @@
 task sourcesJar(type: Jar) {
-    from sourceSets.main.allJava
+    from sourceSets.main.kotlin
     archiveClassifier = 'sources'
 }
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,11 +1,20 @@
+apply plugin: 'org.jetbrains.dokka'
+
+dokka {
+    outputFormat = 'javadoc'
+    outputDirectory = javadoc.destinationDir
+}
+
+dokka.dependsOn javadoc
+
+task javadocJar(type: Jar, dependsOn: dokka) {
+    from javadoc.destinationDir
+    archiveClassifier = 'javadoc'
+}
+
 task sourcesJar(type: Jar) {
     from sourceSets.main.kotlin
     archiveClassifier = 'sources'
-}
-
-task javadocJar(type: Jar) {
-    from javadoc
-    archiveClassifier = 'javadoc'
 }
 
 publishing {


### PR DESCRIPTION
When accessing declarations of functions or classes defined in KotlinTest, IntelliJ is unable to resolve sources.
I noticed that in the `kotlintest-*-3.3.1-sources.jar` contains sources for Java classes, but not Kotlin files.

This pull request fixes 2 documentation-related issues:
- Add Kotlin sources to the published `kotlintest-*-[version]-sources.jar`
- Generate and package Kotlin code documentation in the published `kotlintest-*-[version]-javadoc.jar` using Dokka.