### PR TITLE
add edge cases 0, 1, -1 to Long and Int Generator

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/properties/gens.kt
@@ -43,10 +43,10 @@ fun Gen.Companion.string(minSize: Int = 0, maxSize: Int = 100): Gen<String> = ob
 /**
  * Returns a stream of values where each value is a randomly
  * chosen [Int]. The values always returned include
- * the following edge cases: [[Int.MIN_VALUE], [Int.MAX_VALUE], 0]
+ * the following edge cases: [[Int.MIN_VALUE], [Int.MAX_VALUE], 0, 1, -1]
  */
 fun Gen.Companion.int() = object : Gen<Int> {
-   val literals = listOf(Int.MIN_VALUE, Int.MAX_VALUE, 0)
+   val literals = listOf(Int.MIN_VALUE, Int.MAX_VALUE, 0, 1, -1)
    override fun constants(): Iterable<Int> = literals
    override fun random(seed: Long?): Sequence<Int> {
       val r = if (seed == null) Random.Default else Random(seed)
@@ -213,10 +213,10 @@ fun Gen.Companion.numericFloats(
 /**
  * Returns a stream of values where each value is a randomly
  * chosen long. The values returned always include
- * the following edge cases: [[Long.MIN_VALUE], [Long.MAX_VALUE]]
+ * the following edge cases: [[Long.MIN_VALUE], [Long.MAX_VALUE], 0, 1, -1]
  */
 fun Gen.Companion.long(): Gen<Long> = object : Gen<Long> {
-  val literals = listOf(Long.MIN_VALUE, Long.MAX_VALUE)
+  val literals = listOf(Long.MIN_VALUE, Long.MAX_VALUE, 0L, 1L, -1L)
   override fun constants(): Iterable<Long> = literals
    override fun random(seed: Long?): Sequence<Long> {
       val r = if (seed == null) Random.Default else Random(seed)

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyAssertAllTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyAssertAllTest.kt
@@ -223,7 +223,7 @@ class PropertyAssertAllTest : StringSpec({
       attempts++
       (a * b) * c shouldBe a * (b * c)
     }
-    attempts shouldBe 30
+    attempts shouldBe 125
   }
 
   "assertAll: Three explicit generators failure at the third attempt" {
@@ -273,13 +273,13 @@ class PropertyAssertAllTest : StringSpec({
     attempts shouldBe 1000
   }
 
-  "assertAll: Four explicit generators success after 88 attempts" {
+  "assertAll: Four explicit generators success after 3125 attempts" {
     var attempts = 0
-    assertAll(88, Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
+    assertAll(3125, Gen.int(), Gen.int(), Gen.int(), Gen.int()) { a, b, c, d ->
       attempts++
       a + b + c + d shouldBe d + c + b + a
     }
-    attempts shouldBe 88
+    attempts shouldBe 3125
   }
 
   "assertAll: Four explicit generators failed after 4 attempts" {
@@ -310,28 +310,28 @@ class PropertyAssertAllTest : StringSpec({
     attempts shouldBe 1000
   }
 
-  "assertAll: four implicit generators with 98 attempts" {
+  "assertAll: four implicit generators with 600 attempts" {
     var attempts = 0
-    assertAll(98) { _: Int, _: Int, _: Int, _: Int ->
+    assertAll(600) { _: Int, _: Int, _: Int, _: Int ->
       attempts++
     }
-    attempts shouldBe 98
+    attempts shouldBe 625
   }
 
-  "assertAll: four implicit generators with 250 attempts" {
+  "assertAll: four implicit generators with 800 attempts" {
     var attempts = 0
-    assertAll(250) { _: Int, _: Int, _: Int, _: Int ->
+    assertAll(800) { _: Int, _: Int, _: Int, _: Int ->
       attempts++
     }
-    attempts shouldBe 250
+    attempts shouldBe 800
   }
 
-  "assertAll: five explicit generators with 999 attempts" {
+  "assertAll: five explicit generators with 4000 attempts" {
     var attempts = 0
-    assertAll(999, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _ ->
+    assertAll(4000, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _ ->
       attempts++
     }
-    attempts shouldBe 999
+    attempts shouldBe 4000
   }
 
   "assertAll: five explicit generators with default attempts" {
@@ -339,7 +339,7 @@ class PropertyAssertAllTest : StringSpec({
     assertAll(Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _ ->
       attempts++
     }
-    attempts shouldBe 1000
+    attempts shouldBe 3125
   }
 
   "assertAll: five explicit generators failed after 10 attempts" {
@@ -371,7 +371,7 @@ class PropertyAssertAllTest : StringSpec({
     assertAll { _: Int, _: Int, _: Int, _: Int, _: Int ->
       attempts++
     }
-    attempts shouldBe 1000
+    attempts shouldBe 3125
   }
 
   "assertAll five implicit generators with 9999 attempts" {
@@ -387,15 +387,15 @@ class PropertyAssertAllTest : StringSpec({
     assertAll(Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _, _ ->
       attempts++
     }
-    attempts shouldBe 1000
+    attempts shouldBe 15625
   }
 
-  "assertAll six explicit arguments with 999 attempts" {
+  "assertAll six explicit arguments with 16000 attempts" {
     var attempts = 0
-    assertAll(999, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _, _ ->
+    assertAll(16000, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _, _ ->
       attempts++
     }
-    attempts shouldBe 999
+    attempts shouldBe 16000
   }
 
   "assertAll six explicit arguments failing at 40 attempts" {
@@ -442,12 +442,12 @@ class PropertyAssertAllTest : StringSpec({
     attempts shouldBe 30000
   }
 
-  "assertAll: six implicit arguments 24567 attempts" {
+  "assertAll: six implicit arguments 27000 attempts" {
     var attempts = 0
-    assertAll(24567) { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
+    assertAll(1000) { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
       attempts++
     }
-    attempts shouldBe 24567
+    attempts shouldBe 27000
   }
 
   "assertAll: six implicit arguments default attempts" {
@@ -455,7 +455,7 @@ class PropertyAssertAllTest : StringSpec({
     assertAll { _: Int, _: Double, _: String, _: Long, _: Float, _: Int ->
       attempts++
     }
-    attempts shouldBe 3888
+    attempts shouldBe 27000
   }
 
   "sets" {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForAllTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForAllTest.kt
@@ -208,14 +208,14 @@ class PropertyForAllTest : StringSpec() {
       attempts shouldBe 1000
     }
 
-    "forAll: Three explicit generators 30 attempts" {
+    "forAll: Three explicit generators 200 attempts" {
       // 30 should be ignored as we have many always cases
       var attempts = 0
-      forAll(30, Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
+      forAll(200, Gen.int(), Gen.int(), Gen.int()) { a, b, c ->
         attempts++
         (a * b) * c == a * (b * c)
       }
-      attempts shouldBe 30
+      attempts shouldBe 200
     }
 
     "forAll: Three explicit generators failure" {
@@ -259,7 +259,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         a + b + c + d == d + c + b + a
       }
-      attempts shouldBe 81
+      attempts shouldBe 625
     }
 
     "forAll: Four explicit generators failed after 4 attempts" {
@@ -291,31 +291,22 @@ class PropertyForAllTest : StringSpec() {
       attempts shouldBe 1000
     }
 
-    "forAll: four implicit generators with 92 attempts" {
+    "forAll: four implicit generators with 630 attempts" {
       var attempts = 0
-      forAll(92) { _: Int, _: Int, _: Int, _: Int ->
+      forAll(630) { _: Int, _: Int, _: Int, _: Int ->
         attempts++
         true
       }
-      attempts shouldBe 92
+      attempts shouldBe 630
     }
 
-    "forAll: four implicit generators with 250 attempts" {
+    "forAll: five explicit generators with 4000 attempts" {
       var attempts = 0
-      forAll(250) { _: Int, _: Int, _: Int, _: Int ->
+      forAll(4000, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _ ->
         attempts++
         true
       }
-      attempts shouldBe 250
-    }
-
-    "forAll: five explicit generators with 999 attempts" {
-      var attempts = 0
-      forAll(999, Gen.int(), Gen.int(), Gen.int(), Gen.int(), Gen.int()) { _, _, _, _, _ ->
-        attempts++
-        true
-      }
-      attempts shouldBe 999
+      attempts shouldBe 4000
     }
 
     "forAll: five explicit generators with default attempts" {
@@ -324,7 +315,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 1000
+      attempts shouldBe 3125
     }
 
     "forAll: five explicit generators failure" {
@@ -350,7 +341,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 1000
+      attempts shouldBe 3125
     }
 
     "forAll five implicit generators with 9999 attempts" {
@@ -368,7 +359,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 1000
+      attempts shouldBe 15625
     }
 
     "forAll six explicit arguments with 50 attempts" {
@@ -377,7 +368,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 1000
+      attempts shouldBe 15625
     }
 
     "forAll six explicit arguments failing at 40 attempts" {
@@ -429,7 +420,7 @@ class PropertyForAllTest : StringSpec() {
         attempts++
         true
       }
-      attempts shouldBe 3888
+      attempts shouldBe 27000
     }
 
     "sets" {

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForNoneTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/properties/PropertyForNoneTest.kt
@@ -413,16 +413,16 @@ class PropertyForNoneTest : StringSpec() {
         attempts++
         false
       }
-      attempts shouldBe 1000
+      attempts shouldBe 3600
     }
 
-    "forNone: five explicit generators 3411 attempts" {
+    "forNone: five explicit generators 4600 attempts" {
       var attempts = 0
-      forNone(3411, Gen.int(), Gen.string(), Gen.double(), Gen.long(), Gen.int()) { _, _, _, _, _ ->
+      forNone(4600, Gen.int(), Gen.string(), Gen.double(), Gen.long(), Gen.int()) { _, _, _, _, _ ->
         attempts++
         false
       }
-      attempts shouldBe 3411
+      attempts shouldBe 4600
     }
 
     "forNone: five explicit generators fails after 2 attempts" {
@@ -497,7 +497,7 @@ class PropertyForNoneTest : StringSpec() {
         attempts++
         false
       }
-      attempts shouldBe 1000
+      attempts shouldBe 3125
     }
 
     "forNone: five implicit generators 4144 attempts" {
@@ -515,7 +515,7 @@ class PropertyForNoneTest : StringSpec() {
         attempts++
         false
       }
-      attempts shouldBe 1000
+      attempts shouldBe 15625
     }
 
     "forNone: six explicit generators 17897 attempts" {
@@ -581,7 +581,7 @@ class PropertyForNoneTest : StringSpec() {
         attempts++
         false
       }
-      attempts shouldBe 1000
+      attempts shouldBe 15625
     }
 
     "forNone: six implicit generators 30000 attempts" {


### PR DESCRIPTION
this PR adds the edge cases 0, 1, -1 for the int and long generator

Reason:
the documentation of Gen suggests that number generators should always include values like zero, minus 1, positive 1 but then the int and long Generator do not return all of these values.
