### PR TITLE
Show helpful message when comparing objects that only differ in line endings

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/should.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/should.kt
@@ -1,14 +1,6 @@
 package io.kotest
 
-import io.kotest.assertions.AssertionCounter
-import io.kotest.assertions.ErrorCollector
-import io.kotest.assertions.Failures
-import io.kotest.assertions.clueContextAsString
-import io.kotest.assertions.collectOrThrow
-import io.kotest.assertions.compare
-import io.kotest.assertions.diffLargeString
-import io.kotest.assertions.readSystemProperty
-import io.kotest.assertions.stringRepr
+import io.kotest.assertions.*
 
 @Suppress("UNCHECKED_CAST")
 infix fun <T, U : T> T.shouldBe(any: U?) {
@@ -67,5 +59,15 @@ internal fun equalsError(expected: Any?, actual: Any?): Throwable {
   return Failures.failure(message, expectedRepr, actualRepr)
 }
 
-internal fun equalsErrorMessage(expected: Any?, actual: Any?) = "expected: $expected but was: $actual"
+private val linebreaks = Regex("\r?\n|\r")
+
+internal fun equalsErrorMessage(expected: Any?, actual: Any?): String {
+   return when {
+       expected is String && actual is String &&
+          linebreaks.replace(expected, "\n") == linebreaks.replace(actual, "\n") -> {
+          "line contents match, but line-break characters differ"
+       }
+       else -> "expected: $expected but was: $actual"
+   }
+}
 

--- a/kotest-assertions/src/jvmMain/kotlin/io/kotest/assertions/Failures.kt
+++ b/kotest-assertions/src/jvmMain/kotlin/io/kotest/assertions/Failures.kt
@@ -71,14 +71,14 @@ actual object Failures {
       }
 
       /** If JUnit4 is present, return a org.junit.ComparisonFailure */
-      fun junit4comparisonFailure(expected: String, actual: String): Throwable? {
+      fun junit4comparisonFailure(message: String, expected: String, actual: String): Throwable? {
          return callPublicConstructor("org.junit.ComparisonFailure",
             arrayOf(String::class.java, String::class.java, String::class.java),
-            arrayOf("", expected, actual)) as? Throwable
+            arrayOf(message, expected, actual)) as? Throwable
       }
 
       val t = junit5AssertionFailedError(message, expectedRepr, actualRepr)
-         ?: junit4comparisonFailure(expectedRepr, actualRepr)
+         ?: junit4comparisonFailure(message, expectedRepr, actualRepr)
          ?: AssertionError(message)
       clean(t)
       return t


### PR DESCRIPTION
Currently, if you assert something like `"a\nb" shouldBe `"a\rb"`, the assertions will fail correctly, but the message will be something like

```
expected: a[
]b

found: a[
]b
```

Which is not very helpful, since the two values appear identical in the diff.

This PR checks for this case and adds a message to the assertion error indicating the difference.

The truth assertion library [does something similar](https://github.com/google/truth/blob/3c46f24b8161a089aa6712f4f9c579428071c2e2/core/src/main/java/com/google/common/truth/Platform.java#L136).