### PR TITLE
More JSON test functions

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -82,12 +82,17 @@ For Android-specific matchers, take a look [here](android_matchers.md)
 | `str.shouldStartWith("prefix")` | Asserts that the string starts with the given prefix. The prefix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
 | `str.shouldBeEqualIgnoringCase(other)` | Asserts that the string is equal to another string ignoring case. |
 
-| JSON ||
+| JSON | For convenience, JSONs are simply strings. Also, there are some [type aliases](../kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonTypes.kt) |
 | -------- | ---- |
-| `str.shouldMatchJson(json)` | Asserts that the JSON is equal to another JSON ignoring properties' order and formatting. |
-| `str.shouldContainJsonKey("$.key")` | Asserts that the JSON contains a `key`. |
-| `str.shouldContainJsonKeyValue("$.key", "value")` | Asserts that the JSON contains a `key` with a specific `value`. |
-| `str.shouldMatchJsonResource("/file.json")` | Asserts that the JSON is equal to the existing `/file.json` ignoring properties' order and formatting. |
+| `str?.shouldMatchJson(str?)` | Asserts that the JSON is equal to another JSON ignoring properties' order and formatting. |
+| `str?.shouldContainJsonKey("key"): str` | Asserts that the JSON is a JSON object and it contains a `key`. If true, returns the value of the key. |
+| `str?.shouldContainJsonPath("$.json.path"): str` | Asserts that the JSON contains a JSON path. If true, returns the value of the path. |
+| `str?.shouldContainJsonKeyValue("key", "value")` | Asserts that the JSON is a JSON object and it contains a `key` with a specific `value`. |
+| `str?.shouldContainJsonPathValue("$.json.path", "value")` | Asserts that the JSON contains a JSON path with a specific `value`. |
+| `str?.shouldHaveSize(int)` | Asserts that the JSON is a JSON object or array and it contains the specified number of elements. |
+| `str?.shouldBeOfJsonType(jsonType): T` | Asserts that the JSON is a JSON of the specified type. If true, returns the converted JSON. |
+| `str?.shouldContainOnlyJsonKey("key"): str` | A shorthand for sequential assertions `.shouldHaveSize(1)` and `.shouldContainJsonKey("key")`. Asserts that the JSON is a JSON object and it contains only a single key called `key`. If true, returns the value of the key. |
+| `str?.shouldMatchJsonResource("/file.json")` | Asserts that the JSON is equal to the existing `/file.json` ignoring properties' order and formatting. |
 
 | Integers ||
 | -------- | ---- |

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
@@ -33,7 +33,7 @@ inline fun <reified T : Any?> Json?.shouldBeJsonValueOfType(): T {
             }
         }
 
-        return mapper.readValue(this, T::class.java)
+        return publishedMapper.readValue(this, T::class.java)
     } catch (thrown: Throwable) {
         throw failure("bad type of ${this.representation} - expected: ${typeOf<T>()}", cause = thrown)
     }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
@@ -11,7 +11,8 @@ import kotlin.reflect.typeOf
  * We need to distinct `null` and `"null"`. The first one means there is no JSON at all, the second is null in JSON.
  * So we can't do just `Json?.toString()`.
  */
-val Json?.representation
+@PublishedApi
+internal val Json?.representation
     get(): String = when (this) {
         null -> null.toString()
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
@@ -11,19 +11,12 @@ import kotlin.reflect.typeOf
  *
  * We need to distinct `null` and `"null"`. The first one means there is no JSON at all, the second is null in JSON.
  * So we can't do just `Json.toString()`.
- *
- * TODO: Should we leave error messages unchanged?
- *       It's more logical to just add quotes to non-nullable JSONs like this but it will "break" old tests:
- *         val Json?.representation get(): String? = when (this) {
- *             null -> null.toString()
- *             else -> "\"$this\""
- *         }
  */
 val Json?.representation
     get(): String? = when (this) {
-        "null" -> "'null'"
+        null -> null.toString()
 
-        else -> this
+        else -> "\"$this\""
     }
 
 internal fun Json.limitLength() = if (this.length < 50) this.trim() else this.substring(0, 50).trim() + "..."

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
@@ -9,10 +9,10 @@ import kotlin.reflect.typeOf
  * Returns encoded JSON.
  *
  * We need to distinct `null` and `"null"`. The first one means there is no JSON at all, the second is null in JSON.
- * So we can't do just `Json.toString()`.
+ * So we can't do just `Json?.toString()`.
  */
 val Json?.representation
-    get(): String? = when (this) {
+    get(): String = when (this) {
         null -> null.toString()
 
         else -> "\"$this\""

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonConverters.kt
@@ -1,0 +1,45 @@
+package io.kotest.assertions.json
+
+import com.jayway.jsonpath.JsonPath
+import io.kotest.assertions.failure
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import kotlin.reflect.typeOf
+
+/**
+ * Returns encoded JSON.
+ *
+ * We need to distinct `null` and `"null"`. The first one means there is no JSON at all, the second is null in JSON.
+ * So we can't do just `Json.toString()`.
+ *
+ * TODO: Should we leave error messages unchanged?
+ *       It's more logical to just add quotes to non-nullable JSONs like this but it will "break" old tests:
+ *         val Json?.representation get(): String? = when (this) {
+ *             null -> null.toString()
+ *             else -> "\"$this\""
+ *         }
+ */
+val Json?.representation
+    get(): String? = when (this) {
+        "null" -> "'null'"
+
+        else -> this
+    }
+
+internal fun Json.limitLength() = if (this.length < 50) this.trim() else this.substring(0, 50).trim() + "..."
+
+@OptIn(ExperimentalContracts::class, ExperimentalStdlibApi::class)
+inline fun <reified T> Json?.shouldBeOfType(): T {
+    contract {
+        returns() implies (this@shouldBeOfType != null)
+    }
+
+    return when (val decoded: Any? = JsonPath.read(this, "")) {
+        is T -> decoded
+
+        else -> throw failure(
+            "bad type of ${this.representation} - " +
+                    "expected: ${typeOf<T>()} but was: ${decoded?.javaClass?.name ?: "Nothing?"}"
+        )
+    }
+}

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonCountableElement.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonCountableElement.kt
@@ -1,0 +1,8 @@
+package io.kotest.assertions.json
+
+sealed class JsonCountableElement {
+
+    class JsonKeyValuePairs internal constructor(val count: Int) : JsonCountableElement()
+}
+
+val Int.jsonKeyValueEntries get() = JsonCountableElement.JsonKeyValuePairs(this)

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -107,7 +107,7 @@ fun containJsonKey(path: JsonKey) = object : Matcher<Json> {
 }
 
 fun <T> Json?.shouldContainJsonKeyValue(path: JsonKey, value: T) = this should containJsonKeyValue(path, value)
-fun <T> Json?.shouldNotContainJsonKeyValue(path: JsonKey, value: T) = this shouldNot containJsonKeyValue(path, value)
+fun <T> Json.shouldNotContainJsonKeyValue(path: JsonKey, value: T) = this shouldNot containJsonKeyValue(path, value)
 fun <T> containJsonKeyValue(path: JsonKey, t: T) = object : Matcher<Json?> {
     override fun test(value: Json?): MatcherResult {
         val sub = value?.limitLength()

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -4,78 +4,198 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
+import io.kotest.assertions.failure
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+import kotlin.reflect.KType
+import kotlin.reflect.full.isSupertypeOf
+import kotlin.reflect.typeOf
 
-private val mapper by lazy { ObjectMapper().registerKotlinModule() }
-
-infix fun String.shouldMatchJson(json: String) = this should matchJson(json)
-infix fun String.shouldNotMatchJson(json: String) = this shouldNot matchJson(json)
-fun matchJson(json: String) = object : Matcher<String> {
-
-  override fun test(value: String): MatcherResult {
-
-    val actualJson = mapper.readTree(value)
-    val expectedJson = mapper.readTree(json)
-
-    return MatcherResult(
-        actualJson == expectedJson,
-        "expected: $expectedJson but was: $actualJson",
-        "expected not to match with: $expectedJson but match: $actualJson"
-    )
-  }
-}
-
-infix fun String.shouldMatchJsonResource(resource: String) = this should matchJsonResource(resource)
-infix fun String.shouldNotMatchJsonResource(resource: String) = this shouldNot matchJsonResource(resource)
-
-fun matchJsonResource(resource: String) = object : Matcher<String> {
-  override fun test(value: String): MatcherResult {
-
-    val actualJson = mapper.readTree(value)
-    val expectedJson = mapper.readTree(this.javaClass.getResourceAsStream(resource))
-
-    return MatcherResult(
-        actualJson == expectedJson,
-        "expected: $expectedJson but was: $actualJson",
-        "expected not to match with: $expectedJson but match: $actualJson"
-    )
-  }
-}
-
-infix fun String.shouldContainJsonKey(path: String) = this should containJsonKey(path)
-infix fun String.shouldNotContainJsonKey(path: String) = this shouldNot containJsonKey(path)
-fun containJsonKey(path: String) = object : Matcher<String> {
-
-  override fun test(value: String): MatcherResult {
-
-    val sub = if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
-
-    val passed = try {
-      JsonPath.read<String>(value, path) != null
-    } catch (t: PathNotFoundException) {
-      false
+@OptIn(ExperimentalContracts::class)
+infix fun Json?.shouldMatchJson(json: Json?) {
+    contract {
+        returns() implies (this@shouldMatchJson != null)
     }
 
-    return MatcherResult(
-        passed,
-        "$sub should contain the path $path",
-        "$sub should not contain the path $path"
-    )
-  }
+    this should matchJson(json)
 }
 
-fun <T> String.shouldContainJsonKeyValue(path: String, value: T) = this should containJsonKeyValue(path, value)
-fun <T> String.shouldNotContainJsonKeyValue(path: String, value: T) = this shouldNot containJsonKeyValue(path, value)
-fun <T> containJsonKeyValue(path: String, t: T) = object : Matcher<String> {
-  override fun test(value: String): MatcherResult {
-    val sub = if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
-    return MatcherResult(
-        JsonPath.read<T>(value, path) == t,
-        "$sub should contain the element $path = $t",
-        "$sub should not contain the element $path = $t"
-    )
-  }
+@OptIn(ExperimentalContracts::class)
+infix fun Json?.shouldNotMatchJson(json: Json?) {
+    contract {
+        returns() implies (this@shouldNotMatchJson != null)
+    }
+
+    this shouldNot matchJson(json)
+}
+
+fun matchJson(json: Json?) = object : Matcher<Json?> {
+
+    override fun test(value: Json?): MatcherResult {
+        val actualJson = value?.let { mapper.readTree(it) }
+        val expectedJson = json?.let { mapper.readTree(it) }
+
+        return MatcherResult(
+            actualJson == expectedJson,
+            "expected: $expectedJson but was: $actualJson",
+            "expected not to match with: $expectedJson but match: $actualJson"
+        )
+    }
+}
+
+infix fun Json.shouldMatchJsonResource(resource: String) = this should matchJsonResource(resource)
+infix fun Json.shouldNotMatchJsonResource(resource: String) = this shouldNot matchJsonResource(resource)
+
+fun matchJsonResource(resource: String) = object : Matcher<Json> {
+
+    override fun test(value: Json): MatcherResult {
+        val actualJson = mapper.readTree(value)
+        val expectedJson = mapper.readTree(this.javaClass.getResourceAsStream(resource))
+
+        return MatcherResult(
+            actualJson == expectedJson,
+            "expected: $expectedJson but was: $actualJson",
+            "expected not to match with: $expectedJson but match: $actualJson"
+        )
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+infix fun Json?.shouldContainJsonKey(path: JsonKey): Json? {
+    contract {
+        returns() implies (this@shouldContainJsonKey != null)
+    }
+
+    val result: Any? = try {
+        JsonPath.read(this, path)
+    } catch (thrown: Throwable) {
+        thrown
+    }
+
+    return when (result) {
+        is Throwable -> throw failure(
+            "${this?.limitLength()?.representation} should contain the path $path",
+            cause = result
+        )
+
+        else -> result?.let { mapper.writeValueAsString(it) }
+    }
+}
+
+infix fun Json.shouldNotContainJsonKey(path: JsonKey) = this shouldNot containJsonKey(path)
+fun containJsonKey(path: JsonKey) = object : Matcher<Json> {
+
+    override fun test(value: Json): MatcherResult {
+        val sub = value.limitLength()
+
+        val passed = try {
+            JsonPath.read<String>(value, path) != null
+        } catch (t: PathNotFoundException) {
+            false
+        }
+
+        return MatcherResult(
+            passed,
+            "${sub.representation} should contain the path $path",
+            "${sub.representation} should not contain the path $path"
+        )
+    }
+}
+
+fun <T> Json?.shouldContainJsonKeyValue(path: JsonKey, value: T) = this should containJsonKeyValue(path, value)
+fun <T> Json?.shouldNotContainJsonKeyValue(path: JsonKey, value: T) = this shouldNot containJsonKeyValue(path, value)
+fun <T> containJsonKeyValue(path: JsonKey, t: T) = object : Matcher<Json?> {
+    override fun test(value: Json?): MatcherResult {
+        val sub = value?.limitLength()
+
+        val result: Any? = try {
+            JsonPath.read<T>(value, path)
+        } catch (thrown: Throwable) {
+            thrown
+        }
+
+        return MatcherResult(
+            result == t,
+            "${sub.representation} should contain the element $path = $t",
+            "${sub.representation} should not contain the element $path = $t"
+        )
+    }
+}
+
+infix fun Json?.shouldContainExactly(countableElement: JsonCountableElement) =
+    this should containExactly(countableElement)
+
+infix fun Json?.shouldNotContainExactly(countableElement: JsonCountableElement) =
+    this shouldNot containExactly(countableElement)
+
+fun containExactly(countableElement: JsonCountableElement) = object : Matcher<Json?> {
+
+    override fun test(value: Json?): MatcherResult = when (countableElement) {
+        is JsonCountableElement.JsonKeyValuePairs -> {
+            // todo: check if it's a JSON object and not an array
+
+            val expected = countableElement.count
+            val actual: Int? = value?.let { JsonPath.read(it, "length()") }
+
+            MatcherResult(
+                expected == actual,
+                "bad quantity of key-value pairs in ${value.representation} - expected: $expected but was: $actual",
+                "quantity of key-value pairs in ${value.representation} - " +
+                        "expected not to match with: $expected but match: $actual"
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalContracts::class, ExperimentalStdlibApi::class)
+inline infix fun <reified T> Json?.shouldContainJsonKeyAndValueOfSpecificType(path: JsonKey): T {
+    contract {
+        returns() implies (this@shouldContainJsonKeyAndValueOfSpecificType != null)
+    }
+
+    val result: Any? = try {
+        JsonPath.read(this, path)
+    } catch (thrown: Throwable) {
+        thrown
+    }
+
+    return when (result) {
+        is T -> result
+
+        is Throwable -> throw failure(
+            "${this.representation} should contain the path $path",
+            cause = result
+        )
+
+        else -> throw failure(
+            "${this.representation} should contain an element with type ${typeOf<T>()} with the path $path " +
+                    "but it contains ${result?.let { mapper.writeValueAsString(it) }.representation}."
+        )
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+infix fun Json?.shouldContainOnlyJsonKey(path: JsonKey): Json? {
+    contract {
+        returns() implies (this@shouldContainOnlyJsonKey != null)
+    }
+
+    this shouldContainExactly 1.jsonKeyValueEntries
+
+    return this shouldContainJsonKey path
+}
+
+@OptIn(ExperimentalContracts::class)
+inline infix fun <reified T> Json?.shouldContainOnlyJsonKeyAndValueOfSpecificType(path: JsonKey): T {
+    contract {
+        returns() implies (this@shouldContainOnlyJsonKeyAndValueOfSpecificType != null)
+    }
+
+    this shouldContainExactly 1.jsonKeyValueEntries
+
+    return this shouldContainJsonKeyAndValueOfSpecificType path
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -65,7 +65,7 @@ fun matchJsonResource(resource: String) = object : Matcher<Json> {
 }
 
 @OptIn(ExperimentalContracts::class)
-infix fun Json?.shouldContainJsonKey(path: JsonKey): Json? {
+infix fun Json?.shouldContainJsonKey(path: JsonKey): Json {
     contract {
         returns() implies (this@shouldContainJsonKey != null)
     }
@@ -82,7 +82,7 @@ infix fun Json?.shouldContainJsonKey(path: JsonKey): Json? {
             cause = result
         )
 
-        else -> result?.let { mapper.writeValueAsString(it) }
+        else -> mapper.writeValueAsString(result)
     }
 }
 
@@ -173,13 +173,13 @@ inline infix fun <reified T> Json?.shouldContainJsonKeyAndValueOfSpecificType(pa
 
         else -> throw failure(
             "${this.representation} should contain an element with type ${typeOf<T>()} with the path $path " +
-                    "but it contains ${result?.let { mapper.writeValueAsString(it) }.representation}."
+                    "but it contains ${mapper.writeValueAsString(result)}.representation}."
         )
     }
 }
 
 @OptIn(ExperimentalContracts::class)
-infix fun Json?.shouldContainOnlyJsonKey(path: JsonKey): Json? {
+infix fun Json?.shouldContainOnlyJsonKey(path: JsonKey): Json {
     contract {
         returns() implies (this@shouldContainOnlyJsonKey != null)
     }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -180,7 +180,7 @@ inline infix fun <reified T> Json?.shouldContainJsonKeyAndValueOfSpecificType(pa
 
         else -> throw failure(
             "${this.representation} should contain an element with type ${typeOf<T>()} with the path $path " +
-                    "but it contains ${mapper.writeValueAsString(result)}.representation}."
+                    "but it contains ${mapper.writeValueAsString(result).representation}."
         )
     }
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -20,14 +20,7 @@ infix fun Json?.shouldMatchJson(json: Json?) {
     this should matchJson(json)
 }
 
-@OptIn(ExperimentalContracts::class)
-infix fun Json?.shouldNotMatchJson(json: Json?) {
-    contract {
-        returns() implies (this@shouldNotMatchJson != null)
-    }
-
-    this shouldNot matchJson(json)
-}
+infix fun Json?.shouldNotMatchJson(json: Json?) = this shouldNot matchJson(json)
 
 fun matchJson(json: Json?) = object : Matcher<Json?> {
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -32,8 +32,8 @@ infix fun Json?.shouldNotMatchJson(json: Json?) {
 fun matchJson(json: Json?) = object : Matcher<Json?> {
 
     override fun test(value: Json?): MatcherResult {
-        val actualJson = value?.let { mapper.readTree(it) }
-        val expectedJson = json?.let { mapper.readTree(it) }
+        val actualJson = value?.let { publishedMapper.readTree(it) }
+        val expectedJson = json?.let { publishedMapper.readTree(it) }
 
         return MatcherResult(
             actualJson == expectedJson,
@@ -49,8 +49,8 @@ infix fun Json.shouldNotMatchJsonResource(resource: String) = this shouldNot mat
 fun matchJsonResource(resource: String) = object : Matcher<Json> {
 
     override fun test(value: Json): MatcherResult {
-        val actualJson = mapper.readTree(value)
-        val expectedJson = mapper.readTree(this.javaClass.getResourceAsStream(resource))
+        val actualJson = publishedMapper.readTree(value)
+        val expectedJson = publishedMapper.readTree(this.javaClass.getResourceAsStream(resource))
 
         return MatcherResult(
             actualJson == expectedJson,
@@ -78,7 +78,7 @@ infix fun Json?.shouldContainJsonKey(path: JsonKey): Json {
             cause = result
         )
 
-        else -> mapper.writeValueAsString(result)
+        else -> publishedMapper.writeValueAsString(result)
     }
 }
 
@@ -180,7 +180,7 @@ inline infix fun <reified T> Json?.shouldContainJsonKeyAndValueOfSpecificType(pa
 
         else -> throw failure(
             "${this.representation} should contain an element with type ${typeOf<T>()} with the path $path " +
-                    "but it contains ${mapper.writeValueAsString(result).representation}."
+                    "but it contains ${publishedMapper.writeValueAsString(result).representation}."
         )
     }
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -36,13 +36,21 @@ fun matchJson(json: Json?) = object : Matcher<Json?> {
     }
 }
 
-infix fun Json.shouldMatchJsonResource(resource: String) = this should matchJsonResource(resource)
+@OptIn(ExperimentalContracts::class)
+infix fun Json?.shouldMatchJsonResource(resource: String) {
+    contract {
+        returns() implies (this@shouldMatchJsonResource != null)
+    }
+
+    this should matchJsonResource(resource)
+}
+
 infix fun Json.shouldNotMatchJsonResource(resource: String) = this shouldNot matchJsonResource(resource)
 
-fun matchJsonResource(resource: String) = object : Matcher<Json> {
+fun matchJsonResource(resource: String) = object : Matcher<Json?> {
 
-    override fun test(value: Json): MatcherResult {
-        val actualJson = publishedMapper.readTree(value)
+    override fun test(value: Json?): MatcherResult {
+        val actualJson = value?.let { publishedMapper.readTree(it) }
         val expectedJson = publishedMapper.readTree(this.javaClass.getResourceAsStream(resource))
 
         return MatcherResult(

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -1,7 +1,5 @@
 package io.kotest.assertions.json
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.jayway.jsonpath.JsonPath
 import com.jayway.jsonpath.PathNotFoundException
 import io.kotest.assertions.failure
@@ -11,8 +9,6 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
-import kotlin.reflect.KType
-import kotlin.reflect.full.isSupertypeOf
 import kotlin.reflect.typeOf
 
 @OptIn(ExperimentalContracts::class)
@@ -106,8 +102,17 @@ fun containJsonKey(path: JsonKey) = object : Matcher<Json> {
     }
 }
 
-fun <T> Json?.shouldContainJsonKeyValue(path: JsonKey, value: T) = this should containJsonKeyValue(path, value)
+@OptIn(ExperimentalContracts::class)
+fun <T> Json?.shouldContainJsonKeyValue(path: JsonKey, value: T) {
+    contract {
+        returns() implies (this@shouldContainJsonKeyValue != null)
+    }
+
+    this should containJsonKeyValue(path, value)
+}
+
 fun <T> Json.shouldNotContainJsonKeyValue(path: JsonKey, value: T) = this shouldNot containJsonKeyValue(path, value)
+
 fun <T> containJsonKeyValue(path: JsonKey, t: T) = object : Matcher<Json?> {
     override fun test(value: Json?): MatcherResult {
         val sub = value?.limitLength()

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonTypes.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonTypes.kt
@@ -1,0 +1,18 @@
+package io.kotest.assertions.json
+
+/**
+ * JSON element representation via Kotlin String.
+ *
+ * It can be any JSON value, for example:
+ * * JSON string: `""id""` – please note that it differs from a simple Kotlin string `"id"` which is not valid JSON representation.
+ * * JSON number: `"42"`.
+ * * JSON null: `"null"`.
+ * * JSON object: `"{"id": 42}"`.
+ * * JSON array: `"["id", 42, null]"`.
+ */
+typealias Json = String
+
+/**
+ * String representing a key for JSON value. For example, to access `42` in `"{"id": 42}"`, use `"id"` as a key.
+ */
+typealias JsonKey = String

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonUtil.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonUtil.kt
@@ -1,0 +1,7 @@
+package io.kotest.assertions.json
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+
+// we need to make it public because inline functions use it
+val mapper by lazy { ObjectMapper().registerKotlinModule() }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonUtil.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonUtil.kt
@@ -3,5 +3,8 @@ package io.kotest.assertions.json
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
-// we need to make it public because inline functions use it
-val mapper by lazy { ObjectMapper().registerKotlinModule() }
+private val mapper by lazy { ObjectMapper().registerKotlinModule() }
+
+@PublishedApi
+internal val publishedMapper
+    get() = mapper

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -1,8 +1,5 @@
 package com.sksamuel.kotest.tests.json
 
-import io.kotest.assertions.json.Json
-import io.kotest.assertions.json.representation
-import io.kotest.assertions.json.shouldBeJsonValueOfType
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldMatchJson
@@ -12,7 +9,6 @@ import io.kotest.assertions.json.shouldNotContainJsonKeyValue
 import io.kotest.assertions.json.shouldNotMatchJson
 import io.kotest.assertions.json.shouldNotMatchJsonResource
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
@@ -104,55 +100,5 @@ class JsonAssertionsTest : StringSpec({
     shouldThrow<AssertionError> {
       testJson2.shouldMatchJsonResource("/json1.json")
     }.message shouldBe """expected: {"name":"sam","location":"chicago"} but was: {"name":"sam","location":"london"}"""
-  }
-
-  "test json representation" {
-    null.representation shouldBe """null"""
-    """null""".representation shouldBe """"null""""
-    """{"a": "b"}""".representation shouldBe """"{"a": "b"}""""
-  }
-
-  "test json value conversion" {
-    withClue("JSON string value should be quoted") {
-      "\"str\"".shouldBeJsonValueOfType<String>() shouldBe "str"
-
-      shouldThrow<AssertionError> {
-        @Suppress("RemoveExplicitTypeArguments")
-        "".shouldBeJsonValueOfType<Any?>()
-      }
-
-      shouldThrow<AssertionError> { "str".shouldBeJsonValueOfType<String>() }
-
-      withClue("quotes in JSON string value should be escaped") {
-        """"\"str\""""".shouldBeJsonValueOfType<String>() shouldBe "\"str\""
-      }
-    }
-
-    "10".shouldBeJsonValueOfType<Int>() shouldBe 10
-    "10.0".shouldBeJsonValueOfType<Number>() shouldBe 10.0
-    "10.0".shouldBeJsonValueOfType<Any>() shouldBe 10.0
-
-    "[]".shouldBeJsonValueOfType<Array<*>>() shouldBe emptyArray<Int>()
-
-    "null".shouldBeJsonValueOfType<Any?>() shouldBe null
-    "null".shouldBeJsonValueOfType<String?>() shouldBe null
-    "null".shouldBeJsonValueOfType<Int?>() shouldBe null
-
-    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int?>() }
-    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int>() }
-
-    shouldThrow<AssertionError> { "10".shouldBeJsonValueOfType<String>() }
-
-    withClue("null should always throw") {
-      shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<Int?>() }
-    }
-
-    withClue("smart cast should work") {
-      fun use(json: Json) {}
-
-      val nullableJson: Json? = "10"
-      nullableJson.shouldBeJsonValueOfType<Int>()
-      use(nullableJson)
-    }
   }
 })

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -1,5 +1,8 @@
 package com.sksamuel.kotest.tests.json
 
+import io.kotest.assertions.json.Json
+import io.kotest.assertions.json.representation
+import io.kotest.assertions.json.shouldBeJsonValueOfType
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldMatchJson
@@ -9,6 +12,7 @@ import io.kotest.assertions.json.shouldNotContainJsonKeyValue
 import io.kotest.assertions.json.shouldNotMatchJson
 import io.kotest.assertions.json.shouldNotMatchJsonResource
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
@@ -100,5 +104,55 @@ class JsonAssertionsTest : StringSpec({
     shouldThrow<AssertionError> {
       testJson2.shouldMatchJsonResource("/json1.json")
     }.message shouldBe """expected: {"name":"sam","location":"chicago"} but was: {"name":"sam","location":"london"}"""
+  }
+
+  "test json representation" {
+    null.representation shouldBe """null"""
+    """null""".representation shouldBe """"null""""
+    """{"a": "b"}""".representation shouldBe """"{"a": "b"}""""
+  }
+
+  "test json value conversion" {
+    withClue("JSON string value should be quoted") {
+      "\"str\"".shouldBeJsonValueOfType<String>() shouldBe "str"
+
+      shouldThrow<AssertionError> {
+        @Suppress("RemoveExplicitTypeArguments")
+        "".shouldBeJsonValueOfType<Any?>()
+      }
+
+      shouldThrow<AssertionError> { "str".shouldBeJsonValueOfType<String>() }
+
+      withClue("quotes in JSON string value should be escaped") {
+        """"\"str\""""".shouldBeJsonValueOfType<String>() shouldBe "\"str\""
+      }
+    }
+
+    "10".shouldBeJsonValueOfType<Int>() shouldBe 10
+    "10.0".shouldBeJsonValueOfType<Number>() shouldBe 10.0
+    "10.0".shouldBeJsonValueOfType<Any>() shouldBe 10.0
+
+    "[]".shouldBeJsonValueOfType<Array<*>>() shouldBe emptyArray<Int>()
+
+    "null".shouldBeJsonValueOfType<Any?>() shouldBe null
+    "null".shouldBeJsonValueOfType<String?>() shouldBe null
+    "null".shouldBeJsonValueOfType<Int?>() shouldBe null
+
+    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int?>() }
+    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int>() }
+
+    shouldThrow<AssertionError> { "10".shouldBeJsonValueOfType<String>() }
+
+    withClue("null should always throw") {
+      shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<Int?>() }
+    }
+
+    withClue("smart cast should work") {
+      fun use(json: Json) {}
+
+      val nullableJson: Json? = "10"
+      nullableJson.shouldBeJsonValueOfType<Int>()
+      use(nullableJson)
+    }
   }
 })

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -107,6 +107,8 @@ class JsonAssertionsTest : StringSpec({
     json.shouldContainJsonKeyValue("$.store.book[0].price", 8.95)
     json.shouldContainJsonKeyValue("$.store.book[1].author", "Evelyn Waugh")
 
+    shouldThrow<AssertionError> { null.shouldContainJsonKeyValue("ab", "cd") }
+
     json.shouldNotContainJsonKeyValue("$.store.book[1].author", "JK Rowling")
 
     shouldThrow<AssertionError> {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.tests.json
 
+import io.kotest.assertions.asClue
+import io.kotest.assertions.json.Json
 import io.kotest.assertions.json.jsonKeyValueEntries
 import io.kotest.assertions.json.shouldContainExactly
 import io.kotest.assertions.json.shouldContainJsonKey
@@ -103,6 +105,14 @@ class JsonAssertionsTest : StringSpec({
             {..." should contain the path ${'$'}.store.table"""
 
     """{"data": null}""" shouldContainJsonKey "data" shouldBe "null"
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = """{"data": null}"""
+      nullableJson.shouldContainJsonKey("data")  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
+      use(nullableJson)
+    }
   }
 
   "test json key value" {
@@ -121,6 +131,14 @@ class JsonAssertionsTest : StringSpec({
     "store": {
         "book": [
             {..." should contain the element ${'$'}.store.book[1].author = JK Rowling"""
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = """{"data": "value"}"""
+      nullableJson.shouldContainJsonKeyValue("data", "value")
+      use(nullableJson)
+    }
   }
 
   "test json match by resource" {
@@ -150,5 +168,13 @@ class JsonAssertionsTest : StringSpec({
 
     shouldThrow<AssertionError> { """"string"""" shouldContainExactly 6.jsonKeyValueEntries }
     shouldThrow<AssertionError> { """["array elem"]""" shouldContainExactly 1.jsonKeyValueEntries }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = """{}"""
+      nullableJson.shouldContainExactly(0.jsonKeyValueEntries)  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
+      use(nullableJson)
+    }
   }
 })

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.tests.json
 
+import io.kotest.assertions.json.jsonKeyValueEntries
+import io.kotest.assertions.json.shouldContainExactly
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldMatchJson
@@ -132,5 +134,21 @@ class JsonAssertionsTest : StringSpec({
     shouldThrow<AssertionError> {
       testJson2.shouldMatchJsonResource("/json1.json")
     }.message shouldBe """expected: {"name":"sam","location":"chicago"} but was: {"name":"sam","location":"london"}"""
+  }
+
+  "test json contains countable elements" {
+    """{}""" shouldContainExactly 0.jsonKeyValueEntries
+    """{"a": 1}""" shouldContainExactly 1.jsonKeyValueEntries
+    """{"a": 1, "b": 2}""" shouldContainExactly 2.jsonKeyValueEntries
+
+    shouldThrow<AssertionError> { """{}""" shouldContainExactly 1.jsonKeyValueEntries }
+    shouldThrow<AssertionError> { """{"a": 1}""" shouldContainExactly 2.jsonKeyValueEntries }
+    shouldThrow<AssertionError> { """{"a": 1, "b": 2}""" shouldContainExactly 1.jsonKeyValueEntries }
+
+    shouldThrow<AssertionError> { null shouldContainExactly 0.jsonKeyValueEntries }
+    shouldThrow<AssertionError> { null shouldContainExactly 20.jsonKeyValueEntries }
+
+    shouldThrow<AssertionError> { """"string"""" shouldContainExactly 6.jsonKeyValueEntries }
+    shouldThrow<AssertionError> { """["array elem"]""" shouldContainExactly 1.jsonKeyValueEntries }
   }
 })

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.json.Json
 import io.kotest.assertions.json.jsonKeyValueEntries
 import io.kotest.assertions.json.shouldContainExactly
 import io.kotest.assertions.json.shouldContainJsonKey
+import io.kotest.assertions.json.shouldContainJsonKeyAndValueOfSpecificType
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldMatchJson
 import io.kotest.assertions.json.shouldMatchJsonResource
@@ -174,6 +175,29 @@ class JsonAssertionsTest : StringSpec({
 
       val nullableJson: Json? = """{}"""
       nullableJson.shouldContainExactly(0.jsonKeyValueEntries)  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
+      use(nullableJson)
+    }
+  }
+
+  "test json contains key and value of specific type" {
+    """{"c": null}""".shouldContainJsonKeyAndValueOfSpecificType<Int?>("c") shouldBe null
+    """{"a": 1}""".shouldContainJsonKeyAndValueOfSpecificType<Int>("a") shouldBe 1
+    """{"a": 1, "b": "2"}""".shouldContainJsonKeyAndValueOfSpecificType<String?>("b") shouldBe "2"
+
+    shouldThrow<AssertionError> { """{}""".shouldContainJsonKeyAndValueOfSpecificType<Int>("a") }
+    shouldThrow<AssertionError> { """{"a": 1}""".shouldContainJsonKeyAndValueOfSpecificType<String>("a") }
+
+    shouldThrow<AssertionError> { null.shouldContainJsonKeyAndValueOfSpecificType<Int>("a") }
+    shouldThrow<AssertionError> { null.shouldContainJsonKeyAndValueOfSpecificType<Int?>("a") }
+
+    shouldThrow<AssertionError> { """"string"""".shouldContainJsonKeyAndValueOfSpecificType<Int>("a") }
+    shouldThrow<AssertionError> { """["array elem"]""".shouldContainJsonKeyAndValueOfSpecificType<Int>("a") }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = """{"a": 1}"""
+      nullableJson.shouldContainJsonKeyAndValueOfSpecificType<Int>("a")
       use(nullableJson)
     }
   }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.json.shouldContainExactly
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyAndValueOfSpecificType
 import io.kotest.assertions.json.shouldContainJsonKeyValue
+import io.kotest.assertions.json.shouldContainOnlyJsonKey
 import io.kotest.assertions.json.shouldMatchJson
 import io.kotest.assertions.json.shouldMatchJsonResource
 import io.kotest.assertions.json.shouldNotContainJsonKey
@@ -198,6 +199,26 @@ class JsonAssertionsTest : StringSpec({
 
       val nullableJson: Json? = """{"a": 1}"""
       nullableJson.shouldContainJsonKeyAndValueOfSpecificType<Int>("a")
+      use(nullableJson)
+    }
+  }
+
+  "test json contains single key" {
+    """{"c": null}""".shouldContainOnlyJsonKey("c") shouldBe "null"
+    """{"c": []}""".shouldContainOnlyJsonKey("c") shouldBe "[]"
+    """{"c": "abc"}""".shouldContainOnlyJsonKey("c") shouldBe "\"abc\""
+
+    shouldThrow<AssertionError> { "" shouldContainOnlyJsonKey "c" }
+    shouldThrow<AssertionError> { """{"a": 1, "b": "2"}""" shouldContainOnlyJsonKey "a" }
+
+
+    shouldThrow<AssertionError> { null shouldContainOnlyJsonKey "abc" }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = """{"a": 1}"""
+      nullableJson.shouldContainOnlyJsonKey("a")  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
       use(nullableJson)
     }
   }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -67,10 +67,10 @@ class JsonAssertionsTest : StringSpec({
 
     shouldThrow<AssertionError> {
       json.shouldContainJsonKey("$.store.table")
-    }.message shouldBe """{
+    }.message shouldBe """"{
     "store": {
         "book": [
-            {... should contain the path ${'$'}.store.table"""
+            {..." should contain the path ${'$'}.store.table"""
   }
 
   "test json key value" {
@@ -83,10 +83,10 @@ class JsonAssertionsTest : StringSpec({
 
     shouldThrow<AssertionError> {
       json.shouldContainJsonKeyValue("$.store.book[1].author", "JK Rowling")
-    }.message shouldBe """{
+    }.message shouldBe """"{
     "store": {
         "book": [
-            {... should contain the element ${'$'}.store.book[1].author = JK Rowling"""
+            {..." should contain the element ${'$'}.store.book[1].author = JK Rowling"""
   }
 
   "test json match by resource" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -155,6 +155,16 @@ class JsonAssertionsTest : StringSpec({
     shouldThrow<AssertionError> {
       testJson2.shouldMatchJsonResource("/json1.json")
     }.message shouldBe """expected: {"name":"sam","location":"chicago"} but was: {"name":"sam","location":"london"}"""
+
+    shouldThrow<AssertionError> { null shouldMatchJsonResource "/json1.json" }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = testJson1
+      nullableJson.shouldMatchJsonResource("/json1.json")  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
+      use(nullableJson)
+    }
   }
 
   "test json contains countable elements" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -61,13 +61,37 @@ class JsonAssertionsTest : StringSpec({
   }
 
   "test json path" {
-    json.shouldContainJsonKey("$.store.bicycle")
-    json.shouldContainJsonKey("$.store.book")
-    json.shouldContainJsonKey("$.store.book[0]")
-    json.shouldContainJsonKey("$.store.book[0].category")
-    json.shouldContainJsonKey("$.store.book[1].price")
+    json.shouldContainJsonKey("$.store.bicycle") shouldMatchJson """{"color": "red", "price": 19.95}"""
+    json.shouldContainJsonKey("$.store.book") shouldMatchJson """
+      [
+          {
+              "category": "reference",
+              "author": "Nigel Rees",
+              "title": "Sayings of the Century",
+              "price": 8.95
+          },
+          {
+              "category": "fiction",
+              "author": "Evelyn Waugh",
+              "title": "Sword of Honour",
+              "price": 12.99
+          }
+      ]
+    """
+    json.shouldContainJsonKey("$.store.book[0]") shouldMatchJson """
+      {
+          "category": "reference",
+          "author": "Nigel Rees",
+          "title": "Sayings of the Century",
+          "price": 8.95
+      }
+    """
+    json.shouldContainJsonKey("$.store.book[0].category") shouldBe "\"reference\""
+    json.shouldContainJsonKey("$.store.book[1].price") shouldBe "12.99"
 
     json.shouldNotContainJsonKey("$.store.table")
+
+    shouldThrow<AssertionError> { null.shouldContainJsonKey("abc") }
 
     shouldThrow<AssertionError> {
       json.shouldContainJsonKey("$.store.table")
@@ -75,6 +99,7 @@ class JsonAssertionsTest : StringSpec({
     "store": {
         "book": [
             {..." should contain the path ${'$'}.store.table"""
+
   }
 
   "test json key value" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -99,6 +99,8 @@ class JsonAssertionsTest : StringSpec({
     "store": {
         "book": [
             {..." should contain the path ${'$'}.store.table"""
+
+    """{"data": null}""" shouldContainJsonKey "data" shouldBe "null"
   }
 
   "test json key value" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -99,7 +99,6 @@ class JsonAssertionsTest : StringSpec({
     "store": {
         "book": [
             {..." should contain the path ${'$'}.store.table"""
-
   }
 
   "test json key value" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -44,6 +44,10 @@ class JsonAssertionsTest : StringSpec({
   "test json equality" {
     json1.shouldMatchJson(json2)
     json1.shouldNotMatchJson(json3)
+
+    null.shouldMatchJson(null)
+    null.shouldNotMatchJson(json1)
+    json1.shouldNotMatchJson(null)
   }
 
   "should return correct error message on failure" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyAndValueOfSpecificType
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldContainOnlyJsonKey
+import io.kotest.assertions.json.shouldContainOnlyJsonKeyAndValueOfSpecificType
 import io.kotest.assertions.json.shouldMatchJson
 import io.kotest.assertions.json.shouldMatchJsonResource
 import io.kotest.assertions.json.shouldNotContainJsonKey
@@ -219,6 +220,28 @@ class JsonAssertionsTest : StringSpec({
 
       val nullableJson: Json? = """{"a": 1}"""
       nullableJson.shouldContainOnlyJsonKey("a")  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
+      use(nullableJson)
+    }
+  }
+
+  "test json contains single key and value of specific type" {
+    """{"c": null}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<Int?>("c") shouldBe null
+    """{"c": 22}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<Int?>("c") shouldBe 22
+    """{"c": 22}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<Int>("c") shouldBe 22
+//    """{"c": []}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<Array<Int>>("c") shouldBe emptyArray()  // todo: fix this case
+    """{"c": "abc"}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<String>("c") shouldBe "abc"
+
+    shouldThrow<AssertionError> { "".shouldContainOnlyJsonKeyAndValueOfSpecificType<Int?>("c") }
+    shouldThrow<AssertionError> { """{"c": null}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<Int>("c") }
+    shouldThrow<AssertionError> { """{"a": 1, "b": "2"}""".shouldContainOnlyJsonKeyAndValueOfSpecificType<Int?>("a") }
+
+    shouldThrow<AssertionError> { null.shouldContainOnlyJsonKeyAndValueOfSpecificType<Int?>("c") }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: Json) {}
+
+      val nullableJson: Json? = """{"a": 1}"""
+      nullableJson.shouldContainOnlyJsonKeyAndValueOfSpecificType<Int?>("a")  // todo: use infix form after https://youtrack.jetbrains.com/issue/KT-27261 is resolved
       use(nullableJson)
     }
   }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonConversionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonConversionsTest.kt
@@ -3,68 +3,102 @@ package com.sksamuel.kotest.tests.json
 import io.kotest.assertions.json.Json
 import io.kotest.assertions.json.representation
 import io.kotest.assertions.json.shouldBeJsonValueOfType
-import io.kotest.assertions.json.shouldContainJsonKey
-import io.kotest.assertions.json.shouldContainJsonKeyValue
-import io.kotest.assertions.json.shouldMatchJson
-import io.kotest.assertions.json.shouldMatchJsonResource
-import io.kotest.assertions.json.shouldNotContainJsonKey
-import io.kotest.assertions.json.shouldNotContainJsonKeyValue
-import io.kotest.assertions.json.shouldNotMatchJson
-import io.kotest.assertions.json.shouldNotMatchJsonResource
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.assertions.withClue
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
-class JsonConversionsTest : StringSpec({
+class JsonConversionsTest : FreeSpec({
 
-  "test json representation" {
-    null.representation shouldBe """null"""
-    """null""".representation shouldBe """"null""""
-    """{"a": "b"}""".representation shouldBe """"{"a": "b"}""""
-  }
+    "test json representation" - {
+        "test for null" {
+            null.representation shouldBe """
+        |null
+      """.trimMargin()
+        }
 
-  "test json value conversion" {
-    withClue("JSON string value should be quoted") {
-      "\"str\"".shouldBeJsonValueOfType<String>() shouldBe "str"
+        "test for string" {
+            """
+        |null
+      """.trimMargin().representation shouldBe """
+        |"null"
+      """.trimMargin()
+        }
 
-      shouldThrow<AssertionError> {
-        @Suppress("RemoveExplicitTypeArguments")
-        "".shouldBeJsonValueOfType<Any?>()
-      }
-
-      shouldThrow<AssertionError> { "str".shouldBeJsonValueOfType<String>() }
-
-      withClue("quotes in JSON string value should be escaped") {
-        """"\"str\""""".shouldBeJsonValueOfType<String>() shouldBe "\"str\""
-      }
+        "test for object" {
+            """
+        |{"a": "b"}
+      """.trimMargin().representation shouldBe """
+        |"{"a": "b"}"
+      """.trimMargin()
+        }
     }
 
-    "10".shouldBeJsonValueOfType<Int>() shouldBe 10
-    "10.0".shouldBeJsonValueOfType<Number>() shouldBe 10.0
-    "10.0".shouldBeJsonValueOfType<Any>() shouldBe 10.0
+    "test json value conversion" - {
+        "JSON string value should be outer quoted" - {
+            "correct string" - {
+                "test for string" {
+                    """
+            |"str"
+          """.trimMargin().shouldBeJsonValueOfType<String>() shouldBe "str"
+                }
 
-    "[]".shouldBeJsonValueOfType<Array<*>>() shouldBe emptyArray<Int>()
+                "test for string with inner quotes" - {
+                    """
+            |"\"str\""
+          """.trimMargin().shouldBeJsonValueOfType<String>() shouldBe "\"str\""
+                }
+            }
 
-    "null".shouldBeJsonValueOfType<Any?>() shouldBe null
-    "null".shouldBeJsonValueOfType<String?>() shouldBe null
-    "null".shouldBeJsonValueOfType<Int?>() shouldBe null
+            "incorrect string" - {
+                "test for empty string" {
+                    shouldThrow<AssertionError> {
+                        @Suppress("RemoveExplicitTypeArguments")
+                        "".shouldBeJsonValueOfType<Any?>()
+                    }
+                }
 
-    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int?>() }
-    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int>() }
+                "test for string without outer quotes" {
+                    shouldThrow<AssertionError> { "str".shouldBeJsonValueOfType<String>() }
+                }
+            }
+        }
 
-    shouldThrow<AssertionError> { "10".shouldBeJsonValueOfType<String>() }
+        "test for correct numbers" {
+            "10".shouldBeJsonValueOfType<Int>() shouldBe 10
+            "-10".shouldBeJsonValueOfType<Int>() shouldBe -10
+            "10.0".shouldBeJsonValueOfType<Number>() shouldBe 10.0
+            "10.0".shouldBeJsonValueOfType<Any>() shouldBe 10.0
+        }
 
-    withClue("null should always throw") {
-      shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<Int?>() }
-    }
+        "test for empty array" {
+            "[]".shouldBeJsonValueOfType<Array<*>>() shouldBe emptyArray<Int>()
+        }
 
-    withClue("smart cast should work") {
-      fun use(json: Json) {}
+        "test for nulls" {
+            "null".shouldBeJsonValueOfType<Any?>() shouldBe null
+            "null".shouldBeJsonValueOfType<String?>() shouldBe null
+            "null".shouldBeJsonValueOfType<Int?>() shouldBe null
+        }
 
-      val nullableJson: Json? = "10"
-      nullableJson.shouldBeJsonValueOfType<Int>()
-      use(nullableJson)
-    }
+        "test for type mismatch" {
+            shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int?>() }
+            shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int>() }
+
+            shouldThrow<AssertionError> { "10".shouldBeJsonValueOfType<String>() }
+        }
+
+        "test for null" {
+            shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<Int?>() }
+            shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<Int>() }
+            shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<String>() }
+        }
+
+        "test for smart cast" {
+            fun use(json: Json) {}
+
+            val nullableJson: Json? = "10"
+            nullableJson.shouldBeJsonValueOfType<Int>()
+            use(nullableJson)
+        }
   }
 })

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonConversionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonConversionsTest.kt
@@ -1,0 +1,70 @@
+package com.sksamuel.kotest.tests.json
+
+import io.kotest.assertions.json.Json
+import io.kotest.assertions.json.representation
+import io.kotest.assertions.json.shouldBeJsonValueOfType
+import io.kotest.assertions.json.shouldContainJsonKey
+import io.kotest.assertions.json.shouldContainJsonKeyValue
+import io.kotest.assertions.json.shouldMatchJson
+import io.kotest.assertions.json.shouldMatchJsonResource
+import io.kotest.assertions.json.shouldNotContainJsonKey
+import io.kotest.assertions.json.shouldNotContainJsonKeyValue
+import io.kotest.assertions.json.shouldNotMatchJson
+import io.kotest.assertions.json.shouldNotMatchJsonResource
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class JsonConversionsTest : StringSpec({
+
+  "test json representation" {
+    null.representation shouldBe """null"""
+    """null""".representation shouldBe """"null""""
+    """{"a": "b"}""".representation shouldBe """"{"a": "b"}""""
+  }
+
+  "test json value conversion" {
+    withClue("JSON string value should be quoted") {
+      "\"str\"".shouldBeJsonValueOfType<String>() shouldBe "str"
+
+      shouldThrow<AssertionError> {
+        @Suppress("RemoveExplicitTypeArguments")
+        "".shouldBeJsonValueOfType<Any?>()
+      }
+
+      shouldThrow<AssertionError> { "str".shouldBeJsonValueOfType<String>() }
+
+      withClue("quotes in JSON string value should be escaped") {
+        """"\"str\""""".shouldBeJsonValueOfType<String>() shouldBe "\"str\""
+      }
+    }
+
+    "10".shouldBeJsonValueOfType<Int>() shouldBe 10
+    "10.0".shouldBeJsonValueOfType<Number>() shouldBe 10.0
+    "10.0".shouldBeJsonValueOfType<Any>() shouldBe 10.0
+
+    "[]".shouldBeJsonValueOfType<Array<*>>() shouldBe emptyArray<Int>()
+
+    "null".shouldBeJsonValueOfType<Any?>() shouldBe null
+    "null".shouldBeJsonValueOfType<String?>() shouldBe null
+    "null".shouldBeJsonValueOfType<Int?>() shouldBe null
+
+    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int?>() }
+    shouldThrow<AssertionError> { "\"str\"".shouldBeJsonValueOfType<Int>() }
+
+    shouldThrow<AssertionError> { "10".shouldBeJsonValueOfType<String>() }
+
+    withClue("null should always throw") {
+      shouldThrow<AssertionError> { null.shouldBeJsonValueOfType<Int?>() }
+    }
+
+    withClue("smart cast should work") {
+      fun use(json: Json) {}
+
+      val nullableJson: Json? = "10"
+      nullableJson.shouldBeJsonValueOfType<Int>()
+      use(nullableJson)
+    }
+  }
+})


### PR DESCRIPTION
Hi! Json testing kotest provides covers some of my cases and that's great! I especially like that every JSON value is a string because there is no convertion code so it looks concise.

However, many of my cases are not deterministic so I've needed to use parsers. I want to use kotest-styled functions!

Here I try to make existing functions more handy (use typealiases for self-documenting, add support for nullability with contracts and provide return values). And I add other functions devoted mainly to extract values from JSONs.

I use these changes in my project and I want to add them to the main repo.

TODO list for this PR:
- [x] Propose a PR.
- [x] Depending on the result of #1316, rebase.
- [x] Make tests for changes.
- [x] Update documentation.
- [ ] Resolve TODOs left in code.

Also, I can propose a slightly different style of JSON formatting but it isn't compatible to the current version so I will have to change some of existing tests. I have some questions:  
- Do we need to leave error messages unchanged?
- Why it has been chosen to limit length of output JSONs?
- Where can I learn more about "IntelliJ diff format" (#1106)?

What do you think? Let's discuss!