### PR TITLE
Fix LocalDateTime test

### DIFF
--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
@@ -363,14 +363,7 @@ class DateMatchersTest : StringSpec() {
         LocalDateTime.of(2002, Month.APRIL, 1, 5, 2).shouldBeToday()
       }
       shouldFail {
-        LocalDateTime.now().withHour(23).withMinute(59).withSecond(59).withDayOfMonth(
-          LocalDateTime.now().dayOfMonth - 1
-        ).shouldBeToday()
-      }
-      shouldFail {
-        LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withDayOfMonth(
-          LocalDateTime.now().dayOfMonth + 1
-        ).shouldBeToday()
+        LocalDateTime.now().minusDays(1).shouldBeToday()
       }
     }
 


### PR DESCRIPTION
The test tries to cast a date to it's current day - 1, but that sometimes causes the day to be zero (only on the first day of every month).

This test was not correct, and this commit fixes it.