### PR TITLE
Add Kotlin/Native support to kotest-assertions, kotest-fp, and kotest-properties

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -47,6 +47,7 @@ object Libs {
       const val jdk8 = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$version"
       const val core = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$version"
       const val coreJs = "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:$version"
+      const val coreNative = "org.jetbrains.kotlinx:kotlinx-coroutines-core-native:$version"
    }
 
    object Ktor {

--- a/kotest-assertions/build.gradle.kts
+++ b/kotest-assertions/build.gradle.kts
@@ -9,6 +9,9 @@ repositories {
    mavenCentral()
 }
 
+val ideaActive = System.getProperty("idea.active") == "true"
+val os = org.gradle.internal.os.OperatingSystem.current()
+
 kotlin {
 
    targets {
@@ -25,6 +28,17 @@ kotlin {
                moduleKind = "commonjs"
             }
          }
+      }
+      if (!ideaActive) {
+         linuxX64()
+         mingwX64()
+         macosX64()
+      } else if (os.isMacOsX) {
+         macosX64("native")
+      } else if (os.isWindows) {
+         mingwX64("native")
+      } else {
+         linuxX64("native")
       }
    }
 
@@ -70,6 +84,19 @@ kotlin {
          dependsOn(jvmMain)
          dependencies {
             implementation(project(":kotest-runner:kotest-runner-junit5"))
+         }
+      }
+
+      if (!ideaActive) {
+         val nativeMain by creating {
+            dependsOn(commonMain)
+            dependencies {
+               implementation(Libs.Coroutines.coreNative)
+            }
+         }
+
+         configure(listOf(getByName("macosX64Main"), getByName("linuxX64Main"), getByName("mingwX64Main"))) {
+            dependsOn(nativeMain)
          }
       }
    }

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/assertions/MultiAssertionError.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/assertions/MultiAssertionError.kt
@@ -15,8 +15,8 @@ class MultiAssertionError(errors: List<Throwable>) : AssertionError(createMessag
 
       for ((i, err) in errors.withIndex()) {
         append(i + 1).append(") ").append(err.message).append("\n")
-        if (err.throwableLocation() != null) {
-          append("\tat ").append(err.throwableLocation()).append("\n")
+        err.throwableLocation()?.let {
+          append("\tat ").append(it).append("\n")
         }
       }
     }

--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/assertions/show/Show.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/assertions/show/Show.kt
@@ -20,7 +20,7 @@ fun <T : Any> showFor(t: T): Show<T> = when (t) {
   is Long, t is Boolean, t is Int, t is Double, t is Float, t is Short, t is Byte -> DefaultShow
   is KClass<*> -> KClassShow() as Show<T>
   else -> when {
-    // this won't work in JS so they'll get the boring old toString version
+    // this won't work in JS or native, so they'll get the boring old toString version
     t::class.isDataClass() -> dataClassShow<T>()
     else -> DefaultShow
   }

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/AssertionCounter.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/AssertionCounter.kt
@@ -1,0 +1,27 @@
+package io.kotest.assertions
+
+@ThreadLocal
+actual object AssertionCounter {
+
+   private var counter = 0
+
+   /**
+    * Returns the number of assertions executed in the current context.
+    */
+   actual fun get(): Int = counter
+
+   /**
+    * Resets the count for the current context
+    */
+   actual fun reset() {
+      counter = 0
+   }
+
+   /**
+    * Increments the counter for the current context.
+    */
+   actual fun inc() {
+      counter++
+   }
+
+}

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -1,0 +1,31 @@
+package io.kotest.assertions
+
+@ThreadLocal
+actual object ErrorCollector {
+
+  private val failures = mutableListOf<Throwable>()
+  private var mode = ErrorCollectionMode.Hard
+  private val clues = mutableListOf<Any>()
+
+  actual fun getCollectionMode(): ErrorCollectionMode = mode
+  actual fun setCollectionMode(mode: ErrorCollectionMode) {
+    ErrorCollector.mode = mode
+  }
+
+  actual fun pushClue(clue: Any) {
+    clues.add(0, clue)
+  }
+
+  actual fun popClue() {
+    clues.removeAt(0)
+  }
+
+  actual fun clueContext(): List<Any> = clues.toList()
+
+  actual fun pushError(t: Throwable) {
+    failures.add(t)
+  }
+
+  actual fun errors(): List<Throwable> = failures.toList()
+  actual fun clear() = failures.clear()
+}

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/Failures.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/Failures.kt
@@ -1,0 +1,8 @@
+package io.kotest.assertions
+
+actual object Failures {
+  actual fun failure(message: String): AssertionError = failure(message, null)
+  actual fun failure(message: String, cause: Throwable?): AssertionError = AssertionError(message)
+  actual fun clean(throwable: Throwable): Throwable = throwable
+  actual fun failure(message: String, expectedRepr: String, actualRepr: String): Throwable = failure(message)
+}

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/classname.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/classname.kt
@@ -1,0 +1,5 @@
+package io.kotest.assertions
+
+import kotlin.reflect.KClass
+
+actual fun <T : Any> KClass<T>.classname(): String = simpleName ?: "<anon>"

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/currentTimeMillis.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/currentTimeMillis.kt
@@ -1,0 +1,5 @@
+package io.kotest.assertions
+
+import kotlin.system.getTimeMillis
+
+actual fun currentTimeMillis(): Long = getTimeMillis()

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/diffLargeString.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/diffLargeString.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+actual fun diffLargeString(expected: String, actual: String, minSizeForDiff: Int) = Pair(expected, actual)

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/readSystemProperty.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/readSystemProperty.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+actual fun readSystemProperty(key: String): String? = null

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/show/KClassShow.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/show/KClassShow.kt
@@ -1,0 +1,7 @@
+package io.kotest.assertions.show
+
+import kotlin.reflect.KClass
+
+actual fun KClassShow(): Show<KClass<*>> = object : Show<KClass<*>> {
+   override fun show(a: KClass<*>): String = a.simpleName ?: a.toString()
+}

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/show/dataClassShow.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/show/dataClassShow.kt
@@ -1,0 +1,4 @@
+package io.kotest.assertions.show
+
+// native doesn't support full reflection yet so we just need to delegate to the instances toString
+actual fun <A : Any> dataClassShow(): Show<A> = DefaultShow

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/show/isDataClass.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/show/isDataClass.kt
@@ -1,0 +1,7 @@
+package io.kotest.assertions.show
+
+import kotlin.reflect.KClass
+
+// not supported in native yet
+actual fun <T : Any> KClass<T>.isDataClass(): Boolean = false
+

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/sysprop.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/sysprop.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+actual fun sysprop(name: String): String? = null

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/throwableLocation.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/assertions/throwableLocation.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+actual fun Throwable.throwableLocation(): String? = null

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/data/DataDrivenTestingReflect.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/data/DataDrivenTestingReflect.kt
@@ -1,0 +1,4 @@
+package io.kotest.data
+
+internal actual val Function<*>.paramNames: List<String>
+   get() = emptyList() // kotlin-reflect doesn't support the `reflect()` function on native

--- a/kotest-assertions/src/nativeMain/kotlin/io/kotest/properties/default.kt
+++ b/kotest-assertions/src/nativeMain/kotlin/io/kotest/properties/default.kt
@@ -1,0 +1,20 @@
+package io.kotest.properties
+
+actual inline fun <reified T> Gen.Companion.default(): Gen<T> {
+  val classname = T::class.simpleName ?: "<anon>"
+  return forClassName(classname) as Gen<T>
+}
+
+fun forClassName(className: String): Gen<*> {
+  return when (className) {
+    "java.lang.String", "kotlin.String", "String" -> Gen.string()
+    "java.lang.Integer", "kotlin.Int", "Int" -> Gen.int()
+    "java.lang.Short", "kotlin.Short", "Short" -> Gen.short()
+    "java.lang.Byte", "kotlin.Byte", "Byte" -> Gen.byte()
+    "java.lang.Long", "kotlin.Long", "Long" -> Gen.long()
+    "java.lang.Boolean", "kotlin.Boolean", "Boolean" -> Gen.bool()
+    "java.lang.Float", "kotlin.Float", "Float" -> Gen.float()
+    "java.lang.Double", "kotlin.Double", "Double" -> Gen.double()
+    else -> throw IllegalArgumentException("Cannot infer generator for $className; specify generators explicitly")
+  }
+}

--- a/kotest-fp/build.gradle.kts
+++ b/kotest-fp/build.gradle.kts
@@ -8,6 +8,9 @@ repositories {
    mavenCentral()
 }
 
+val ideaActive = System.getProperty("idea.active") == "true"
+val os = org.gradle.internal.os.OperatingSystem.current()
+
 kotlin {
 
    targets {
@@ -24,6 +27,17 @@ kotlin {
                moduleKind = "commonjs"
             }
          }
+      }
+      if (!ideaActive) {
+         linuxX64()
+         mingwX64()
+         macosX64()
+      } else if (os.isMacOsX) {
+         macosX64("native")
+      } else if (os.isWindows) {
+         mingwX64("native")
+      } else {
+         linuxX64("native")
       }
    }
 
@@ -54,6 +68,16 @@ kotlin {
          dependsOn(commonMain)
          dependencies {
             implementation(kotlin("stdlib-jdk8"))
+         }
+      }
+
+      if (!ideaActive) {
+         val nativeMain by creating {
+            dependsOn(commonMain)
+         }
+
+         configure(listOf(getByName("macosX64Main"), getByName("linuxX64Main"), getByName("mingwX64Main"))) {
+            dependsOn(nativeMain)
          }
       }
    }

--- a/kotest-fp/src/nativeMain/kotlin/io/kotest/fp/nonFatal.kt
+++ b/kotest-fp/src/nativeMain/kotlin/io/kotest/fp/nonFatal.kt
@@ -1,0 +1,3 @@
+package io.kotest.fp
+
+actual fun nonFatal(t: Throwable): Boolean = true

--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -9,17 +9,16 @@ repositories {
    mavenCentral()
 }
 
+val ideaActive = System.getProperty("idea.active") == "true"
+val os = org.gradle.internal.os.OperatingSystem.current()
+
 kotlin {
 
    targets {
       jvm {
-         targets {
-            jvm {
-               compilations.all {
-                  kotlinOptions {
-                     jvmTarget = "1.8"
-                  }
-               }
+         compilations.all {
+            kotlinOptions {
+               jvmTarget = "1.8"
             }
          }
       }
@@ -29,6 +28,17 @@ kotlin {
                moduleKind = "commonjs"
             }
          }
+      }
+      if (!ideaActive) {
+         linuxX64()
+         mingwX64()
+         macosX64()
+      } else if (os.isMacOsX) {
+         macosX64("native")
+      } else if (os.isWindows) {
+         mingwX64("native")
+      } else {
+         linuxX64("native")
       }
    }
 
@@ -74,6 +84,19 @@ kotlin {
          dependsOn(jvmMain)
          dependencies {
             implementation(project(":kotest-runner:kotest-runner-junit5"))
+         }
+      }
+
+      if (!ideaActive) {
+         val nativeMain by creating {
+            dependsOn(commonMain)
+            dependencies {
+               implementation(Libs.Coroutines.coreNative)
+            }
+         }
+
+         configure(listOf(getByName("macosX64Main"), getByName("linuxX64Main"), getByName("mingwX64Main"))) {
+            dependsOn(nativeMain)
          }
       }
    }


### PR DESCRIPTION
I set up native targets to all depend on a single source set to avoid code duplication. IntelliJ doesn't understand source sets without a target, though, so I took an approach similar to [kotlinx-io](https://github.com/Kotlin/kotlinx-io/blob/master/core/build.gradle) and make a single native target  that's an alias to the common native source set in IntelliJ. I expanded on their approach to support development on any OS. When running the build through gradle, all targets are defined normally.

I didn't add native targets to kotest-core, since I'm not sure how test runners work on native. 