### PR TITLE
added `asClue` helper and rewrote `withClue` to allow nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,20 @@ myImageFile.shouldHaveExtension(".jpg")
 cityMap.shouldContainKey("London")
 ```
 
-The `withClue` helper can add extra context to assertions so failures are self explanatory:
+The `withClue` and `asClue` helpers can add extra context to assertions so failures are self explanatory:
 
 ```kotlin
 withClue("Name should be present") { user.name shouldNotBe null }
+
+data class HttpResponse(val status: Int, body: String)
+val response = HttpResponse(200, "the content")
+response.asClue {
+    it.status shouldBe 200
+    it.body shouldBe "the content"
+}
 ```
+
+Nesting is allowed in both cases and will show all available clues.
 
 Matchers are extension methods and so your IDE will auto complete. See the [full list of matchers](doc/matchers.md) or write your own.
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/ErrorCollector.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/ErrorCollector.kt
@@ -2,6 +2,7 @@ package io.kotlintest
 
 import io.kotlintest.Failures.removeKotlintestElementsFromStacktrace
 import io.kotlintest.tables.MultiAssertionError
+import java.util.Stack
 
 @PublishedApi
 internal object ErrorCollector {
@@ -15,9 +16,11 @@ internal object ErrorCollector {
     override fun initialValue() = false
   }
 
-  internal val clueContext = object: ThreadLocal<String>() {
-    override fun initialValue(): String = ""
+  internal val clueContext = object: ThreadLocal<Stack<Any>>() {
+    override fun initialValue(): Stack<Any> = Stack()
   }
+
+  internal fun clueContextAsString() = clueContext.get().let { if (it.isEmpty()) "" else it.joinToString("\n", postfix = "\n") }
 
   @PublishedApi
   internal fun collectOrThrow(error: Throwable) {

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/dsl.kt
@@ -110,7 +110,7 @@ infix fun <T> T.shouldHave(matcher: Matcher<T>) = should(matcher)
 infix fun <T> T.should(matcher: Matcher<T>) {
   val result = matcher.test(this)
   if (!result.passed) {
-    ErrorCollector.collectOrThrow(Failures.failure(ErrorCollector.clueContext.get() + result.failureMessage))
+    ErrorCollector.collectOrThrow(Failures.failure(ErrorCollector.clueContextAsString() + result.failureMessage))
   }
 }
 
@@ -125,7 +125,7 @@ infix fun <T> T.should(matcher: (T) -> Unit) = matcher(this)
 internal fun equalsError(expected: Any?, actual: Any?): Throwable {
 
   val (expectedRepr, actualRepr) = diffLargeString(stringRepr(expected), stringRepr(actual))
-  val message = ErrorCollector.clueContext.get() + equalsErrorMessage(expectedRepr, actualRepr)
+  val message = ErrorCollector.clueContextAsString() + equalsErrorMessage(expectedRepr, actualRepr)
 
   val throwable = junit5AssertionFailedError(message, expectedRepr, actualRepr)
       ?: junit4comparisonFailure(expectedRepr, actualRepr)

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/matchers.kt
@@ -4,13 +4,16 @@ package io.kotlintest.matchers
 
 import io.kotlintest.*
 
-fun withClue(clue: String, thunk: () -> Any) {
-  val currentClue = ErrorCollector.clueContext.get()
+fun <ReturnType> withClue(clue: Any, thunk: () -> ReturnType): ReturnType {
+    return clue.asClue { thunk() }
+}
+
+fun <ClueType, ReturnType> ClueType.asClue(body: (ClueType) -> ReturnType): ReturnType {
   try {
-    ErrorCollector.clueContext.set("$clue ")
-    thunk()
+    ErrorCollector.clueContext.get().push(this)
+    return body(this)
   } finally {
-    ErrorCollector.clueContext.set(currentClue)
+    ErrorCollector.clueContext.get().pop()
   }
 }
 

--- a/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/matchers.kt
+++ b/kotlintest-assertions/src/main/kotlin/io/kotlintest/matchers/matchers.kt
@@ -4,14 +4,28 @@ package io.kotlintest.matchers
 
 import io.kotlintest.*
 
+/**
+ * Add [clue] as additional info to the assertion error message in case an assertion fails.
+ * Can be nested, the error message will contain all available clues.
+ *
+ * @param thunk the code with assertions to be executed
+ * @return the return value of the supplied [thunk]
+ */
 fun <ReturnType> withClue(clue: Any, thunk: () -> ReturnType): ReturnType {
     return clue.asClue { thunk() }
 }
 
-fun <ClueType, ReturnType> ClueType.asClue(body: (ClueType) -> ReturnType): ReturnType {
+/**
+ * Similar to `let`, but will add `this` as a clue to the assertion error message in case an assertion fails.
+ * Can be nested, the error message will contain all available clues.
+ *
+ * @param block the code with assertions to be executed
+ * @return the return value of the supplied [block]
+ */
+fun <ClueType, ReturnType> ClueType.asClue(block: (ClueType) -> ReturnType): ReturnType {
   try {
     ErrorCollector.clueContext.get().push(this)
-    return body(this)
+    return block(this)
   } finally {
     ErrorCollector.clueContext.get().pop()
   }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/MatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/MatchersTest.kt
@@ -3,12 +3,8 @@ package com.sksamuel.kotlintest.matchers
 import io.kotlintest.Matcher
 import io.kotlintest.Result
 import io.kotlintest.assertSoftly
-import io.kotlintest.matchers.beInstanceOf
-import io.kotlintest.matchers.haveLength
-import io.kotlintest.matchers.haveSameHashCodeAs
-import io.kotlintest.matchers.haveSize
+import io.kotlintest.matchers.*
 import io.kotlintest.matchers.string.shouldContain
-import io.kotlintest.matchers.withClue
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNot
@@ -27,11 +23,11 @@ class MatchersTest : FreeSpec({
               "Should have the details of '$value' and $other")
     }
 
-    "should prepend clue to message" {
+    "should prepend clue to message with a newline" {
       val ex = shouldThrow<AssertionError> {
         withClue("a clue:") { "1" shouldBe withClueEcho("here are the details!") }
       }
-      ex.message shouldBe "a clue: Should have the details of '1' and here are the details!"
+      ex.message shouldBe "a clue:\nShould have the details of '1' and here are the details!"
     }
 
     "should add clues correctly with multiple/softAssert" {
@@ -44,23 +40,65 @@ class MatchersTest : FreeSpec({
         }
       }
       ex.message.apply {
-        shouldContain("outer clue: Should have the details of '1' and the details!")
-        shouldContain("inner clue: expected: \"1\" but was: \"2\"")
+        shouldContain("outer clue:\nShould have the details of '1' and the details!")
+        shouldContain("inner clue:\nexpected: \"1\" but was: \"2\"")
       }
     }
 
-    "should remember previous clue contexts" {
+    "should show all available nested clue contexts" {
       withClue("clue outer:") {
-        shouldThrow<AssertionError> {"1" shouldBe "2" }.message shouldBe "clue outer: expected: \"2\" but was: \"1\""
+        shouldThrow<AssertionError> {"1" shouldBe "2" }.message shouldBe "clue outer:\nexpected: \"2\" but was: \"1\""
         withClue("clue inner:") {
-          shouldThrow<AssertionError> {"3" shouldBe "4" }.message shouldBe "clue inner: expected: \"4\" but was: \"3\""
+          shouldThrow<AssertionError> {"3" shouldBe "4" }.message shouldBe "clue outer:\nclue inner:\nexpected: \"4\" but was: \"3\""
         }
-        shouldThrow<AssertionError> {"5" shouldBe "6" }.message shouldBe "clue outer: expected: \"6\" but was: \"5\""
+        shouldThrow<AssertionError> {"5" shouldBe "6" }.message shouldBe "clue outer:\nexpected: \"6\" but was: \"5\""
       }
       //And resets completely when leaving final clue block
       shouldThrow<AssertionError> {"7" shouldBe "8" }.message shouldBe "expected: \"8\" but was: \"7\""
     }
 
+  }
+  "asClue()" - {
+    "should prepend clue to message with a newline" {
+      val ex = shouldThrow<AssertionError> {
+        "a clue:".asClue { "1" shouldBe "2" }
+      }
+      ex.message shouldBe "a clue:\nexpected: \"2\" but was: \"1\""
+    }
+
+    "should add clues correctly with multiple/softAssert" {
+      val ex = shouldThrow<AssertionError> {
+        "outer clue:".asClue {
+          assertSoftly {
+            "1" shouldBe "the details"
+            "inner clue:".asClue {"2" shouldBe "1"}
+          }
+        }
+      }
+      ex.message.apply {
+        shouldContain("outer clue:\nexpected: \"the details\" but was: \"1\"")
+        shouldContain("outer clue:\ninner clue:\nexpected: \"1\" but was: \"2\"")
+      }
+    }
+
+    "should show all available nested clue contexts" {
+      data class MyData(val a: Int, val b: String)
+      MyData(10, "clue object").asClue {
+        shouldThrow<AssertionError> {it.b shouldBe "2" }.message shouldBe "MyData(a=10, b=clue object)\nexpected: \"2\" but was: \"clue object\""
+      }
+
+      data class HttpResponse(val status: Int, val body: String)
+      val response = HttpResponse(404, "not found")
+      response.asClue {
+        shouldThrow<AssertionError> {it.status shouldBe 200}.message shouldBe "HttpResponse(status=404, body=not found)\nexpected: 200 but was: 404"
+        MyData(20, "nest it").asClue { inner ->
+          shouldThrow<AssertionError> {it.status shouldBe 200}.message shouldBe "HttpResponse(status=404, body=not found)\nMyData(a=20, b=nest it)\nexpected: 200 but was: 404"
+          shouldThrow<AssertionError> {inner.a shouldBe 10}.message shouldBe "HttpResponse(status=404, body=not found)\nMyData(a=20, b=nest it)\nexpected: 10 but was: 20"
+        }
+        //after nesting, everything looks as before
+        shouldThrow<AssertionError> {it.status shouldBe 200}.message shouldBe "HttpResponse(status=404, body=not found)\nexpected: 200 but was: 404"
+      }
+    }
   }
 
   "haveSameHashCode()" {


### PR DESCRIPTION
fixes #783

I changed to formatting of the former `withClue` to add newlines after each clue, since I think this is more readable, especially when using data classes as clue. Additionally, I allowed returning something from the body (in both cases). It is not strictly needed for these cases, but sometimes comes in handy to write code in an immutable way and does not hurt either.