### PR TITLE
Remove duplicate classes

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -24,6 +24,7 @@ object Libs {
 
    object JUnitPlatform {
       private const val version = "1.6.0"
+      const val commons = "org.junit.platform:junit-platform-commons:$version"
       const val engine = "org.junit.platform:junit-platform-engine:$version"
       const val launcher = "org.junit.platform:junit-platform-launcher:$version"
       const val api = "org.junit.platform:junit-platform-suite-api:$version"

--- a/kotest-assertions/src/commonMain/kotlin/io.kotlintest/aliases.kt
+++ b/kotest-assertions/src/commonMain/kotlin/io.kotlintest/aliases.kt
@@ -1,7 +1,9 @@
+@file:JvmName("AssertionAliases")
 package io.kotlintest
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlin.jvm.JvmName
 
 @Deprecated(
    "All packages are now io.kotest",

--- a/kotest-core/build.gradle.kts
+++ b/kotest-core/build.gradle.kts
@@ -63,6 +63,7 @@ kotlin {
             api(kotlin("stdlib-jdk8"))
             implementation(kotlin("reflect"))
             implementation(Libs.Coroutines.core)
+            implementation(Libs.JUnitPlatform.commons)
             api(Libs.JUnitJupiter.api)
             implementation(Libs.Classgraph.classgraph)
          }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -13,7 +13,7 @@ import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
 import io.kotest.fp.Tuple2
-import org.junit.platform.commons.annotation.Testable
+
 
 @Testable
 abstract class Spec : TestConfiguration(), SpecConfigurationMethods {

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/testable.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/testable.kt
@@ -1,3 +1,4 @@
-package org.junit.platform.commons.annotation
+package io.kotest.core.spec
 
-annotation class Testable
+@Target(AnnotationTarget.CLASS)
+expect annotation class Testable()

--- a/kotest-core/src/jsMain/kotlin/io/kotest/core/spec/Testable.kt
+++ b/kotest-core/src/jsMain/kotlin/io/kotest/core/spec/Testable.kt
@@ -1,0 +1,3 @@
+package io.kotest.core.spec
+
+actual annotation class Testable

--- a/kotest-core/src/jvmMain/kotlin/io/kotest/core/spec/Testable.kt
+++ b/kotest-core/src/jvmMain/kotlin/io/kotest/core/spec/Testable.kt
@@ -1,0 +1,3 @@
+package io.kotest.core.spec
+
+actual typealias Testable = org.junit.platform.commons.annotation.Testable

--- a/kotest-core/src/jvmMain/kotlin/io/kotlintest/aliases.kt
+++ b/kotest-core/src/jvmMain/kotlin/io/kotlintest/aliases.kt
@@ -1,3 +1,4 @@
+@file:JvmName("CoreAliases")
 package io.kotlintest
 
 typealias Spec = io.kotest.core.spec.Spec


### PR DESCRIPTION
This commit fixes two issues that were only noticed when Android was
merging jars.

One of them is JUnit's Testable annotation. We keep that annotation as
a way to execute in IntelliJ (green icon). However, when Android is
using something that depends on JUnit itself, our Testable annotation
(which was placed in JUnit's package as it's hardcoded in IntelliJ)
would clash with the official JUnit's Annotation, and android wouldn't
merge the jars.

To fix this issue we needed to include the official annotation in
Kotest. This commit introduces the smallest possible dependency to make
that work.

The other issue was on some aliases which would end on the same JVM
Class, and thus would break the jar merge as well. This was simpler than
 JUnit's.

 Closes #1312