### PR TITLE
Reduce visibility on NamedThreadFactory to internal

### DIFF
--- a/kotlintest-runner/kotlintest-runner-jvm/build.gradle
+++ b/kotlintest-runner/kotlintest-runner-jvm/build.gradle
@@ -13,7 +13,23 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile "io.arrow-kt:arrow-core-extensions:$arrow_version"
     compile 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.1'
+
+    testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
 }
 
+test {
+    useJUnitPlatform()
+
+    // show standard out and standard error of the test JVM(s) on the console
+    testLogging.showStandardStreams = true
+
+    // Always run tests, even when nothing changed.
+    dependsOn 'cleanTest'
+
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED", "STANDARD_OUT", "STANDARD_ERROR"
+        exceptionFormat = 'full'
+    }
+}
 
 apply from: '../../publish.gradle'

--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/internal/NamedThreadFactory.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/internal/NamedThreadFactory.kt
@@ -3,7 +3,7 @@ package io.kotlintest.runner.jvm.internal
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
 
-class NamedThreadFactory(val name: String) : ThreadFactory {
+internal class NamedThreadFactory(val name: String) : ThreadFactory {
   private val counter = AtomicInteger(0)
   override fun newThread(r: Runnable): Thread {
     return Thread(r, String.format(name, counter.getAndIncrement()))

--- a/kotlintest-runner/kotlintest-runner-jvm/src/test/kotlin/com/sksmauel/kotlintest/runner/jvm/internal/NamedThreadFactoryTest.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/test/kotlin/com/sksmauel/kotlintest/runner/jvm/internal/NamedThreadFactoryTest.kt
@@ -1,4 +1,4 @@
-package com.sksamuel.kotlintest.runner.jvm
+package com.sksmauel.kotlintest.runner.jvm.internal
 
 import io.kotlintest.runner.jvm.internal.NamedThreadFactory
 import io.kotlintest.shouldBe


### PR DESCRIPTION
For this, the test was moved, as it wouldn't have visibility on its module. To move the test, we had to change the build.gradle to include this change and execute test correctly.

Fixes #755