### PR TITLE
issues/1284: Fix containInOrder matcher message

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -1,6 +1,7 @@
 package io.kotest.matchers.string
 
 import io.kotest.assertions.show.show
+import io.kotest.assertions.stringRepr
 import io.kotest.matchers.*
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.string.UUIDVersion.ANY
@@ -135,8 +136,8 @@ fun containInOrder(vararg substrings: String) = neverNullMatcher<String> { value
 
   MatcherResult(
      recTest(value, substrings.filter{ it.isNotEmpty() }),
-    { "${value.show()} should include substrings ${substrings.show()} in order" },
-    { "$value should not include substrings ${substrings.show()} in order" })
+    { "${value.show()} should include substrings ${stringRepr(substrings)} in order" },
+    { "$value should not include substrings ${stringRepr(substrings)} in order" })
 }
 
 infix fun String?.shouldContain(substr: String) = this should contain(substr)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -335,6 +335,16 @@ class StringMatchersTest : FreeSpec() {
         "ab" should containInOrder("", "a", "", "b", "")
       }
 
+      "should print the substrings in matcher messages" {
+        shouldThrow<AssertionError> {
+          "zhelzloz" should containInOrder("hel", "no", "lo")
+        }.message shouldBe "zhelzloz should include substrings [\"hel\", \"no\", \"lo\"] in order"
+
+        shouldThrow<AssertionError> {
+          "zhelznozloz" shouldNot containInOrder("hel", "no", "lo")
+        }.message shouldBe "zhelznozloz should not include substrings [\"hel\", \"no\", \"lo\"] in order"
+      }
+
       "should fail if value is null" {
         shouldThrow<AssertionError> {
           null shouldNot containInOrder("")


### PR DESCRIPTION
This would close https://github.com/kotest/kotest/issues/1284 .

The `containInOrder` matcher now uses `io.kotest.assertions.stringRepr` instead of `io.kotest.assertions.show.show` to format the vararg parameters. This behavior is parallel to the implementation of `io.kotest.matchers.collections.containExactly`.

-Claas