### PR TITLE
#1036 - Fix duplicates issue when asserting containsExactlyInAnyOrder

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -150,12 +150,16 @@ fun <T> containExactlyInAnyOrder(vararg expected: T): Matcher<Collection<T>?> =
 
 /** Assert that a collection contains exactly the given values and nothing else, in any order. */
 fun <T, C : Collection<T>> containExactlyInAnyOrder(expected: C): Matcher<C?> = neverNullMatcher { value ->
-   val passed = value.size == expected.size && expected.all { value.contains(it) }
-   MatcherResult(
-      passed,
-      "Collection should contain ${stringRepr(expected)} in any order, but was ${stringRepr(value)}",
-      "Collection should not contain exactly ${stringRepr(expected)} in any order"
-   )
+  val valueGroupedCounts: Map<T, Int> = value.groupBy { it }.mapValues { it.value.size }
+  val expectedGroupedCounts: Map<T, Int> = expected.groupBy { it }.mapValues { it.value.size }
+  val passed = expectedGroupedCounts.size == valueGroupedCounts.size
+    && expectedGroupedCounts.all { valueGroupedCounts[it.key] == it.value }
+
+  MatcherResult(
+    passed,
+    "Collection should contain ${stringRepr(expected)} in any order, but was ${stringRepr(value)}",
+    "Collection should not contain exactly ${stringRepr(expected)} in any order"
+  )
 }
 
 infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(t: T) = asList().shouldHaveUpperBound(t)

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -521,7 +521,7 @@ class CollectionMatchersTest : WordSpec() {
     }
 
     "containExactlyInAnyOrder" should {
-      "test that a collection contains given elements in any order"  {
+      "test that a collection contains given elements exactly in any order"  {
         val actual = listOf(1, 2, 3)
         actual should containExactlyInAnyOrder(1, 2, 3)
         actual.shouldContainExactlyInAnyOrder(3, 2, 1)
@@ -530,11 +530,33 @@ class CollectionMatchersTest : WordSpec() {
         actual shouldNot containExactlyInAnyOrder(1, 2)
         actual.shouldNotContainExactlyInAnyOrder(1, 2, 3, 4)
         actual.shouldNotContainExactlyInAnyOrder(listOf(5, 6, 7))
+        actual.shouldNotContainExactlyInAnyOrder(1, 1, 1)
+        actual.shouldNotContainExactlyInAnyOrder(listOf(2, 2, 3))
+        actual.shouldNotContainExactlyInAnyOrder(listOf(1, 1, 2, 3))
+
+        val actualDuplicates = listOf(1,1,2)
+        actualDuplicates.shouldContainExactlyInAnyOrder(1,2,1)
+        actualDuplicates.shouldContainExactlyInAnyOrder(2,1,1)
+
+        actualDuplicates.shouldNotContainExactlyInAnyOrder(1,2)
+        actualDuplicates.shouldNotContainExactlyInAnyOrder(1,2,2)
+        actualDuplicates.shouldNotContainExactlyInAnyOrder(1,1,2,2)
+        actualDuplicates.shouldNotContainExactlyInAnyOrder(1,2,7)
+
         shouldThrow<AssertionError> {
           actual should containExactlyInAnyOrder(1, 2)
         }
         shouldThrow<AssertionError> {
           actual should containExactlyInAnyOrder(1, 2, 3, 4)
+        }
+        shouldThrow<AssertionError> {
+          actual should containExactlyInAnyOrder(1,1,1)
+        }
+        shouldThrow<AssertionError> {
+          actual should containExactlyInAnyOrder(1,1,2,3)
+        }
+        shouldThrow<AssertionError> {
+          actualDuplicates should containExactlyInAnyOrder(1,2,2)
         }
       }
 


### PR DESCRIPTION
Fixes [#1036](https://github.com/kotlintest/kotlintest/issues/1036)