### PR TITLE
Update docs related to defaultTestCaseConfig

### DIFF
--- a/doc/reference_3.1.md
+++ b/doc/reference_3.1.md
@@ -731,7 +731,7 @@ You can also specify a default TestCaseConfig for all test cases of a Spec:
 ```kotlin
 class MySpec : StringSpec() {
 
-  override val defaultTestCaseConfig = TestCaseConfig(invocations = 3)
+  override fun defaultTestCaseConfig() = TestCaseConfig(invocations = 3)
 
   init {
     // your test cases ...

--- a/doc/reference_3.2.md
+++ b/doc/reference_3.2.md
@@ -736,7 +736,7 @@ You can also specify a default TestCaseConfig for all test cases of a Spec:
 ```kotlin
 class MySpec : StringSpec() {
 
-  override val defaultTestCaseConfig = TestCaseConfig(invocations = 3)
+  override fun defaultTestCaseConfig() = TestCaseConfig(invocations = 3)
 
   init {
     // your test cases ...

--- a/doc/reference_3.3.md
+++ b/doc/reference_3.3.md
@@ -762,7 +762,7 @@ You can also specify a default TestCaseConfig for all test cases of a Spec:
 ```kotlin
 class MySpec : StringSpec() {
 
-  override val defaultTestCaseConfig = TestCaseConfig(invocations = 3)
+  override fun defaultTestCaseConfig() = TestCaseConfig(invocations = 3)
 
   init {
     // your test cases ...

--- a/doc/test_case_config.md
+++ b/doc/test_case_config.md
@@ -57,7 +57,7 @@ You can also specify a default TestCaseConfig for all test cases of a Spec:
 ```kotlin
 class MySpec : StringSpec() {
 
-  override val defaultTestCaseConfig = TestCaseConfig(invocations = 3)
+  override fun defaultTestCaseConfig() = TestCaseConfig(invocations = 3)
 
   init {
     // your test cases ...


### PR DESCRIPTION
It seems defaultTestCaseConfig changed from a val to a fun.
https://github.com/kotest/kotest/blob/master/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/SpecConfigurationMethods.kt#L15