### PR TITLE
Feature/arrowcontracts

### DIFF
--- a/kotlintest-assertions/kotlintest-assertions-arrow/build.gradle
+++ b/kotlintest-assertions/kotlintest-assertions-arrow/build.gradle
@@ -23,4 +23,11 @@ dependencies {
     testCompile project(":kotlintest-runner:kotlintest-runner-junit5")
 }
 
+compileKotlin {
+    kotlinOptions {
+        freeCompilerArgs += '-Xuse-experimental=kotlin.Experimental'
+    }
+}
+
+
 apply from: '../../publish.gradle'

--- a/kotlintest-assertions/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/either/matchers.kt
+++ b/kotlintest-assertions/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/either/matchers.kt
@@ -6,14 +6,20 @@ import io.kotlintest.Result
 import io.kotlintest.matchers.beInstanceOf2
 import io.kotlintest.should
 import io.kotlintest.shouldNot
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
-fun <T> Either<Any?, T>.shouldBeRight() = this should beRight()
+@UseExperimental(ExperimentalContracts::class)
+fun <T> Either<*, T>.shouldBeRight() {
+  contract {
+    returns() implies (this@shouldBeRight is Either.Right<*>)
+  }
+  this should beRight()
+}
+
 fun <T> Either<Any?, T>.shouldNotBeRight() = this shouldNot beRight()
 fun <T> beRight() = beInstanceOf2<Either<Any?, T>, Either.Right<T>>()
 
-fun <T> Either<T, Any?>.shouldBeLeft() = this should beLeft()
-fun <T> Either<T, Any?>.shouldNotBeLeft() = this shouldNot beLeft()
-fun <T> beLeft() = beInstanceOf2<Either<T, Any?>, Either.Left<T>>()
 
 inline fun <B> Either<*, B>.shouldBeRight(fn: (B) -> Unit) {
   this should beRight()
@@ -37,6 +43,17 @@ fun <B> beRight(b: B) = object : Matcher<Either<Any?, B>> {
     }
   }
 }
+
+@UseExperimental(ExperimentalContracts::class)
+fun <T> Either<T, Any?>.shouldBeLeft() {
+  contract {
+    returns() implies (this@shouldBeLeft is Either.Left<*>)
+  }
+  this should beLeft()
+}
+
+fun <T> Either<T, Any?>.shouldNotBeLeft() = this shouldNot beLeft()
+fun <T> beLeft() = beInstanceOf2<Either<T, Any?>, Either.Left<T>>()
 
 inline fun <A> Either<A, *>.shouldBeLeft(fn: (A) -> Unit) {
   this should beLeft()

--- a/kotlintest-assertions/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/option/matchers.kt
+++ b/kotlintest-assertions/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/option/matchers.kt
@@ -3,10 +3,26 @@ package io.kotlintest.assertions.arrow.option
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
+import arrow.data.Validated
 import io.kotlintest.Matcher
 import io.kotlintest.Result
 import io.kotlintest.should
 import io.kotlintest.shouldNot
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@UseExperimental(ExperimentalContracts::class)
+fun Option<*>.shouldBeSome() {
+  contract {
+    returns() implies (this@shouldBeSome is Some<*>)
+  }
+  this should beSome()
+}
+
+fun beSome() = object : Matcher<Option<*>> {
+  override fun test(value: Option<*>): Result =
+      Result(value is Some, "$value should be Some", "$value should not be Some")
+}
 
 fun <T> Option<T>.shouldBeSome(t: T) = this should beSome(t)
 fun <T> Option<T>.shouldNotBeSome(t: T) = this shouldNot beSome(t)

--- a/kotlintest-assertions/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/validation/matchers.kt
+++ b/kotlintest-assertions/kotlintest-assertions-arrow/src/main/kotlin/io/kotlintest/assertions/arrow/validation/matchers.kt
@@ -7,9 +7,18 @@ import io.kotlintest.Matcher
 import io.kotlintest.Result
 import io.kotlintest.should
 import io.kotlintest.shouldNot
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
-fun Validated<*, *>.shouldBeValid() = this should beValid()
-fun Validated<*, *>.shouldNotBeValid() = this shouldNot beValid()
+@UseExperimental(ExperimentalContracts::class)
+fun Validated<*, *>.shouldBeValid() {
+  contract {
+    returns() implies (this@shouldBeValid is Valid<*>)
+  }
+  this should beValid()
+}
+
+fun <T> Validated<*, T>.shouldNotBeValid() = this shouldNot beValid()
 
 fun <T> Validated<*, T>.shouldBeValid(value: T) = this should beValid(value)
 fun <T> Validated<*, T>.shouldNotBeValid(value: T) = this shouldNot beValid(value)
@@ -29,7 +38,13 @@ fun <A> beValid(a: A) = object : Matcher<Validated<*, A>> {
       Result(value == Valid(a), "$value should be Valid(a=$a)", "$value should not be Valid(a=$a)")
 }
 
-fun Validated<*, *>.shouldBeInvalid() = this should beInvalid()
+@UseExperimental(ExperimentalContracts::class)
+fun Validated<*, *>.shouldBeInvalid() {
+  contract {
+    returns() implies (this@shouldBeInvalid is Invalid<*>)
+  }
+  this should beInvalid()
+}
 fun Validated<*, *>.shouldNotBeInvalid() = this shouldNot beInvalid()
 
 fun <T> Validated<*, T>.shouldBeInvalid(value: T) = this should beInvalid(value)

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/EitherMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/EitherMatchersTest.kt
@@ -21,6 +21,11 @@ class EitherMatchersTest : WordSpec() {
         Either.right("boo").shouldBeRight()
         Either.left("boo").shouldNotBeRight()
       }
+      "use contracts to expose Right<*>" {
+        val e = Either.right("boo")
+        e.shouldBeRight()
+        e.b shouldBe "boo"
+      }
     }
 
     "Either should beRight(fn)" should {
@@ -56,6 +61,11 @@ class EitherMatchersTest : WordSpec() {
       "test that the either is of type left" {
         Either.left("boo").shouldBeLeft()
         Either.right("boo").shouldNotBeLeft()
+      }
+      "use contracts to expose Left<*>" {
+        val e = Either.left("boo")
+        e.shouldBeLeft()
+        e.a shouldBe "boo"
       }
     }
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/OptionMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/OptionMatchersTest.kt
@@ -13,6 +13,14 @@ class OptionMatchersTest : WordSpec() {
 
   init {
 
+    "Option.shouldBeSome()" should {
+      "use contracts" {
+        val o = Option("foo")
+        o.shouldBeSome()
+        o.t shouldBe "foo"
+      }
+    }
+
     "Option shouldBe some(value)" should {
       "test that an option is a Some with the given value" {
 

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/ValidatedMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/ValidatedMatchersTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.kotlintest.assertions.arrow
 
 import arrow.data.Invalid
 import arrow.data.Valid
+import arrow.data.invalid
+import arrow.data.valid
 import io.kotlintest.assertions.arrow.validation.beInvalid
 import io.kotlintest.assertions.arrow.validation.beValid
 import io.kotlintest.assertions.arrow.validation.shouldBeInvalid
@@ -33,6 +35,12 @@ class ValidatedMatchersTest : StringSpec({
     }.message shouldBe "Invalid(e=error) should be Valid(a=error)"
   }
 
+  "Validated should use contracts to smart cast Valids" {
+    val e = "boo".valid()
+    e.shouldBeValid()
+    e.a shouldBe "boo"
+  }
+
   "Validated shouldBe Invalid" {
 
     shouldThrow<AssertionError> {
@@ -41,5 +49,11 @@ class ValidatedMatchersTest : StringSpec({
 
     Invalid("error") should beInvalid()
     Invalid("error").shouldBeInvalid()
+  }
+
+  "use contracts to smart cast Invalids" {
+    val e = "boo".invalid()
+    e.shouldBeInvalid()
+    e.e shouldBe "boo"
   }
 })


### PR DESCRIPTION
I've added contracts for Validated, Either and Option.
These contracts allow us to extract the field from these datatypes, but because of the issue with contracts not supporting generics yet, the extracted field will be `Any?`.
This is still a big improvement I think, and also means when contracts support generics (1.4?) we can easily update these matchers.

Current example:

```kotlin
val either = "foo".right()
either.shouldBeRight()
(either as Either.Right<String>).b shouldBe "foo"
(either as Either.Right<String>).b.length shouldBe 3
```

Example with this PR:

```kotlin
val either = "foo".right()
either.shouldBeRight()
either.b shouldBe "foo"
(either.b as String).length shouldBe 3
```

Example in the future:

```kotlin
val either = "foo".right()
either.shouldBeRight()
either.b shouldBe "foo"
either.b.length shouldBe 3
```

This partially addresses the feature request of #612 