### PR TITLE
Update set up with kts example

### DIFF
--- a/doc/reference.md
+++ b/doc/reference.md
@@ -26,6 +26,18 @@ dependencies {
 }
 ```
 
+Or, if using Kotlin KTS gradle:
+
+```kotlin
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
+dependencies {
+  testImplementation("io.kotlintest:kotlintest-runner-junit5:3.3.0")
+}
+```
+
 #### Maven
 
 For maven you must configure the surefire plugin for junit tests.


### PR DESCRIPTION
The set up on the reference documentation doesn't include an example for people using kts for the Gradle build files.