### PR TITLE
shouldBeInstanceOf and shouldBeTypeOf should return typecasted instance

### DIFF
--- a/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/types/matchers.kt
+++ b/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/types/matchers.kt
@@ -28,11 +28,22 @@ import io.kotest.shouldNotBe
  * }
  *
  * ```
+ * ```
+ *
+ * val list: List<Int> = arraylistOf(1, 2, 3)
+ *
+ * // arrayList is typecasted to ArrayList<Int>
+ * val arrayList = list.shouldBeInstanceOf<ArrayList<Int>>()
+ *
+ * ```
+ * @param block Lambda that receives typecasted instance as argument for further assertions.
+ * @return The typecasted instance
  */
-inline fun <reified T : Any> Any?.shouldBeInstanceOf(block: (T) -> Unit = { }) {
+inline fun <reified T : Any> Any?.shouldBeInstanceOf(block: (T) -> Unit = { }): T {
   val matcher = beInstanceOf<T>()
   this shouldBe matcher
   block(this as T)
+  return this
 }
 
 /**
@@ -72,11 +83,21 @@ inline fun <reified T : Any> Any?.shouldNotBeInstanceOf() {
  * // Use it
  * }
  * ```
+ * ```
+ * val list: List<Int> = arrayListOf(1, 2, 3)
+ *
+ * // arrayList is typecasted to ArrayList<Int>()
+ * val arrayList = list.shouldBeTypeOf<ArrayList<Int>>()
+ * ```
+ *
+ * @param block Lambda that receives typecasted instance  as argument for further assertions.
+ * @return The typecasted instance
  */
-inline fun <reified T : Any> Any?.shouldBeTypeOf(block: (T) -> Unit = { }) {
+inline fun <reified T : Any> Any?.shouldBeTypeOf(block: (T) -> Unit = { }):T {
   val matcher = beOfType<T>()
   this shouldBe matcher
   block(this as T)
+  return this
 }
 
 /**

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/types/TypeMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/types/TypeMatchersTest.kt
@@ -24,167 +24,197 @@ import java.util.LinkedList
 @Suppress("UnnecessaryVariable")
 class TypeMatchersTest : WordSpec() {
 
-  @Retention(AnnotationRetention.RUNTIME)
-  annotation class Vod
+   @Retention(AnnotationRetention.RUNTIME)
+   annotation class Vod
 
-  @Vod
-  class Wibble
+   @Vod
+   class Wibble
 
-  init {
+   init {
 
-    "typeOf" should {
-      "test for exact type" {
-        val arrayList: List<Int> = arrayListOf(1, 2, 3)
-        arrayList.shouldBeTypeOf<ArrayList<*>>()
-        arrayList.shouldNotBeTypeOf<List<*>>()
-      }
-    }
-
-    "haveAnnotation(annotation)" should {
-      "test for the presence of an annotation" {
-        Wibble::class.java should haveAnnotation(Vod::class.java)
-        Wibble::class.java.shouldHaveAnnotation(Vod::class.java)
-      }
-    }
-
-    "beInstanceOf" should {
-      "test that value is assignable to class" {
-        val arrayList: List<Int> = arrayListOf(1, 2, 3)
-
-        arrayList should beInstanceOf(ArrayList::class)
-        arrayList.shouldBeInstanceOf<ArrayList<*>>()
-
-        arrayList should beInstanceOf(List::class)
-
-        shouldThrow<AssertionError> {
-          arrayList should beInstanceOf(LinkedList::class)
-        }
-
-        arrayList.shouldNotBeInstanceOf<LinkedList<*>>()
-
-        shouldThrow<AssertionError> {
-          arrayList.shouldNotBeInstanceOf<ArrayList<*>>()
-        }
+      "typeOf" should {
+         "test for exact type" {
+            val arrayList: List<Int> = arrayListOf(1, 2, 3)
+            arrayList.shouldBeTypeOf<ArrayList<*>>()
+            arrayList.shouldNotBeTypeOf<List<*>>()
+         }
       }
 
-      "Allow execution with a lambda" {
-        val list = arrayListOf(1, 2, 3)
-
-        list.shouldBeInstanceOf<ArrayList<Int>> { it: ArrayList<Int> ->
-          it shouldBeSameInstanceAs list
-        }
+      "haveAnnotation(annotation)" should {
+         "test for the presence of an annotation" {
+            Wibble::class.java should haveAnnotation(Vod::class.java)
+            Wibble::class.java.shouldHaveAnnotation(Vod::class.java)
+         }
       }
 
-      "accepts null values" {
-        val arrayList: List<Int>? = null
-        shouldThrow<AssertionError> { arrayList should beInstanceOf(ArrayList::class) }
-        shouldThrow<AssertionError> { arrayList.shouldBeInstanceOf<ArrayList<*>>() }
-        shouldThrow<AssertionError> { arrayList shouldNot beInstanceOf(List::class) }
-        shouldThrow<AssertionError> { arrayList.shouldNotBeInstanceOf<LinkedList<*>>() }
-      }
-    }
+      "beInstanceOf" should {
+         "test that value is assignable to class" {
+            val arrayList: List<Int> = arrayListOf(1, 2, 3)
 
-    "beOfType" should {
-      "test that value have exactly the same type" {
-        val arrayList: List<Int> = arrayListOf(1, 2, 3)
+            arrayList should beInstanceOf(ArrayList::class)
+            arrayList.shouldBeInstanceOf<ArrayList<*>>()
 
-        arrayList should beOfType<ArrayList<Int>>()
+            arrayList should beInstanceOf(List::class)
 
-        shouldThrow<AssertionError> {
-          arrayList should beOfType<LinkedList<Int>>()
-        }
+            shouldThrow<AssertionError> {
+               arrayList should beInstanceOf(LinkedList::class)
+            }
 
-        shouldThrow<AssertionError> {
-          arrayList should beOfType<List<Int>>()
-        }
-      }
+            arrayList.shouldNotBeInstanceOf<LinkedList<*>>()
 
-      "Allow execution with a lambda" {
-        val list: Any = arrayListOf(1, 2, 3)
+            shouldThrow<AssertionError> {
+               arrayList.shouldNotBeInstanceOf<ArrayList<*>>()
+            }
+         }
 
-        list.shouldBeTypeOf<ArrayList<Int>> { it: ArrayList<Int> ->
-          it shouldBeSameInstanceAs list
-          it[0] shouldBe 1
-        }
-      }
+         "Allow execution with a lambda" {
+            val list = arrayListOf(1, 2, 3)
 
-      "accepts null values" {
-        val arrayList: List<Int>? = null
-        shouldThrow<AssertionError> { arrayList should beOfType<List<Int>>() }
-        shouldThrow<AssertionError> { arrayList.shouldBeTypeOf<List<*>>() }
-        shouldThrow<AssertionError> { arrayList shouldNot beOfType<List<Int>>() }
-        shouldThrow<AssertionError> { arrayList.shouldNotBeTypeOf<List<*>>() }
-      }
-    }
+            list.shouldBeInstanceOf<ArrayList<Int>> { it: ArrayList<Int> ->
+               it shouldBeSameInstanceAs list
+            }
+         }
 
-    "TypeMatchers.theSameInstanceAs" should {
-      "test that references are equal" {
-        val b: List<Int>? = listOf(1, 2, 3)
-        val a: List<Int>? = b
-        val c: List<Int>? = listOf(1, 2, 3)
+         "Returns typecasted value when invoked with a lambda" {
+            val list = arrayListOf(1, 2, 3)
 
-        a should beTheSameInstanceAs(b)
-        a.shouldBeSameInstanceAs(b)
+            val typecastedList = list.shouldBeInstanceOf<ArrayList<Int>> {}
+            typecastedList shouldBeSameInstanceAs list
+         }
 
-        shouldThrow<AssertionError> {
-          a should beTheSameInstanceAs(c)
-        }
+         "Returns typecasted value when invoked without arguments" {
+            val list = arrayListOf(1, 2, 3)
+            val typecastedList = list.shouldBeInstanceOf<ArrayList<Int>>()
 
-        shouldThrow<AssertionError> {
-          a.shouldBeSameInstanceAs(c)
-        }
-      }
-    }
+            typecastedList shouldBeSameInstanceAs list
+         }
 
-    "beTheSameInstanceAs" should {
-      "test that references are equal" {
-        val b = listOf(1, 2, 3)
-        val a = b
-        val c = listOf(1, 2, 3)
-
-        a should beTheSameInstanceAs(b)
-        shouldThrow<AssertionError> {
-          a should beTheSameInstanceAs(c)
-        }
-      }
-    }
-
-    "beNull" should {
-      val nullString: String? = null
-      val nonNullString: String? = "Foo"
-      "Pass for a null value" {
-        nullString.shouldBeNull()
-        nullString should beNull()
+         "accepts null values" {
+            val arrayList: List<Int>? = null
+            shouldThrow<AssertionError> { arrayList should beInstanceOf(ArrayList::class) }
+            shouldThrow<AssertionError> { arrayList.shouldBeInstanceOf<ArrayList<*>>() }
+            shouldThrow<AssertionError> { arrayList shouldNot beInstanceOf(List::class) }
+            shouldThrow<AssertionError> { arrayList.shouldNotBeInstanceOf<LinkedList<*>>() }
+         }
       }
 
-      "Fail for a non-null value" {
-        shouldThrow<AssertionError> { nonNullString.shouldBeNull() }
-        shouldThrow<AssertionError> { nonNullString should beNull() }
+      "beOfType" should {
+         "test that value have exactly the same type" {
+            val arrayList: List<Int> = arrayListOf(1, 2, 3)
+
+            arrayList should beOfType<ArrayList<Int>>()
+
+            shouldThrow<AssertionError> {
+               arrayList should beOfType<LinkedList<Int>>()
+            }
+
+            shouldThrow<AssertionError> {
+               arrayList should beOfType<List<Int>>()
+            }
+         }
+
+         "Allow execution with a lambda" {
+            val list: Any = arrayListOf(1, 2, 3)
+
+            list.shouldBeTypeOf<ArrayList<Int>> { it: ArrayList<Int> ->
+               it shouldBeSameInstanceAs list
+               it[0] shouldBe 1
+            }
+         }
+
+         "Returns typecasted value when executed with a lambda" {
+            val list: Any = arrayListOf(1, 2, 3)
+
+            val typecastedList = list.shouldBeTypeOf<ArrayList<Int>> {}
+            typecastedList shouldBeSameInstanceAs list
+            typecastedList[0] shouldBe 1
+         }
+
+         "Returns typecasted value when executed without argument" {
+            val list: Any = arrayListOf(1, 2, 3)
+
+            val typecastedList = list.shouldBeTypeOf<ArrayList<Int>>()
+            typecastedList shouldBeSameInstanceAs list
+            typecastedList[0] shouldBe 1
+         }
+
+         "accepts null values" {
+            val arrayList: List<Int>? = null
+            shouldThrow<AssertionError> { arrayList should beOfType<List<Int>>() }
+            shouldThrow<AssertionError> { arrayList.shouldBeTypeOf<List<*>>() }
+            shouldThrow<AssertionError> { arrayList shouldNot beOfType<List<Int>>() }
+            shouldThrow<AssertionError> { arrayList.shouldNotBeTypeOf<List<*>>() }
+         }
       }
-    }
 
-    "notBeNull" should {
-      val nullString: String? = null
-      val nonNullString: String? = "Foo"
+      "TypeMatchers.theSameInstanceAs" should {
+         "test that references are equal" {
+            val b: List<Int>? = listOf(1, 2, 3)
+            val a: List<Int>? = b
+            val c: List<Int>? = listOf(1, 2, 3)
 
-      "Pass for a non-null value" {
-        nonNullString.shouldNotBeNull()
-        nonNullString shouldNot beNull()
+            a should beTheSameInstanceAs(b)
+            a.shouldBeSameInstanceAs(b)
+
+            shouldThrow<AssertionError> {
+               a should beTheSameInstanceAs(c)
+            }
+
+            shouldThrow<AssertionError> {
+               a.shouldBeSameInstanceAs(c)
+            }
+         }
       }
 
-      "Fail for a null value" {
-        shouldThrow<AssertionError> { nullString.shouldNotBeNull() }
-        shouldThrow<AssertionError> { nullString shouldNot beNull() }
+      "beTheSameInstanceAs" should {
+         "test that references are equal" {
+            val b = listOf(1, 2, 3)
+            val a = b
+            val c = listOf(1, 2, 3)
+
+            a should beTheSameInstanceAs(b)
+            shouldThrow<AssertionError> {
+               a should beTheSameInstanceAs(c)
+            }
+         }
       }
 
-      "Allow automatic type cast" {
-        fun useString(string: String) {  }
+      "beNull" should {
+         val nullString: String? = null
+         val nonNullString: String? = "Foo"
+         "Pass for a null value" {
+            nullString.shouldBeNull()
+            nullString should beNull()
+         }
 
-        nonNullString.shouldNotBeNull()
-        useString(nonNullString)
-        nonNullString shouldBe "Foo"
+         "Fail for a non-null value" {
+            shouldThrow<AssertionError> { nonNullString.shouldBeNull() }
+            shouldThrow<AssertionError> { nonNullString should beNull() }
+         }
       }
-    }
-  }
+
+      "notBeNull" should {
+         val nullString: String? = null
+         val nonNullString: String? = "Foo"
+
+         "Pass for a non-null value" {
+            nonNullString.shouldNotBeNull()
+            nonNullString shouldNot beNull()
+         }
+
+         "Fail for a null value" {
+            shouldThrow<AssertionError> { nullString.shouldNotBeNull() }
+            shouldThrow<AssertionError> { nullString shouldNot beNull() }
+         }
+
+         "Allow automatic type cast" {
+            fun useString(string: String) {}
+
+            nonNullString.shouldNotBeNull()
+            useString(nonNullString)
+            nonNullString shouldBe "Foo"
+         }
+      }
+   }
 
 }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/types/TypeMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/types/TypeMatchersTest.kt
@@ -24,197 +24,197 @@ import java.util.LinkedList
 @Suppress("UnnecessaryVariable")
 class TypeMatchersTest : WordSpec() {
 
-   @Retention(AnnotationRetention.RUNTIME)
-   annotation class Vod
+  @Retention(AnnotationRetention.RUNTIME)
+  annotation class Vod
 
-   @Vod
-   class Wibble
+  @Vod
+  class Wibble
 
-   init {
+  init {
 
-      "typeOf" should {
-         "test for exact type" {
-            val arrayList: List<Int> = arrayListOf(1, 2, 3)
-            arrayList.shouldBeTypeOf<ArrayList<*>>()
-            arrayList.shouldNotBeTypeOf<List<*>>()
-         }
+    "typeOf" should {
+      "test for exact type" {
+        val arrayList: List<Int> = arrayListOf(1, 2, 3)
+        arrayList.shouldBeTypeOf<ArrayList<*>>()
+        arrayList.shouldNotBeTypeOf<List<*>>()
+      }
+    }
+
+    "haveAnnotation(annotation)" should {
+      "test for the presence of an annotation" {
+        Wibble::class.java should haveAnnotation(Vod::class.java)
+        Wibble::class.java.shouldHaveAnnotation(Vod::class.java)
+      }
+    }
+
+    "beInstanceOf" should {
+      "test that value is assignable to class" {
+        val arrayList: List<Int> = arrayListOf(1, 2, 3)
+
+        arrayList should beInstanceOf(ArrayList::class)
+        arrayList.shouldBeInstanceOf<ArrayList<*>>()
+
+        arrayList should beInstanceOf(List::class)
+
+        shouldThrow<AssertionError> {
+          arrayList should beInstanceOf(LinkedList::class)
+        }
+
+        arrayList.shouldNotBeInstanceOf<LinkedList<*>>()
+
+        shouldThrow<AssertionError> {
+          arrayList.shouldNotBeInstanceOf<ArrayList<*>>()
+        }
       }
 
-      "haveAnnotation(annotation)" should {
-         "test for the presence of an annotation" {
-            Wibble::class.java should haveAnnotation(Vod::class.java)
-            Wibble::class.java.shouldHaveAnnotation(Vod::class.java)
-         }
+      "Allow execution with a lambda" {
+        val list = arrayListOf(1, 2, 3)
+
+        list.shouldBeInstanceOf<ArrayList<Int>> { it: ArrayList<Int> ->
+          it shouldBeSameInstanceAs list
+        }
       }
 
-      "beInstanceOf" should {
-         "test that value is assignable to class" {
-            val arrayList: List<Int> = arrayListOf(1, 2, 3)
+      "Returns typecasted value when invoked with a lambda" {
+        val list = arrayListOf(1, 2, 3)
 
-            arrayList should beInstanceOf(ArrayList::class)
-            arrayList.shouldBeInstanceOf<ArrayList<*>>()
-
-            arrayList should beInstanceOf(List::class)
-
-            shouldThrow<AssertionError> {
-               arrayList should beInstanceOf(LinkedList::class)
-            }
-
-            arrayList.shouldNotBeInstanceOf<LinkedList<*>>()
-
-            shouldThrow<AssertionError> {
-               arrayList.shouldNotBeInstanceOf<ArrayList<*>>()
-            }
-         }
-
-         "Allow execution with a lambda" {
-            val list = arrayListOf(1, 2, 3)
-
-            list.shouldBeInstanceOf<ArrayList<Int>> { it: ArrayList<Int> ->
-               it shouldBeSameInstanceAs list
-            }
-         }
-
-         "Returns typecasted value when invoked with a lambda" {
-            val list = arrayListOf(1, 2, 3)
-
-            val typecastedList = list.shouldBeInstanceOf<ArrayList<Int>> {}
-            typecastedList shouldBeSameInstanceAs list
-         }
-
-         "Returns typecasted value when invoked without arguments" {
-            val list = arrayListOf(1, 2, 3)
-            val typecastedList = list.shouldBeInstanceOf<ArrayList<Int>>()
-
-            typecastedList shouldBeSameInstanceAs list
-         }
-
-         "accepts null values" {
-            val arrayList: List<Int>? = null
-            shouldThrow<AssertionError> { arrayList should beInstanceOf(ArrayList::class) }
-            shouldThrow<AssertionError> { arrayList.shouldBeInstanceOf<ArrayList<*>>() }
-            shouldThrow<AssertionError> { arrayList shouldNot beInstanceOf(List::class) }
-            shouldThrow<AssertionError> { arrayList.shouldNotBeInstanceOf<LinkedList<*>>() }
-         }
+        val typecastedList = list.shouldBeInstanceOf<ArrayList<Int>> {}
+        typecastedList shouldBeSameInstanceAs list
       }
 
-      "beOfType" should {
-         "test that value have exactly the same type" {
-            val arrayList: List<Int> = arrayListOf(1, 2, 3)
+      "Returns typecasted value when invoked without arguments" {
+        val list = arrayListOf(1, 2, 3)
+        val typecastedList = list.shouldBeInstanceOf<ArrayList<Int>>()
 
-            arrayList should beOfType<ArrayList<Int>>()
-
-            shouldThrow<AssertionError> {
-               arrayList should beOfType<LinkedList<Int>>()
-            }
-
-            shouldThrow<AssertionError> {
-               arrayList should beOfType<List<Int>>()
-            }
-         }
-
-         "Allow execution with a lambda" {
-            val list: Any = arrayListOf(1, 2, 3)
-
-            list.shouldBeTypeOf<ArrayList<Int>> { it: ArrayList<Int> ->
-               it shouldBeSameInstanceAs list
-               it[0] shouldBe 1
-            }
-         }
-
-         "Returns typecasted value when executed with a lambda" {
-            val list: Any = arrayListOf(1, 2, 3)
-
-            val typecastedList = list.shouldBeTypeOf<ArrayList<Int>> {}
-            typecastedList shouldBeSameInstanceAs list
-            typecastedList[0] shouldBe 1
-         }
-
-         "Returns typecasted value when executed without argument" {
-            val list: Any = arrayListOf(1, 2, 3)
-
-            val typecastedList = list.shouldBeTypeOf<ArrayList<Int>>()
-            typecastedList shouldBeSameInstanceAs list
-            typecastedList[0] shouldBe 1
-         }
-
-         "accepts null values" {
-            val arrayList: List<Int>? = null
-            shouldThrow<AssertionError> { arrayList should beOfType<List<Int>>() }
-            shouldThrow<AssertionError> { arrayList.shouldBeTypeOf<List<*>>() }
-            shouldThrow<AssertionError> { arrayList shouldNot beOfType<List<Int>>() }
-            shouldThrow<AssertionError> { arrayList.shouldNotBeTypeOf<List<*>>() }
-         }
+        typecastedList shouldBeSameInstanceAs list
       }
 
-      "TypeMatchers.theSameInstanceAs" should {
-         "test that references are equal" {
-            val b: List<Int>? = listOf(1, 2, 3)
-            val a: List<Int>? = b
-            val c: List<Int>? = listOf(1, 2, 3)
+      "accepts null values" {
+        val arrayList: List<Int>? = null
+        shouldThrow<AssertionError> { arrayList should beInstanceOf(ArrayList::class) }
+        shouldThrow<AssertionError> { arrayList.shouldBeInstanceOf<ArrayList<*>>() }
+        shouldThrow<AssertionError> { arrayList shouldNot beInstanceOf(List::class) }
+        shouldThrow<AssertionError> { arrayList.shouldNotBeInstanceOf<LinkedList<*>>() }
+      }
+    }
 
-            a should beTheSameInstanceAs(b)
-            a.shouldBeSameInstanceAs(b)
+    "beOfType" should {
+      "test that value have exactly the same type" {
+        val arrayList: List<Int> = arrayListOf(1, 2, 3)
 
-            shouldThrow<AssertionError> {
-               a should beTheSameInstanceAs(c)
-            }
+        arrayList should beOfType<ArrayList<Int>>()
 
-            shouldThrow<AssertionError> {
-               a.shouldBeSameInstanceAs(c)
-            }
-         }
+        shouldThrow<AssertionError> {
+          arrayList should beOfType<LinkedList<Int>>()
+        }
+
+        shouldThrow<AssertionError> {
+          arrayList should beOfType<List<Int>>()
+        }
       }
 
-      "beTheSameInstanceAs" should {
-         "test that references are equal" {
-            val b = listOf(1, 2, 3)
-            val a = b
-            val c = listOf(1, 2, 3)
+      "Allow execution with a lambda" {
+        val list: Any = arrayListOf(1, 2, 3)
 
-            a should beTheSameInstanceAs(b)
-            shouldThrow<AssertionError> {
-               a should beTheSameInstanceAs(c)
-            }
-         }
+        list.shouldBeTypeOf<ArrayList<Int>> { it: ArrayList<Int> ->
+          it shouldBeSameInstanceAs list
+          it[0] shouldBe 1
+        }
       }
 
-      "beNull" should {
-         val nullString: String? = null
-         val nonNullString: String? = "Foo"
-         "Pass for a null value" {
-            nullString.shouldBeNull()
-            nullString should beNull()
-         }
+      "Returns typecasted value when executed with a lambda" {
+        val list: Any = arrayListOf(1, 2, 3)
 
-         "Fail for a non-null value" {
-            shouldThrow<AssertionError> { nonNullString.shouldBeNull() }
-            shouldThrow<AssertionError> { nonNullString should beNull() }
-         }
+        val typecastedList = list.shouldBeTypeOf<ArrayList<Int>> {}
+        typecastedList shouldBeSameInstanceAs list
+        typecastedList[0] shouldBe 1
       }
 
-      "notBeNull" should {
-         val nullString: String? = null
-         val nonNullString: String? = "Foo"
+      "Returns typecasted value when executed without argument" {
+        val list: Any = arrayListOf(1, 2, 3)
 
-         "Pass for a non-null value" {
-            nonNullString.shouldNotBeNull()
-            nonNullString shouldNot beNull()
-         }
-
-         "Fail for a null value" {
-            shouldThrow<AssertionError> { nullString.shouldNotBeNull() }
-            shouldThrow<AssertionError> { nullString shouldNot beNull() }
-         }
-
-         "Allow automatic type cast" {
-            fun useString(string: String) {}
-
-            nonNullString.shouldNotBeNull()
-            useString(nonNullString)
-            nonNullString shouldBe "Foo"
-         }
+        val typecastedList = list.shouldBeTypeOf<ArrayList<Int>>()
+        typecastedList shouldBeSameInstanceAs list
+        typecastedList[0] shouldBe 1
       }
-   }
+
+      "accepts null values" {
+        val arrayList: List<Int>? = null
+        shouldThrow<AssertionError> { arrayList should beOfType<List<Int>>() }
+        shouldThrow<AssertionError> { arrayList.shouldBeTypeOf<List<*>>() }
+        shouldThrow<AssertionError> { arrayList shouldNot beOfType<List<Int>>() }
+        shouldThrow<AssertionError> { arrayList.shouldNotBeTypeOf<List<*>>() }
+      }
+    }
+
+    "TypeMatchers.theSameInstanceAs" should {
+      "test that references are equal" {
+        val b: List<Int>? = listOf(1, 2, 3)
+        val a: List<Int>? = b
+        val c: List<Int>? = listOf(1, 2, 3)
+
+        a should beTheSameInstanceAs(b)
+        a.shouldBeSameInstanceAs(b)
+
+        shouldThrow<AssertionError> {
+          a should beTheSameInstanceAs(c)
+        }
+
+        shouldThrow<AssertionError> {
+          a.shouldBeSameInstanceAs(c)
+        }
+      }
+    }
+
+    "beTheSameInstanceAs" should {
+      "test that references are equal" {
+        val b = listOf(1, 2, 3)
+        val a = b
+        val c = listOf(1, 2, 3)
+
+        a should beTheSameInstanceAs(b)
+        shouldThrow<AssertionError> {
+          a should beTheSameInstanceAs(c)
+        }
+      }
+    }
+
+    "beNull" should {
+      val nullString: String? = null
+      val nonNullString: String? = "Foo"
+      "Pass for a null value" {
+        nullString.shouldBeNull()
+        nullString should beNull()
+      }
+
+      "Fail for a non-null value" {
+        shouldThrow<AssertionError> { nonNullString.shouldBeNull() }
+        shouldThrow<AssertionError> { nonNullString should beNull() }
+      }
+    }
+
+    "notBeNull" should {
+      val nullString: String? = null
+      val nonNullString: String? = "Foo"
+
+      "Pass for a non-null value" {
+        nonNullString.shouldNotBeNull()
+        nonNullString shouldNot beNull()
+      }
+
+      "Fail for a null value" {
+        shouldThrow<AssertionError> { nullString.shouldNotBeNull() }
+        shouldThrow<AssertionError> { nullString shouldNot beNull() }
+      }
+
+      "Allow automatic type cast" {
+        fun useString(string: String) {}
+
+        nonNullString.shouldNotBeNull()
+        useString(nonNullString)
+        nonNullString shouldBe "Foo"
+      }
+    }
+  }
 
 }


### PR DESCRIPTION
Both methods `shouldBeInstanceOf` and `shouldBeTypeOf` allow to use typecasted instance as argument of lambda.
In case of big nesting such approach leads to code that is hard to read. 

Suppose that we have a Parser:
```
class Parser {
    sealed class ParsingResult {
        class Error(val msg: String) : ParsingResult()
        class Model(val data: Data) : ParsingResult()
    }
    sealed class Data {
        class ValidData(val paylaod: Payload) : Data()
        class InvalidData() : Data()
    }
    sealed class Payload {
        class NumericPayload(val number: Int) : Payload()
        class TextPayload() : Payload()
    }
    fun parse(text: String): ParsingResult { ... }
}
```
Current version of assertions leads us to nesting:
```
    Parser().parse("model with valid data").shouldBeInstanceOf<ParsingResult.Model> {
        it.data.shouldBeInstanceOf<Data.ValidData> {
            it.paylaod.shouldBeInstanceOf<Payload.NumericPayload> {
                it.number.shouldBeLessThan(12)
            }
        }
    }
```
**Suggestion:**
Both method should return typecasted instance
* shouldBeInstanceOf
* shouldBeTypeOf

New version of assertions not required nesting:
```
val parsingResult = Parser().parse("model 12").shouldBeInstanceOf<ParsingResult.Model>()
val validData = parsingResult.data.shouldBeInstanceOf<Data.ValidData>()
val numericPayload = validData.paylaod.shouldBeInstanceOf<Payload.NumericPayload>()
numericPayload.number.shouldNotBeGreaterThan(10)
```
Now user can choose which way is more suitable to use.
This approach also opens another possibility to use `this` instead of `it` inside lambda: 
```
//old way
result.shouldBeInstanceOf<Some>{
  it.oneField.shouldBe(12)
  it.anotherField.shouldBe(42)
}
//new possible approach
result.shouldBeInstanceOf<Some>().apply{
  oneField.shouldBe(12)
  anotherField.shouldBe(42)
}
```
**Possible drawbacks:**
Return type of shouldBeInstanceOf changes from `Unit` to `T`.
This will break such test:
```
@Test
fun test() = Some().shouldBeInstanceOf<Some>()
```
with output error:
```
No tests were found
```
As JUnit expects test method to return void. 
I consider such cases are rare.
And benefit is worth the cost. 

Anyway upgrade from 3.3.x to 3.4.x requires code update from user side. 

Other test cases: 
```
@Test
fun test(){ 
  Some().shouldBeInstanceOf<Some>() 
}
```
will not be broken by this change.

**Alternative scenario:**
Kotlin Contracts was considered here: https://github.com/kotlintest/kotlintest/issues/601
Unforutately, as @sksamuel and @Kerooker  already mentioned earlier, Kotlin Contracts  does not support `is` condition. 
https://youtrack.jetbrains.com/issue/KT-28298

