### PR TITLE
Fix the regex property generator so it produces new values

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/regex.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/regex.kt
@@ -1,11 +1,18 @@
 package io.kotest.property.arbitrary
 
 import com.mifmif.common.regex.Generex
+import io.kotest.property.RandomSource
+import io.kotest.property.Sample
 
-fun Arb.Companion.regex(regex: String) = arb {
-   val generex = Generex(regex)
-   generex.setSeed(it.seed)
-   generex.random()
+fun Arb.Companion.regex(regex: String) = object : Arb<String> {
+   override fun edgecases(): List<String> = emptyList()
+
+   override fun samples(rs: RandomSource): Sequence<Sample<String>> {
+      val generex = Generex(regex)
+      generex.setSeed(rs.seed)
+
+      return generateSequence { Sample(generex.random()) }
+   }
 }
 
 fun Arb.Companion.regex(regex: Regex) = regex(regex.pattern)


### PR DESCRIPTION
The arb was generating a sequence of the same value; the first value for the
RandomSource seed.