### PR TITLE
#975 Adds a concat method in Gen which concatenates given gen

### DIFF
--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/properties/Gen.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/properties/Gen.kt
@@ -118,6 +118,19 @@ interface Gen<T> {
        }
     }
   }
+
+  /**
+   * Returns a new [[Gen]] which will return the values from this gen and only once values
+   * of this gen exhaust it will return the values from the supplied gen.
+   * The supplied gen must be a subtype of the type of this gen.
+   */
+  fun <U : T> concat(gen: Gen<U>): Gen<T> {
+    val outer = this
+    return object : Gen<T> {
+      override fun constants(): Iterable<T> = outer.constants() + gen.constants()
+      override fun random(seed: Long?): Sequence<T> = outer.random(seed) + gen.random(seed)
+    }
+  }
 }
 
 /**

--- a/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenTest.kt
+++ b/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenTest.kt
@@ -2,6 +2,8 @@
 
 package com.sksamuel.kotlintest.properties
 
+import com.sksamuel.kotlintest.properties.X.*
+import io.kotlintest.*
 import io.kotlintest.inspectors.forAll
 import io.kotlintest.matchers.booleans.shouldBeTrue
 import io.kotlintest.matchers.collections.*
@@ -15,10 +17,6 @@ import io.kotlintest.matchers.floats.shouldBeLessThanOrEqual
 import io.kotlintest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotlintest.matchers.string.include
 import io.kotlintest.properties.*
-import io.kotlintest.shouldBe
-import io.kotlintest.shouldHave
-import io.kotlintest.shouldNotBe
-import io.kotlintest.shouldThrow
 import io.kotlintest.specs.WordSpec
 import io.kotlintest.tables.headers
 import io.kotlintest.tables.row
@@ -636,6 +634,28 @@ class GenTest : WordSpec() {
         val classesFilesInReflectionTestDirectory = File("$reflectionTestDirectory/classes").listFiles()!!.toList()
 
         randomFilesFromReflectionDirectory shouldContainAnyOf classesFilesInReflectionTestDirectory
+      }
+    }
+
+    "Gen.concat(gen)" should {
+      val genOfClassA = object : Gen<X> {
+        override fun constants(): Iterable<X> = emptyList()
+        override fun random(seed: Long?): Sequence<X> = sequenceOf(A(1), A(2), A(3))
+      }
+
+      val genOfClassB = object : Gen<X> {
+        override fun constants(): Iterable<X> = emptyList()
+        override fun random(seed: Long?): Sequence<X> = sequenceOf(B(1), B(2), B(3))
+      }
+
+      "given elements from it self when its elements are not exhausted" {
+        val threeElementsFromConcatenatedGen = genOfClassA.concat(genOfClassB).random().take(3).toList()
+        threeElementsFromConcatenatedGen shouldBe listOf(A(1), A(2), A(3))
+      }
+
+      "given elements from the other gen when its elements are exhausted" {
+        val sixElementsFromConcatenatedGen = genOfClassA.concat(genOfClassB).random().take(6).toList()
+        sixElementsFromConcatenatedGen shouldBe listOf(A(1), A(2), A(3), B(1), B(2), B(3))
       }
     }
   }


### PR DESCRIPTION
```kotlin
val concatenatedGen = gen1.concat(gen2)
```
The resulting concatenatedGen will gives elements from gen1 and once gen1 exhaust it will give elements from gen2.