### PR TITLE
Fix shouldContainExactly for Arrays (#1364)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -123,18 +123,15 @@ fun <T, C : Collection<T>> contain(t: T) = object : Matcher<C> {
    )
 }
 
-infix fun <T> Array<T>.shouldNotContainExactly(expected: Array<T>) = asList().shouldNotContainExactly(expected.asList())
+fun <T> Array<T>?.shouldNotContainExactly(vararg expected: T) = this?.asList() shouldNot containExactly(*expected)
 infix fun <T, C : Collection<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
+fun <T> Collection<T>?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
 
-fun <T, C : Collection<T>> C?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
-infix fun <T> Array<T>.shouldContainExactly(expected: Array<T>) = asList().shouldContainExactly(expected)
+fun <T> Array<T>?.shouldContainExactly(vararg expected: T) = this?.asList() should containExactly(*expected)
 infix fun <T, C : Collection<T>> C?.shouldContainExactly(expected: C) = this should containExactly(expected)
+fun <T> Collection<T>?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)
 
-fun <T, C : Collection<T>> C?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)
-
-fun <T> containExactly(vararg expected: T): Matcher<Collection<T>?> = containExactly(
-   expected.asList()
-)
+fun <T> containExactly(vararg expected: T): Matcher<Collection<T>?> = containExactly(expected.asList())
 
 /** Assert that a collection contains exactly the given values and nothing else, in order. */
 fun <T, C : Collection<T>> containExactly(expected: C): Matcher<C?> = neverNullMatcher { value ->

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -123,10 +123,14 @@ fun <T, C : Collection<T>> contain(t: T) = object : Matcher<C> {
    )
 }
 
+@JvmName("shouldNotContainExactly_array")
+infix fun <T> Array<T>?.shouldNotContainExactly(expected: Array<T>) = this?.asList() shouldNot containExactly(*expected)
 fun <T> Array<T>?.shouldNotContainExactly(vararg expected: T) = this?.asList() shouldNot containExactly(*expected)
 infix fun <T, C : Collection<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
 fun <T> Collection<T>?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
 
+@JvmName("shouldContainExactly_array")
+infix fun <T> Array<T>?.shouldContainExactly(expected: Array<T>) = this?.asList() should containExactly(*expected)
 fun <T> Array<T>?.shouldContainExactly(vararg expected: T) = this?.asList() should containExactly(*expected)
 infix fun <T, C : Collection<T>> C?.shouldContainExactly(expected: C) = this should containExactly(expected)
 fun <T> Collection<T>?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -94,12 +94,12 @@ import io.kotest.matchers.collections.strictlyDecreasingWith
 import io.kotest.matchers.collections.strictlyIncreasing
 import io.kotest.matchers.collections.strictlyIncreasingWith
 import io.kotest.matchers.should
-import io.kotest.matchers.throwable.shouldHaveMessage
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldHave
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.shouldNotHave
+import io.kotest.matchers.throwable.shouldHaveMessage
 import java.util.ArrayList
 import java.util.Comparator
 
@@ -556,6 +556,27 @@ class CollectionMatchersTest : WordSpec() {
       }
 
       "containExactly" should {
+         "test that an array contains given elements exactly" {
+            val actual = arrayOf(1, 2, 3)
+            actual.shouldContainExactly(1, 2, 3)
+            actual.shouldNotContainExactly(3, 2, 1)
+
+            shouldThrow<AssertionError> {
+               actual.shouldContainExactly(3, 2, 1)
+            }
+            shouldThrow<AssertionError> {
+               actual.shouldNotContainExactly(1, 2, 3)
+            }
+
+            val actualNull: Array<Int>? = null
+            shouldThrow<AssertionError> {
+               actualNull.shouldContainExactly(1, 2, 3)
+            }.shouldHaveMessage("Expecting actual not to be null")
+            shouldThrow<AssertionError> {
+               actualNull.shouldNotContainExactly()
+            }.shouldHaveMessage("Expecting actual not to be null")
+         }
+
          "test that a collection contains given elements exactly"  {
             val actual = listOf(1, 2, 3)
             emptyList<Int>() should containExactly()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -559,13 +559,21 @@ class CollectionMatchersTest : WordSpec() {
          "test that an array contains given elements exactly" {
             val actual = arrayOf(1, 2, 3)
             actual.shouldContainExactly(1, 2, 3)
+            actual shouldContainExactly arrayOf(1, 2, 3)
             actual.shouldNotContainExactly(3, 2, 1)
+            actual shouldNotContainExactly arrayOf(3, 2, 1)
 
             shouldThrow<AssertionError> {
                actual.shouldContainExactly(3, 2, 1)
             }
             shouldThrow<AssertionError> {
+               actual shouldContainExactly arrayOf(3, 2, 1)
+            }
+            shouldThrow<AssertionError> {
                actual.shouldNotContainExactly(1, 2, 3)
+            }
+            shouldThrow<AssertionError> {
+               actual shouldNotContainExactly arrayOf(1, 2, 3)
             }
 
             val actualNull: Array<Int>? = null


### PR DESCRIPTION
This is to fix the issue https://github.com/kotest/kotest/issues/1364