### PR TITLE
Expressive Arrow Try Asserts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+
+indent_style = space
+indent_size = 2
+
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/TryMatchersTest.kt
+++ b/kotlintest-tests/kotlintest-tests-core/src/test/kotlin/com/sksamuel/kotlintest/assertions/arrow/TryMatchersTest.kt
@@ -1,11 +1,7 @@
 package com.sksamuel.kotlintest.assertions.arrow
 
 import arrow.core.Try
-import io.kotlintest.assertions.arrow.`try`.beFailure
-import io.kotlintest.assertions.arrow.`try`.beFailureOfType
-import io.kotlintest.assertions.arrow.`try`.beSuccess
-import io.kotlintest.assertions.arrow.`try`.shouldBeFailure
-import io.kotlintest.assertions.arrow.`try`.shouldBeSuccess
+import io.kotlintest.assertions.arrow.`try`.*
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNot
@@ -19,7 +15,6 @@ class TryMatchersTest : WordSpec() {
 
     "Try shouldBe Success(value)" should {
       "test that a try is a Success with the given value" {
-
         shouldThrow<AssertionError> {
           Try.Failure(RuntimeException()) should beSuccess("foo")
         }.message shouldBe "Try should be a Success(foo) but was Failure(null)"
@@ -29,7 +24,11 @@ class TryMatchersTest : WordSpec() {
         }.message shouldBe "Try should be Success(foo) but was Success(boo)"
 
         Try.Success("foo") should beSuccess("foo")
+
+        Try.Success("foo") shouldBeSuccess "foo"
+        Try.Success("foo") shouldBeSuccess { it shouldBe "foo" }
       }
+
       "use contracts to expose Success<*>" {
         val t = Try { "boo" }
         t.shouldBeSuccess()
@@ -38,6 +37,8 @@ class TryMatchersTest : WordSpec() {
     }
 
     "Try shouldBe Failure" should {
+      data class Failure(override val message: String) : RuntimeException(message)
+
       "test that a try is a Failure" {
         shouldThrow<AssertionError> {
           Try.Success("foo") should beFailure()
@@ -58,11 +59,14 @@ class TryMatchersTest : WordSpec() {
         Try.Failure(RuntimeException()) should beFailureOfType<RuntimeException>()
         Try.Failure(RuntimeException()) should beFailureOfType<Exception>()
         Try.Failure(Exception()) shouldNot beFailureOfType<RuntimeException>()
+
+        Try.Failure(Failure("boo")) shouldBeFailure Failure("boo")
+        Try.Failure(Failure("boo")) shouldBeFailure { it.message shouldBe "boo" }
       }
       "use contracts to expose Failure" {
-        val t = Try.Failure(RuntimeException("boo"))
+        val t = Try.Failure(Failure("boo"))
         t.shouldBeFailure()
-        t.exception shouldBe RuntimeException("boo")
+        t.exception shouldBe Failure("boo")
       }
     }
   }


### PR DESCRIPTION
I tried the assertions today and I felt that the assertion can be a bit more expressive.
I added some more asserts, usage examples can be found in tests.
I had a bit of a dilemma when testing success/failure values, between:
`Try.Success("foo") shouldBeSuccess { it shouldBe "foo" }`
and 
`Try.Success("foo") shouldBeSuccess { this shouldBe "foo" }`

I also noticed that diffs are not properly highlighted in IntelliJ for `shouldBeSuccess [value]`. That's why I delegated testing failure equality to `equalityMatcher`. The result can be compared easier with IntelliJ, at the cost of losing the `Failure()` wrapper.

Other changes:
- use contracts to expose Failure was failing, I added a data class Exception to fix it
- added `.editorconfig` with some basic rules
