### PR TITLE
Remove AutoScan from KoinListener

### DIFF
--- a/kotest-core/src/jvmMain/kotlin/io/kotest/core/config/detectConfig.kt
+++ b/kotest-core/src/jvmMain/kotlin/io/kotest/core/config/detectConfig.kt
@@ -5,7 +5,6 @@ import io.kotest.core.extensions.Extension
 import io.kotest.core.filters.Filter
 import io.kotest.core.listeners.Listener
 import io.kotest.core.listeners.ProjectListener
-import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.AutoScan
 import io.kotest.fp.toOption
 import kotlin.math.max
@@ -19,7 +18,11 @@ actual fun detectConfig(): ProjectConf {
    fun <T> instantiate(klass: Class<T>): T =
       when (val field = klass.declaredFields.find { it.name == "INSTANCE" }) {
          // if the static field for an object cannot be found, then instantiate
-         null -> klass.constructors[0].newInstance() as T
+         null -> {
+            val zeroArgsConstructor = klass.constructors.find { it.parameterCount == 0 }
+                ?: throw IllegalArgumentException("Class ${klass.name} should have a zero-arg constructor")
+            zeroArgsConstructor.newInstance() as T
+         }
          // if the static field can be found then use it
          else -> field.get(null) as T
       }

--- a/kotest-extensions/kotest-extensions-koin/src/jvmMain/kotlin/io/kotest/koin/KoinListener.kt
+++ b/kotest-extensions/kotest-extensions-koin/src/jvmMain/kotlin/io/kotest/koin/KoinListener.kt
@@ -1,14 +1,12 @@
 package io.kotest.koin
 
+import io.kotest.core.listeners.TestListener
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
-import io.kotest.core.listeners.TestListener
-import io.kotest.core.spec.AutoScan
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.module.Module
 
-@AutoScan
 class KoinListener(private val modules: List<Module>) : TestListener {
 
    constructor(module: Module) : this(listOf(module))


### PR DESCRIPTION
This commit also improves the way we instantiate classes, providing a better error if anything is misdefined.

Closes #1246