### PR TITLE
Make JSON and pitest tests work

### DIFF
--- a/kotest-assertions/kotest-assertions-json/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-json/build.gradle.kts
@@ -55,7 +55,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
    kotlinOptions.jvmTarget = "1.8"
 }
 
-tasks.named<Test>("test") {
+tasks.named<Test>("jvmTest") {
    useJUnitPlatform()
    filter {
       isFailOnNoMatchingTests = false

--- a/kotest-plugins/kotest-plugins-pitest/build.gradle.kts
+++ b/kotest-plugins/kotest-plugins-pitest/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
    id("java")
    kotlin("multiplatform")
    id("java-library")
+   id("com.adarshr.test-logger")
 }
 
 repositories {
@@ -54,7 +55,7 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
    kotlinOptions.jvmTarget = "1.8"
 }
 
-tasks.named<Test>("test") {
+tasks.named<Test>("jvmTest") {
    useJUnitPlatform()
    filter {
       isFailOnNoMatchingTests = false


### PR DESCRIPTION
I've just found out that I can't run JSON tests (by the way, I'm preparing my pull request for JSON functions 😉).

I see the same for CI, for example, for my another PR: https://github.com/kotest/kotest/pull/1315/checks?check_run_id=542151737

![image](https://user-images.githubusercontent.com/20105593/77857096-3e5ded00-7204-11ea-99e7-5fe59993725b.png)

I've searched for other "Executed 0 tests" entries: there are 3 more, but they seem just to not have any tests.

The solution I propose is to switch from multiplatform plugin to the jvm one. It works. Also, there are no other source sets but jvm so it makes sense I think.

However, if there is another solution, I'll be totally OK with it.