### PR TITLE
add the ability for eventually to defaultly handle AssertionErrors

### DIFF
--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/Eventually.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/Eventually.kt
@@ -13,7 +13,7 @@ fun <T, E : Throwable> eventually(duration: Duration, exceptionClass: Class<E>, 
     try {
       return f()
     } catch (e: Throwable) {
-      if (!exceptionClass.isAssignableFrom(e.javaClass)) {
+      if (!exceptionClass.isAssignableFrom(e.javaClass) && !AssertionError::class.java.isAssignableFrom(e.javaClass)) {
         // Not the kind of exception we were prepared to tolerate
         throw e
       }

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/AbstractProjectConfig.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/AbstractProjectConfig.kt
@@ -59,10 +59,11 @@ abstract class AbstractProjectConfig {
   /**
    * When set to true, failed specs are written to a file called spec_failures.
    * This file is used on subsequent test runs to run the failed specs first.
-   * To disable this feature, set this to false, or set the system property
-   * 'kotlintest.write.specfailures=false'
+   *
+   * To enable this feature, set this to true, or set the system property
+   * 'kotlintest.write.specfailures=true'
    */
-  open fun writeSpecFailureFile(): Boolean = true
+  open fun writeSpecFailureFile(): Boolean = false
 
   /**
    * Sets the order of top level tests in a spec.

--- a/kotlintest-runner/kotlintest-runner-junit5/src/main/kotlin/io/kotlintest/runner/junit5/JUnitTestRunnerListener.kt
+++ b/kotlintest-runner/kotlintest-runner-junit5/src/main/kotlin/io/kotlintest/runner/junit5/JUnitTestRunnerListener.kt
@@ -203,11 +203,11 @@ class JUnitTestRunnerListener(private val listener: EngineExecutionListener,
   }
 
   // returns the most important result for a given description
-  // by searching all the results stored for that description and child descriptions
+  // by searching all the results stored for that description in order of importnance
   private fun findResultFor(description: Description): TestResult? {
 
     fun findByStatus(status: TestStatus): TestResult? = results
-        .filter { it.testCase.description == description || description.isAncestorOf(it.testCase.description) }
+        .filter { it.testCase.description == description }
         .filter { it.result.status == status }
         .map { it.result }
         .firstOrNull()

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/EventuallyTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/EventuallyTest.kt
@@ -45,6 +45,13 @@ class EventuallyTest : WordSpec() {
             assert(false)
         }
       }
+      "pass tests that completed within the time allowed, custom exception"  {
+        val end = System.currentTimeMillis() + 2000
+        eventually(Duration.ofSeconds(5), FileNotFoundException::class.java) {
+          if (System.currentTimeMillis() < end)
+            throw FileNotFoundException()
+        }
+      }
       "fail tests throw unexpected exception type"  {
         shouldThrow<KotlinNullPointerException> {
           eventually(Duration.ofSeconds(2), IOException::class.java) {

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/EventuallyTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/EventuallyTest.kt
@@ -38,9 +38,9 @@ class EventuallyTest : WordSpec() {
         }
         result shouldBe 1
       }
-      "pass tests that completed within the time allowed, custom exception"  {
+      "pass tests that completed within the time allowed, AssertionError"  {
         val end = System.currentTimeMillis() + 2000
-        eventually(Duration.ofDays(5), AssertionError::class.java) {
+        eventually(Duration.ofDays(5)) {
           if (System.currentTimeMillis() < end)
             assert(false)
         }
@@ -74,7 +74,7 @@ class EventuallyTest : WordSpec() {
       }
       "display the underlying assertion failure" {
         shouldThrow<AssertionError> {
-          eventually(Duration.ofMillis(10), AssertionError::class.java) {
+          eventually(Duration.ofMillis(10)) {
             1 shouldBe 2
           }
         }.message.shouldEndWith("; underlying cause was expected: 2 but was: 1")

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/runner/junit5/JUnitTestRunnerListenerTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/runner/junit5/JUnitTestRunnerListenerTest.kt
@@ -154,7 +154,7 @@ class JUnitTestRunnerListenerTest : WordSpec({
       then(mock).should(times(1)).executionStarted(argThat { this.uniqueId.toString() == "[engine:engine-test]/[spec:com.sksamuel.kotlintest.runner.junit5.JUnitTestRunnerListenerTest]/[test:my test]" })
     }
 
-    "propagate nested failure to parent test" {
+    "nested failure should not affect test" {
       val rootDescriptor = EngineDescriptor(UniqueId.forEngine("engine-test"), "engine-test")
 
       val mock = mock<EngineExecutionListener> {}
@@ -176,7 +176,7 @@ class JUnitTestRunnerListenerTest : WordSpec({
       listener.afterSpecClass(spec::class, null)
 
       then(mock).should().executionFinished(argThat { this.uniqueId.toString() == "[engine:engine-test]/[spec:com.sksamuel.kotlintest.runner.junit5.JUnitTestRunnerListenerTest]/[test:test1]/[test:test2]" }, argThat { this.status == TestExecutionResult.Status.FAILED })
-      then(mock).should().executionFinished(argThat { this.uniqueId.toString() == "[engine:engine-test]/[spec:com.sksamuel.kotlintest.runner.junit5.JUnitTestRunnerListenerTest]/[test:test1]" }, argThat { this.status == TestExecutionResult.Status.FAILED })
+      then(mock).should().executionFinished(argThat { this.uniqueId.toString() == "[engine:engine-test]/[spec:com.sksamuel.kotlintest.runner.junit5.JUnitTestRunnerListenerTest]/[test:test1]" }, argThat { this.status == TestExecutionResult.Status.SUCCESSFUL })
     }
 
     "mark inactive test as skipped" {


### PR DESCRIPTION
A strong use case for using `eventually` is so that something you are
asserting eventually becomes true. Before this change you would have to
explicitly pass `AssertionError` as an exception to handle. Now it will
do this automatically. This enables you to pass a different exception if
you should so choose.

Fixes #753