### PR TITLE
Update maven 

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,14 +206,7 @@ For maven you must configure the surefire plugin for junit tests.
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-surefire-plugin</artifactId>
-    <version>2.22.1</version>
-    <dependencies>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.3.2</version>
-        </dependency>
-    </dependencies>
+    <version>2.22.2</version>
 </plugin>
 ```
 


### PR DESCRIPTION
When configuring a maven project as described, the following warning will appear during build:

```
 +-------------------------------------------------------------------------------+
 | WARNING:                                                                      |
 | The junit-platform-surefire-provider has been deprecated and is scheduled to  |
 | be removed in JUnit Platform 1.4. Please use the built-in support in Maven    |
 | Surefire >= 2.22.0 instead.                                                   |
 | » https://junit.org/junit5/docs/current/user-guide/#running-tests-build-maven |
 +-------------------------------------------------------------------------------+
```

It's not required to add `junit-platform-surefire-provider` anymore.

Also, a new version was released.