### PR TITLE
Implement Gen.string() with Gen.char() - Closes #1078

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -14,7 +14,7 @@ import kotlin.random.nextInt
 import kotlin.random.nextLong
 
 /**
- * Returns a stream of values where each value is a random string base.
+ * Returns a stream of values where each value is a random string.
  *
  */
 @JvmOverloads

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -14,31 +14,21 @@ import kotlin.random.nextInt
 import kotlin.random.nextLong
 
 /**
- * Returns a stream of values where each value is a random
- * printed string.
+ * Returns a stream of values where each value is a random string base.
  *
- * The constant values are:
- * The empty string
- * A line separator
- * Multi-line string
- * a UTF8 string.
  */
 @JvmOverloads
-fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100): Gen<String> = object : Gen<String> {
+fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100, genChar: Gen<Char> = Gen.char()): Gen<String> = object : Gen<String> {
    init {
       require(minSize >= 0) { "minSize must be >= 0" }
       require(maxSize >= minSize) { "maxSize must be >= minSize"}
    }
-   private val genChar = Gen.char(CharSets.PRINTABLE_BASIC_LATIN)
+   private val padChar = genChar.take(1).first()
    private val genInt =
       if (minSize == maxSize) Gen.constant(minSize)
       else Gen.choose(minSize, maxSize)
-   private val literals = listOf("",
-      "\n",
-      "\nabc\n123\n",
-      "\u006c\u0069b/\u0062\u002f\u006d\u0069nd/m\u0061x\u002e\u0070h\u0070")
 
-   override fun constants(): Iterable<String> = literals.filter { it.length in minSize..maxSize }
+   override fun constants(): Iterable<String> = emptyList()
    override fun random(seed: Long?): Sequence<String> {
       return generateSequence {
          val size = genInt.next(seed = seed)
@@ -46,7 +36,7 @@ fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100): Gen<String> = ob
          chars.joinToString(separator = "")
       }
    }
-   override fun shrinker(): Shrinker<String>? = StringShrinker
+   override fun shrinker(): Shrinker<String>? = StringShrinker(minSize, padChar)
 }
 
 /**

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -249,8 +249,7 @@ fun Gen.Companion.bool(): Gen<Boolean> = object : Gen<Boolean> {
    }
 }
 
-private object
-CharSets {
+private object CharSets {
   val CONTROL     = listOf('\u0000'..'\u001F', '\u007F'..'\u007F')
   val WHITESPACE  = listOf('\u0020'..'\u0020', '\u0009'..'\u0009', '\u000A'..'\u000A')
   val PRINTABLE_BASIC_LATIN = listOf('\u0021'..'\u007E')

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -18,11 +18,16 @@ import kotlin.random.nextLong
  *
  */
 @JvmOverloads
-fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100, genChar: Gen<Char> = Gen.char()): Gen<String> = object : Gen<String> {
+fun Gen.Companion.string(
+   minSize: Int = 0,
+   maxSize: Int = 100,
+   genChar: Gen<Char> = Gen.char()
+): Gen<String> = object : Gen<String> {
    init {
       require(minSize >= 0) { "minSize must be >= 0" }
-      require(maxSize >= minSize) { "maxSize must be >= minSize"}
+      require(maxSize >= minSize) { "maxSize must be >= minSize" }
    }
+
    private val padChar = genChar.take(1).first()
    private val genInt =
       if (minSize == maxSize) Gen.constant(minSize)
@@ -36,6 +41,7 @@ fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100, genChar: Gen<Char
          chars.joinToString(separator = "")
       }
    }
+
    override fun shrinker(): Shrinker<String>? = StringShrinker(minSize, padChar)
 }
 

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/shrinking/StringShrinker.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/shrinking/StringShrinker.kt
@@ -1,14 +1,22 @@
 package io.kotest.properties.shrinking
 
-object StringShrinker : Shrinker<String> {
-  override fun shrink(failure: String): List<String> = when (failure.length) {
-    0 -> emptyList()
-    1 -> listOf("", "a")
-    else -> {
-      val first = failure.take(failure.length / 2 + failure.length % 2)
-      val second = failure.takeLast(failure.length / 2)
-      // always include empty string as the best io.kotest.properties.shrinking.shrink
-     listOf("", first, first.padEnd(failure.length, 'a'), second, second.padStart(failure.length, 'a'))
-    }
-  }
+class StringShrinker(private val minSize: Int, private val padChar: Char) : Shrinker<String> {
+
+   init {
+      require(minSize >= 0) { "minSize must be >= 0" }
+   }
+
+   override fun shrink(failure: String): List<String> {
+      return if (failure.length <= minSize) {
+         emptyList()
+      } else {
+         val overLen  = failure.length - minSize
+         val over     = failure.takeLast(overLen)
+         val left     = over.take(overLen / 2 + overLen % 2)
+         val right    = over.takeLast(overLen / 2)
+         val minFail  = failure.take(minSize)
+         val l = listOf("", left, left.padEnd(overLen, padChar), right, right.padStart(overLen, padChar))
+         generateSequence { minFail }.asIterable().zip(l) { a, b -> a + b }
+      }
+   }
 }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/ExtensionAssertAllTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/ExtensionAssertAllTest.kt
@@ -1,8 +1,9 @@
 package com.sksamuel.kotest.properties
 
-import io.kotest.matchers.comparables.lt
+import io.kotest.matchers.comparables.gt
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldHaveSameLengthAs
+import io.kotest.matchers.string.shouldMatch
 import io.kotest.properties.assertAll
 import io.kotest.shouldBe
 import io.kotest.shouldThrow
@@ -22,12 +23,14 @@ class ExtensionAssertAllTest : StringSpec({
   "KFunction1 should report errors" {
     shouldThrow<AssertionError> {
       ::reverse.assertAll { input, _ ->
-        input.shouldHaveSameLengthAs("qwqew")
+        input.shouldHaveSameLengthAs(input + input)
       }
-    }.message shouldBe "Property failed for\n" +
-        "Arg 0: <empty string>\n" +
-        "after 1 attempts\n" +
-        "Caused by: <empty string> should have the same length as qwqew"
+    }.message!!.split("\n").run {
+      this[0] shouldMatch "Property failed for"
+      this[1] shouldMatch "Arg 0: . \\(shrunk from .*\\)"
+      this[2] shouldMatch "after 1 attempts"
+      this[3] shouldMatch "Caused by: \\S+ should have the same length as \\S+"
+    }
   }
 
   "concat should have consistent lengths" {
@@ -38,15 +41,14 @@ class ExtensionAssertAllTest : StringSpec({
   "KFunction2 should report errors" {
     shouldThrow<AssertionError> {
       ::concat.assertAll { _, _, output ->
-        output.length shouldBe lt(5)
+        output.length shouldBe gt(output.length + 5)
       }
-    }.message shouldBe "Property failed for\n" +
-        "Arg 0: <empty string>\n" +
-        "Arg 1: aaaaa (shrunk from \n" +
-        "abc\n" +
-        "123\n" +
-        ")\n" +
-        "after 3 attempts\n" +
-        "Caused by: 9 should be < 5"
+    }.message!!.split("\n").run {
+      this[0] shouldMatch "Property failed for"
+      this[1] shouldMatch "Arg 0: <empty string>.*"
+      this[2] shouldMatch "Arg 1: <empty string>.*"
+      this[3] shouldMatch "after \\d+ attempts"
+      this[4] shouldMatch "Caused by: \\d+ should be > \\d+"
+    }
   }
 })

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
@@ -9,9 +9,11 @@ import io.kotest.matchers.string.shouldHaveMinLength
 import io.kotest.properties.Gen
 import io.kotest.properties.assertAll
 import io.kotest.properties.char
+import io.kotest.properties.choose
 import io.kotest.properties.string
 import io.kotest.properties.take
 import io.kotest.shouldBe
+import io.kotest.shouldThrow
 import io.kotest.specs.FunSpec
 import io.kotest.tables.row
 
@@ -25,6 +27,18 @@ class GenStringTest : FunSpec({
       val strings2 = testGenString.take(500, testSeed).toList()
 
       strings1 shouldBe strings2
+   }
+
+   test("should not allow min size < 0") {
+      assertAll(Gen.choose(-10, -1)) { min ->
+         shouldThrow<IllegalArgumentException> { Gen.string(min) }
+      }
+   }
+
+   test("should not allow max size < min size") {
+      assertAll(Gen.choose(20, 100)) { max ->
+         shouldThrow<IllegalArgumentException> { Gen.string(200, max) }
+      }
    }
 
    test("should honour min size") {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
@@ -13,6 +13,7 @@ import io.kotest.properties.choose
 import io.kotest.properties.string
 import io.kotest.properties.take
 import io.kotest.shouldBe
+import io.kotest.shouldNotThrow
 import io.kotest.shouldThrow
 import io.kotest.specs.FunSpec
 import io.kotest.tables.row
@@ -39,6 +40,10 @@ class GenStringTest : FunSpec({
       assertAll(Gen.choose(20, 100)) { max ->
          shouldThrow<IllegalArgumentException> { Gen.string(200, max) }
       }
+   }
+
+   test("should allow max size == min size") {
+      shouldNotThrow<Exception> { Gen.string(10, 10) }
    }
 
    test("should honour min size") {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
@@ -1,12 +1,17 @@
 package com.sksamuel.kotest.properties
 
+import io.kotest.data.forall
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldHaveMaxLength
 import io.kotest.matchers.string.shouldHaveMinLength
 import io.kotest.properties.Gen
 import io.kotest.properties.assertAll
+import io.kotest.properties.char
 import io.kotest.properties.string
 import io.kotest.specs.FunSpec
+import io.kotest.tables.row
 
 class GenStringTest : FunSpec({
 
@@ -29,5 +34,27 @@ class GenStringTest : FunSpec({
          it.shouldHaveMaxLength(3)
       }
       assertAll(Gen.string(minSize = 1, maxSize = 1)) { it.shouldHaveLength(1) }
+   }
+
+   test("should produce non-whitespace ASCII characters when no Gen<Char> provided") {
+      assertAll(10000, Gen.string(minSize = 1, maxSize = 100)) { string ->
+         string.forEach { char -> char.toInt() shouldBeInRange (33..126) }
+      }
+   }
+
+   test("should produce only characters from provided Gen<Char>") {
+      val cyrillicRange = '\u0400'..'\u04FF'
+      val thaiRange     = '\u0E01'..'\u0E2F'
+      val runicRange    = '\u16A0'..'\u16F0'
+      forall(
+         row(cyrillicRange),
+         row(thaiRange),
+         row(runicRange)
+      ) { charRange ->
+         val genString = Gen.string(minSize = 1, maxSize = 100, genChar = Gen.char(charRange))
+         assertAll(500, genString) { string ->
+            string.forEach { char -> (char in charRange).shouldBeTrue() }
+         }
+      }
    }
 })

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
@@ -8,7 +8,7 @@ import io.kotest.properties.assertAll
 import io.kotest.properties.string
 import io.kotest.specs.FunSpec
 
-class StringGenTest : FunSpec({
+class GenStringTest : FunSpec({
 
    test("should honour min size") {
       assertAll(Gen.string(minSize = 10)) { it.shouldHaveMinLength(10) }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/GenStringTest.kt
@@ -10,10 +10,22 @@ import io.kotest.properties.Gen
 import io.kotest.properties.assertAll
 import io.kotest.properties.char
 import io.kotest.properties.string
+import io.kotest.properties.take
+import io.kotest.shouldBe
 import io.kotest.specs.FunSpec
 import io.kotest.tables.row
 
 class GenStringTest : FunSpec({
+
+   test("should honour seed") {
+      val testSeed = 909789123L
+      val testGenString = Gen.string()
+
+      val strings1 = testGenString.take(500, testSeed).toList()
+      val strings2 = testGenString.take(500, testSeed).toList()
+
+      strings1 shouldBe strings2
+   }
 
    test("should honour min size") {
       assertAll(Gen.string(minSize = 10)) { it.shouldHaveMinLength(10) }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyAssertAllTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyAssertAllTest.kt
@@ -444,7 +444,7 @@ class PropertyAssertAllTest : StringSpec({
 
   "assertAll: six implicit arguments 27000 attempts" {
     var attempts = 0
-    assertAll(1000) { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
+    assertAll(27000) { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
       attempts++
     }
     attempts shouldBe 27000

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyAssertAllTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyAssertAllTest.kt
@@ -455,7 +455,7 @@ class PropertyAssertAllTest : StringSpec({
     assertAll { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
       attempts++
     }
-    attempts shouldBe 3888
+    attempts shouldBe 1000
   }
 
   "sets" {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForAllTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForAllTest.kt
@@ -429,7 +429,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 3888
+      attempts shouldBe 1000
     }
 
     "sets" {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForNoneTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForNoneTest.kt
@@ -413,7 +413,7 @@ class PropertyForNoneTest : StringSpec() {
         attempts++
         false
       }
-      attempts shouldBe 3600
+      attempts shouldBe 1000
     }
 
     "forNone: five explicit generators 4600 attempts" {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/shrinking/ShrinkTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/shrinking/ShrinkTest.kt
@@ -3,7 +3,9 @@ package com.sksamuel.kotest.properties.shrinking
 import io.kotest.matchers.comparables.lte
 import io.kotest.matchers.doubles.lt
 import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldHaveLength
+import io.kotest.matchers.string.shouldMatch
 import io.kotest.properties.Gen
 import io.kotest.properties.PropertyTesting
 import io.kotest.properties.assertAll
@@ -34,25 +36,26 @@ class ShrinkTest : StringSpec({
          assertAll(Gen.int()) {
             it.shouldBeLessThan(5)
          }
-      }.message shouldBe "Property failed for\n" +
-         "Arg 0: 5 (shrunk from 2147483647)\n" +
-         "after 2 attempts\n" +
-         "Caused by: 2147483647 should be < 5"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: 5 (shrunk from 2147483647)"
+         lines[2] shouldBe "after 2 attempts"
+         lines[3] shouldBe "Caused by: 2147483647 should be < 5"
+      }
    }
 
    "should shrink arity 2 strings" {
       shouldThrowAny {
-         assertAll(Gen.string(), Gen.string()) { a, b ->
+         assertAll(Gen.string(4), Gen.string(4)) { a, b ->
             (a.length + b.length).shouldBeLessThan(4)
          }
-      }.message shouldBe "Property failed for\n" +
-         "Arg 0: <empty string>\n" +
-         "Arg 1: aaaaa (shrunk from \n" +
-         "abc\n" +
-         "123\n" +
-         ")\n" +
-         "after 3 attempts\n" +
-         "Caused by: 9 should be < 4"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldMatch "Property failed for"
+         lines[1] shouldMatch "Arg 0: \\S+ \\(shrunk from \\S+\\)"
+         lines[2] shouldMatch "Arg 1: \\S+ \\(shrunk from \\S+\\)"
+         lines[3] shouldMatch "after \\d+ attempts"
+         lines[4] shouldMatch "Caused by: \\d+ should be < 4"
+      }
    }
 
    "should shrink arity 3 positiveIntegers" {
@@ -60,7 +63,14 @@ class ShrinkTest : StringSpec({
          assertAll(Gen.positiveIntegers(), Gen.positiveIntegers(), Gen.positiveIntegers()) { a, b, c ->
             a.toLong() + b.toLong() + c.toLong() shouldBe 4L
          }
-      }.message shouldBe "Property failed for\nArg 0: 1 (shrunk from 2147483647)\nArg 1: 1 (shrunk from 2147483647)\nArg 2: 1 (shrunk from 2147483647)\nafter 1 attempts\nCaused by: expected: 4L but was: 6442450941L"
+      }.message!!.split("\n").also { lines->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: 1 (shrunk from 2147483647)"
+         lines[2] shouldBe "Arg 1: 1 (shrunk from 2147483647)"
+         lines[3] shouldBe "Arg 2: 1 (shrunk from 2147483647)"
+         lines[4] shouldBe "after 1 attempts"
+         lines[5] shouldBe "Caused by: expected: 4L but was: 6442450941L"
+      }
    }
 
    "should shrink arity 4 negativeIntegers" {
@@ -71,7 +81,15 @@ class ShrinkTest : StringSpec({
             Gen.negativeIntegers()) { a, b, c, d ->
             a + b + c + d shouldBe 4
          }
-      }.message shouldBe "Property failed for\nArg 0: -1 (shrunk from -2147483648)\nArg 1: -1 (shrunk from -2147483648)\nArg 2: -1 (shrunk from -2147483648)\nArg 3: -1 (shrunk from -2147483648)\nafter 1 attempts\nCaused by: expected: 4 but was: 0"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: -1 (shrunk from -2147483648)"
+         lines[2] shouldBe "Arg 1: -1 (shrunk from -2147483648)"
+         lines[3] shouldBe "Arg 2: -1 (shrunk from -2147483648)"
+         lines[4] shouldBe "Arg 3: -1 (shrunk from -2147483648)"
+         lines[5] shouldBe "after 1 attempts"
+         lines[6] shouldBe "Caused by: expected: 4 but was: 0"
+      }
    }
 
    "should shrink arity 1 doubles" {
@@ -79,7 +97,12 @@ class ShrinkTest : StringSpec({
          assertAll(Gen.double()) { a ->
             a shouldBe lt(3.0)
          }
-      }.message shouldBe "Property failed for\nArg 0: 3.0 (shrunk from 1.0E300)\nafter 4 attempts\nCaused by: 1.0E300 should be < 3.0"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: 3.0 (shrunk from 1.0E300)"
+         lines[2] shouldBe "after 4 attempts"
+         lines[3] shouldBe "Caused by: 1.0E300 should be < 3.0"
+      }
    }
 
    "should shrink Gen.choose" {
@@ -91,32 +114,47 @@ class ShrinkTest : StringSpec({
          }) { a ->
             a shouldBe lte(10)
          }
-      }.message shouldBe "Property failed for\nArg 0: 11 (shrunk from 14)\nafter 1 attempts\nCaused by: 14 should be <= 10"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: 11 (shrunk from 14)"
+         lines[2] shouldBe "after 1 attempts"
+         lines[3] shouldBe "Caused by: 14 should be <= 10"
+      }
    }
 
    "should shrink strings to empty string" {
       val gen = object : Gen<String> {
          override fun random(seed: Long?): Sequence<String> = generateSequence { "asjfiojoqiwehuoahsuidhqweqwe" }
          override fun constants(): Iterable<String> = emptyList()
-         override fun shrinker(): Shrinker<String>? = StringShrinker
+         override fun shrinker(): Shrinker<String>? = StringShrinker(0, 'a')
       }
       shouldThrowAny {
          assertAll(gen) { a ->
             a.shouldHaveLength(10)
          }
-      }.message shouldBe "Property failed for\nArg 0: <empty string> (shrunk from asjfiojoqiwehuoahsuidhqweqwe)\nafter 1 attempts\nCaused by: asjfiojoqiwehuoahsuidhqweqwe should have length 10, but instead was 28"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: <empty string> (shrunk from asjfiojoqiwehuoahsuidhqweqwe)"
+         lines[2] shouldBe "after 1 attempts"
+         lines[3] shouldBe "Caused by: asjfiojoqiwehuoahsuidhqweqwe should have length 10, but instead was 28"
+      }
    }
 
    "should shrink strings to min failing size" {
       val gen = object : Gen<String> {
          override fun random(seed: Long?): Sequence<String> = generateSequence { "asjfiojoqiwehuoahsuidhqweqwe" }
          override fun constants(): Iterable<String> = emptyList()
-         override fun shrinker(): Shrinker<String>? = StringShrinker
+         override fun shrinker(): Shrinker<String>? = StringShrinker(0, 'a')
       }
       shouldThrowAny {
          assertAll(gen) { a ->
             a.padEnd(10, '*').shouldHaveLength(10)
          }
-      }.message shouldBe "Property failed for\nArg 0: aaaaaaaaaaaaaa (shrunk from asjfiojoqiwehuoahsuidhqweqwe)\nafter 1 attempts\nCaused by: asjfiojoqiwehuoahsuidhqweqwe should have length 10, but instead was 28"
+      }.message!!.split("\n").also { lines ->
+         lines[0] shouldBe "Property failed for"
+         lines[1] shouldBe "Arg 0: aaaaaaaaaaaaaa (shrunk from asjfiojoqiwehuoahsuidhqweqwe)"
+         lines[2] shouldBe "after 1 attempts"
+         lines[3] shouldBe "Caused by: asjfiojoqiwehuoahsuidhqweqwe should have length 10, but instead was 28"
+      }
    }
 })

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/shrinking/StringShrinkerTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/shrinking/StringShrinkerTest.kt
@@ -3,15 +3,17 @@ package com.sksamuel.kotest.properties.shrinking
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldHaveLength
-import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.properties.Gen
 import io.kotest.properties.PropertyTesting
 import io.kotest.properties.assertAll
+import io.kotest.properties.char
+import io.kotest.properties.choose
 import io.kotest.properties.shrinking.StringShrinker
 import io.kotest.properties.shrinking.shrink
 import io.kotest.properties.string
 import io.kotest.shouldBe
+import io.kotest.shouldThrow
 import io.kotest.specs.StringSpec
 
 class StringShrinkerTest : StringSpec({
@@ -24,46 +26,70 @@ class StringShrinkerTest : StringSpec({
       PropertyTesting.shouldPrintShrinkSteps = true
    }
 
-  "StringShrinker should include empty string as the first candidate" {
-    assertAll { a: String ->
-      if (a.isNotEmpty())
-        StringShrinker.shrink(a)[0].shouldHaveLength(0)
-    }
-  }
-
-  "StringShrinker should bisect input as 2nd and 4th candidate" {
-    assertAll { a: String ->
-      if (a.length > 1) {
-        val candidates = StringShrinker.shrink(a)
-        candidates[1].shouldHaveLength(a.length / 2 + a.length % 2)
-        candidates[3].shouldHaveLength(a.length / 2)
+   "StringShrinker should not allow minimum size < 0" {
+      assertAll(Gen.choose(-10, -1)) { minSize ->
+         shouldThrow<IllegalArgumentException> { StringShrinker(minSize, 'a') }
       }
-    }
-  }
+   }
 
-  "StringShrinker should include 2 padded 'a's as the 3rd to 5th candidates" {
-    assertAll { a: String ->
-      if (a.length > 1) {
-        val candidates = StringShrinker.shrink(a)
-        candidates[2].shouldEndWith("a".repeat(a.length / 2))
-        candidates[4].shouldStartWith("a".repeat(a.length / 2))
+   "StringShrinker should shrink to minimum size when > 0" {
+      StringShrinker(3, '~').shrink("abcdef") shouldBe listOf(
+         "abc", "abcde", "abcde~", "abcf", "abc~~f"
+      )
+   }
+
+   "StringShrinker should shrink to minimum size when is 0" {
+      StringShrinker(0, '~').shrink("abcdef") shouldBe listOf(
+         "", "abc", "abc~~~", "def", "~~~def"
+      )
+   }
+
+   "StringShrinker should shrink to zero when minimum Size is zero" {
+      StringShrinker(3, '~').shrink("abcdef") shouldBe listOf(
+         "abc", "abcde", "abcde~", "abcf", "abc~~f"
+      )
+   }
+
+   "StringShrinker should include empty string as the first candidate when minSize is 0" {
+      assertAll(Gen.string(1)) { a: String ->
+         StringShrinker(0, 'a').shrink(a)[0].shouldHaveLength(0)
       }
-    }
-  }
+   }
 
-  "StringShrinker should io.kotest.properties.shrinking.shrink to expected value" {
-    assertAll { it: String ->
-      val shrunk = shrink(it, Gen.string()) { it.shouldNotContain("#") }
-      if (it.contains("#")) {
-        shrunk shouldBe "#"
-      } else {
-        shrunk shouldBe it
+   "StringShrinker should bisect input as 2nd and 4th candidate" {
+      assertAll(Gen.string(2)) { a: String ->
+         StringShrinker(0, 'a').shrink(a).also { candidates ->
+            candidates[1].shouldHaveLength(a.length / 2 + a.length % 2)
+            candidates[3].shouldHaveLength(a.length / 2)
+         }
       }
-    }
-  }
+   }
 
-  "StringShrinker should prefer padded values" {
-    shrink("97asd!@#ASD'''234)*safmasd", Gen.string()) { it.length.shouldBeLessThan(13) } shouldBe "aaaaaaaaaaaaa"
-    shrink("97a", Gen.string()) { it.length.shouldBeLessThan(13) } shouldBe "97a"
-  }
+   "StringShrinker should include 2 padded 'a's as the 3rd to 5th candidates" {
+      assertAll(Gen.string(2)) { a: String ->
+         StringShrinker(0, 'a').shrink(a).also { candidates ->
+            candidates[2].shouldEndWith("a".repeat(a.length / 2))
+            candidates[4].shouldStartWith("a".repeat(a.length / 2))
+         }
+      }
+   }
+
+   "StringShrinker should io.kotest.properties.shrinking.shrink to expected value" {
+      assertAll(Gen.string(minSize = 3, genChar = Gen.char('a'..'z'))) { s: String ->
+         shrink(s, StringShrinker(0, 'a')) { testValue ->
+            testValue.length shouldBe 0
+         }.also { shrunk ->
+            shrunk shouldBe "a"
+         }
+      }
+   }
+
+   "StringShrinker should prefer padded values" {
+      shrink("97asd!@#ASD'''234)*safmasd", StringShrinker(0, 'a')) {
+         it.length.shouldBeLessThan(13)
+      } shouldBe "aaaaaaaaaaaaa"
+      shrink("97a", StringShrinker(0, 'a')) {
+         it.length.shouldBeLessThan(13)
+      } shouldBe "97a"
+   }
 })

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/shrinking/StringShrinkerTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/shrinking/StringShrinkerTest.kt
@@ -44,12 +44,6 @@ class StringShrinkerTest : StringSpec({
       )
    }
 
-   "StringShrinker should shrink to zero when minimum Size is zero" {
-      StringShrinker(3, '~').shrink("abcdef") shouldBe listOf(
-         "abc", "abcde", "abcde~", "abcf", "abc~~f"
-      )
-   }
-
    "StringShrinker should include empty string as the first candidate when minSize is 0" {
       assertAll(Gen.string(1)) { a: String ->
          StringShrinker(0, 'a').shrink(a)[0].shouldHaveLength(0)


### PR DESCRIPTION
Implement `Gen.string()` using `Gen.char()`.

- Rewrote `Gen.string()` completely
- `StringShrinker` also had to be rewritten  to obey `minSize`
- Rewriting these broke a lot of tests that were expecting certain output
- Refactored / organized tests as fixes were done

