### PR TITLE
Publish native artifacts for all supported platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,25 +43,58 @@ jobs:
                name: error-report
                path: build-reports.zip
 
-   deploy:
-      needs: build
-      runs-on: ubuntu-latest
-
-      steps:
          -  name: Generate build number
+            if: success()
             uses: einaregilsson/build-number@v2
             with:
                token: ${{secrets.github_token}}
 
+         -  name: Upload build number
+            if: success()
+            uses: actions/upload-artifact@v1
+            with:
+               name: BUILD_NUMBER
+               path: BUILD_NUMBER
+
+   deploy-mac-and-linux:
+      needs: build
+      runs-on: macOS-latest
+
+      steps:
          -  name: Checkout the repo
             uses: actions/checkout@v2
-
+         -  name: Download build number
+            uses: actions/download-artifact@v1
+            with:
+               name: BUILD_NUMBER
+         -  name: Restore build number
+            id: buildnumber
+            uses: einaregilsson/build-number@v2
          -  name: deploy to sonatype snapshots
             run: ./gradlew publish
             env:
                OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
                OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
+   deploy-windows:
+      needs: build
+      runs-on: windows-latest
+
+      steps:
+         -  name: Checkout the repo
+            uses: actions/checkout@v2
+         -  name: Download build number
+            uses: actions/download-artifact@v1
+            with:
+               name: BUILD_NUMBER
+         -  name: Restore build number
+            id: buildnumber
+            uses: einaregilsson/build-number@v2
+         -  name: deploy to sonatype snapshots
+            run: ./gradlew publishMingwPublicationToMavenRepository
+            env:
+               OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+               OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
 env:
    GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=true -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"


### PR DESCRIPTION
Currently, only the linux artifact is being published. This PR updates the workflow to use the maxOS runner to publish linux and macOS artifacts, and the windows runner to publish the windows artifact.

The build number is generated once in the build job, then downloaded in the two publish jobs.