### PR TITLE
Enhances SpringListener to work correctly with all Spring's Listeners

### DIFF
--- a/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
+++ b/kotlintest-extensions/kotlintest-extensions-spring/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.jetbrains.kotlin.multiplatform'
     id 'java-library'
+    id "org.jetbrains.kotlin.plugin.spring" version "1.3.41"
 }
 
 repositories {
@@ -23,6 +24,7 @@ kotlin {
                 implementation kotlin('reflect')
                 implementation 'org.springframework:spring-test:5.1.7.RELEASE'
                 implementation 'org.springframework:spring-context:5.1.7.RELEASE'
+                implementation 'net.bytebuddy:byte-buddy:1.10.1'
             }
         }
 

--- a/kotlintest-extensions/kotlintest-extensions-spring/src/jvmTest/kotlin/com/sksamuel/kt/spring/SpringTestExecutionListenerTest.kt
+++ b/kotlintest-extensions/kotlintest-extensions-spring/src/jvmTest/kotlin/com/sksamuel/kt/spring/SpringTestExecutionListenerTest.kt
@@ -38,7 +38,7 @@ class SpringTestExecutionListenerTest : FunSpec() {
     DummyTestExecutionListener.beforeTestClass shouldBe 1
     DummyTestExecutionListener.beforeTestMethod shouldBe 2
     DummyTestExecutionListener.beforeTestExecution shouldBe 2
-    DummyTestExecutionListener.prepareTestInstance shouldBe 2
+    DummyTestExecutionListener.prepareTestInstance shouldBe 1
     DummyTestExecutionListener.afterTestExecution shouldBe 2
     DummyTestExecutionListener.afterTestmethod shouldBe 2
     DummyTestExecutionListener.afterTestClass shouldBe 1


### PR DESCRIPTION
More information at https://github.com/kotlintest/kotlintest/issues/950

Spring executes transactions (and this include anything inside @DataJPATest) through a Listener called TransactionalTestExecutionListener. This comes pre-registered with a SpringBootTest, and KotlinTest was executing this listener correctly as per #887.

However, only executing the Listener wasn't enough, as it couldn't autowire the EntityManager. Initially, this was happening because our SpringListener had a fake "test method" that was a pointer to java.lang.Object.hashcode method. We made this hack to allow us to execute code inside Spring Test Framework, and it seemed fine on our tests.

Due to hashcode being a java.lang.Object method, Spring couldn't find the transaction attribute, as it verified directly that the method wasn't from Java Object.

With this in mind, we must use an object from another class. My first attempt was to use a dummy method, declared in the SpringListener itself. But this also wouldn't work, as the listener would never find the TransactionAttribute, as the method doesn't (and shouldn't) declare a @Transaction, and SpringListener also didn't declare that annotation. The only way to have a method with that annotation would be inside user's Spec definition, where the user would choose it.

We don't have methods, as we define everything through a DSL. But that didn't seem an issue, as Spring's Listener would get the Transaction Attribute from the method's class if it doesn't declare it. @DataJPATest already declare transaction attributes, so if we managed to get a method inside it, it would work without having to declare @Transaction.

If we could guarantee that our users were overriding a method, we could get its reference, but we couldn't force that, and referecing a method from Spec wouldn't work (as Spec doesn't declare the attributes).

The only way to solve this issue that I found was to inject a dummy method into the class, and get it through reflection, so that Spring Listener would correctly find the Transaction Attributes, and that's what I've done.

Fixes #950