### PR TITLE
#1418 Depreciate `isolation` in favor of new `isolationMode` parameter for inline test configuration

### DIFF
--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -49,7 +49,14 @@ abstract class Spec : TestConfiguration(), SpecConfigurationMethods {
     * Sets the [IsolationMode] used by the test engine when running tests in this spec.
     * If left null, then the project default is applied.
     */
+   @Deprecated("This has been deprecated in favor of the isolationMode parameter", ReplaceWith("isolationMode"), DeprecationLevel.WARNING)
    var isolation: IsolationMode? = null
+
+   /**
+    * Sets the [IsolationMode] used by the test engine when running tests in this spec.
+    * If left null, then the project default is applied.
+    */
+   var isolationMode: IsolationMode? = null
 
    /**
     * Sets the [TestCaseOrder] to control the order of execution of root level tests in this spec.
@@ -140,7 +147,7 @@ fun Spec.resolvedTestCaseOrder() =
    this.testOrder ?: this.testCaseOrder() ?: Project.testCaseOrder()
 
 fun Spec.resolvedIsolationMode() =
-   this.isolation ?: this.isolationMode() ?: Project.isolationMode()
+   this.isolationMode ?: this.isolation ?: this.isolationMode() ?: Project.isolationMode()
 
 /**
  * Orders the collection of [TestCase]s based on the provided [TestCaseOrder].


### PR DESCRIPTION
Resolves issue #1418 