### PR TITLE
Refactor gradle builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,8 @@ plugins {
    id("java-library")
    id("maven-publish")
    signing
-   id("com.adarshr.test-logger") version "2.0.0"
-   id("org.jetbrains.dokka") version "0.10.1"
+   id("com.adarshr.test-logger") version Libs.adarshrTestLoggerVersion
+   id("org.jetbrains.dokka") version Libs.dokkaVersion
 }
 
 // Configure existing Dokka task to output HTML to typical Javadoc directory

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,11 @@ plugins {
    signing
    id("com.adarshr.test-logger") version Libs.adarshrTestLoggerVersion
    id("org.jetbrains.dokka") version Libs.dokkaVersion
+
+   // To get versions report, execute:
+   // Win: .\gradlew.bat dependencyUpdates -Drevision=release
+   // Other: gradle dependencyUpdates -Drevision=release
+   id("com.github.ben-manes.versions") version Libs.gradleVersionsPluginVersion
 }
 
 // Configure existing Dokka task to output HTML to typical Javadoc directory

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -3,6 +3,7 @@ object Libs {
    const val kotlinVersion = "1.3.61"
    const val dokkaVersion = "0.10.1"
    const val adarshrTestLoggerVersion = "2.0.0"
+   const val gradleVersionsPluginVersion = "0.28.0"
 
    object Arrow {
       private const val version = "0.10.4"

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -1,7 +1,8 @@
 object Libs {
 
-   val kotlinVersion = "1.3.61"
-   val dokkaVersion = "0.10.0"
+   const val kotlinVersion = "1.3.61"
+   const val dokkaVersion = "0.10.1"
+   const val adarshrTestLoggerVersion = "2.0.0"
 
    object Arrow {
       private const val version = "0.10.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Added plugin to get version updates. Please check the report below. Probably some of dependencies can be updated:

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - com.adarshr.test-logger:com.adarshr.test-logger.gradle.plugin:2.0.0
 - com.fasterxml.jackson.module:jackson-module-kotlin:2.10.2
 - com.github.ben-manes.versions:com.github.ben-manes.versions.gradle.plugin:0.28.0
 - com.github.mifmif:generex:1.0.2
 - com.github.tschuchortdev:kotlin-compile-testing:1.2.6
 - com.jayway.jsonpath:json-path:2.4.0
 - com.nhaarman:mockito-kotlin:1.6.0
 - com.sun.xml.bind:jaxb-core:2.3.0.1
 - commons-io:commons-io:2.6
 - io.arrow-kt:arrow-core:0.10.4
 - io.arrow-kt:arrow-fx:0.10.4
 - io.arrow-kt:arrow-syntax:0.10.4
 - io.arrow-kt:arrow-validation:0.10.4
 - io.konform:konform:0.1.0
 - io.mockk:mockk:1.9.3
 - org.jetbrains.dokka:org.jetbrains.dokka.gradle.plugin:0.10.1
 - org.jetbrains.kotlin:kotlin-allopen:1.3.61
 - org.jetbrains.kotlin:kotlin-reflect:1.3.61
 - org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:1.3.61
 - org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 - org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.61
 - org.jetbrains.kotlin:kotlin-stdlib-js:1.3.61
 - org.jetbrains.kotlin:kotlin-test-js:1.3.61
 - org.jetbrains.kotlin.multiplatform:org.jetbrains.kotlin.multiplatform.gradle.plugin:1.3.61
 - org.jetbrains.kotlin.plugin.spring:org.jetbrains.kotlin.plugin.spring.gradle.plugin:1.3.61
 - org.junit.jupiter:junit-jupiter-api:5.6.0
 - org.junit.jupiter:junit-jupiter-engine:5.6.0
 - org.junit.platform:junit-platform-engine:1.6.0
 - org.junit.platform:junit-platform-launcher:1.6.0
 - org.junit.platform:junit-platform-suite-api:1.6.0
 - org.junit.platform:junit-platform-testkit:1.6.0
 - org.mock-server:mockserver-client-java:5.9.0
 - org.mock-server:mockserver-netty:5.9.0

The following dependencies have later release versions:
 - ch.qos.logback:logback-classic [1.2.3 -> 1.3.0-alpha5]
     http://logback.qos.ch
 - com.android.tools.build:gradle [3.5.3 -> 4.1.0-alpha01]
     https://developer.android.com/studio
 - com.github.node-gradle.node:com.github.node-gradle.node.gradle.plugin [2.2.0 -> 2.2.3]
 - com.github.wumpz:diffutils [2.2 -> 3.0]
     https://github.com/wumpz/java-diff-utils
 - com.sun.xml.bind:jaxb-impl [2.3.2 -> 2.4.0-b180830.0438]
     http://jaxb.java.net
 - com.univocity:univocity-parsers [2.8.3 -> 2.8.4]
     http://github.com/univocity/univocity-parsers
 - io.github.classgraph:classgraph [4.8.60 -> 4.8.65]
     https://github.com/classgraph/classgraph
 - io.ktor:ktor-client-apache [1.3.0 -> 1.3.1]
     https://github.com/ktorio/ktor
 - io.ktor:ktor-client-core [1.3.0 -> 1.3.1]
     https://github.com/ktorio/ktor
 - io.ktor:ktor-client-js [1.3.0 -> 1.3.1]
     https://github.com/ktorio/ktor
 - io.ktor:ktor-server-core [1.2.6 -> 1.3.1]
     https://github.com/ktorio/ktor
 - io.ktor:ktor-server-test-host [1.2.6 -> 1.3.1]
     https://github.com/ktorio/ktor
 - io.qameta.allure:allure-java-commons [2.13.1 -> 2.13.2]
     https://github.com/allure-framework/allure-java
 - javax.xml.bind:jaxb-api [2.3.1 -> 2.4.0-b180830.0359]
     https://github.com/javaee/jaxb-spec
 - junit:junit [4.12 -> 4.13]
     http://junit.org
 - net.bytebuddy:byte-buddy [1.10.7 -> 1.10.8]
     https://bytebuddy.net
 - org.jetbrains.kotlinx:kotlinx-coroutines-core [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-core-common [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-core-js [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jetbrains.kotlinx:kotlinx-coroutines-jdk8 [1.3.3 -> 1.3.3-1.3.70-eap-42]
     https://github.com/Kotlin/kotlinx.coroutines
 - org.jsoup:jsoup [1.12.2 -> 1.13.1]
     https://jsoup.org/
 - org.koin:koin-core [2.0.1 -> 2.1.1]
 - org.koin:koin-test [2.0.1 -> 2.1.1]
 - org.mockito:mockito-core [2.24.0 -> 3.3.1]
     https://github.com/mockito/mockito
 - org.pitest:pitest [1.4.11 -> 1.5.0]
     http://pitest.org
 - org.robolectric:robolectric [4.3 -> 4.3.1]
     http://robolectric.org
 - org.slf4j:slf4j-api [1.7.30 -> 2.0.0-alpha1]
     http://www.slf4j.org
 - org.springframework:spring-context [5.2.2.RELEASE -> 5.2.4.RELEASE]
     https://github.com/spring-projects/spring-framework
 - org.springframework:spring-test [5.2.2.RELEASE -> 5.2.4.RELEASE]
     https://github.com/spring-projects/spring-framework
 - org.springframework.boot:spring-boot-starter-test [2.2.2.RELEASE -> 2.2.5.RELEASE]
     https://projects.spring.io/spring-boot/#/spring-boot-parent/spring-boot-starters/spring-boot-starter-test

Failed to determine the latest version for the following dependencies (use --info for details):
 - com.soywiz.korlibs.klock:klock
     1.8.9
 - org.jetbrains.kotlinx:kotlinx-coroutines-core-native
     1.3.3-1.3.70-eap-42

Gradle release-candidate updates:
 - Gradle: [6.2.1: UP-TO-DATE]