### PR TITLE
Remove the deprecated JUnit surefire provider from reference

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -35,13 +35,6 @@ For maven you must configure the surefire plugin for junit tests.
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-surefire-plugin</artifactId>
     <version>2.22.1</version>
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-    </dependencies>
 </plugin>
 ```
 


### PR DESCRIPTION
It's recommended to use the built-in provider from version 2.22.0 of the maven-surefire-plugin onwards.