### PR TITLE
[Documentation] - Update documentation on gens and Gen

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/Gen.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/Gen.kt
@@ -16,8 +16,8 @@ import io.kotest.properties.shrinking.Shrinker
  * The first are values that should always be included - those
  * edge cases values which are common sources of bugs. For
  * example, a generator for [Int]s should always include
- * values like zero, minus 1, positive 1, Integer.MAX_VALUE
- * and Integer.MIN_VALUE.
+ * values like zero, minus 1, positive 1, [Int.MAX_VALUE]
+ * and [Int.MIN_VALUE].
  *
  * Another example would be for a generator for enums. That
  * should include _all_ the values of the enum to ensure
@@ -44,6 +44,9 @@ interface Gen<T> {
    */
   fun random(seed: Long? = null): Sequence<T>
 
+  /**
+   * @return the [Shrinker] for this gen or `null`
+   */
   fun shrinker(): Shrinker<T>? = null
 
   /**
@@ -63,6 +66,9 @@ interface Gen<T> {
      }
   }
 
+  /**
+   * @return a new [Gen] by filtering this gen's output by the negated function [f]
+   */
   fun filterNot(f: (T) -> Boolean): Gen<T> = filter { !f(it) }
 
   /**
@@ -146,6 +152,20 @@ inline fun <T, reified U : T> Gen<T>.filterIsInstance(): Gen<U> {
    }
 }
 
+/**
+ * Create a infinite sequence of the given [generator]
+ *
+ * ```kotlin
+ * // Example
+ * generateInfiniteSequence { 42 }
+ *     .take(3)
+ *     .joinToString()
+ *     .let { println(it) }
+ * // Prints: 42, 42, 42
+ * ```
+ *
+ * @return a new [Sequence] of [T] which always returns the result of [generator]
+ */
 inline fun <T> generateInfiniteSequence(crossinline generator: () -> T): Sequence<T> =
     Sequence {
       object : Iterator<T> {
@@ -203,4 +223,7 @@ fun <T> Gen<T>.next(predicate: (T) -> Boolean = { true }, seed: Long?): T {
    return random(seed).first(predicate)
 }
 
+/**
+ * @return the result of calling [next] with the given [predicate] defaulting seed to `null`
+ */
 fun <T> Gen<T>.next(predicate: (T) -> Boolean = { true }): T = next(predicate, null)

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -515,6 +515,9 @@ fun <T> Gen.Companion.from(values: List<T>): Gen<T> = object : Gen<T> {
    }
 }
 
+/**
+ * @return a new [Gen] created from the given [values] (see [from] List for more details)
+ */
 fun <T> Gen.Companion.from(values: Array<T>): Gen<T> = from(values.toList())
 
 /**
@@ -619,6 +622,11 @@ fun <K, V> Gen.Companion.map(genK: Gen<K>, genV: Gen<V>, maxSize: Int = 100): Ge
    }
 }
 
+/**
+ * @return a stream of values, where each value is a [Map] of [Pair]s from the given [gen]
+ *   the size of the [Map] is bounded between [0, [maxSize])
+ */
+@JvmOverloads
 fun <K, V> Gen.Companion.map(gen: Gen<Pair<K, V>>, maxSize: Int = 100): Gen<Map<K, V>> = object : Gen<Map<K, V>> {
   init {
     require(maxSize >= 0) { "maxSize must be positive" }
@@ -640,6 +648,21 @@ fun <K, V> Gen.Companion.map(gen: Gen<Pair<K, V>>, maxSize: Int = 100): Gen<Map<
  */
 fun Random.nextPrintableChar(): Char = nextInt(from = 32, until = 127).toChar()
 
+/**
+ * Generates a [String] of [length] by calling [nextPrintableChar]
+ *
+ * ```kotlin
+ * // Examples
+ * val r = Random.Default
+ * r.nextPrintableString(-10) // ""
+ * r.nextPrintableString(0)   // ""
+ * r.nextPrintableString(1)   // " ", "a", "Z", etc.
+ * r.nextPrintableString(5)   // "Ha Ha", "gens!", "[{-}]", etc.
+ * ```
+ *
+ * @param length of String
+ * @return a given length String of random printable Chars
+ */
 fun Random.nextPrintableString(length: Int): String {
    return (0 until length).map { nextPrintableChar() }.joinToString("")
 }

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -43,7 +43,7 @@ fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100): Gen<String> = ob
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [Int]. The values always returned include
- * the following edge cases: [Int.MIN_VALUE, Int.MAX_VALUE, 0]
+ * the following edge cases: [[Int.MIN_VALUE], [Int.MAX_VALUE], 0]
  */
 fun Gen.Companion.int() = object : Gen<Int> {
    val literals = listOf(Int.MIN_VALUE, Int.MAX_VALUE, 0)
@@ -59,7 +59,7 @@ fun Gen.Companion.int() = object : Gen<Int> {
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [UInt]. The values always returned include
- * the following edge cases: [UInt.MIN_VALUE, UInt.MAX_VALUE]
+ * the following edge cases: [[UInt.MIN_VALUE], [UInt.MAX_VALUE]]
  */
 @ExperimentalUnsignedTypes
 fun Gen.Companion.uint() = object : Gen<UInt> {
@@ -74,14 +74,14 @@ fun Gen.Companion.uint() = object : Gen<UInt> {
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [Short]. The values always returned include
- * the following edge cases: [Short.MIN_VALUE, Short.MAX_VALUE, 0]
+ * the following edge cases: [[Short.MIN_VALUE], [Short.MAX_VALUE], 0]
  */
 fun Gen.Companion.short() = int().map { it.ushr(Int.SIZE_BITS - Short.SIZE_BITS).toShort() }
 
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [UShort]. The values always returned include
- * the following edge cases: [UShort.MIN_VALUE, UShort.MAX_VALUE]
+ * the following edge cases: [[UShort.MIN_VALUE], [UShort.MAX_VALUE]]
  */
 @ExperimentalUnsignedTypes
 fun Gen.Companion.ushort() = uint().map { it.shr(UInt.SIZE_BITS - UShort.SIZE_BITS).toUShort() }
@@ -89,14 +89,14 @@ fun Gen.Companion.ushort() = uint().map { it.shr(UInt.SIZE_BITS - UShort.SIZE_BI
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [Byte]. The values always returned include
- * the following edge cases: [Byte.MIN_VALUE, Byte.MAX_VALUE, 0]
+ * the following edge cases: [[Byte.MIN_VALUE], [Byte.MAX_VALUE], 0]
  */
 fun Gen.Companion.byte() = int().map { it.ushr(Int.SIZE_BITS - Byte.SIZE_BITS).toByte() }
 
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [UByte]. The values always returned include
- * the following edge cases: [UByte.MIN_VALUE, UByte.MAX_VALUE]
+ * the following edge cases: [[UByte.MIN_VALUE], [UByte.MAX_VALUE]]
  */
 @ExperimentalUnsignedTypes
 fun Gen.Companion.ubyte() = uint().map { it.shr(UInt.SIZE_BITS - UByte.SIZE_BITS).toByte() }
@@ -213,7 +213,7 @@ fun Gen.Companion.numericFloats(
 /**
  * Returns a stream of values where each value is a randomly
  * chosen long. The values returned always include
- * the following edge cases: [Long.MIN_VALUE, Long.MAX_VALUE]
+ * the following edge cases: [[Long.MIN_VALUE], [Long.MAX_VALUE]]
  */
 fun Gen.Companion.long(): Gen<Long> = object : Gen<Long> {
   val literals = listOf(Long.MIN_VALUE, Long.MAX_VALUE)
@@ -227,7 +227,7 @@ fun Gen.Companion.long(): Gen<Long> = object : Gen<Long> {
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [ULong]. The values returned always include
- * the following edge cases: [ULong.MIN_VALUE, ULong.MAX_VALUE]
+ * the following edge cases: [[ULong.MIN_VALUE], [ULong.MAX_VALUE]]
  */
 @ExperimentalUnsignedTypes
 fun Gen.Companion.ulong(): Gen<ULong> = object : Gen<ULong> {

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -638,11 +638,7 @@ fun <K, V> Gen.Companion.map(gen: Gen<Pair<K, V>>, maxSize: Int = 100): Gen<Map<
  * Returns the next pseudorandom, uniformly distributed value
  * from the ASCII range 33-126.
  */
-fun Random.nextPrintableChar(): Char {
-  val low = 32
-  val high = 127
-  return (nextInt(high - low) + low).toChar()
-}
+fun Random.nextPrintableChar(): Char = nextInt(from = 32, until = 127).toChar()
 
 fun Random.nextPrintableString(length: Int): String {
    return (0 until length).map { nextPrintableChar() }.joinToString("")


### PR DESCRIPTION
- [x] Add missing documentation on `gens.kt` and `Gen.kt`
- [x] Fix documentation on edge cases
    - Why? (Using IntelliJ `ctrl` + `j`) Basically the old version attempts to link the full String:
    ![KotlintestDocumentationUpdates](https://user-images.githubusercontent.com/5482320/67827441-66ef8880-faa6-11e9-90b0-5d5adcee4bba.gif)
