### PR TITLE
Fixes AutoClose ordering

### DIFF
--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/runtime/callbacks.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/runtime/callbacks.kt
@@ -1,6 +1,5 @@
 package io.kotest.core.runtime
 
-import io.kotest.mpp.log
 import io.kotest.core.config.Project
 import io.kotest.core.config.dumpProjectConfig
 import io.kotest.core.extensions.TestCaseExtension
@@ -12,6 +11,7 @@ import io.kotest.core.spec.resolvedTestListeners
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.fp.Try
+import io.kotest.mpp.log
 
 /**
  * Invokes any afterProject functions from the given listeners.
@@ -83,10 +83,11 @@ suspend fun Spec.invokeBeforeSpec(): Try<Spec> = Try {
  */
 suspend fun Spec.invokeAfterSpec(): Try<Spec> = Try {
    log("invokeAfterSpec $this")
+
+   autoCloseables.forEach { it.close() }
+
    val listeners = resolvedTestListeners() + Project.testListeners()
-   listeners.forEach {
-      it.afterSpec(this)
-   }
+   listeners.forEach { it.afterSpec(this) }
    this
 }
 

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/configuration.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/configuration.kt
@@ -186,6 +186,8 @@ abstract class TestConfiguration {
       fun DynamicTest.addPrefix() = copy(name = prefix + name)
       factories = factories + factory.copy(tests = factory.tests.map { it.addPrefix() })
    }
+
+   internal var autoCloseables = emptyList<AutoCloseable>()
 }
 
 // we need to include setting the adapter as a top level val in here so that it runs before any suite/test in js
@@ -197,9 +199,7 @@ val initializeRuntime = configureRuntime()
  * which invokes the [AutoCloseable.close] method.
  */
 fun <T : AutoCloseable> TestConfiguration.autoClose(closeable: T): T {
-   afterSpec {
-      closeable.close()
-   }
+   autoCloseables = listOf(closeable) + autoCloseables
    return closeable
 }
 
@@ -208,8 +208,6 @@ fun <T : AutoCloseable> TestConfiguration.autoClose(closeable: T): T {
  * which invokes the [AutoCloseable.close] method.
  */
 fun <T : AutoCloseable> TestConfiguration.autoClose(closeable: Lazy<T>): Lazy<T> {
-   afterSpec {
-      closeable.value.close()
-   }
+   autoClose(closeable.value)
    return closeable
 }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/AutoCloseTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/AutoCloseTest.kt
@@ -1,72 +1,55 @@
 package com.sksamuel.kotest
 
-import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.Spec
 import io.kotest.core.spec.autoClose
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.core.spec.style.StringSpec
-import java.io.Closeable
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
 
-// this is here to test for github issue #294
-internal object Resources
 
 class AutoCloseTest : StringSpec() {
 
-  private val resourceA = autoClose(AutoCloseable4)
-  private val resourceB = autoClose(Closeable3)
-  private val resourceC = autoClose(Closeable2)
-  private val resourceD = autoClose(AutoCloseable1)
+  private val first = autoClose(FirstAutoclose)
+  private val second = autoClose(SecondAutoclose)
+  private val third = autoClose(ThirdAutoclose)
 
   init {
     "should close resources in reverse order" {
-      resourceA.closed = false
-      resourceB.closed = false
-      resourceC.closed = false
-      resourceD.closed = false
+       // Test will be verified in AfterSpec
     }
   }
+
+   override fun afterSpec(spec: Spec) {
+      first.closed shouldBe 3
+      second.closed shouldBe 2
+      third.closed shouldBe 1
+   }
+
 }
 
-object AutoCloseListener : ProjectListener {
-  override fun afterProject() {
-    AutoCloseable1.closed.shouldBeTrue()
-    Closeable2.closed.shouldBeTrue()
-    Closeable3.closed.shouldBeTrue()
-    AutoCloseable4.closed.shouldBeTrue()
-  }
+private val closedNumber = AtomicInteger(0)
+
+private object FirstAutoclose : AutoCloseable {
+
+   var closed = -1
+
+   override fun close() {
+      closed = closedNumber.incrementAndGet()
+   }
 }
 
-object AutoCloseable1 : AutoCloseable {
+private object SecondAutoclose : AutoCloseable {
+   var closed = -1
 
-  var closed = true
-
-  override fun close() {
-    closed = true
-  }
+   override fun close() {
+      closed = closedNumber.incrementAndGet()
+   }
 }
 
-object Closeable2 : Closeable {
+private object ThirdAutoclose : AutoCloseable {
+   var closed = -1
 
-  var closed = true
-
-  override fun close() {
-    closed = true
-  }
-}
-
-object Closeable3 : Closeable {
-
-  var closed = true
-
-  override fun close() {
-    closed = true
-  }
-}
-
-object AutoCloseable4 : AutoCloseable {
-
-  var closed = true
-
-  override fun close() {
-    closed = true
-  }
+   override fun close() {
+      closed = closedNumber.incrementAndGet()
+   }
 }


### PR DESCRIPTION
Until 4.0.0 we had the intended behavior for autoclose: closing the closeables in the reverse order.

This commit fixes that behavior so the expected behavior is brought back.

Fixes #1382