### PR TITLE
Improve and document ComparableMatchers

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/comparables/ComparableMatchers.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/comparables/ComparableMatchers.kt
@@ -2,31 +2,176 @@ package io.kotest.matchers.comparables
 
 import io.kotest.Matcher
 import io.kotest.MatcherResult
+import io.kotest.should
+import io.kotest.shouldBe
+import io.kotest.shouldNot
+import io.kotest.shouldNotBe
 
+/**
+ * Verifies that this is less than [other]
+ *
+ * Opposite of [shouldNotBeLessThan]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is less than [other] (compareTo returns < 0).
+ *
+ * @see [shouldNotBeLessThan]
+ * @see [shouldBeLessThanOrEqualTo]
+ */
+infix fun <T : Comparable<T>> T.shouldBeLessThan(other: T) = this shouldBe lt(other)
+
+/**
+ * Verifies that this is NOT less than [other]
+ *
+ * Opposite of [shouldBeLessThan]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is not less than [other] (compareTo doesn't return < 0).
+ *
+ * @see [shouldBeLessThan]
+ * @see [shouldNotBeLessThanOrEqualTo]
+ */
+infix fun <T : Comparable<T>> T.shouldNotBeLessThan(other: T) = this shouldNotBe lt(other)
 fun <T : Comparable<T>> lt(x: T) = beLessThan(x)
 fun <T : Comparable<T>> beLessThan(x: T) = object : Matcher<Comparable<T>> {
   override fun test(value: Comparable<T>) = MatcherResult(value < x, "$value should be < $x", "$value should not be < $x")
 }
 
+/**
+ * Verifies that this is less than or equal[other]
+ *
+ * Opposite of [shouldNotBeLessThanOrEqualTo]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is less than or equal to [other] (compareTo returns <= 0).
+ *
+ * @see [shouldNotBeLessThanOrEqualTo]
+ * @see [shouldBeLessThan]
+ */
+infix fun <T : Comparable<T>> T.shouldBeLessThanOrEqualTo(other: T) = this shouldBe lte(other)
+/**
+ * Verifies that this is NOT less than nor equal to [other]
+ *
+ * Opposite of [shouldBeLessThanOrEqualTo]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is not less than nor equal to [other] (compareTo doesn't return <= 0).
+ *
+ * @see [shouldBeLessThanOrEqualTo]
+ * @see [shouldNotBeLessThan]
+ */
+infix fun <T : Comparable<T>> T.shouldNotBeLessThanOrEqualTo(other: T) = this shouldNotBe lte(other)
 fun <T : Comparable<T>> lte(x: T) = beLessThanOrEqualTo(x)
 fun <T : Comparable<T>> beLessThanOrEqualTo(x: T) = object : Matcher<Comparable<T>> {
   override fun test(value: Comparable<T>) = MatcherResult(value <= x, "$value should be <= $x", "$value should not be <= $x")
 }
 
+/**
+ * Verifies that this is greater than [other]
+ *
+ * Opposite of [shouldNotBeGreaterThan]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is greater than [other] (compareTo returns > 0).
+ *
+ * @see [shouldNotBeGreaterThan]
+ * @see [shouldBeGreaterThanOrEqualTo]
+ */
+infix fun <T : Comparable<T>> T.shouldBeGreaterThan(other: T) = this shouldBe gt(other)
+/**
+ * Verifies that this is NOT greater than [other]
+ *
+ * Opposite of [shouldBeGreaterThan]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is NOT greater than [other] (compareTo doesn't return > 0).
+ *
+ * @see [shouldBeGreaterThan]
+ * @see [shouldNotBeGreaterThanOrEqualTo]
+ */
+infix fun <T : Comparable<T>> T.shouldNotBeGreaterThan(other: T) = this shouldNotBe gt(other)
 fun <T : Comparable<T>> gt(x: T) = beGreaterThan(x)
 fun <T : Comparable<T>> beGreaterThan(x: T) = object : Matcher<Comparable<T>> {
   override fun test(value: Comparable<T>) = MatcherResult(value > x, "$value should be > $x", "$value should not be > $x")
 }
 
+/**
+ * Verifies that this is greater than or equal to [other]
+ *
+ * Opposite of [shouldNotBeGreaterThanOrEqualTo]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is greater than or equal to [other] (compareTo returns >= 0).
+ *
+ * @see [shouldNotBeGreaterThanOrEqualTo]
+ * @see [shouldBeGreaterThan]
+ */
+infix fun <T : Comparable<T>> T.shouldBeGreaterThanOrEqualTo(other: T) = this shouldBe gte(other)
+/**
+ * Verifies that this is NOT greater than nor equal to [other]
+ *
+ * Opposite of [shouldBeGreaterThanOrEqualTo]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is NOT greater than nor equal to [other] (compareTo doesn't return >= 0).
+ *
+ * @see [shouldBeGreaterThanOrEqualTo]
+ * @see [shouldNotBeGreaterThan]
+ */
+infix fun <T : Comparable<T>> T.shouldNotBeGreaterThanOrEqualTo(other: T) = this shouldNotBe gte(other)
 fun <T : Comparable<T>> gte(x: T) = beGreaterThanOrEqualTo(x)
 fun <T : Comparable<T>> beGreaterThanOrEqualTo(x: T) = object : Matcher<Comparable<T>> {
   override fun test(value: Comparable<T>) = MatcherResult(value >= x, "$value should be >= $x", "$value should not be >= $x")
 }
 
+/**
+ * Verifies that this is equal to [other] using compareTo
+ *
+ * Opposite of [shouldNotBeEqualComparingTo]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is equal to [other] (compareTo returns 0).
+ *
+ */
+infix fun <T : Comparable<T>> T.shouldBeEqualComparingTo(other: T) = this should beEqualComparingTo(other)
+/**
+ * Verifies that this is NOT equal to [other] using compareTo
+ *
+ * Opposite of [shouldBeEqualComparingTo]
+ *
+ * This function will check for the result of [Comparable.compareTo] and result accordingly.
+ * This will pass if the value is NOT equal to [other] (compareTo doesn't return 0).
+ *
+ */
+infix fun <T : Comparable<T>> T.shouldNotBeEqualComparingTo(other: T) = this shouldNot beEqualComparingTo(other)
+fun <T : Comparable<T>> beEqualComparingTo(other: T) = object : Matcher<T> {
+  override fun test(value: T): MatcherResult {
+    val passed = value.compareTo(other) == 0
+    return MatcherResult(passed, "Value $value should compare equal to $other", "Value $value should not compare equal to $other")
+  }
+}
+
+/**
+ * Verifies that this is equal to [other] using compare from [comparator]
+ *
+ *
+ * This function will check for the result of [comparator.compare] and result accordingly.
+ * This will pass if the value is equal to [other] (compare returns 0).
+ *
+ */
+fun <T : Comparable<T>> T.shouldBeEqualComparingTo(other: T, comparator: Comparator<T>) = this should compareTo(other, comparator)
+/**
+ * Verifies that this is NOT equal to [other] using compare from [comparator]
+ *
+ *
+ * This function will check for the result of [comparator.compare] and result accordingly.
+ * This will pass if the value is NOT equal to [other] (compare doesn't return 0).
+ *
+ */
+fun <T : Comparable<T>> T.shouldNotBeEqualComparingTo(other: T, comparator: Comparator<T>) = this shouldNot compareTo(other, comparator)
 fun <T> compareTo(other: T, comparator: Comparator<T>) = object : Matcher<T> {
   override fun test(value: T): MatcherResult {
     val passed = comparator.compare(value, other) == 0
     return MatcherResult(passed, "Value $value should compare equal to $other", "Value $value should not compare equal to $other")
   }
-
 }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/comparables/ComparableMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/comparables/ComparableMatchersTest.kt
@@ -1,6 +1,6 @@
-package com.sksamuel.kotest.matchers
+package com.sksamuel.kotest.matchers.comparables
 
-import io.kotest.forAll
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.comparables.beGreaterThan
 import io.kotest.matchers.comparables.beGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.beLessThan
@@ -10,6 +10,12 @@ import io.kotest.matchers.comparables.gt
 import io.kotest.matchers.comparables.gte
 import io.kotest.matchers.comparables.lt
 import io.kotest.matchers.comparables.lte
+import io.kotest.matchers.comparables.shouldBeEqualComparingTo
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
+import io.kotest.matchers.comparables.shouldNotBeEqualComparingTo
 import io.kotest.properties.assertAll
 import io.kotest.should
 import io.kotest.shouldBe
@@ -18,13 +24,15 @@ import io.kotest.shouldThrow
 import io.kotest.specs.FreeSpec
 
 class ComparableMatchersTest : FreeSpec() {
-
-  class ComparableExample(private val underlying: Int) : Comparable<ComparableExample> {
+  
+  class ComparableExample(
+    private val underlying: Int
+  ) : Comparable<ComparableExample> {
     override fun compareTo(other: ComparableExample): Int {
       return when {
         underlying == other.underlying -> 0
-        underlying > other.underlying -> 1
-        else -> -1
+        underlying > other.underlying  -> 1
+        else                           -> -1
       }
     }
   }
@@ -40,23 +48,26 @@ class ComparableMatchersTest : FreeSpec() {
       "beLessThan (`<`) comparison" - {
 
         "should pass test for lesser values" {
-          forAll(arrayOf(Pair(cn, cz), Pair(cz, cp))) {
+          arrayOf(cn to cz, cz to cp).forAll {
             it.first shouldBe lt(it.second)
             it.first should beLessThan(it.second)
+            it.first shouldBeLessThan it.second
           }
         }
 
         "should throw exception for equal values" {
-          forAll(arrayOf(cn, cz, cp)) {
+          arrayOf(cn, cz, cp).forAll {
             shouldThrow<AssertionError> { it shouldBe lt(it) }
             shouldThrow<AssertionError> { it should beLessThan(it) }
+            shouldThrow<AssertionError> { it shouldBeLessThan it }
           }
         }
 
         "should throw exception for greater values" {
-          forAll(arrayOf(Pair(cp, cz), Pair(cz, cn))) {
+          arrayOf(cp to cz, cz to cn).forAll {
             shouldThrow<AssertionError> { it.first shouldBe lt(it.second) }
             shouldThrow<AssertionError> { it.first should beLessThan(it.second) }
+            shouldThrow<AssertionError> { it.first shouldBeLessThan it.second }
           }
         }
 
@@ -65,16 +76,18 @@ class ComparableMatchersTest : FreeSpec() {
       "beLessThanOrEqualTo (`<=`) comparison" - {
 
         "should pass for lesser or equal values" {
-          forAll(arrayOf(Pair(cn, cn), Pair(cn, cz), Pair(cz, cz), Pair(cz, cp), Pair(cp, cp))) {
+          arrayOf(cn to cn, cn to cz, cz to cz, cz to cp, cp to cp).forAll {
             it.first shouldBe lte(it.second)
             it.first should beLessThanOrEqualTo(it.second)
+            it.first shouldBeLessThanOrEqualTo it.second
           }
         }
 
         "should throw exception for greater values" {
-          forAll(arrayOf(Pair(cp, cz), Pair(cz, cn))) {
+          arrayOf(cp to cz, cz to cn).forAll {
             shouldThrow<AssertionError> { it.first shouldBe lte(it.second) }
             shouldThrow<AssertionError> { it.first should beLessThanOrEqualTo(it.second) }
+            shouldThrow<AssertionError> { it.first shouldBeLessThanOrEqualTo it.second }
           }
         }
 
@@ -83,23 +96,26 @@ class ComparableMatchersTest : FreeSpec() {
       "beGreaterThan (`>`) comparison" - {
 
         "should pass for greater values" {
-          forAll(arrayOf(Pair(cp, cz), Pair(cz, cn))) {
+          arrayOf(cp to cz, cz to cn).forAll {
             it.first shouldBe gt(it.second)
             it.first should beGreaterThan(it.second)
+            it.first shouldBeGreaterThan it.second
           }
         }
 
         "should throw exception for equal values" {
-          forAll(arrayOf(cn, cz, cp)) {
+          arrayOf(cn, cz, cp).forAll {
             shouldThrow<AssertionError> { it shouldBe gt(it) }
             shouldThrow<AssertionError> { it should beGreaterThan(it) }
+            shouldThrow<AssertionError> { it shouldBeGreaterThan it }
           }
         }
 
         "should throw exception for lesser values" {
-          forAll(arrayOf(Pair(cn, cz), Pair(cz, cp))) {
+          arrayOf(cn to cz, cz to cp).forAll {
             shouldThrow<AssertionError> { it.first shouldBe gt(it.second) }
             shouldThrow<AssertionError> { it.first should beGreaterThan(it.second) }
+            shouldThrow<AssertionError> { it.first shouldBeGreaterThan it.second }
           }
         }
 
@@ -108,29 +124,36 @@ class ComparableMatchersTest : FreeSpec() {
       "beGreaterThanOrEqualTo (`>=`) comparison" - {
 
         "should pass for greater than or equal values" {
-          forAll(arrayOf(Pair(cp, cp), Pair(cp, cz), Pair(cz, cz), Pair(cz, cn), Pair(cn, cn))) {
+          arrayOf(cp to cp, cp to cz, cz to cz, cz to cn, cn to cn).forAll {
             it.first shouldBe gte(it.second)
             it.first should beGreaterThanOrEqualTo(it.second)
+            it.first shouldBeGreaterThanOrEqualTo it.second
           }
         }
 
         "should throw exception for lesser values" {
-          forAll(arrayOf(Pair(cn, cz), Pair(cz, cp))) {
+          arrayOf(cn to cz, cz to cp).forAll {
             shouldThrow<AssertionError> { it.first shouldBe gte(it.second) }
             shouldThrow<AssertionError> { it.first should beGreaterThanOrEqualTo(it.second) }
+            shouldThrow<AssertionError> { it.first shouldBeGreaterThanOrEqualTo it.second }
           }
         }
-
       }
 
       "compareTo" - {
 
         "should pass for equal values" {
           assertAll { a: Int, b: Int ->
-            if (a == b)
+            if (a == b) {
               a should compareTo(b, Comparator { o1, o2 -> o1 - o2 })
-            else
+              a.shouldBeEqualComparingTo(b, Comparator { o1, o2 -> o1 - o2 } )
+              a shouldBeEqualComparingTo b
+            }
+            else {
               a shouldNot compareTo(b, Comparator { o1, o2 -> o1 - o2 })
+              a.shouldNotBeEqualComparingTo(b, Comparator { o1, o2 -> o1 - o2 } )
+              a shouldNotBeEqualComparingTo b
+            }
           }
         }
       }


### PR DESCRIPTION
This commit aims to improve some of the available comparable matchers by adding extension infix functions.

 The new and old functions were documented to improve user's understandability of functions instead of having to navigate through the source code (CTRL + Q in IntelliJ).

 On the `shouldBeEqualComparingTo` function, I chose this name so it is not confusing to `shouldBe` and not ambiguous to `shouldCompareTo`. Although the name is a little big, I don't believe it will be a problem.

 There are no more matchers to be added to `compareTo`. All possible behavior for the compareTo matcher were added.

 Closes #668