### PR TITLE
#1127 Add matchers for java.time.Instant

### DIFF
--- a/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -6,16 +6,6 @@ import io.kotest.should
 import io.kotest.shouldNot
 import java.time.Instant
 
-fun equalInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
-   override fun test(value: Instant): MatcherResult {
-      return MatcherResult(
-         anotherInstant == value,
-         {"Expecting instant $value to be equal to instant $anotherInstant, but it's not"},
-         {"Not expecting instant $value and instant $anotherInstant to be equal, but they are equal"}
-      )
-   }
-}
-
 fun beforeInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
    override fun test(value: Instant): MatcherResult {
       return MatcherResult(
@@ -35,18 +25,6 @@ fun afterInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
       )
    }
 }
-
-/**
- * Assert that [Instant] is equal to [anotherInstant].
- * @see [shouldNotBe]
- * */
-infix fun Instant.shouldBe(anotherInstant: Instant) = this should equalInstantMatcher(anotherInstant)
-
-/**
- * Assert that [Instant] is not equal to [anotherInstant].
- * @see [shouldBe]
- * */
-infix fun Instant.shouldNotBe(anotherInstant: Instant) = this shouldNot equalInstantMatcher(anotherInstant)
 
 /**
  * Assert that [Instant] is before [anotherInstant].

--- a/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -61,7 +61,7 @@ infix fun Instant.shouldNotBeAfter(anotherInstant: Instant) = this shouldNot aft
  * Assert that [Instant] is between [fromInstant] and [toInstant].
  * @see [shouldNotBeBetween]
  * */
-fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this should between(fromInstant, toInstant)
+fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldBe between(fromInstant, toInstant)
 
 /**
  * Assert that [Instant] is between [fromInstant] and [toInstant].

--- a/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -1,0 +1,73 @@
+package io.kotest.matchers.date
+
+import io.kotest.Matcher
+import io.kotest.MatcherResult
+import io.kotest.should
+import io.kotest.shouldNot
+import java.time.Instant
+
+fun equalInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
+   override fun test(value: Instant): MatcherResult {
+      return MatcherResult(
+         anotherInstant == value,
+         {"Expecting instant $value to be equal to instant $anotherInstant, but it's not"},
+         {"Not expecting instant $value and instant $anotherInstant to be equal, but they are equal"}
+      )
+   }
+}
+
+fun beforeInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
+   override fun test(value: Instant): MatcherResult {
+      return MatcherResult(
+         value.isBefore(anotherInstant),
+         {"Expected $value to be before $anotherInstant, but it's not."},
+         {"$anotherInstant is not expected to be before $value."}
+      )
+   }
+}
+
+fun afterInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
+   override fun test(value: Instant): MatcherResult {
+      return MatcherResult(
+         value.isAfter(anotherInstant),
+         {"Expected $value to be after $anotherInstant, but it's not."},
+         {"$anotherInstant is not expected to be after $value."}
+      )
+   }
+}
+
+/**
+ * Assert that [Instant] is equal to [anotherInstant].
+ * @see [shouldNotBe]
+ * */
+infix fun Instant.shouldBe(anotherInstant: Instant) = this should equalInstantMatcher(anotherInstant)
+
+/**
+ * Assert that [Instant] is not equal to [anotherInstant].
+ * @see [shouldBe]
+ * */
+infix fun Instant.shouldNotBe(anotherInstant: Instant) = this shouldNot equalInstantMatcher(anotherInstant)
+
+/**
+ * Assert that [Instant] is before [anotherInstant].
+ * @see [shouldNotBeBefore]
+ * */
+infix fun Instant.shouldBeBefore(anotherInstant: Instant) = this should beforeInstantMatcher(anotherInstant)
+
+/**
+ * Assert that [Instant] is not before [anotherInstant].
+ * @see [shouldBeBefore]
+ * */
+infix fun Instant.shouldNotBeBefore(anotherInstant: Instant) = this shouldNot beforeInstantMatcher(anotherInstant)
+
+/**
+ * Assert that [Instant] is after [anotherInstant].
+ * @see [shouldNotBeAfter]
+ * */
+infix fun Instant.shouldBeAfter(anotherInstant: Instant) = this should afterInstantMatcher(anotherInstant)
+
+/**
+ * Assert that [Instant] is not after [anotherInstant].
+ * @see [shouldNotBeAfter]
+ * */
+infix fun Instant.shouldNotBeAfter(anotherInstant: Instant) = this shouldNot afterInstantMatcher(anotherInstant)

--- a/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -1,12 +1,9 @@
 package io.kotest.matchers.date
 
-import io.kotest.Matcher
-import io.kotest.MatcherResult
-import io.kotest.should
-import io.kotest.shouldNot
+import io.kotest.*
 import java.time.Instant
 
-fun beforeInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
+fun before(anotherInstant: Instant) = object : Matcher<Instant> {
    override fun test(value: Instant): MatcherResult {
       return MatcherResult(
          value.isBefore(anotherInstant),
@@ -16,7 +13,7 @@ fun beforeInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
    }
 }
 
-fun afterInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
+fun after(anotherInstant: Instant) = object : Matcher<Instant> {
    override fun test(value: Instant): MatcherResult {
       return MatcherResult(
          value.isAfter(anotherInstant),
@@ -26,26 +23,48 @@ fun afterInstantMatcher(anotherInstant: Instant) = object : Matcher<Instant> {
    }
 }
 
+fun between(fromInstant: Instant, toInstant: Instant) = object : Matcher<Instant> {
+   override fun test(value: Instant): MatcherResult {
+      return MatcherResult(
+         value.isAfter(fromInstant) && value.isBefore(toInstant),
+         { "$value should be after $fromInstant and before $toInstant" },
+         { "$value should not be be after $fromInstant and before $toInstant" }
+      )
+   }
+}
+
 /**
  * Assert that [Instant] is before [anotherInstant].
  * @see [shouldNotBeBefore]
  * */
-infix fun Instant.shouldBeBefore(anotherInstant: Instant) = this should beforeInstantMatcher(anotherInstant)
+infix fun Instant.shouldBeBefore(anotherInstant: Instant) = this shouldBe before(anotherInstant)
 
 /**
  * Assert that [Instant] is not before [anotherInstant].
  * @see [shouldBeBefore]
  * */
-infix fun Instant.shouldNotBeBefore(anotherInstant: Instant) = this shouldNot beforeInstantMatcher(anotherInstant)
+infix fun Instant.shouldNotBeBefore(anotherInstant: Instant) = this shouldNotBe before(anotherInstant)
 
 /**
  * Assert that [Instant] is after [anotherInstant].
  * @see [shouldNotBeAfter]
  * */
-infix fun Instant.shouldBeAfter(anotherInstant: Instant) = this should afterInstantMatcher(anotherInstant)
+infix fun Instant.shouldBeAfter(anotherInstant: Instant) = this shouldBe after(anotherInstant)
 
 /**
  * Assert that [Instant] is not after [anotherInstant].
  * @see [shouldNotBeAfter]
  * */
-infix fun Instant.shouldNotBeAfter(anotherInstant: Instant) = this shouldNot afterInstantMatcher(anotherInstant)
+infix fun Instant.shouldNotBeAfter(anotherInstant: Instant) = this shouldNot after(anotherInstant)
+
+/**
+ * Assert that [Instant] is between [fromInstant] and [toInstant].
+ * @see [shouldNotBeBetween]
+ * */
+fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this should between(fromInstant, toInstant)
+
+/**
+ * Assert that [Instant] is between [fromInstant] and [toInstant].
+ * @see [shouldBeBetween]
+ * */
+fun Instant.shouldNotBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldNotBe between(fromInstant, toInstant)

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -59,5 +59,29 @@ class InstantMatcherTest : FreeSpec() {
          Instant.ofEpochMilli(30000) shouldNotBeAfter Instant.ofEpochMilli(30000)
       }
 
+      "current instant should be between past instant and future instant" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(30000)
+         val futureInstant = currentInstant.plusMillis(30000)
+
+         currentInstant.shouldBeBetween(pastInstant, futureInstant)
+      }
+
+      "past instant should not be between current instant and future instant" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(30000)
+         val futureInstant = currentInstant.plusMillis(30000)
+
+         pastInstant.shouldNotBeBetween(currentInstant, futureInstant)
+      }
+
+      "future instant should not be between past instant and current instant" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(30000)
+         val futureInstant = currentInstant.plusMillis(30000)
+
+         futureInstant.shouldNotBeBetween(pastInstant, currentInstant)
+      }
+
    }
 }

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -1,11 +1,28 @@
 package com.sksamuel.kotest.matchers.date
 
 import io.kotest.matchers.date.*
+import io.kotest.shouldBe
+import io.kotest.shouldNotBe
 import io.kotest.specs.FreeSpec
 import java.time.Instant
 
 class InstantMatcherTest : FreeSpec() {
    init {
+      "same instance of instant should be same" {
+         val currentInstant = Instant.now()
+         currentInstant shouldBe currentInstant
+      }
+
+      "different instance of instant having same time should be same" {
+         Instant.ofEpochMilli(10000) shouldBe Instant.ofEpochMilli(10000)
+      }
+
+      "instance of different time should be different" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(40000)
+         currentInstant shouldNotBe pastInstant
+      }
+
       "past instant should be before current instant" {
          val currentInstant = Instant.now()
          val pastInstant = currentInstant.minusMillis(1000)

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.matchers.date
+
+import io.kotest.matchers.date.*
+import io.kotest.specs.FreeSpec
+import java.time.Instant
+
+class InstantMatcherTest : FreeSpec() {
+   init {
+      "same instance of instant should be same" {
+         val currentInstant = Instant.now()
+         currentInstant shouldBe currentInstant
+      }
+
+      "different instance of instant having same time should be same" {
+         Instant.ofEpochMilli(10000) shouldBe Instant.ofEpochMilli(10000)
+      }
+
+      "instance of different time should be different" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(40000)
+         currentInstant shouldNotBe pastInstant
+      }
+
+      "past instant should be before current instant" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(1000)
+
+         pastInstant shouldBeBefore currentInstant
+      }
+
+      "current instant should not be before past instant" {
+         val currentInstant = Instant.now()
+         val pastInstant = currentInstant.minusMillis(1000)
+
+         currentInstant shouldNotBeBefore pastInstant
+      }
+
+      "future instant should be after current instant" {
+         val currentInstant = Instant.now()
+         val futureInstant = currentInstant.plusMillis(1000)
+
+         futureInstant shouldBeAfter currentInstant
+      }
+
+      "current instant should not be after past instant" {
+         val currentInstant = Instant.now()
+         val futureInstant = currentInstant.plusMillis(1000)
+
+         currentInstant shouldNotBeAfter futureInstant
+      }
+
+      "instant of same time should not be before another instant of same time" {
+         Instant.ofEpochMilli(30000) shouldNotBeBefore Instant.ofEpochMilli(30000)
+      }
+
+      "instant of same time should not be after another instant of same time" {
+         Instant.ofEpochMilli(30000) shouldNotBeAfter Instant.ofEpochMilli(30000)
+      }
+
+   }
+}

--- a/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -6,21 +6,6 @@ import java.time.Instant
 
 class InstantMatcherTest : FreeSpec() {
    init {
-      "same instance of instant should be same" {
-         val currentInstant = Instant.now()
-         currentInstant shouldBe currentInstant
-      }
-
-      "different instance of instant having same time should be same" {
-         Instant.ofEpochMilli(10000) shouldBe Instant.ofEpochMilli(10000)
-      }
-
-      "instance of different time should be different" {
-         val currentInstant = Instant.now()
-         val pastInstant = currentInstant.minusMillis(40000)
-         currentInstant shouldNotBe pastInstant
-      }
-
       "past instant should be before current instant" {
          val currentInstant = Instant.now()
          val pastInstant = currentInstant.minusMillis(1000)


### PR DESCRIPTION
Matchers added for Instant

1. shouldBeAfter
2. shouldNotBeAfter
3. shouldBeBefore
4. shouldNotBeBefore