### PR TITLE
Change return type of buildAssertionError

### DIFF
--- a/kotest-assertions/src/commonMain/kotlin/io/kotest/inspectors/error.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io/kotest/inspectors/error.kt
@@ -17,7 +17,7 @@ import io.kotest.mpp.sysprop
  *     -Dkotlintest.assertions.output.max=20
  * ```
  */
-fun <T> buildAssertionError(msg: String, results: List<ElementResult<T>>): String {
+fun <T> buildAssertionError(msg: String, results: List<ElementResult<T>>): Nothing {
 
    val maxResults = sysprop("kotlintest.assertions.output.max")?.toInt() ?: 10
 


### PR DESCRIPTION
buildAssertionError never returns anything but always throws, so it should return Nothing