### PR TITLE
#1406 Adding a Arb.Choice function that returns an Arb instance, deprecated…

### DIFF
--- a/doc/generators.md
+++ b/doc/generators.md
@@ -51,7 +51,7 @@ Most generators are available on all platforms. Some are JVM specific.
 | -------- | ----------- | --- | --- | ------ |
 | `Arb.choose(pairs)` | Generates values based on weights. For example, `Arb.choose(1 to 'A', 2 to 'B')` will generate 'A' 33% of the time and 'B' 66% of the time. | ✓ | ✓ | ✓ |
 | `Arb.shuffle(list)` | Generates random permutations of a list. For example, `Arb.shuffle(listOf(1,2,3))` could generate `listOf(3,1,2)`, `listOf(1,3,2)` and so on. | ✓ | ✓ | ✓ |
-| `Arb.choice(gens)` | Randomly selects one of the given gens and then uses that to generate the next element. | ✓ | ✓ | ✓ |
+| `Arb.choice(arbs)` | Randomly selects one of the given arbs and then uses that to generate the next element.  | ✓ | ✓ | ✓ |
 | `Arb.subsequence(list)` | Generates a random subsequence of the given list starting at index 0 and including the empty list. For example, `Arb.subsequence(listOf(1,2,3))` could generate `listOf(1)`, `listOf(1,2)`, and so on. | ✓ | ✓ | ✓ |
 
 |  Collections  | Description | JVM | JS  | Native |

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
@@ -63,8 +63,39 @@ fun <A> Arb.Companion.subsequence(list: List<A>) = arb {
  * The input must be non-empty.
  * The input gens must be infinite.
  */
-fun <A> Arb.Companion.choice(vararg gens: Gen<A>): Arb<A> = arb { rs ->
+@Deprecated(
+   message = "Deprecated in favor of a function that returns an Arb instead of a Gen",
+   replaceWith = ReplaceWith("Arb.Companion.choice(vararg arbs: Arb<A>)")
+)
+fun <A> Arb.Companion.choice(vararg gens: Gen<A>): Gen<A> = arb { rs ->
    val iters = gens.map { it.generate(rs).iterator() }
+   fun next(): Sample<A>? {
+      val iter = iters.shuffled(rs.random).first()
+      return if (iter.hasNext()) iter.next() else null
+   }
+   sequence {
+      while (true) {
+         var next: Sample<A>? = null
+         while (next == null)
+            next = next()
+         yield(next.value)
+      }
+   }
+}
+
+/**
+ * Uses the Arbs provided to randomly generate the next element.
+ * The returned Arb.edgecases() contains all of edgecases of the provided arbs
+ * The input must be non-empty.
+ * The input arbs must be infinite.
+ *
+ * @throws IllegalArgumentException if no arbs have been passed to this function
+ * @return A new Arb<A> that will randomly select values from the provided Arbs, and combine all of the provided
+ * Arbs edgecases
+ */
+fun <A> Arb.Companion.choice(vararg arbs: Arb<A>): Arb<A> = arb(arbs.flatMap(Arb<A>::edgecases)) { rs ->
+   require(arbs.isNotEmpty()) { "No Arb instances passed to Arb.choice()." }
+   val iters = arbs.map { it.values(rs).iterator() }
    fun next(): Sample<A>? {
       val iter = iters.shuffled(rs.random).first()
       return if (iter.hasNext()) iter.next() else null

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ChoiceTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ChoiceTest.kt
@@ -1,20 +1,26 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.comparables.beGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.Sample
+import io.kotest.property.arbitrary.arb
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.negativeInts
+import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.positiveInts
 import io.kotest.property.forAll
 
 class ChoiceTest : WordSpec({
 
-   "Gen.oneOf" should {
+   "Arb.choice" should {
       "correctly handle multiple generators" {
          val gen = Arb.choice(Arb.positiveInts(), Arb.negativeInts())
          var positiveNumbers = 0
@@ -34,9 +40,46 @@ class ChoiceTest : WordSpec({
       "support covariance" {
          Arb.choice(
             Arb.int().map { X.A(it) },
-            Arb.int().map { X.A(it) },
-            Arb.int().map { X.A(it) }
+            Arb.int().map { X.B(it) },
+            Arb.int().map { X.C(it) }
          )
+      }
+      "combines the provided Arb instances edgecases"{
+         Arb.choice(
+            arb(listOf(1, 2)) { emptySequence() },
+            arb(listOf(3, 4)) { emptySequence() }
+         ).edgecases() shouldBe listOf(1, 2, 3, 4)
+      }
+      "provides both edgecases and values when used as a Gen"{
+         val values = mutableSetOf<Int>()
+         forAll(Arb.choice(
+            arb(listOf(1)) { generateSequence { 2 } },
+            arb(listOf(3)) { generateSequence { 4 } }
+         )) { i ->
+            values.add(i)
+            listOf(1, 2, 3, 4).contains(i)
+         }
+         values shouldBe setOf(1, 2, 3, 4)
+      }
+      "edgecases should not be in Arb.values"{
+         val valueSet = Arb.choice(
+            arb(listOf(-1)) { generateSequence { 1 } },
+            arb(listOf(-2)) { generateSequence { 2 } }
+         )
+            .values(RandomSource.Default)
+            .map(Sample<Int>::value)
+            .take(1000)
+            .toSet()
+
+         valueSet shouldBe setOf(1, 2)
+      }
+      "Arguments must be passed to Arb.choice" {
+         assertSoftly {
+            val ex = shouldThrowExactly<IllegalArgumentException> {
+               Arb.choice(*arrayOf<Arb<Int>>()).next()
+            }
+            ex.message shouldBe "No Arb instances passed to Arb.choice()."
+         }
       }
    }
 })


### PR DESCRIPTION
… Arb.Choice that returns a Gen.

The compiler didn't complain about conflicting JVM names, so I didn't need to add the the JvmName annotation, can add it if required? 

https://github.com/kotest/kotest/issues/1406