### PR TITLE
Added shouldBeSymbolicLink and shouldHaveParent matchers for files (#817)

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -160,6 +160,8 @@ For the extension function style, each function has an equivalent negated versio
 | `file.shouldStartWithPath(prefix)` | Asserts that the file's path starts with the given prefix. |
 | `dir.shouldContainFileDeep(name)` | Assert that file is a directory and that it or any sub directory contains a file with the given name. |
 | `dir.shouldContainFiles(name1, name2, ..., nameN)` | Asserts that the file is a directory and that it contains al files with the given name. |
+| `file.shouldBeSymbolicLink()` | Asserts that the file is a symbolic link. |
+| `file.shouldHaveParent(name)` |  Assert that the file has a parent with the given name | 
 
 | Dates ||
 | -------- | ---- |

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/file/FileMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/matchers/file/FileMatchersTest.kt
@@ -194,5 +194,36 @@ class FileMatchersTest : FunSpec() {
         testDir.shouldNotContainFiles("a.txt", "b.gif")
       }.message shouldBe "Files a.txt, b.gif should not exist in $testDir"
     }
+
+    test("shouldBeSymbolicLink should check if file is symbolic link") {
+      val testDir = Files.createTempDirectory("testdir")
+
+      val existingFile = Files.write(testDir.resolve("original.txt"), byteArrayOf(1, 2, 3, 4))
+      val existingFileAsFile = existingFile.toFile()
+      val link = Files.createSymbolicLink(testDir.resolve("a.txt"), existingFile)
+      val linkAsFile = link.toFile()
+
+      link.shouldBeSymbolicLink()
+      linkAsFile.shouldBeSymbolicLink()
+
+      existingFile.shouldNotBeSymbolicLink()
+      existingFileAsFile.shouldNotBeSymbolicLink()
+    }
+
+    test("shouldHaveParent should check if file has any parent with given name") {
+      val testDir = Files.createTempDirectory("testdir")
+
+      val subdir = Files.createDirectory(testDir.resolve("sub_testdir"))
+      val file = Files.write(subdir.resolve("a.txt"), byteArrayOf(1, 2, 3, 4))
+      val fileAsFile =  file.toFile()
+
+      file.shouldHaveParent(testDir.toFile().name)
+      file.shouldHaveParent(subdir.toFile().name)
+      file.shouldNotHaveParent("super_hyper_long_random_file_name")
+
+      fileAsFile.shouldHaveParent(testDir.toFile().name)
+      fileAsFile.shouldHaveParent(subdir.toFile().name)
+      fileAsFile.shouldNotHaveParent("super_hyper_long_random_file_name")
+    }
   }
 }


### PR DESCRIPTION
References #817

---

Add:
- [ ] Pair.shouldBePair(x,y)
- [X] File.isSymbolicLink
- [X] Path.isSymbolicLink
- [X] File.shouldHaveParent
- [X] Path.shouldHaveParent
- [ ] Number.shouldHaveRoot