### PR TITLE
Add String?.shouldBeInteger([Int]): Int

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -70,6 +70,7 @@ For Android-specific matchers, take a look [here](android_matchers.md)
 | `str.shouldContainADigit()` | Asserts that the string contains at least one digit. |
 | `str.shouldContainIgnoringCase(substring)` | Asserts that the string contains the substring ignoring case. |
 | `str.shouldContainOnlyDigits()` | Asserts that the string contains only digits, or is empty. |
+| `str.shouldBeInteger([radix])` | Asserts that the string contains an integer and returns it. |
 | `str.shouldContainOnlyOnce(substring)` | Asserts that the string contains the substring exactly once. |
 | `str.shouldEndWith("suffix")` | Asserts that the string ends with the given suffix. The suffix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
 | `str.shouldHaveLength(length)` | Asserts that the string has the given length. |

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -5,6 +5,8 @@ import io.kotest.assertions.show.show
 import io.kotest.matchers.*
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.string.UUIDVersion.ANY
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.text.RegexOption.IGNORE_CASE
 
 fun String?.shouldContainOnlyDigits() = this should containOnlyDigits()
@@ -447,12 +449,19 @@ fun beUUID(
   private fun String.isNilUUID() = this == "00000000-0000-0000-0000-000000000000"
 }
 
-fun String?.shouldBeInteger(radix: Int = 10) = when (this) {
-  null -> throw failure("String is null, but it should be integer.")
+@OptIn(ExperimentalContracts::class)
+fun String?.shouldBeInteger(radix: Int = 10): Int {
+  contract {
+    returns() implies (this@shouldBeInteger != null)
+  }
 
-  else -> when (val integer = this.toIntOrNull(radix)) {
-    null -> throw failure("String '$this' is not integer, but it should be.")
+  return when (this) {
+    null -> throw failure("String is null, but it should be integer.")
 
-    else -> integer
+    else -> when (val integer = this.toIntOrNull(radix)) {
+      null -> throw failure("String '$this' is not integer, but it should be.")
+
+      else -> integer
+    }
   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.string
 
+import io.kotest.assertions.failure
 import io.kotest.assertions.show.show
 import io.kotest.matchers.*
 import io.kotest.matchers.neverNullMatcher
@@ -444,4 +445,14 @@ fun beUUID(
   )
 
   private fun String.isNilUUID() = this == "00000000-0000-0000-0000-000000000000"
+}
+
+fun String?.shouldBeInteger(radix: Int = 10) = when (this) {
+  null -> throw failure("String is null, but it should be integer.")
+
+  else -> when (val integer = this.toIntOrNull(radix)) {
+    null -> throw failure("String '$this' is not integer, but it should be.")
+
+    else -> integer
+  }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.string.shouldBeBlank
 import io.kotest.matchers.string.shouldBeEmpty
 import io.kotest.matchers.string.shouldBeEqualIgnoringCase
 import io.kotest.matchers.string.shouldBeFalsy
+import io.kotest.matchers.string.shouldBeInteger
 import io.kotest.matchers.string.shouldBeLowerCase
 import io.kotest.matchers.string.shouldBeSingleLine
 import io.kotest.matchers.string.shouldBeTruthy
@@ -893,6 +894,48 @@ class StringMatchersTest : FreeSpec() {
 
       "should fail when outside range" {
         shouldThrow<AssertionError> { "FOO".shouldHaveLengthIn(9..10) }
+      }
+    }
+
+    "should be integer" - {
+      "should return integer for integer string" {
+        "123123".shouldBeInteger() shouldBe 123123
+        "0".shouldBeInteger() shouldBe 0
+        "1".shouldBeInteger() shouldBe 1
+        "-9876".shouldBeInteger() shouldBe -9876
+
+        "BABE".shouldBeInteger(16) shouldBe 0xBABE
+        "-babe".shouldBeInteger(16) shouldBe -0xBABE
+
+        "100".shouldBeInteger(2) shouldBe 0b100
+        "-100".shouldBeInteger(2) shouldBe -0b100
+
+        "0124".shouldBeInteger() shouldBe 124
+      }
+
+      "should fail for null" {
+        shouldThrow<AssertionError> { null.shouldBeInteger() }
+      }
+
+      "should fail for non-integer string" {
+        shouldThrow<AssertionError> { " 123123".shouldBeInteger() }
+        shouldThrow<AssertionError> { "0 ".shouldBeInteger() }
+        shouldThrow<AssertionError> { "1-".shouldBeInteger() }
+        shouldThrow<AssertionError> { "-9876.0".shouldBeInteger() }
+        shouldThrow<AssertionError> { "fail".shouldBeInteger() }
+
+        shouldThrow<AssertionError> { "BABEg".shouldBeInteger(16) }
+        shouldThrow<AssertionError> { "-baGbe".shouldBeInteger(16) }
+      }
+
+      "should fail for overflowing integer strings" {
+        shouldThrow<AssertionError> { Int.MAX_VALUE.toLong().plus(1).toString().shouldBeInteger() }
+        shouldThrow<AssertionError> { Int.MIN_VALUE.toLong().minus(1).toString().shouldBeInteger() }
+      }
+
+      "should fail with a proper exception for bad radix" {
+        shouldThrow<IllegalArgumentException> { "1".shouldBeInteger(1) }
+        shouldThrow<IllegalArgumentException> { "11".shouldBeInteger(100) }
       }
     }
   }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -937,6 +937,14 @@ class StringMatchersTest : FreeSpec() {
         shouldThrow<IllegalArgumentException> { "1".shouldBeInteger(1) }
         shouldThrow<IllegalArgumentException> { "11".shouldBeInteger(100) }
       }
+
+      "should make smart cast of receiver to non-null string" {
+        fun use(string: String) {}
+
+        val value: String? = "456"
+        value.shouldBeInteger()
+        use(value)  // if this is compiled, then smart cast works
+      }
     }
   }
 }


### PR DESCRIPTION
Hi! I frequently do something like
```kotlin
val int = str?.toIntOrNull()
int.shouldNotBeNull()

// work with int
```

So I've defined `shouldBeInteger` function in my project and now it's like
```kotlin
val int = str.shouldBeInteger()

// work with int
```
 
Is it OK to add this function to the repo?