### PR TITLE
Fix kotlintest gradle plugin version

### DIFF
--- a/kotlintest-samples/kotlintest-samples-gradle/build.gradle
+++ b/kotlintest-samples/kotlintest-samples-gradle/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.3.21"
-    id "io.kotlintest" version "3.3.2"
+    id "io.kotlintest" version "1.0.2"
 }
 
 repositories {


### PR DESCRIPTION
I wanted to use KotlinTest Gradle example but in build.gradle was bad kotlintest plugin version... So I fixed it...

https://plugins.gradle.org/plugin/io.kotlintest