### PR TITLE
Fixes tests passing when before test fails

### DIFF
--- a/kotlintest-runner/kotlintest-runner-console/src/main/kotlin/io/kotlintest/runner/console/TeamCityConsoleWriter.kt
+++ b/kotlintest-runner/kotlintest-runner-console/src/main/kotlin/io/kotlintest/runner/console/TeamCityConsoleWriter.kt
@@ -1,11 +1,6 @@
 package io.kotlintest.runner.console
 
-import io.kotlintest.Description
-import io.kotlintest.Spec
-import io.kotlintest.TestCase
-import io.kotlintest.TestResult
-import io.kotlintest.TestStatus
-import io.kotlintest.TestType
+import io.kotlintest.*
 import java.io.PrintWriter
 import java.io.StringWriter
 import kotlin.reflect.KClass
@@ -97,6 +92,13 @@ class TeamCityConsoleWriter : ConsoleWriter {
         }
         println(msg)
       }
+    }
+  }
+
+  override fun exitTestCase(testCase: TestCase, result: TestResult) {
+    if(result.status == TestStatus.Error || result.status == TestStatus.Failure) {
+      errors = true
+      insertDummyFailure(testCase.description, result.error)
     }
   }
 }

--- a/kotlintest-tests/kotlintest-tests-core/build.gradle
+++ b/kotlintest-tests/kotlintest-tests-core/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.11.2'
     testImplementation "com.nhaarman:mockito-kotlin:1.6.0"
     testImplementation 'org.mockito:mockito-core:2.24.0'
+    testImplementation "io.mockk:mockk:1.9.3"
     // this is here to test that the intellij marker 'dummy' test doesn't appear in intellij
     testCompile 'org.junit.jupiter:junit-jupiter-engine:5.4.0'
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.4.0'


### PR DESCRIPTION
The problem with this issue was that any exception that happened in either `BeforeTest` or `AfterTest` was being silently ignored due to Coroutine Launch instead of `async`.

This commit fixes that error, and also modifies listener execution to notify `JUnit` and our executor to be able to identify these errors and show that in the interface.

Part of #771