### PR TITLE
Remove unused reference

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/Gen.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/Gen.kt
@@ -1,7 +1,6 @@
 package io.kotest.properties
 
 import io.kotest.properties.shrinking.Shrinker
-import kotlinx.coroutines.yield
 
 /**
  * A Generator, or [Gen] is responsible for generating data


### PR DESCRIPTION
I tried to build the project locally, this is the error I received:

```
% ./gradlew build

> Configure project :
Kotlin Multiplatform Projects are an experimental feature.

The Kotlin source set commonTest was configured but not added to any Kotlin compilation. You can add a source set to a target's compilation by connecting it with the compilation's default source set using 'dependsOn'.
See https://kotlinlang.org/docs/reference/building-mpp-with-gradle.html#connecting-source-sets

> Task :kotest-assertions:compileKotlinJs FAILED
e: /src/kotlintest/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/Gen.kt: (4, 8): Unresolved reference: kotlinx

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':kotest-assertions:compileKotlinJs'.
> Compilation error. See log for more details

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 4s
76 actionable tasks: 1 executed, 75 up-to-date
```

Local env:
```
% sdk current java

Using java version 11.0.4.hs-adpt
```
It does not fail on Travis, the error might be in my setup, but I recall being able to build this locally before.
