### PR TITLE
Fix max treated as exclusive on Gen.choose() for int and long - Fixes #1011

### DIFF
--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/properties/gens.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/properties/gens.kt
@@ -468,7 +468,7 @@ fun Gen.Companion.choose(min: Int, max: Int): Gen<Int> {
     override fun constants(): Iterable<Int> = emptyList()
      override fun random(seed: Long?): Sequence<Int> {
         val r = if (seed == null) Random.Default else Random(seed)
-        return generateSequence { r.nextInt(min, max) }
+        return generateSequence { r.nextInt(min, max + 1) }
      }
 
     override fun shrinker() = ChooseShrinker(min, max)
@@ -485,7 +485,7 @@ fun Gen.Companion.choose(min: Long, max: Long): Gen<Long> {
      override fun constants(): Iterable<Long> = emptyList()
      override fun random(seed: Long?): Sequence<Long> {
         val r = if (seed == null) Random.Default else Random(seed)
-        return generateSequence { r.nextLong(min, max) }
+        return generateSequence { r.nextLong(min, max + 1) }
      }
   }
 }

--- a/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/properties/gens.kt
+++ b/kotlintest-assertions/src/commonMain/kotlin/io/kotlintest/properties/gens.kt
@@ -4,6 +4,8 @@ import io.kotlintest.properties.shrinking.*
 import kotlin.jvm.JvmOverloads
 import kotlin.math.abs
 import kotlin.random.Random
+import kotlin.random.nextInt
+import kotlin.random.nextLong
 
 /**
  * Returns a stream of values where each value is a random
@@ -468,7 +470,7 @@ fun Gen.Companion.choose(min: Int, max: Int): Gen<Int> {
     override fun constants(): Iterable<Int> = emptyList()
      override fun random(seed: Long?): Sequence<Int> {
         val r = if (seed == null) Random.Default else Random(seed)
-        return generateSequence { r.nextInt(min, max + 1) }
+        return generateSequence { r.nextInt(min..max) }
      }
 
     override fun shrinker() = ChooseShrinker(min, max)
@@ -485,7 +487,7 @@ fun Gen.Companion.choose(min: Long, max: Long): Gen<Long> {
      override fun constants(): Iterable<Long> = emptyList()
      override fun random(seed: Long?): Sequence<Long> {
         val r = if (seed == null) Random.Default else Random(seed)
-        return generateSequence { r.nextLong(min, max + 1) }
+        return generateSequence { r.nextLong(min..max) }
      }
   }
 }

--- a/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenChooseTest.kt
+++ b/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenChooseTest.kt
@@ -1,0 +1,39 @@
+package com.sksamuel.kotlintest.properties
+
+import io.kotlintest.data.forall
+import io.kotlintest.properties.Gen
+import io.kotlintest.properties.choose
+import io.kotlintest.properties.next
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+import io.kotlintest.tables.row
+
+class GenChooseTest : FunSpec({
+  test("should give ints in between min and max inclusive") {
+    forall(
+      row(-10 to -1, (-10..-1).toSet()),
+      row(1 to 3, (1..3).toSet()),
+      row(-100 to 100, (-100..100).toSet())
+    ) { minMax, expectedValues ->
+      val vmin = minMax.first
+      val vmax = minMax.second
+      val actualValues = (1..100000).map { Gen.choose(vmin, vmax).next() }.toSet()
+
+      actualValues shouldBe expectedValues
+    }
+  }
+
+  test("should give longs in between min and max inclusive") {
+    forall(
+      row(-10L to -1L, (-10L..-1L).toSet()),
+      row(1L to 3L, (1L..3L).toSet()),
+      row(-100L to 100L, (-100L..100L).toSet())
+    ) { minMax, expectedValues ->
+      val vmin = minMax.first
+      val vmax = minMax.second
+      val actualValues = (1..100000).map { Gen.choose(vmin, vmax).next() }.toSet()
+
+      actualValues shouldBe expectedValues
+    }
+  }
+})

--- a/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenChooseTest.kt
+++ b/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenChooseTest.kt
@@ -9,29 +9,33 @@ import io.kotlintest.specs.FunSpec
 import io.kotlintest.tables.row
 
 class GenChooseTest : FunSpec({
-  test("should give ints in between min and max inclusive") {
+  test("<Int, Int> should give values between min and max inclusive") {
+    // Test parameters include the test for negative bounds
     forall(
-      row(-10 to -1, (-10..-1).toSet()),
-      row(1 to 3, (1..3).toSet()),
-      row(-100 to 100, (-100..100).toSet())
-    ) { minMax, expectedValues ->
-      val vmin = minMax.first
-      val vmax = minMax.second
-      val actualValues = (1..100000).map { Gen.choose(vmin, vmax).next() }.toSet()
+      row(-10, -1),
+      row(1, 3),
+      row(-100, 100),
+      row(Int.MAX_VALUE - 10, Int.MAX_VALUE),
+      row(Int.MIN_VALUE, Int.MIN_VALUE + 10)
+    ) { vMin, vMax ->
+      val expectedValues = (vMin..vMax).toSet()
+      val actualValues = (1..100000).map { Gen.choose(vMin, vMax).next() }.toSet()
 
       actualValues shouldBe expectedValues
     }
   }
 
-  test("should give longs in between min and max inclusive") {
+  test("<Long, Long> should give values between min and max inclusive") {
+    // Test parameters include the test for negative bounds
     forall(
-      row(-10L to -1L, (-10L..-1L).toSet()),
-      row(1L to 3L, (1L..3L).toSet()),
-      row(-100L to 100L, (-100L..100L).toSet())
-    ) { minMax, expectedValues ->
-      val vmin = minMax.first
-      val vmax = minMax.second
-      val actualValues = (1..100000).map { Gen.choose(vmin, vmax).next() }.toSet()
+      row(-10L, -1L),
+      row(1L, 3L),
+      row(-100L, 100L),
+      row(Long.MAX_VALUE - 10L, Long.MAX_VALUE),
+      row(Long.MIN_VALUE, Long.MIN_VALUE + 10L)
+    ) { vMin, vMax ->
+      val expectedValues = (vMin..vMax).toSet()
+      val actualValues = (1..100000).map { Gen.choose(vMin, vMax).next() }.toSet()
 
       actualValues shouldBe expectedValues
     }

--- a/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenTest.kt
+++ b/kotlintest-assertions/src/jvmTest/kotlin/com/sksamuel/kotlintest/properties/GenTest.kt
@@ -43,62 +43,6 @@ class GenTest : WordSpec() {
         string.length shouldBe rand
       }
     }
-    "Gen.choose<int, int>" should {
-
-      "only give out numbers in the given range".config(invocations = 10000, threads = 8) {
-        val random = Random()
-
-        val min = random.nextInt(10000) - 10000
-        val max = random.nextInt(10000) + 10000
-
-        val rand = Gen.choose(min, max).random().take(10)
-        rand.forEach {
-          it shouldBe gte(min)
-          it shouldBe lt(max)
-        }
-      }
-
-      "support negative bounds".config(invocations = 1000, threads = 8) {
-
-        val random = Random()
-
-        val max = random.nextInt(10000)
-
-        val rand = Gen.choose(Int.MIN_VALUE, max).random().take(10)
-        rand.forEach {
-          it shouldBe gte(Int.MIN_VALUE)
-          it shouldBe lt(max)
-        }
-
-      }
-    }
-    "Gen.choose<long, long>" should {
-      "only give out numbers in the given range".config(invocations = 10000, threads = 8) {
-        val random = Random()
-
-        val min = random.nextInt(10000) - 10000
-        val max = random.nextInt(10000) + 10000
-
-        val rand = Gen.choose(min.toLong(), max.toLong()).random().take(10)
-        rand.forEach {
-          it shouldBe gte(min.toLong())
-          it shouldBe lt(max.toLong())
-        }
-
-      }
-      "support negative bounds".config(invocations = 10000, threads = 8) {
-        val random = Random()
-
-        val max = random.nextInt(10000) + 10000
-
-        val rand = Gen.choose(Long.MIN_VALUE, max.toLong()).random().take(10)
-        rand.forEach {
-          it shouldBe gte(Long.MIN_VALUE)
-          it shouldBe lt(max.toLong())
-        }
-
-      }
-    }
     "Gen.forClassName" should {
       "gives the right result" {
 


### PR DESCRIPTION
For `Gen.choose()` on the overloads with min and max, for int and long, the max was treated as exclusive and it should be inclusive. This is, of course, making the assumption that max is supposed to be inclusive. At least, that is the way the docs for the functions sound to me.