### PR TITLE
[NEXT RELEASE] #1123 Adds documentation for timestamp matcher

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -297,8 +297,6 @@ For the extension function style, each function has an equivalent negated versio
 
 | Timestamp ||
 | -------- | ---- |
-| `timestamp.shouldBe(anotherTimestamp)` | Asserts that the timestamps are equal |
-| `timestamp.shouldNotBe(anotherTimestamp)` | Asserts that the timestamps are not equal |
 | `timestamp.shouldBeAfter(anotherTimestamp)` | Asserts that the timestamp is after anotherTimestamp |
 | `timestamp.shouldNotBeAfter(anotherTimestamp)` | Asserts that the timestamp is not after anotherTimestamp which means the timestamps are either equal or timestamp is before anotherTimestamp |
 | `timestamp.shouldBeBefore(anotherTimestamp)` | Asserts that the timestamp is before anotherTimestamp |

--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -31,7 +31,7 @@ For the extension function style, each function has an equivalent negated versio
 
 | Iterables ||
 | ------- | ---- |
-| `iterable.shouldBeEmpty()` | Asserts that the iterable's iterator does not have a next value. 
+| `iterable.shouldBeEmpty()` | Asserts that the iterable's iterator does not have a next value.
 
 | Maps ||
 | -------- | ---- |
@@ -118,11 +118,11 @@ For the extension function style, each function has an equivalent negated versio
 | `bigDecimal.shouldBePositive()` | Asserts that the bigDecimal is positive |
 | `bigDecimal.shouldBeNegative()` | Asserts that the bigDecimal is negative |
 | `bigDecimal.shouldBeZero()` | Asserts that the bigDecimal is zero |
-| `bigDecimal.shouldBeLessThan(n)` | Asserts that the bigDecimal is less than the given value n | 
+| `bigDecimal.shouldBeLessThan(n)` | Asserts that the bigDecimal is less than the given value n |
 | `bigDecimal.shouldBeLessThanOrEquals(n)` | Asserts that the bigDecimal is less than or equ
-| `bigDecimal.shouldBeGreaterThan(n)` | Asserts that the bigDecimal is greater than the given value n | 
-| `bigDecimal.shouldBeGreaterThanOrEquals(n)` | Asserts that the bigDecimal is greater than or equals to the given value n | 
-| `bigDecimal.shouldBeInRange(r)` | Asserts that the bigDecimal is in the given range | 
+| `bigDecimal.shouldBeGreaterThan(n)` | Asserts that the bigDecimal is greater than the given value n |
+| `bigDecimal.shouldBeGreaterThanOrEquals(n)` | Asserts that the bigDecimal is greater than or equals to the given value n |
+| `bigDecimal.shouldBeInRange(r)` | Asserts that the bigDecimal is in the given range |
 
 | Collections ||
 | -------- | ---- |
@@ -189,7 +189,7 @@ For the extension function style, each function has an equivalent negated versio
 | `dir.shouldContainFileDeep(name)` | Assert that file is a directory and that it or any sub directory contains a file with the given name. |
 | `dir.shouldContainFiles(name1, name2, ..., nameN)` | Asserts that the file is a directory and that it contains al files with the given name. |
 | `file.shouldBeSymbolicLink()` | Asserts that the file is a symbolic link. |
-| `file.shouldHaveParent(name)` |  Assert that the file has a parent with the given name | 
+| `file.shouldHaveParent(name)` |  Assert that the file has a parent with the given name |
 
 | Dates ||
 | -------- | ---- |
@@ -258,31 +258,31 @@ For the extension function style, each function has an equivalent negated versio
 
 | Reflection |     |
 | ---------- | --- |
-| `kclass.shouldHaveAnnotations()` | Asserts that the class has some annotation | 
-| `kclass.shouldHaveAnnotations(n)` | Asserts that the class has exactly N annotation | 
+| `kclass.shouldHaveAnnotations()` | Asserts that the class has some annotation |
+| `kclass.shouldHaveAnnotations(n)` | Asserts that the class has exactly N annotation |
 | `kclass.shouldBeAnnotatedWith<T>()` | Asserts that the class is annotated with the given type |
-| `kclass.shouldBeAnnotatedWith<T> { block }` | Asserts that the class is annotated with the given type, and then, runs the block with the annotation | 
-| `kclass.shouldHaveFunction(name)` | Asserts that the class have a function with the given name | 
+| `kclass.shouldBeAnnotatedWith<T> { block }` | Asserts that the class is annotated with the given type, and then, runs the block with the annotation |
+| `kclass.shouldHaveFunction(name)` | Asserts that the class have a function with the given name |
 | `kclass.shouldHaveFunction(name) { block }` | Asserts that the class have a function with the given name, and then, runs the block with the function |
-| `kclass.shouldHaveMemberProperty(name)` | Asserts that the class have a member property with the given name | 
+| `kclass.shouldHaveMemberProperty(name)` | Asserts that the class have a member property with the given name |
 | `kclass.shouldHaveMemberProperty(name) { block }` | Asserts that the class have a member property with the given name, and then, runs the block with the function |
 | `kclass.shouldBeSubtypeOf<T>()` | Asserts that the class is a subtype of T |
 | `kclass.shouldBeSupertypeOf<T>()` | Asserts that the class is a supertype of T |
 | `kclass.shouldBeData()` | Asserts that the class is a data class |
-| `kclass.shouldBeSealed()` | Asserts that the class is a sealed class | 
-| `kclass.shouldBeCompanion()` | Asserts that the class is a companion object | 
+| `kclass.shouldBeSealed()` | Asserts that the class is a sealed class |
+| `kclass.shouldBeCompanion()` | Asserts that the class is a companion object |
 | `kclass.shouldHavePrimaryConstructor()` | Asserts that the class has a primary constructor |
-| `kclass.shouldHaveVisibility(visibility)` | Asserts that the class has the given visibility | 
-| `kfunction.shouldHaveAnnotations()` | Asserts that the function has some annotation | 
-| `kfunction.shouldHaveAnnotations(n)` | Asserts that the function has exactly N annotation | 
+| `kclass.shouldHaveVisibility(visibility)` | Asserts that the class has the given visibility |
+| `kfunction.shouldHaveAnnotations()` | Asserts that the function has some annotation |
+| `kfunction.shouldHaveAnnotations(n)` | Asserts that the function has exactly N annotation |
 | `kfunction.shouldBeAnnotatedWith<T>()` | Asserts that the function is annotated with the given type |
-| `kfunction.shouldBeAnnotatedWith<T> { block }` | Asserts that the function is annotated with the given type, and then, runs the block with the annotation | 
+| `kfunction.shouldBeAnnotatedWith<T> { block }` | Asserts that the function is annotated with the given type, and then, runs the block with the annotation |
 | `kfunction.shouldHaveReturnType<T>()` | Asserts that the function returns the given type |
 | `kfunction.shouldBeInline()` | Asserts that the function is inline |
 | `kfunction.shouldBeInfix()` | Asserts that the function is infix |
 | `kproperty.shouldBeOfType<T>()` | Asserts that the property is of the given type |
-| `kproperty.shouldBeConst()` | Asserts that the property is a const | 
-| `kproperty.shouldBeLateInit()` | Asserts that the property is a late init var | 
+| `kproperty.shouldBeConst()` | Asserts that the property is a const |
+| `kproperty.shouldBeLateInit()` | Asserts that the property is a late init var |
 | `kcallable.shouldHaveVisibility(visibility)` | Asserts that the member have the given visibility |
 | `kcallable.shouldBeFinal()` | Asserts that the member is final |
 | `kcallable.shouldBeOpen()` | Asserts that the member is open |
@@ -292,4 +292,14 @@ For the extension function style, each function has an equivalent negated versio
 | `kcallable.shouldAcceptParameters(parameters) { block }` | Asserts that the member can be called with the parameters (check the types), and then, runs the block with the annotation |
 | `kcallable.shouldHaveParametersWithName(parameters)` | Asserts that the member has the parameters with the given name |
 | `kcallable.shouldHaveParametersWithName(parameters) { block }` | Asserts that the member has the parameters with the given name, and then, runs the block with the annotation |
-| `ktype.shouldBeOfType<T>()` | Asserts that the KType has the type T | 
+| `ktype.shouldBeOfType<T>()` | Asserts that the KType has the type T |
+
+
+| Timestamp ||
+| -------- | ---- |
+| `timestamp.shouldBe(anotherTimestamp)` | Asserts that the timestamps are equal |
+| `timestamp.shouldNotBe(anotherTimestamp)` | Asserts that the timestamps are not equal |
+| `timestamp.shouldBeAfter(anotherTimestamp)` | Asserts that the timestamp is after anotherTimestamp |
+| `timestamp.shouldNotBeAfter(anotherTimestamp)` | Asserts that the timestamp is not after anotherTimestamp which means the timestamps are either equal or timestamp is before anotherTimestamp |
+| `timestamp.shouldBeBefore(anotherTimestamp)` | Asserts that the timestamp is before anotherTimestamp |
+| `timestamp.shouldNotBeBefore(anotherTimestamp)` | Asserts that the timestamp is not before anotherTimestamp which means the timestamps are either equal or timestamp is after anotherTimestamp |


### PR DESCRIPTION
This adds documentation for the timestamp matcher added in [PR](https://github.com/kotlintest/kotlintest/pull/1124)