### PR TITLE
Modifies SpringListener to include Spring's Test Listeners

### DIFF
--- a/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
@@ -9,8 +9,8 @@ plugins {
 dependencies {
     compile project(':kotlintest-core')
     compile project(':kotlintest-assertions')
-    compile 'org.springframework:spring-test:4.3.14.RELEASE'
-    compile 'org.springframework:spring-context:4.3.14.RELEASE'
+    compile 'org.springframework:spring-test:5.1.7.RELEASE'
+    compile 'org.springframework:spring-context:5.1.7.RELEASE'
     testCompile project(':kotlintest-runner:kotlintest-runner-junit5')
 
     testImplementation('org.springframework.boot:spring-boot-starter-test:2.1.5.RELEASE')

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/main/kotlin/io/kotlintest/spring/SpringListener.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/main/kotlin/io/kotlintest/spring/SpringListener.kt
@@ -1,8 +1,11 @@
 package io.kotlintest.spring
 
 import io.kotlintest.Spec
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
 import io.kotlintest.extensions.ConstructorExtension
 import io.kotlintest.extensions.TestListener
+import io.kotlintest.extensions.TopLevelTest
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR
 import org.springframework.test.context.TestContextManager
 import kotlin.reflect.KClass
@@ -10,13 +13,41 @@ import kotlin.reflect.full.primaryConstructor
 
 object SpringListener : TestListener {
 
-  override fun beforeSpec(spec: Spec) {
-    try {
-      TestContextManager(spec.javaClass).prepareTestInstance(spec)
-    } catch (t: Throwable) {
-      t.printStackTrace()
-    }
+  // Each Spec needs its own context. However, this listener is a singleton, so we need
+  // to keep this map to separate those contexts instead of making this class non-singleton, thus
+  // breaking client code
+  private val testContexts = mutableMapOf<Spec, TestContextManager>()
+
+  override fun beforeSpecClass(spec: Spec, tests: List<TopLevelTest>) {
+    testContexts[spec] = TestContextManager(spec.javaClass)
   }
+
+  override fun beforeSpec(spec: Spec) {
+    spec.testContext.beforeTestClass()
+  }
+
+  override fun beforeTest(testCase: TestCase) {
+    testCase.spec.testContext.beforeTestMethod(testCase.spec, method)
+    testCase.spec.testContext.prepareTestInstance(testCase.spec)
+    testCase.spec.testContext.beforeTestExecution(testCase.spec, method)
+
+  }
+
+  override fun afterTest(testCase: TestCase, result: TestResult) {
+    testCase.spec.testContext.afterTestMethod(testCase.spec, method, null as Throwable?)
+    testCase.spec.testContext.afterTestExecution(testCase.spec, method, null as Throwable?)
+  }
+
+  override fun afterSpec(spec: Spec) {
+    spec.testContext.afterTestClass()
+  }
+
+  private val Spec.testContext: TestContextManager
+    get() = testContexts.getValue(this)
+
+  // We don't run methods, but we need to pass one to TestContextManager, so we'll pass any.
+  private val method = SpringListener::class.java.getMethod("hashCode")
+
 }
 
 object SpringAutowireConstructorExtension : ConstructorExtension {

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/ActiveProfileSpringTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/ActiveProfileSpringTest.kt
@@ -1,7 +1,8 @@
-package io.kotlintest.spring
+package com.sksamuel.kt.spring
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FunSpec
+import io.kotlintest.spring.SpringListener
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/Components.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/Components.kt
@@ -1,4 +1,4 @@
-package io.kotlintest.spring
+package com.sksamuel.kt.spring
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringAutowiredConstructorTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringAutowiredConstructorTest.kt
@@ -1,4 +1,4 @@
-package io.kotlintest.spring
+package com.sksamuel.kt.spring
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringBootTestTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringBootTestTest.kt
@@ -1,7 +1,8 @@
-package io.kotlintest.spring
+package com.sksamuel.kt.spring
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.FunSpec
+import io.kotlintest.spring.SpringListener
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringListenerTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringListenerTest.kt
@@ -1,7 +1,8 @@
-package io.kotlintest.spring
+package com.sksamuel.kt.spring
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
+import io.kotlintest.spring.SpringListener
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringTestExecutionListenerTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/SpringTestExecutionListenerTest.kt
@@ -1,0 +1,87 @@
+package com.sksamuel.kt.spring
+
+import io.kotlintest.Spec
+import io.kotlintest.TestCase
+import io.kotlintest.TestResult
+import io.kotlintest.extensions.TestListener
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+import io.kotlintest.spring.SpringListener
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestContext
+import org.springframework.test.context.TestExecutionListeners
+import org.springframework.test.context.TestExecutionListener as SpringTestExecutionListener
+
+@TestExecutionListeners(DummyTestExecutionListener::class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@SpringBootTest(classes = [Components::class])
+class SpringTestExecutionListenerTest : FunSpec() {
+
+  @Autowired
+  lateinit var userService: UserService
+
+  override fun listeners(): List<TestListener> {
+    return listOf(SpringListener)
+  }
+
+  init {
+    test("Should autowire with spring listeners") {
+      userService.repository.findUser()
+    }
+
+    test("Dummy test to test spring listener in afterSpecClass") {
+      // Only here to verify counts are incremented
+    }
+  }
+
+  override fun afterSpecClass(spec: Spec, results: Map<TestCase, TestResult>) {
+    DummyTestExecutionListener.beforeTestClass shouldBe 1
+    DummyTestExecutionListener.beforeTestMethod shouldBe 2
+    DummyTestExecutionListener.beforeTestExecution shouldBe 2
+    DummyTestExecutionListener.prepareTestInstance shouldBe 2
+    DummyTestExecutionListener.afterTestExecution shouldBe 2
+    DummyTestExecutionListener.afterTestmethod shouldBe 2
+    DummyTestExecutionListener.afterTestClass shouldBe 1
+  }
+}
+
+class DummyTestExecutionListener : SpringTestExecutionListener {
+
+  override fun beforeTestClass(testContext: TestContext) {
+    beforeTestClass++
+  }
+
+  override fun beforeTestMethod(testContext: TestContext) {
+    beforeTestMethod++
+  }
+
+  override fun beforeTestExecution(testContext: TestContext) {
+    beforeTestExecution++
+  }
+
+  override fun prepareTestInstance(testContext: TestContext) {
+    prepareTestInstance++
+  }
+
+  override fun afterTestExecution(testContext: TestContext) {
+    afterTestExecution++
+  }
+
+  override fun afterTestMethod(testContext: TestContext) {
+    afterTestmethod++
+  }
+
+  override fun afterTestClass(testContext: TestContext) {
+    afterTestClass++
+  }
+
+  companion object {
+    var beforeTestClass = 0
+    var beforeTestMethod = 0
+    var beforeTestExecution = 0
+    var prepareTestInstance = 0
+    var afterTestExecution = 0
+    var afterTestmethod = 0
+    var afterTestClass = 0
+  }
+}

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/UserService.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/test/kotlin/com/sksamuel/kt/spring/UserService.kt
@@ -1,4 +1,4 @@
-package io.kotlintest.spring
+package com.sksamuel.kt.spring
 
 import org.springframework.stereotype.Component
 


### PR DESCRIPTION
Originally, our SpringLister would only execute one part of the Spring Test Context's API. This was insufficient for some of Spring's implementations, such as the TestExecutionListener api.

This commit changes the way the listener works to enable that kind of listener. It was very similar to our listener execution, so we just had to hook the executions.

Users that didn't use these features before won't be impacted in any way.

Implements #886