### PR TITLE
[#1060] Added matcher for Iterator

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -29,6 +29,10 @@ For the extension function style, each function has an equivalent negated versio
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
 | `obj.shouldBeNull()` | Asserts that a given reference is null.|
 
+| Iterables ||
+| ------- | ---- |
+| `iterable.shouldBeEmpty()` | Asserts that the iterable's iterator does not have a next value. 
+
 | Maps ||
 | -------- | ---- |
 | `map.shouldContain("key", "value")` | Asserts that the map contains the mapping "key" to "value" |

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -3,6 +3,8 @@ package io.kotest.matchers.collections
 import io.kotest.Matcher
 import io.kotest.MatcherResult
 import io.kotest.assertions.stringRepr
+import io.kotest.matchers.iterator.shouldBeEmpty
+import io.kotest.matchers.iterator.shouldNotBeEmpty
 import io.kotest.neverNullMatcher
 import io.kotest.should
 import io.kotest.shouldHave

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/iterator/IteratorMatchers.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/iterator/IteratorMatchers.kt
@@ -1,0 +1,19 @@
+package io.kotest.matchers.iterator
+
+import io.kotest.Matcher
+import io.kotest.MatcherResult
+import io.kotest.assertions.stringRepr
+import io.kotest.should
+import io.kotest.shouldNot
+
+fun <T> Iterator<T>.shouldBeEmpty() = this should beEmpty()
+fun <T> Iterator<T>.shouldNotBeEmpty() = this shouldNot beEmpty()
+fun <T> beEmpty(): Matcher<Iterator<T>> = object : Matcher<Iterator<T>> {
+   override fun test(value: Iterator<T>): MatcherResult {
+      return MatcherResult(
+         !value.hasNext(),
+         "Iterable should be empty but next value is ${stringRepr(value.next())}",
+         "Iterable should not be empty"
+      )
+   }
+}

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/iterator/IteratorMatchers.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/iterator/IteratorMatchers.kt
@@ -12,8 +12,8 @@ fun <T> beEmpty(): Matcher<Iterator<T>> = object : Matcher<Iterator<T>> {
    override fun test(value: Iterator<T>): MatcherResult {
       return MatcherResult(
          !value.hasNext(),
-         "Iterable should be empty but next value is ${stringRepr(value.next())}",
-         "Iterable should not be empty"
+         "Iterator should be empty but still has values",
+         "Iterator should not be empty"
       )
    }
 }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/iterator/IteratorMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/iterator/IteratorMatchersTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.kotest.matchers.iterator
+
+import io.kotest.matchers.iterator.shouldBeEmpty
+import io.kotest.matchers.iterator.shouldNotBeEmpty
+import io.kotest.specs.WordSpec
+
+class IteratorMatchersTest: WordSpec() {
+
+   init {
+
+      "shouldBeEmpty" should {
+         "return true when the iterator does not have a next element" {
+            val emptyIterator =  object : Iterator<Int> {
+               override fun hasNext(): Boolean {
+                  return false
+               }
+
+               override fun next(): Int {
+                  return 0
+               }
+
+            }
+
+            emptyIterator.shouldBeEmpty()
+         }
+
+         "return false when the iterator has a next element" {
+            val nonEmptyIterator =  object : Iterator<Int> {
+               override fun hasNext(): Boolean {
+                  return true
+               }
+
+               override fun next(): Int {
+                  return 0
+               }
+
+            }
+
+            nonEmptyIterator.shouldNotBeEmpty()
+         }
+      }
+
+   }
+
+}

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/iterator/IteratorMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/iterator/IteratorMatchersTest.kt
@@ -10,33 +10,11 @@ class IteratorMatchersTest: WordSpec() {
 
       "shouldBeEmpty" should {
          "return true when the iterator does not have a next element" {
-            val emptyIterator =  object : Iterator<Int> {
-               override fun hasNext(): Boolean {
-                  return false
-               }
-
-               override fun next(): Int {
-                  return 0
-               }
-
-            }
-
-            emptyIterator.shouldBeEmpty()
+            emptyList<Int>().iterator().shouldBeEmpty()
          }
 
          "return false when the iterator has a next element" {
-            val nonEmptyIterator =  object : Iterator<Int> {
-               override fun hasNext(): Boolean {
-                  return true
-               }
-
-               override fun next(): Int {
-                  return 0
-               }
-
-            }
-
-            nonEmptyIterator.shouldNotBeEmpty()
+            listOf(1).iterator().shouldNotBeEmpty()
          }
       }
 


### PR DESCRIPTION
Closes #1060 

Added a matcher for Iterator that checks value of `hasNext()` to determine if the iterator is empty or not.