### PR TITLE
Caching result of scanUris (#1325)

### DIFF
--- a/kotest-core/src/jvmMain/kotlin/io/kotest/core/engine/discovery/Discovery.kt
+++ b/kotest-core/src/jvmMain/kotlin/io/kotest/core/engine/discovery/Discovery.kt
@@ -28,6 +28,11 @@ object Discovery {
    private val isSpecSubclass: (KClass<*>) -> Boolean = { Spec::class.java.isAssignableFrom(it.java) }
    private val isAbstract: (KClass<*>) -> Boolean = { it.isAbstract }
    private val isClass: (KClass<*>) -> Boolean = { it.objectInstance == null }
+   private val fromClassPaths: List<KClass<out Spec>> by lazy {
+      scanUris().apply {
+         log("Scan discovered $size classes in the classpaths...")
+      }
+   }
 
    /**
     * Returns a function that applies all the [DiscoveryFilter]s to a given class.
@@ -46,10 +51,6 @@ object Discovery {
    }
 
    fun discover(request: DiscoveryRequest): DiscoveryResult = requests.getOrPut(request) {
-
-      val fromClassPaths = scanUris()
-      log("Scan discovered ${fromClassPaths.size} classes in the classpaths...")
-
       val filtered = fromClassPaths
          .asSequence()
          .filter(selectorFn(request.selectors))
@@ -84,7 +85,7 @@ object Discovery {
             .blacklistPackages("java.*", "javax.*", "sun.*", "com.sun.*", "kotlin.*")
             .scan()
       }
-      log("Test discovery competed in $time")
+      log("Test discovery completed in $time")
 
       return scanResult.use { result ->
          result.getSubclasses(Spec::class.java.name)


### PR DESCRIPTION
Started caching the result of `Discovery.scanUris()` since Surefire creates a unique query per spec class.

Not sure how to automatically test this. 
I verified manually that the penalty of classpath scanning is now incurred only once instead of once per spec class. This significantly improves the initialization time for Maven projects with large classpaths and many specs. In my case by  50 * ~600ms.

Fixes kotest/kotest#1325