### PR TITLE
Add infix modifier to Ktor matchers

### DIFF
--- a/kotest-assertions/kotest-assertions-ktor/src/jvmMain/kotlin/io/kotest/assertions/ktor/ResponseMatchers.kt
+++ b/kotest-assertions/kotest-assertions-ktor/src/jvmMain/kotlin/io/kotest/assertions/ktor/ResponseMatchers.kt
@@ -8,10 +8,10 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.response.ApplicationResponse
 import io.ktor.server.testing.TestApplicationResponse
 
-fun TestApplicationResponse.shouldHaveStatus(httpStatusCode: HttpStatusCode) = this.shouldHaveStatus(httpStatusCode.value)
-fun TestApplicationResponse.shouldHaveStatus(code: Int) = this should haveStatus(code)
-fun TestApplicationResponse.shouldNotHaveStatus(httpStatusCode: HttpStatusCode) = this.shouldNotHaveStatus(httpStatusCode.value)
-fun TestApplicationResponse.shouldNotHaveStatus(code: Int) = this shouldNot haveStatus(code)
+infix fun TestApplicationResponse.shouldHaveStatus(httpStatusCode: HttpStatusCode) = this.shouldHaveStatus(httpStatusCode.value)
+infix fun TestApplicationResponse.shouldHaveStatus(code: Int) = this should haveStatus(code)
+infix fun TestApplicationResponse.shouldNotHaveStatus(httpStatusCode: HttpStatusCode) = this.shouldNotHaveStatus(httpStatusCode.value)
+infix fun TestApplicationResponse.shouldNotHaveStatus(code: Int) = this shouldNot haveStatus(code)
 fun haveStatus(code: Int) = object : Matcher<TestApplicationResponse> {
   override fun test(value: TestApplicationResponse): MatcherResult {
     return MatcherResult(
@@ -22,12 +22,12 @@ fun haveStatus(code: Int) = object : Matcher<TestApplicationResponse> {
   }
 }
 
-fun TestApplicationResponse.shouldHaveContent(content: String) = this should haveContent(content)
-fun TestApplicationResponse.shouldNotHaveContent(content: String) = this shouldNot haveContent(content)
+infix fun TestApplicationResponse.shouldHaveContent(content: String) = this should haveContent(content)
+infix fun TestApplicationResponse.shouldNotHaveContent(content: String) = this shouldNot haveContent(content)
 fun haveContent(content: String) = object : Matcher<TestApplicationResponse> {
   override fun test(value: TestApplicationResponse): MatcherResult {
     return MatcherResult(
-        value.content!! == content,
+        value.content == content,
         "Response should have content $content but had content ${value.content}",
         "Response should not have content $content"
     )

--- a/kotest-assertions/kotest-assertions-ktor/src/jvmTest/kotlin/com/sksamuel/kotest/tests/ktor/KtorAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-ktor/src/jvmTest/kotlin/com/sksamuel/kotest/tests/ktor/KtorAssertionsTest.kt
@@ -4,7 +4,9 @@ import io.kotest.assertions.ktor.shouldHaveContent
 import io.kotest.assertions.ktor.shouldHaveCookie
 import io.kotest.assertions.ktor.shouldHaveHeader
 import io.kotest.assertions.ktor.shouldHaveStatus
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.ktor.application.Application
 import io.ktor.application.ApplicationCallPipeline
 import io.ktor.application.call
@@ -31,7 +33,7 @@ class KtorAssertionsTest : StringSpec({
   "test status code matcher" {
     withTestApplication({ testableModule() }) {
       handleRequest(HttpMethod.Get, "/").apply {
-        response.shouldHaveStatus(200)
+        response shouldHaveStatus 200
       }
     }
   }
@@ -39,7 +41,7 @@ class KtorAssertionsTest : StringSpec({
   "test status code matcher (enum version)" {
     withTestApplication({ testableModule() }) {
       handleRequest(HttpMethod.Get, "/").apply {
-        response.shouldHaveStatus(HttpStatusCode.OK)
+        response shouldHaveStatus HttpStatusCode.OK
       }
     }
   }
@@ -55,7 +57,7 @@ class KtorAssertionsTest : StringSpec({
   "test content matcher" {
     withTestApplication({ testableModule() }) {
       handleRequest(HttpMethod.Get, "/").apply {
-        response.shouldHaveContent("ok")
+        response shouldHaveContent "ok"
       }
     }
   }
@@ -65,6 +67,18 @@ class KtorAssertionsTest : StringSpec({
       handleRequest(HttpMethod.Get, "/").apply {
         response.shouldHaveCookie("mycookie", "myvalue")
       }
+    }
+  }
+
+  "test null response doesn't end with KotlinNullpointerException" {
+    withTestApplication({ testableModule() }) {
+      handleRequest(HttpMethod.Get, "/not-mapped").apply {
+        response.content shouldBe null
+        shouldThrow<AssertionError> {
+          response shouldHaveContent "fail"
+        }
+      }
+
     }
   }
 })


### PR DESCRIPTION
In addition to this, this commit also fixes a possible `KotlinNullPointerException` on the `shouldHaveContent` method.

Closes #1240