### PR TITLE
Ensure specs that fail in initialisation fail a Maven build (#832)

### DIFF
--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/IsolationTestEngineListener.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/IsolationTestEngineListener.kt
@@ -41,6 +41,12 @@ class IsolationTestEngineListener(val listener: TestEngineListener) : TestEngine
     }
   }
 
+  override fun specInitialisationFailed(klass: KClass<out Spec>, t: Throwable) {
+    runningSpec.compareAndSet(null, Description.spec(klass)) // otherwise the before & after spec functions do nothing
+    beforeSpecClass(klass)
+    afterSpecClass(klass, t)
+  }
+
   override fun beforeSpecClass(klass: KClass<out Spec>) {
     if (runningSpec.get() == Description.spec(klass)) {
       listener.beforeSpecClass(klass)

--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/SynchronizedTestEngineListener.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/SynchronizedTestEngineListener.kt
@@ -31,6 +31,12 @@ class SynchronizedTestEngineListener(val listener: TestEngineListener) : TestEng
     }
   }
 
+  override fun specInitialisationFailed(klass: KClass<out Spec>, t: Throwable) {
+    synchronized(listener) {
+      listener.specInitialisationFailed(klass, t)
+    }
+  }
+
   override fun enterTestCase(testCase: TestCase) {
     synchronized(listener) {
       listener.enterTestCase(testCase)

--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestEngine.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestEngine.kt
@@ -93,8 +93,7 @@ class TestEngine(val classes: List<KClass<out Spec>>,
           // will add a placeholder spec so we can see the error in intellij/gradle
           // otherwise it won't appear
           { t ->
-            listener.beforeSpecClass(klass)
-            listener.afterSpecClass(klass, t)
+            listener.specInitialisationFailed(klass, t)
             error.compareAndSet(null, t)
             executor.shutdownNow()
           },

--- a/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestEngineListener.kt
+++ b/kotlintest-runner/kotlintest-runner-jvm/src/main/kotlin/io/kotlintest/runner/jvm/TestEngineListener.kt
@@ -41,6 +41,14 @@ interface TestEngineListener {
   fun afterSpecClass(klass: KClass<out Spec>, t: Throwable?) {}
 
   /**
+   * Is invoked if a [Spec] throws an exception during initialisation
+   */
+  fun specInitialisationFailed(klass: KClass<out Spec>, t: Throwable) {
+    beforeSpecClass(klass)
+    afterSpecClass(klass, t)
+  }
+
+  /**
    * Invoked each time a [TestCase] has been entered from a parent test.
    *
    * If a parent test has been configured with multiple invocations, then this

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/runner/jvm/TestEngineTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/runner/jvm/TestEngineTest.kt
@@ -28,8 +28,7 @@ class TestEngineTest : WordSpec({
       val listener = mock<TestEngineListener> {}
       val engine = TestEngine(listOf(InitErrorSpec::class), emptyList(), 1, listener)
       engine.execute()
-      then(listener).should().beforeSpecClass(argThat { jvmName == "com.sksamuel.kotlintest.runner.jvm.InitErrorSpec" })
-      then(listener).should().afterSpecClass(any(), any<InvocationTargetException>())
+      then(listener).should().specInitialisationFailed(argThat { jvmName == "com.sksamuel.kotlintest.runner.jvm.InitErrorSpec" }, any<InvocationTargetException>())
       then(listener).should().engineFinished(any<InvocationTargetException>())
     }
 

--- a/kotlintest-tests/kotlintest-tests-junit5/src/test/kotlin/com/sksamuel/kotlintest/junit5/InitErrorEngineKitTest.kt
+++ b/kotlintest-tests/kotlintest-tests-junit5/src/test/kotlin/com/sksamuel/kotlintest/junit5/InitErrorEngineKitTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.kotlintest.junit5
+
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.specs.FunSpec
+import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
+import org.junit.platform.testkit.engine.EngineTestKit
+
+class InitErrorEngineKitTest : FunSpec({
+
+  test("a test that fails to initialise should fail the run") {
+
+    System.setProperty("KotlinTestEngineTest", "true")
+
+    val results = EngineTestKit
+            .engine("kotlintest")
+            .selectors(selectClass(InitErrorSpec::class.java))
+            .execute()
+
+    /*
+    There should be the following container events:
+      - Event [type = STARTED,                 testDescriptor = KotlinTestEngineDescriptor: [engine:kotlintest],                                                            payload = null]
+      - Event [type = DYNAMIC_TEST_REGISTERED, testDescriptor = createSpecDescriptor$descriptor$1: [engine:kotlintest]/[spec:com.sksamuel.kotlintest.junit5.InitErrorSpec], payload = null]
+      - Event [type = STARTED,                 testDescriptor = createSpecDescriptor$descriptor$1: [engine:kotlintest]/[spec:com.sksamuel.kotlintest.junit5.InitErrorSpec], payload = null]
+      - Event [type = FINISHED,                testDescriptor = createSpecDescriptor$descriptor$1: [engine:kotlintest]/[spec:com.sksamuel.kotlintest.junit5.InitErrorSpec], payload = TestExecutionResult [status = FAILED, throwable = java.lang.reflect.InvocationTargetException]]
+      - Event [type = FINISHED,                testDescriptor = KotlinTestEngineDescriptor: [engine:kotlintest],                                                            payload = TestExecutionResult [status = FAILED, throwable = java.lang.reflect.InvocationTargetException]]
+     */
+    results
+         .containers()
+         .assertStatistics { it
+                 .skipped(0)
+                 .started(2)
+                 .succeeded(0)
+                 .aborted(0)
+                 .failed(2)
+                 .finished(2)
+         }
+  }
+}) {
+  override fun afterTest(testCase: TestCase, result: TestResult) {
+    super.afterTest(testCase, result)
+    System.clearProperty("KotlinTestEngineTest")
+  }
+}

--- a/kotlintest-tests/kotlintest-tests-junit5/src/test/kotlin/com/sksamuel/kotlintest/junit5/InitErrorTestCase.kt
+++ b/kotlintest-tests/kotlintest-tests-junit5/src/test/kotlin/com/sksamuel/kotlintest/junit5/InitErrorTestCase.kt
@@ -1,0 +1,12 @@
+package com.sksamuel.kotlintest.junit5
+
+import io.kotlintest.specs.StringSpec
+
+class InitErrorSpec : StringSpec() {
+  init {
+    // we only want to throw this when are testing it via TestEngineTest above
+    // and not through normal discovery of all tests
+    if (System.getProperty("KotlinTestEngineTest") == "true")
+      throw Throwable("kaboom")
+  }
+}


### PR DESCRIPTION
KotlinTest fails to notify the Maven Surefire plugin properly via the
JUnit platform if a spec throws an exception during initialisation.

This is because whilst `TestEngine` does try to register a spec that
fails during initialisation, it accidentally skips the beforeSpecClass
and afterSpecClass methods on the `TestEngineListener` because it is
wrapped in an `IsolationTestEngineListener` which has guards around
those methods, and the guards always return false because the spec was
never created.

See https://github.com/Mahoney/maven-kotlintest for an example of the
problem.

(cherry picked from commit b99f7f7595d3f15f7b453f014c7ce9647ccc0c23)