### PR TITLE
#1381 Makes LinkageError as fatal error

### DIFF
--- a/kotest-fp/src/jvmMain/kotlin/io/kotest/fp/nonFatal.kt
+++ b/kotest-fp/src/jvmMain/kotlin/io/kotest/fp/nonFatal.kt
@@ -1,6 +1,6 @@
 package io.kotest.fp
 
 actual fun nonFatal(t: Throwable): Boolean = when (t) {
-   is VirtualMachineError, is ThreadDeath, is InterruptedException, is LinkageError -> false
+   is VirtualMachineError, is ThreadDeath, is InterruptedException -> false
    else -> true
 }

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/StringSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/StringSpecEngineKitTest.kt
@@ -286,6 +286,44 @@ class StringSpecEngineKitTest : FunSpec({
          }
    }
 
+   test("ExceptionInInitializerError exception in beforeTest") {
+      val fullyQualifiedTestClassName = "com.sksamuel.kotest.runner.junit5.StringSpecExceptionInInitializerErrorInBeforeTestFunction"
+
+      EngineTestKit
+         .engine("kotest")
+         .selectors(selectClass(StringSpecExceptionInInitializerErrorInBeforeTestFunction::class.java))
+         .configurationParameter("allow_private", "true")
+         .execute()
+         .allEvents().apply {
+            count() shouldBe 11
+            started().shouldHaveNames(
+               "Kotest",
+               fullyQualifiedTestClassName,
+               "a failing test",
+               "a passing test"
+            )
+            skipped().shouldBeEmpty()
+            failed().shouldHaveNames(
+               "a failing test",
+               "a passing test",
+               fullyQualifiedTestClassName
+            )
+            succeeded().shouldHaveNames("Kotest")
+            finished().shouldHaveNames(
+               "a failing test",
+               "a passing test",
+               fullyQualifiedTestClassName,
+               "Kotest"
+            )
+            aborted().shouldBeEmpty()
+            dynamicallyRegistered().shouldHaveNames(
+               fullyQualifiedTestClassName,
+               "a failing test",
+               "a passing test"
+            )
+         }
+   }
+
    test("exception in afterTest override") {
       EngineTestKit
          .engine("kotest")
@@ -428,7 +466,6 @@ private class StringSpecExceptionInAfterTestFunction : StringSpec() {
    }
 }
 
-
 private class StringSpecExceptionInAfterSpec : StringSpec() {
 
    init {
@@ -498,6 +535,23 @@ private class StringSpecExceptionInBeforeTestFunction : StringSpec() {
       }
    }
 }
+
+private class StringSpecExceptionInInitializerErrorInBeforeTestFunction : StringSpec() {
+   init {
+      "a failing test" {
+         1 shouldBe 2
+      }
+
+      "a passing test" {
+         1 shouldBe 1
+      }
+
+      beforeTest {
+         throw ExceptionInInitializerError("Unable to initialize")
+      }
+   }
+}
+
 
 private class StringSpecTestCase : StringSpec({
 


### PR DESCRIPTION
This fixes issues where beforeTest swallow exceptions like ExceptionInInitializerError, NoClassDefFoundError etc