### PR TITLE
Close ScanResult (#1323)

### DIFF
--- a/kotest-core/src/jvmMain/kotlin/io/kotest/core/engine/discovery/Discovery.kt
+++ b/kotest-core/src/jvmMain/kotlin/io/kotest/core/engine/discovery/Discovery.kt
@@ -86,9 +86,10 @@ object Discovery {
       }
       log("Test discovery competed in $time")
 
-      return scanResult
-         .getSubclasses(Spec::class.java.name)
-         .map { Class.forName(it.name).kotlin }
-         .filterIsInstance<KClass<out Spec>>()
+      return scanResult.use { result ->
+         result.getSubclasses(Spec::class.java.name)
+            .map { Class.forName(it.name).kotlin }
+            .filterIsInstance<KClass<out Spec>>()
+      }
    }
 }


### PR DESCRIPTION
Started closing `ScanResult` after usage to avoid resource leakage.
Failing to close the scan result can lead to running out of file descriptors when running on *nix OS.

I did not find a repeatable and platform independent way to automatically test this fix.
I verified it manually on my Mac by doing this

```kotlin
println((ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean).openFileDescriptorCount)
```
It showed the number of open file descriptors increasing with the number of jars on the classpath for each individual spec discovered. After the fix this issue disappeared.

This is *nix/mac specific  data and is also affected by other processes running on the OS so not suited for automatic testing.

Fixes kotest/kotest#1323
