### PR TITLE
[#1006] Updated comment to reflect the correct ASCII range

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -636,7 +636,7 @@ fun <K, V> Gen.Companion.map(gen: Gen<Pair<K, V>>, maxSize: Int = 100): Gen<Map<
 
 /**
  * Returns the next pseudorandom, uniformly distributed value
- * from the ASCII range 33-126.
+ * from the ASCII range 32-126.
  */
 fun Random.nextPrintableChar(): Char {
   val low = 32


### PR DESCRIPTION
Updated the comment on `Random.nextPrintableCharacter` to reflect the correct ASCII range of 32-126.



Closes #1006 