### PR TITLE
Update doc matchers json

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -61,6 +61,13 @@ For the extension function style, each function has an equivalent negated versio
 | `str.shouldStartWith("prefix")` | Asserts that the string starts with the given prefix. The prefix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
 | `str.shouldBeEqualIgnoringCase(other)` | Asserts that the string is equal to another string ignoring case. |
 
+| JSON ||
+| -------- | ---- |
+| `str.shouldMatchJson(json)` | Asserts that the JSON is equal to another JSON ignoring properties' order and formatting. |
+| `str.shouldContainJsonKey("$.key")` | Asserts that the JSON contains a `key`. |
+| `str.shouldContainJsonKeyValue("$.key", "value")` | Asserts that the JSON contains a `key` with a specific `value`. |
+| `str.shouldMatchJsonResource("/file.json")` | Asserts that the JSON is equal to the existing `/file.json` ignoring properties' order and formatting. |
+
 | Integers ||
 | -------- | ---- |
 | `int.shouldBeBetween(x, y)` | Asserts that the integer is between x and y, inclusive on both x and y |

--- a/kotlintest-core/src/main/kotlin/io/kotlintest/Project.kt
+++ b/kotlintest-core/src/main/kotlin/io/kotlintest/Project.kt
@@ -54,7 +54,7 @@ object Project {
   private val _projectlisteners = mutableListOf<ProjectListener>()
   private val _filters = mutableListOf<ProjectLevelFilter>()
   private var _specExecutionOrder: SpecExecutionOrder = LexicographicSpecExecutionOrder
-  private var writeSpecFailureFile: Boolean = true
+  private var writeSpecFailureFile: Boolean = false
   private var _globalAssertSoftly: Boolean = false
   private var parallelism: Int = 1
   private var _timeout: Duration? = null


### PR DESCRIPTION
I verified the behavior running existing tests, then wrote the documentation.
In general, it would be nice having some examples for every assertion, too. What do you think?