### PR TITLE
Add documentation to Pitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ This page gives you just a short overview of KotlinTest. There are many more fea
 * Handle tricky scenarios such as System Environment with [extensions](doc/extensions.md)
 * Use the [Spring extension](doc/extensions.md#Spring) to automatically inject your spring test classes.
 * Test [Arrow](doc/extensions.md#Arrow) data types with the Arrow extension.
+* Make use of custom plugins for integrations with tools such as [Pitest](doc/plugins.md#Pitest)
 
 See [full documentation](doc/reference.md).
 

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -1,0 +1,29 @@
+## KotlinTest Plugins
+
+Sometimes there's a need for special integration with some tools. These integrations are available at the `kotlintest-plugins` modules and they can be whatever it's necessary to integrate with a specific tool.
+
+Sometimes this is available with less complex integrations, such as using [Listeners](reference.md#listeners) or [Extensions](reference.md#extensions), but in some cases this isn't possible, and thus plugins are necessary.
+
+
+### Pitest
+
+The Mutation Testing tool [Pitest](https://pitest.org/) is integrated via plugin with KotlinTest. After [configuring](https://gradle-pitest-plugin.solidsoft.info/) the Pitest extension, add the KotlinTest Plugin dependency to your dependencies as well:
+
+```kotlin
+    testImplementation("io.kotlintet:kotlintest-plugins-pitest:{kotlintestVersion}")
+```
+
+After doing that, tell Pitest that we're going to use the `KotlinTest` as a `testPlugin`:
+
+```kotlin
+// Assuming that you have already configured the Gradle/Maven extension
+configure<PitestPluginExtension> {
+
+    testPlugin.set("KotlinTest")    // <-- Telling Pitest that we're using KotlinTest
+    
+    
+    targetClasses.set(listOf("my.company.package.*"))
+}
+```
+
+This should set everything up, and running `./gradlew pitest` will generate reports in the way you configured.

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -979,3 +979,13 @@ Some others provides helpers to tricky System Testing situations, such as `Syste
 We also provide a `Locale Extension`, for locale-dependent code, and `Timezone Extension` for timezone-dependent code.
 
 Take a better look at all the extensions available in the [extensions-reference](extensions.md)
+
+
+Plugins
+----------
+
+Sometimes it's not enough to use Extensions or Listeners to integrat with external systems or tools, and for this we use custom Plugins, available at `kotlintest-plugins` module.
+
+Integrations such as `Pitest` require a more complex solution, and thus the plugins module was necessary.
+
+For more information on plugins, take a look at the [plugins reference](plugins.md)


### PR DESCRIPTION
Note: Although at this point in time we're changing names to Kotest, this still refers to old code and thus the KotlinTest name was kept.
When we switch to Kotest we'll need to change all documentation to Kotest as well.

Closes #1072