### PR TITLE
Replace TravisCI with GitHub Actions for CI tests

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,0 +1,64 @@
+name: Test
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'doc/**'
+      - '*.md'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Cache gradle
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      -  name: Cache gradle wrapper
+         uses: actions/cache@v1
+         with:
+            path: ~/.gradle/caches
+            key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+            restore-keys: |
+               ${{ runner.os }}-gradlewrapper-
+      -  name: Cache maven
+         uses: actions/cache@v1
+         with:
+            path: ~/.m2/repository/
+            key: ${{ runner.os }}-maven-${{ hashFiles('**/*.gradle') }}
+            restore-keys: |
+               ${{ runner.os }}-maven-
+
+      - name: Run ubuntu tests
+        if: matrix.os == 'ubuntu-latest'
+        run: ./gradlew check
+      - name: Run windows tests
+        if: matrix.os == 'windows-latest'
+        run: ./gradlew mingwX64Test
+      - name: Run macOS tests
+        if: matrix.os == 'macOS-latest'
+        run: ./gradlew macosX64Test
+
+      - name: Bundle the build report
+        if: failure()
+        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
+      - name: Upload the build report
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: error-report
+          path: build-reports.zip
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ install: "/bin/true"
 
 jobs:
   include:
-    - stage: test
-      name: "run MPP unit tests"
-      script: "./gradlew check"
+#    - stage: test
+#      name: "run MPP unit tests"
+#      script: "./gradlew check"
 #    - stage: test
 #      name: "kotest gradle plugin"
 #      script: "./gradlew compileKotlin kotest"

--- a/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/CIServerTagExtension.kt
+++ b/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/CIServerTagExtension.kt
@@ -4,5 +4,5 @@ import io.kotest.Tags
 import io.kotest.extensions.TagExtension
 
 object CIServerTagExtension : TagExtension {
-  override fun tags(): Tags = if (isCI()) Tags.Empty else Tags.exclude(AppveyorTag, TravisTag)
+  override fun tags(): Tags = if (isCI()) Tags.Empty else Tags.exclude(AppveyorTag, TravisTag, GithubActionsTag)
 }

--- a/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/JUnitHTMLReportTest.kt
+++ b/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/JUnitHTMLReportTest.kt
@@ -8,7 +8,7 @@ import java.nio.file.Files
 
 class JUnitHTMLReportTest : WordSpec() {
 
-  override fun tags(): Set<Tag> = setOf(AppveyorTag, TravisTag)
+  override fun tags(): Set<Tag> = setOf(AppveyorTag, TravisTag, GithubActionsTag)
 
   fun indexHtml(): String {
     val ReportPath = "kotest-tests/kotest-tests-core/build/reports/tests/test/index.html"

--- a/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/JUnitXMLReportTest.kt
+++ b/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/JUnitXMLReportTest.kt
@@ -9,12 +9,16 @@ import java.io.File
 
 class JUnitXMLReportTest : WordSpec() {
 
-  override fun tags(): Set<Tag> = setOf(AppveyorTag, TravisTag)
+  override fun tags(): Set<Tag> = setOf(AppveyorTag, TravisTag, GithubActionsTag)
 
   fun root(): Element {
 
     val ReportPath = "kotest-tests/kotest-tests-core/build/test-results/test/TEST-com.sksamuel.kotest.specs.wordspec.WordSpecTest.xml"
     val file = when {
+      System.getenv("GITHUB_ACTIONS") == "true" -> {
+         println("XML: " + File(System.getenv("GITHUB_WORKSPACE") + "/kotlintest/kotest-tests/kotest-tests-core/build/test-results/test").listFiles().joinToString("\n"))
+         File(System.getenv("GITHUB_WORKSPACE") + "/kotlintest/$ReportPath")
+      }
       System.getenv("TRAVIS") == "true" -> {
         println("XML: " + File(System.getenv("TRAVIS_BUILD_DIR") + "/kotest-tests/kotest-tests-core/build/test-results/test").listFiles().joinToString("\n"))
         File(System.getenv("TRAVIS_BUILD_DIR") + "/$ReportPath")

--- a/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/ci.kt
+++ b/kotest-tests/kotest-tests-junit-report/src/jvmTest/kotlin/com/sksamuel/kotest/ci.kt
@@ -4,7 +4,9 @@ import io.kotest.Tag
 
 fun isTravis() = System.getenv("TRAVIS") == "true"
 fun isAppveyor() = System.getenv("APPVEYOR") == "True"
-fun isCI() = isTravis() || isAppveyor()
+fun isGitHubActions() = System.getenc("GITHUB_ACTIONS") == "true"
+fun isCI() = isTravis() || isAppveyor() || isGitHubActions()
 
 object AppveyorTag : Tag()
 object TravisTag : Tag()
+object GithubActionsTag : Tag()


### PR DESCRIPTION
This allows us to run unit tests for native targets.

I set up the workflow based on information from [this blog post](https://www.alecstrong.com/2020/01/github-actions-mpp/). The linux host will run JVM, JS and linux native tests, while the macOS and Windows hosts will save time by only running the native tests for their respective platforms.