### PR TITLE
Add support to isEqual for ZonedDateTime

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/matchers.kt
@@ -2280,3 +2280,77 @@ infix fun LocalDateTime.shouldHaveSecond(second: Int) = this.second shouldBe sec
  * ```
  */
 infix fun LocalDateTime.shouldHaveNano(nano: Int) = this.nano shouldBe nano
+
+/**
+ * Asserts that this is equal to [other] using the [ChronoZonedDateTime.isEqual]
+ *
+ * Opposite of [ChronoZonedDateTime.shouldNotBeEqual]
+ *
+ * ```
+ *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldBeEqual(other)  // Assertion passes
+ *
+ *
+ *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldNotBeEqual(other)  // Assertion fails, date is NOT equal to the other date
+ * ```
+ *
+ * @see ZonedDateTime.shouldNotBeEqual
+ */
+infix fun ZonedDateTime.shouldBeEqual(other: ZonedDateTime) = this shouldBe equal(other)
+
+/**
+ * Asserts that this is NOT equal to [other] using the [ChronoZonedDateTime.isEqual]
+ *
+ * Opposite of [ChronoZonedDateTime.shouldBeEqual]
+ *
+ * ```
+ *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldBeEqual(other)  // Assertion passes
+ *
+ *
+ *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldNotBeEqual(other)  // Assertion fails, date is equal to the other date
+ * ```
+ *
+ * @see ZonedDateTime.shouldBeEqual
+ */
+infix fun ZonedDateTime.shouldNotBeEqual(other: ZonedDateTime) = this shouldNotBe equal(other)
+
+/**
+ * Matcher that checks if ZonedDateTime is equal to another ZonedDateTime using the
+ * [ChronoZonedDateTime.isEqual]
+ *
+ *
+ * ```
+ *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldBeEqual(other)  // Assertion passes
+ *
+ *
+ *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldNotBeEqual(other)  // Assertion fails, date is NOT equal to the other date
+ * ```
+ *
+ * @see ZonedDateTime.shouldBeEqual
+ * @see ZonedDateTime.shouldNotBeEqual
+ */
+fun equal(other: ZonedDateTime) = object : Matcher<ZonedDateTime> {
+   override fun test(value: ZonedDateTime): MatcherResult =
+      MatcherResult(
+         passed = value.isEqual(other),
+         failureMessage = "$value should be equal to $other",
+         negatedFailureMessage = "$value should not be equal to $other"
+      )
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/matchers.kt
@@ -2284,46 +2284,46 @@ infix fun LocalDateTime.shouldHaveNano(nano: Int) = this.nano shouldBe nano
 /**
  * Asserts that this is equal to [other] using the [ChronoZonedDateTime.isEqual]
  *
- * Opposite of [ChronoZonedDateTime.shouldNotBeEqual]
+ * Opposite of [ZonedDateTime.shouldNotHaveSameInstantAs]
  *
  * ```
  *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
  *    val other = ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
  *
- *    date.shouldBeEqual(other)  // Assertion passes
+ *    date.shouldHaveSameInstantAs(other)  // Assertion passes
  *
  *
  *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
  *    val other = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
  *
- *    date.shouldNotBeEqual(other)  // Assertion fails, date is NOT equal to the other date
+ *    date.shouldHaveSameInstantAs(other)  // Assertion fails, date is NOT equal to the other date
  * ```
  *
- * @see ZonedDateTime.shouldNotBeEqual
+ * @see ZonedDateTime.shouldNotHaveSameInstant
  */
-infix fun ZonedDateTime.shouldBeEqual(other: ZonedDateTime) = this shouldBe equal(other)
+infix fun ZonedDateTime.shouldHaveSameInstantAs(other: ZonedDateTime) = this should haveSameInstantAs(other)
 
 /**
  * Asserts that this is NOT equal to [other] using the [ChronoZonedDateTime.isEqual]
  *
- * Opposite of [ChronoZonedDateTime.shouldBeEqual]
+ * Opposite of [ZonedDateTime.shouldHaveSameInstantAs]
  *
  * ```
  *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
  *    val other = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
  *
- *    date.shouldBeEqual(other)  // Assertion passes
+ *    date.shouldNotHaveSameInstantAs(other)  // Assertion passes
  *
  *
  *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
  *    val other = ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
  *
- *    date.shouldNotBeEqual(other)  // Assertion fails, date is equal to the other date
+ *    date.shouldNotHaveSameInstantAs(other)  // Assertion fails, date is equal to the other date
  * ```
  *
- * @see ZonedDateTime.shouldBeEqual
+ * @see ZonedDateTime.shouldHaveSameInstantAs
  */
-infix fun ZonedDateTime.shouldNotBeEqual(other: ZonedDateTime) = this shouldNotBe equal(other)
+infix fun ZonedDateTime.shouldNotHaveSameInstantAs(other: ZonedDateTime) = this shouldNot haveSameInstantAs(other)
 
 /**
  * Matcher that checks if ZonedDateTime is equal to another ZonedDateTime using the
@@ -2334,19 +2334,19 @@ infix fun ZonedDateTime.shouldNotBeEqual(other: ZonedDateTime) = this shouldNotB
  *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
  *    val other = ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
  *
- *    date.shouldBeEqual(other)  // Assertion passes
+ *    date.haveSameInstantAs(other)  // Assertion passes
  *
  *
  *    val date = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
  *    val other = ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
  *
- *    date.shouldNotBeEqual(other)  // Assertion fails, date is NOT equal to the other date
+ *    date.haveSameInstantAs(other)  // Assertion fails, date is NOT equal to the other date
  * ```
  *
- * @see ZonedDateTime.shouldBeEqual
- * @see ZonedDateTime.shouldNotBeEqual
+ * @see ZonedDateTime.shouldHaveSameInstantAs
+ * @see ZonedDateTime.shouldNotHaveSameInstantAs
  */
-fun equal(other: ZonedDateTime) = object : Matcher<ZonedDateTime> {
+fun haveSameInstantAs(other: ZonedDateTime) = object : Matcher<ZonedDateTime> {
    override fun test(value: ZonedDateTime): MatcherResult =
       MatcherResult(
          passed = value.isEqual(other),

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.date.after
 import io.kotest.matchers.date.atSameZone
 import io.kotest.matchers.date.before
+import io.kotest.matchers.date.equal
 import io.kotest.matchers.date.haveSameDay
 import io.kotest.matchers.date.haveSameHours
 import io.kotest.matchers.date.haveSameMinutes
@@ -15,6 +16,7 @@ import io.kotest.matchers.date.haveSameYear
 import io.kotest.matchers.date.shouldBeAfter
 import io.kotest.matchers.date.shouldBeBefore
 import io.kotest.matchers.date.shouldBeBetween
+import io.kotest.matchers.date.shouldBeEqual
 import io.kotest.matchers.date.shouldBeToday
 import io.kotest.matchers.date.shouldBeWithin
 import io.kotest.matchers.date.shouldHaveDayOfMonth
@@ -35,6 +37,7 @@ import io.kotest.matchers.date.shouldHaveSecond
 import io.kotest.matchers.date.shouldNotBeAfter
 import io.kotest.matchers.date.shouldNotBeBefore
 import io.kotest.matchers.date.shouldNotBeBetween
+import io.kotest.matchers.date.shouldNotBeEqual
 import io.kotest.matchers.date.shouldNotBeToday
 import io.kotest.matchers.date.shouldNotBeWithin
 import io.kotest.matchers.date.shouldNotHaveSameDayAs
@@ -408,6 +411,13 @@ class DateMatchersTest : StringSpec() {
     }
     "LocalDateTime should have nano" {
       LocalDateTime.of(2019, 2, 16, 12, 10, 0, 14) shouldHaveNano  14
+    }
+
+    "ZonedDateTime should be equal to another ZonedDateTime if these are equal irrespective of their timezone" {
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldBe equal(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3)))
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldBeEqual ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotBe equal(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2)))
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotBeEqual ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2))
     }
   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
@@ -2,12 +2,13 @@ package com.sksamuel.kotest.matchers.date
 
 import io.kotest.assertions.shouldFail
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.date.after
 import io.kotest.matchers.date.atSameZone
 import io.kotest.matchers.date.before
-import io.kotest.matchers.date.equal
 import io.kotest.matchers.date.haveSameDay
 import io.kotest.matchers.date.haveSameHours
+import io.kotest.matchers.date.haveSameInstantAs
 import io.kotest.matchers.date.haveSameMinutes
 import io.kotest.matchers.date.haveSameMonth
 import io.kotest.matchers.date.haveSameNanos
@@ -16,7 +17,6 @@ import io.kotest.matchers.date.haveSameYear
 import io.kotest.matchers.date.shouldBeAfter
 import io.kotest.matchers.date.shouldBeBefore
 import io.kotest.matchers.date.shouldBeBetween
-import io.kotest.matchers.date.shouldBeEqual
 import io.kotest.matchers.date.shouldBeToday
 import io.kotest.matchers.date.shouldBeWithin
 import io.kotest.matchers.date.shouldHaveDayOfMonth
@@ -28,6 +28,7 @@ import io.kotest.matchers.date.shouldHaveMonth
 import io.kotest.matchers.date.shouldHaveNano
 import io.kotest.matchers.date.shouldHaveSameDayAs
 import io.kotest.matchers.date.shouldHaveSameHoursAs
+import io.kotest.matchers.date.shouldHaveSameInstantAs
 import io.kotest.matchers.date.shouldHaveSameMinutesAs
 import io.kotest.matchers.date.shouldHaveSameMonthAs
 import io.kotest.matchers.date.shouldHaveSameNanosAs
@@ -37,11 +38,11 @@ import io.kotest.matchers.date.shouldHaveSecond
 import io.kotest.matchers.date.shouldNotBeAfter
 import io.kotest.matchers.date.shouldNotBeBefore
 import io.kotest.matchers.date.shouldNotBeBetween
-import io.kotest.matchers.date.shouldNotBeEqual
 import io.kotest.matchers.date.shouldNotBeToday
 import io.kotest.matchers.date.shouldNotBeWithin
 import io.kotest.matchers.date.shouldNotHaveSameDayAs
 import io.kotest.matchers.date.shouldNotHaveSameHoursAs
+import io.kotest.matchers.date.shouldNotHaveSameInstantAs
 import io.kotest.matchers.date.shouldNotHaveSameMinutesAs
 import io.kotest.matchers.date.shouldNotHaveSameMonthAs
 import io.kotest.matchers.date.shouldNotHaveSameNanosAs
@@ -49,7 +50,6 @@ import io.kotest.matchers.date.shouldNotHaveSameSecondsAs
 import io.kotest.matchers.date.shouldNotHaveSameYearAs
 import io.kotest.matchers.date.within
 import io.kotest.matchers.shouldBe
-import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
@@ -413,11 +413,11 @@ class DateMatchersTest : StringSpec() {
       LocalDateTime.of(2019, 2, 16, 12, 10, 0, 14) shouldHaveNano  14
     }
 
-    "ZonedDateTime should be equal to another ZonedDateTime if these are equal irrespective of their timezone" {
-       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldBe equal(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3)))
-       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldBeEqual ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
-       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotBe equal(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2)))
-       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotBeEqual ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2))
+    "ZonedDateTime should be have same instant of the given ZonedDateTime irrespective of their timezone" {
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) should haveSameInstantAs(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3)))
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldHaveSameInstantAs ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNot haveSameInstantAs(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2)))
+       ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotHaveSameInstantAs ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2))
     }
   }
 }


### PR DESCRIPTION
The `ZonedDateTime` [equals()](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html#equals-java.lang.Object-) method also compares the time zone.  It will return `false` if the two instances have a different time zone.

The [isEqual()](https://docs.oracle.com/javase/8/docs/api/java/time/chrono/ChronoZonedDateTime.html#isEqual-java.time.chrono.ChronoZonedDateTime-) method, on the other hand, returns `true` if the instant equals the instant of the specified date-time.  This works across time zones.
