### PR TITLE
Make probability of DateTest failing lower

### DIFF
--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -82,7 +82,7 @@ class DateTest : WordSpec({
          val minutes = mutableSetOf<Int>()
          val seconds = mutableSetOf<Int>()
 
-         checkAll(500, Arb.localDateTime(1998, 1999)) {
+         checkAll(5000, Arb.localDateTime(1998, 1999)) {
             println(it)
             years += it.year
             months += it.monthValue


### PR DESCRIPTION
In #1318 we've found that the test is really blinky. See the https://github.com/kotest/kotest/pull/1318#issuecomment-606145960 for more details.