### PR TITLE
Feature/move throwable handling to common

### DIFF
--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/AnyThrowableHandling.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/AnyThrowableHandling.kt
@@ -1,0 +1,101 @@
+package io.kotlintest
+
+import kotlin.reflect.KClass
+
+/**
+ * Verifies that a block of code throws any [Throwable]
+ *
+ * Use function to wrap a block of code that you want to verify that throws any kind of [Throwable], where using
+ * [shouldThrowAny] can't be used for any reason, such as an assignment of a variable (assignments are statements,
+ * therefore has no return value).
+ *
+ * If you want to verify a specific [Throwable], use [shouldThrowExactlyUnit].
+ *
+ * If you want to verify a [Throwable] and any subclass, use [shouldThrowUnit].
+ *
+ * @see [shouldThrowAny]
+ */
+inline fun shouldThrowAnyUnit(block: () -> Unit) = shouldThrowAny(block)
+
+/**
+ * Verifies that a block of code does NOT throw any [Throwable]
+ *
+ * Use function to wrap a block of code that you want to make sure doesn't throw any [Throwable],
+ * where using [shouldNotThrowAny] can't be used for any reason, such as an assignment of a variable (assignments are
+ * statements, therefore has no return value).
+ *
+ * Note that executing this code is no different to executing [block] itself, as any uncaught exception will
+ * be propagated up anyways.
+ *
+ * @see [shouldNotThrowAny]
+ * @see [shouldNotThrowExactlyUnit]
+ * @see [shouldNotThrowUnit]
+ *
+ */
+inline fun shouldNotThrowAnyUnit(block: () -> Unit) = shouldNotThrowAny(block)
+
+/**
+ * Verifies that a block of code throws any [Throwable]
+ *
+ * Use function to wrap a block of code that you want to verify that throws any kind of [Throwable].
+ *
+ * If you want to verify a specific [Throwable], use [shouldThrowExactly].
+ *
+ * If you want to verify a [Throwable] and any subclasses, use [shouldThrow]
+ *
+ *
+ * **Attention to assignment operations:**
+ *
+ * When doing an assignment to a variable, the code won't compile, because an assignment is not of type [Any], as required
+ * by [block]. If you need to test that an assignment throws a [Throwable], use [shouldThrowAnyUnit] or it's variations.
+ *
+ * ```
+ *     val thrownThrowable: Throwable = shouldThrowAny {
+ *         throw FooException() // This is a random Throwable, could be anything
+ *     }
+ * ```
+ *
+ * @see [shouldThrowAnyUnit]
+ */
+inline fun shouldThrowAny(block: () -> Any?): Throwable {
+  val thrownException = try {
+    block()
+    null
+  } catch (e: Throwable) { e }
+  
+  return thrownException ?: throw Failures.failure("Expected a throwable, but nothing was thrown.")
+}
+
+
+/**
+ * Verifies that a block of code does NOT throw any [Throwable]
+ *
+ * Use function to wrap a block of code that you want to make sure doesn't throw any [Throwable].
+ *
+ * Note that executing this code is no different to executing [block] itself, as any uncaught exception will
+ * be propagated up anyways.
+ *
+ * **Attention to assignment operations:**
+ *
+ * When doing an assignment to a variable, the code won't compile, because an assignment is not of type [Any], as required
+ * by [block]. If you need to test that an assignment doesn't throw a [Throwable], use [shouldNotThrowAnyUnit] or it's
+ * variations.
+ *
+ * @see [shouldNotThrowAnyUnit]
+ * @see [shouldNotThrowExactly]
+ * @see [shouldNotThrow]
+ *
+ */
+inline fun shouldNotThrowAny(block: () -> Unit) {
+  val thrownException = try {
+    block()
+    return
+  } catch (e: Throwable) { e }
+  
+  throw Failures.failure("No exception expected, but a ${thrownException::class.simpleName} was thrown.", thrownException)
+}
+
+
+@PublishedApi
+@Deprecated("Using this method because Kotlin JS currently doesn't support qualified name on reflection.")
+internal expect val KClass<*>.platformQualifiedName: String

--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/CovarianteThrowableHandling.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/CovarianteThrowableHandling.kt
@@ -89,12 +89,12 @@ inline fun <reified T : Throwable> shouldThrow(block: () -> Any?): T {
     block()
     null  // Can't throw Failures.failure here directly, as it would be caught by the catch clause, and it's an AssertionError, which is a special case
   } catch (thrown: Throwable) { thrown }
-
+  
   return when (thrownThrowable) {
-    null -> throw Failures.failure("Expected exception ${expectedExceptionClass.qualifiedName} but no exception was thrown.")
+    null -> throw Failures.failure("Expected exception ${expectedExceptionClass.platformQualifiedName} but no exception was thrown.")
     is T -> thrownThrowable               // This should be before `is AssertionError`. If the user is purposefully trying to verify `shouldThrow<AssertionError>{}` this will take priority
     is AssertionError -> throw thrownThrowable
-    else -> throw Failures.failure("Expected exception ${expectedExceptionClass.qualifiedName} but a ${thrownThrowable::class.simpleName} was thrown instead.", thrownThrowable)
+    else -> throw Failures.failure("Expected exception ${expectedExceptionClass.platformQualifiedName} but a ${thrownThrowable::class.simpleName} was thrown instead.", thrownThrowable)
   }
 }
 
@@ -131,8 +131,8 @@ inline fun <reified T : Throwable> shouldNotThrow(block: () -> Any?) {
     block()
     return
   } catch (e: Throwable) { e }
-
+  
   if(thrown is T) throw Failures.failure("No exception expected, but a ${thrown::class.simpleName} was thrown.", thrown)
   throw thrown
-
+  
 }

--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/Failures.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/Failures.kt
@@ -1,5 +1,24 @@
 package io.kotlintest
 
+/**
+ * Verifies that [block] throws an [AssertionError]
+ *
+ * If [block] throws an [AssertionError], this method will pass. Otherwise, it will throw an error, as a failure was
+ * expected.
+ *
+ * This should be used mainly to check that an assertion fails, for example:
+ *
+ * ```
+ *     shouldFail {
+ *        1 shouldBe 2  // This should fail
+ *     }
+ * ```
+ *
+ * @see shouldThrowAny
+ * @see shouldThrow
+ * @see shouldThrowExactly
+ */
+fun shouldFail(block: () -> Any?): AssertionError = shouldThrow(block)
 
 
 expect object Failures {

--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/StrictThrowableHandling.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/StrictThrowableHandling.kt
@@ -8,9 +8,9 @@ package io.kotlintest
  * can't be used for whatever reason, such as assignment operations (assignments are statements therefore has no return
  * value).
  *
- * This function will exclude subclasses of [T]. For example, if you test for [java.io.IOException] and the code block
- * throws [java.io.FileNotFoundException], the test will fail, as [java.io.FileNotFoundException] is a subclass of
- * [java.io.IOException], but not exactly [java.io.IOException].
+ * This function will exclude subclasses of [T]. For example, if you test for [Exception] and the code block
+ * throws [RuntimeException], the test will fail, as [RuntimeException] is a subclass of
+ * [Exception], but not exactly [Exception].
  *
  * If you wish to include any subclasses, you should use [shouldThrowUnit] instead.
  *
@@ -38,8 +38,8 @@ inline fun <reified T : Throwable> shouldThrowExactlyUnit(block: () -> Unit): T 
  * This should be used when [shouldNotThrowExactly] can't be used, such as when doing assignments (assignments are statements,
  * therefore has no return value).
  *
- * This function won't include subclasses of [T]. For example, if you test for [java.io.IOException] and the code block
- * throws [java.io.FileNotFoundException], propagate the [java.io.FileNotFoundException] instead of wrapping it in an AssertionError.
+ * This function won't include subclasses of [T]. For example, if you test for [Exception] and the code block
+ * throws [RuntimeException], propagate the [RuntimeException] instead of wrapping it in an AssertionError.
  *
  * If you wish to test [T] and subclasses, use [shouldNotThrowUnit].
  *
@@ -61,9 +61,9 @@ inline fun <reified T : Throwable> shouldNotThrowExactlyUnit(block: () -> Unit) 
  *
  * Use this function to wrap a block of code to verify if it throws a specific throwable [T]
  *
- * This function will exclude subclasses of [T]. For example, if you test for [java.io.IOException] and the code block
- * throws [java.io.FileNotFoundException], the test will fail, as [java.io.FileNotFoundException] is a subclass of
- * [java.io.IOException], but not exactly [java.io.IOException].
+ * This function will exclude subclasses of [T]. For example, if you test for [Exception] and the code block
+ * throws [RuntimeException], the test will fail, as [RuntimeException] is a subclass of
+ * [Exception], but not exactly [Exception].
  *
  * If you wish to include any subclasses, you should use [shouldThrow] instead.
  *
@@ -91,12 +91,12 @@ inline fun <reified T : Throwable> shouldThrowExactly(block: () -> Any?): T {
     block()
     null  // Can't throw Failures.failure here directly, as it would be caught by the catch clause, and it's an AssertionError, which is a special case
   } catch (thrown: Throwable) { thrown  }
-
+  
   return when {
-    thrownThrowable == null -> throw Failures.failure("Expected exception ${T::class.qualifiedName} but no exception was thrown.")
+    thrownThrowable == null -> throw Failures.failure("Expected exception ${T::class.platformQualifiedName} but no exception was thrown.")
     thrownThrowable::class == expectedExceptionClass -> thrownThrowable as T  // This should be before `is AssertionError`. If the user is purposefully trying to verify `shouldThrow<AssertionError>{}` this will take priority
     thrownThrowable is AssertionError -> throw thrownThrowable
-    else -> throw Failures.failure("Expected exception ${expectedExceptionClass.qualifiedName} but a ${thrownThrowable::class.simpleName} was thrown instead.", thrownThrowable)
+    else -> throw Failures.failure("Expected exception ${expectedExceptionClass.platformQualifiedName} but a ${thrownThrowable::class.simpleName} was thrown instead.", thrownThrowable)
   }
 }
 
@@ -109,8 +109,8 @@ inline fun <reified T : Throwable> shouldThrowExactly(block: () -> Any?): T {
  * This is done so that no unexpected error is silently ignored.
  *
  *
- * This function won't include subclasses of [T]. For example, if you test for [java.io.IOException] and the code block
- * throws [java.io.FileNotFoundException], propagate the [java.io.FileNotFoundException] instead of wrapping it in an AssertionError.
+ * This function won't include subclasses of [T]. For example, if you test for [Exception] and the code block
+ * throws [RuntimeException], propagate the [RuntimeException] instead of wrapping it in an AssertionError.
  *
  * If you wish to test [T] and subclasses, use [shouldNotThrow].
  *
@@ -136,7 +136,7 @@ inline fun <reified T : Throwable> shouldNotThrowExactly(block: () -> Any?) {
     block()
     return
   } catch(t: Throwable) { t }
-
+  
   if(thrown::class == T::class) throw Failures.failure("No exception expected, but a ${thrown::class.simpleName} was thrown.", thrown)
   throw thrown
 }

--- a/kotlintest-assertions/src/jsMain/kotlin/io/kotlintest/AnyThrowableHandling.kt
+++ b/kotlintest-assertions/src/jsMain/kotlin/io/kotlintest/AnyThrowableHandling.kt
@@ -1,9 +1,7 @@
-@file:JvmName("AnyThrowableHandlingFunctions")
-
 package io.kotlintest
 
 import kotlin.reflect.KClass
 
 @PublishedApi
 internal actual val KClass<*>.platformQualifiedName: String
-  get() = this.qualifiedName.toString()
+  get() = this.simpleName.toString()

--- a/kotlintest-assertions/src/jvmMain/kotlin/io/kotlintest/Failures.kt
+++ b/kotlintest-assertions/src/jvmMain/kotlin/io/kotlintest/Failures.kt
@@ -1,25 +1,5 @@
 package io.kotlintest
 
-/**
- * Verifies that [block] throws an [AssertionError]
- *
- * If [block] throws an [AssertionError], this method will pass. Otherwise, it will throw an error, as a failure was
- * expected.
- *
- * This should be used mainly to check that an assertion fails, for example:
- *
- * ```
- *     shouldFail {
- *        1 shouldBe 2  // This should fail
- *     }
- * ```
- *
- * @see shouldThrowAny
- * @see shouldThrow
- * @see shouldThrowExactly
- */
-fun shouldFail(block: () -> Any?): AssertionError = shouldThrow(block)
-
 actual object Failures {
 
   /**


### PR DESCRIPTION
Please, only merge after #725 . This PR expects that to be merged already.

Noticeable changes are in documentations (I removed JVM references), and the qualified name of exceptions, as JS classes can't have a qualified name yet.