### PR TITLE
Changed autoClose to accept an AutoCloseable

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -896,7 +896,7 @@ class StringSpecExample : StringSpec() {
 }
 ```
 
-Resources that should be closed this way must implement [`java.io.Closeable`](http://docs.oracle.com/javase/6/docs/api/java/io/Closeable.html). Closing is performed in
+Resources that should be closed this way must implement [`java.lang.AutoCloseable`](https://docs.oracle.com/javase/7/docs/api/java/lang/AutoCloseable.html). Closing is performed in
 reversed order of declaration after the return of the last spec interceptor.
 
 

--- a/doc/reference_3.1.md
+++ b/doc/reference_3.1.md
@@ -898,7 +898,7 @@ class StringSpecExample : StringSpec() {
 }
 ```
 
-Resources that should be closed this way must implement [`java.io.Closeable`](http://docs.oracle.com/javase/6/docs/api/java/io/Closeable.html). Closing is performed in
+Resources that should be closed this way must implement [`java.lang.AutoCloseable`](https://docs.oracle.com/javase/7/docs/api/java/lang/AutoCloseable.html). Closing is performed in
 reversed order of declaration after the return of the last spec interceptor.
 
 

--- a/doc/reference_3.2.md
+++ b/doc/reference_3.2.md
@@ -903,7 +903,7 @@ class StringSpecExample : StringSpec() {
 }
 ```
 
-Resources that should be closed this way must implement [`java.io.Closeable`](http://docs.oracle.com/javase/6/docs/api/java/io/Closeable.html). Closing is performed in
+Resources that should be closed this way must implement [`java.lang.AutoCloseable`](https://docs.oracle.com/javase/7/docs/api/java/lang/AutoCloseable.html). Closing is performed in
 reversed order of declaration after the return of the last spec interceptor.
 
 

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/AbstractSpec.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/AbstractSpec.kt
@@ -1,7 +1,7 @@
 package io.kotlintest
 
 import org.junit.platform.commons.annotation.Testable
-import java.io.Closeable
+import java.lang.AutoCloseable
 import java.util.*
 
 @Testable
@@ -26,12 +26,12 @@ abstract class AbstractSpec : Spec {
     rootTestCases.add(createTestCase(name, test, config, type))
   }
 
-  private val closeablesInReverseOrder = LinkedList<Closeable>()
+  private val closeablesInReverseOrder = LinkedList<AutoCloseable>()
 
   /**
    * Registers a field for auto closing after all tests have run.
    */
-  protected fun <T : Closeable> autoClose(closeable: T): T {
+  protected fun <T : AutoCloseable> autoClose(closeable: T): T {
     closeablesInReverseOrder.addFirst(closeable)
     return closeable
   }

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/AutoCloseTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/AutoCloseTest.kt
@@ -4,31 +4,38 @@ import io.kotlintest.extensions.TestListener
 import io.kotlintest.matchers.boolean.shouldBeTrue
 import io.kotlintest.specs.StringSpec
 import java.io.Closeable
+import java.lang.AutoCloseable
 
 // this is here to test for github issue #294
 internal object Resources
 
 class AutoCloseTest : StringSpec() {
 
-  private val resourceA = autoClose(Closeable2)
-  private val resourceB = autoClose(Closeable1)
+  private val resourceA = autoClose(AutoCloseable4)
+  private val resourceB = autoClose(Closeable3)
+  private val resourceC = autoClose(Closeable2)
+  private val resourceD = autoClose(AutoCloseable1)
 
   init {
     "should close resources in reverse order" {
       resourceA.closed = false
       resourceB.closed = false
+      resourceC.closed = false
+      resourceD.closed = false
     }
   }
 }
 
 object AutoCloseListener : TestListener {
   override fun afterProject() {
-    Closeable1.closed.shouldBeTrue()
+    AutoCloseable1.closed.shouldBeTrue()
     Closeable2.closed.shouldBeTrue()
+    Closeable3.closed.shouldBeTrue()
+    AutoCloseable4.closed.shouldBeTrue()
   }
 }
 
-object Closeable1 : Closeable {
+object AutoCloseable1 : AutoCloseable {
 
   var closed = true
 
@@ -42,7 +49,27 @@ object Closeable2 : Closeable {
   var closed = true
 
   override fun close() {
-    assert(Closeable1.closed)
+    assert(AutoCloseable1.closed)
+    closed = true
+  }
+}
+
+object Closeable3 : Closeable {
+
+  var closed = true
+
+  override fun close() {
+    assert(Closeable2.closed)
+    closed = true
+  }
+}
+
+object AutoCloseable4 : AutoCloseable {
+
+  var closed = true
+
+  override fun close() {
+    assert(Closeable3.closed)
     closed = true
   }
 }


### PR DESCRIPTION
Previously autoClose's parameter was a Closeable. Unfortunately, some
classes implement AutoCloseable but not Closeable (JDBC and
testcontainers are a couple of examples).

Closeable extends AutoCloseable, so autoClose will continue working with
Closeable objects.