### PR TITLE
Team city service message fixes and updates

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/show/Show.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/show/Show.kt
@@ -18,6 +18,10 @@ interface Show<in A> {
    fun show(a: A): Printed
 }
 
+/**
+ * Represents a value that has been appropriately formatted for display in output logs or error messages.
+ * For example, a null might be formatted as <null>.
+ */
 data class Printed(val value: String)
 
 fun String.printed() = Printed(this)

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/show/platformShow.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/show/platformShow.kt
@@ -1,3 +1,4 @@
+@file:JvmName("platformjvm")
 package io.kotest.assertions.show
 
 import java.nio.file.Path

--- a/kotest-core/src/jsMain/kotlin/io/kotest/core/runtime/kotlinTest.kt
+++ b/kotest-core/src/jsMain/kotlin/io/kotest/core/runtime/kotlinTest.kt
@@ -2,4 +2,5 @@
 @file:JsNonModule
 package io.kotest.core.runtime
 
+//this file is called kotlinTest.kt because it is from kotlin.test
 external fun setAdapter(adapter: dynamic)

--- a/kotest-runner/kotest-runner-console/src/jvmMain/kotlin/io/kotest/runner/console/TeamCityMessages.kt
+++ b/kotest-runner/kotest-runner-console/src/jvmMain/kotlin/io/kotest/runner/console/TeamCityMessages.kt
@@ -5,6 +5,8 @@ import kotlin.time.ExperimentalTime
 
 /**
  * Message format:
+ *
+ * https://www.jetbrains.com/help/teamcity/build-script-interaction-with-teamcity.html
  * https://confluence.jetbrains.com/display/TCD65/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-servMsgsServiceMessages
  *
  * Some message implementations:
@@ -12,17 +14,25 @@ import kotlin.time.ExperimentalTime
  * https://github.com/JetBrains/intellij-community/blob/master/plugins/testng/testSources/com/theoryinpractice/testng/configuration/TestNGTreeHierarchyTest.java
  * https://github.com/JetBrains/intellij-community/blob/master/plugins/junit_rt/src/com/intellij/junit4/JUnit4TestListener.java
  */
-class TeamCityMessages(command: String) {
+class TeamCityMessages(prefix: String?, command: String) {
 
-   private val myText = StringBuilder("##teamcity[$command")
+   private val myText = StringBuilder(prefix ?: "##teamcity").append("[$command")
 
    fun addAttribute(name: String, value: String): TeamCityMessages {
-      myText.append(' ').append(name).append("='").append(value).append('\'')
+      myText
+         .append(' ')
+         .append(name).append("='")
+         .append(value.replace("[", "|[").replace("]", "|]").replace("'", "|'").replace("\n".toRegex(), "|n"))
+         .append("'")
       return this
    }
 
    internal fun ignoreComment(value: String): TeamCityMessages = addAttribute("ignoreComment", value)
    internal fun message(value: String): TeamCityMessages = addAttribute("message", value.trim())
+   internal fun details(value: String): TeamCityMessages = addAttribute("details", value.trim())
+   internal fun type(value: String): TeamCityMessages = addAttribute("type", value.trim())
+   internal fun actual(value: String): TeamCityMessages = addAttribute("actual", value.trim())
+   internal fun expected(value: String): TeamCityMessages = addAttribute("expected", value.trim())
    internal fun locationHint(value: String): TeamCityMessages = addAttribute("locationHint", value)
 
    @OptIn(ExperimentalTime::class)
@@ -30,6 +40,23 @@ class TeamCityMessages(command: String) {
       addAttribute("duration", duration.toLongMilliseconds().toString())
 
    override fun toString(): String = "$myText]"
+
+   fun withException(error: Throwable?): TeamCityMessages {
+      return if (error == null) this else {
+         val line1 = error.message?.lines()?.firstOrNull()
+         val message = if (line1.isNullOrBlank()) "Test failed" else line1
+         val withMessage = message(message)
+         when (error) {
+            is org.opentest4j.AssertionFailedError ->
+               if (error.isActualDefined && error.isExpectedDefined) {
+                  withMessage.type("comparisonFailure")
+                     .actual(error.actual.stringRepresentation)
+                     .expected(error.expected.stringRepresentation)
+               } else withMessage
+            else -> withMessage
+         }
+      }
+   }
 
    companion object {
 
@@ -42,36 +69,36 @@ class TeamCityMessages(command: String) {
       private const val TEST_STD_ERR = "testStdErr"
       private const val TEST_FAILED = "testFailed"
 
-      fun testSuiteStarted(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_SUITE_STARTED).addAttribute("name", name)
+      fun testSuiteStarted(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_SUITE_STARTED).addAttribute("name", name)
       }
 
-      fun testSuiteFinished(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_SUITE_FINISHED).addAttribute("name", name)
+      fun testSuiteFinished(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_SUITE_FINISHED).addAttribute("name", name)
       }
 
-      fun testStarted(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_STARTED).addAttribute("name", name)
+      fun testStarted(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_STARTED).addAttribute("name", name)
       }
 
-      fun testFinished(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_FINISHED).addAttribute("name", name)
+      fun testFinished(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_FINISHED).addAttribute("name", name)
       }
 
-      fun testStdOut(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_STD_OUT).addAttribute("name", name)
+      fun testStdOut(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_STD_OUT).addAttribute("name", name)
       }
 
-      fun testStdErr(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_STD_ERR).addAttribute("name", name)
+      fun testStdErr(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_STD_ERR).addAttribute("name", name)
       }
 
-      fun testFailed(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_FAILED).addAttribute("name", name)
+      fun testFailed(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_FAILED).addAttribute("name", name)
       }
 
-      fun testIgnored(name: String): TeamCityMessages {
-         return TeamCityMessages(TEST_IGNORED).addAttribute("name", name)
+      fun testIgnored(prefix: String?, name: String): TeamCityMessages {
+         return TeamCityMessages(prefix, TEST_IGNORED).addAttribute("name", name)
       }
    }
 }

--- a/kotest-runner/kotest-runner-console/src/jvmTest/kotlin/com/sksamuel/kotest/runner/console/TeamCityConsoleWriterTest.kt
+++ b/kotest-runner/kotest-runner-console/src/jvmTest/kotlin/com/sksamuel/kotest/runner/console/TeamCityConsoleWriterTest.kt
@@ -1,6 +1,10 @@
 package com.sksamuel.kotest.runner.console
 
+import io.kotest.assertions.Actual
+import io.kotest.assertions.Expected
+import io.kotest.assertions.failure
 import io.kotest.assertions.shouldFail
+import io.kotest.assertions.show.Printed
 import io.kotest.core.sourceRef
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.description
@@ -17,7 +21,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.runner.console.TeamCityConsoleWriter
 import kotlin.reflect.KClass
-import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
@@ -46,36 +49,36 @@ class TeamCityConsoleWriterTest : FunSpec() {
 
       test("before spec class should write testSuiteStarted started") {
          captureStandardOut {
-            TeamCityConsoleWriter().specStarted(kclass)
-         } shouldBe "\n##teamcity[testSuiteStarted name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest']\n"
+            TeamCityConsoleWriter("testcity").specStarted(kclass)
+         } shouldBe "\ntestcity[testSuiteStarted name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest' locationHint='kotest://com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest:1']\n"
       }
 
       test("before test should write testSuiteStarted for TestType.Container") {
          captureStandardOut {
-            TeamCityConsoleWriter().testStarted(testCaseContainer)
-         } shouldBe "\n##teamcity[testSuiteStarted name='my test container' locationHint='kotest://com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest:33']\n"
+            TeamCityConsoleWriter("testcity").testStarted(testCaseContainer)
+         } shouldBe "\ntestcity[testSuiteStarted name='my test container' locationHint='kotest://com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest:36']\n"
       }
 
       test("before test should write testStarted for TestType.Test") {
          captureStandardOut {
-            TeamCityConsoleWriter().testStarted(testCaseTest)
-         } shouldBe "\n##teamcity[testStarted name='my test case' locationHint='kotest://com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest:33']\n"
+            TeamCityConsoleWriter("testcity").testStarted(testCaseTest)
+         } shouldBe "\ntestcity[testStarted name='my test case' locationHint='kotest://com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest:36']\n"
       }
 
       test("after spec class should write testSuiteFinished") {
          captureStandardOut {
-            TeamCityConsoleWriter().specFinished(kclass, null, emptyMap())
-         } shouldBe "\n##teamcity[testSuiteFinished name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest']\n"
+            TeamCityConsoleWriter("testcity").specFinished(kclass, null, emptyMap())
+         } shouldBe "\ntestcity[testSuiteFinished name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest']\n"
       }
 
       test("afterSpecClass should insert dummy test and write testSuiteFinished for spec error") {
          val err = captureStandardErr {
             captureStandardOut {
-               TeamCityConsoleWriter().specFinished(kclass, AssertionError("boom"), emptyMap())
+               TeamCityConsoleWriter("testcity").specFinished(kclass, AssertionError("boom"), emptyMap())
             } shouldBe "\n" +
-               "##teamcity[testStarted name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest <init>']\n" +
-               "##teamcity[testFailed name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest <init>' message='boom']\n" +
-               "##teamcity[testSuiteFinished name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest']\n"
+               "testcity[testStarted name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest <init>']\n" +
+               "testcity[testFailed name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest <init>' message='boom']\n" +
+               "testcity[testSuiteFinished name='com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest']\n"
          }
          err shouldStartWith "\njava.lang.AssertionError: boom\n" +
             "\tat com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest"
@@ -83,65 +86,65 @@ class TeamCityConsoleWriterTest : FunSpec() {
 
       test("after test should write testSuiteFinished for container success") {
          captureStandardOut {
-            TeamCityConsoleWriter().testFinished(testCaseContainer, TestResult.success(15.milliseconds))
-         } shouldBe "\n##teamcity[testSuiteFinished name='my test container' duration='15']\n"
+            TeamCityConsoleWriter("testcity").testFinished(testCaseContainer, TestResult.success(15.milliseconds))
+         } shouldBe "\ntestcity[testSuiteFinished name='my test container' duration='15']\n"
       }
 
       test("after test should insert dummy test and write testSuiteFinished for container error") {
          captureStandardErr {
             captureStandardOut {
-               TeamCityConsoleWriter().testFinished(
+               TeamCityConsoleWriter("testcity").testFinished(
                   testCaseContainer,
                   TestResult.throwable(AssertionError("wibble"), 51.milliseconds)
                )
             } shouldBe "\n" +
-               "##teamcity[testStarted name='my test container <init>']\n" +
-               "##teamcity[testFailed name='my test container <init>' message='wibble']\n" +
-               "##teamcity[testSuiteFinished name='my test container' duration='51']\n"
+               "testcity[testStarted name='my test container <init>']\n" +
+               "testcity[testFailed name='my test container <init>' message='wibble']\n" +
+               "testcity[testSuiteFinished name='my test container' duration='51']\n"
          } shouldStartWith "\njava.lang.AssertionError: wibble\n" +
             "\tat com.sksamuel.kotest.runner.console.TeamCityConsoleWriterTest"
       }
 
       test("after test should write testSuiteFinished for container ignored") {
          captureStandardOut {
-            TeamCityConsoleWriter().testFinished(testCaseContainer, TestResult.ignored("ignore me?"))
-         } shouldBe "\n##teamcity[testSuiteFinished name='my test container']\n"
+            TeamCityConsoleWriter("testcity").testFinished(testCaseContainer, TestResult.ignored("ignore me?"))
+         } shouldBe "\ntestcity[testSuiteFinished name='my test container']\n"
       }
 
       test("after test should write testFinished for test success") {
          captureStandardOut {
-            TeamCityConsoleWriter().testFinished(testCaseTest, TestResult.success(234.milliseconds))
-         } shouldBe "\n##teamcity[testFinished name='my test case' duration='234']\n"
+            TeamCityConsoleWriter("testcity").testFinished(testCaseTest, TestResult.success(234.milliseconds))
+         } shouldBe "\ntestcity[testFinished name='my test case' duration='234']\n"
       }
 
       test("afterTestCaseExecution for errored test should write stack trace for error to std err, and write testFailed to std out") {
          captureStandardOut {
             captureStandardErr {
-               TeamCityConsoleWriter().testFinished(
+               TeamCityConsoleWriter("testcity").testFinished(
                   testCaseTest,
                   TestResult.throwable(AssertionError("wibble"), 925.milliseconds)
                )
             } shouldStartWith "\njava.lang.AssertionError: wibble\n" +
                "\tat com.sksamuel.kotest.runner.console.TeamCityConsoleWriter"
-         } shouldBe "\n##teamcity[testFailed name='my test case' message='wibble' duration='925']\n"
+         } shouldBe "\ntestcity[testFailed name='my test case' message='wibble' duration='925']\n"
       }
 
       test("afterTestCaseExecution for failed test should write stack trace for error to std err, and write testFailed to std out") {
          captureStandardOut {
             captureStandardErr {
-               TeamCityConsoleWriter().testFinished(
+               TeamCityConsoleWriter("testcity").testFinished(
                   testCaseTest,
                   TestResult.throwable(AssertionError("wibble"), 33.milliseconds)
                )
             } shouldStartWith "\njava.lang.AssertionError: wibble\n" +
                "\tat com.sksamuel.kotest.runner.console.TeamCityConsoleWriter"
-         } shouldBe "\n##teamcity[testFailed name='my test case' message='wibble' duration='33']\n"
+         } shouldBe "\ntestcity[testFailed name='my test case' message='wibble' duration='33']\n"
       }
 
       test("after test should write testIgnored for test with ignored") {
          captureStandardOut {
-            TeamCityConsoleWriter().testFinished(testCaseTest, TestResult.ignored("ignore me?"))
-         } shouldBe "\n##teamcity[testIgnored name='my test case' ignoreComment='ignore me?']\n"
+            TeamCityConsoleWriter("testcity").testFinished(testCaseTest, TestResult.ignored("ignore me?"))
+         } shouldBe "\ntestcity[testIgnored name='my test case' ignoreComment='ignore me?']\n"
       }
 
       test("after test with error should handle multiline messages") {
@@ -156,8 +159,14 @@ class TeamCityConsoleWriterTest : FunSpec() {
          }
 
          captureStandardOut {
-            TeamCityConsoleWriter().testFinished(testCaseTest, TestResult.throwable(error, 8123.milliseconds))
-         } shouldBe "\n##teamcity[testFailed name='my test case' message='Test failed' duration='8123']\n"
+            TeamCityConsoleWriter("testcity").testFinished(testCaseTest, TestResult.throwable(error, 8123.milliseconds))
+         } shouldBe "\ntestcity[testFailed name='my test case' message='Test failed' duration='8123']\n"
+      }
+
+      test("should use comparison values when a supported exception type") {
+         captureStandardOut {
+            TeamCityConsoleWriter("testcity").testFinished(testCaseTest, TestResult.throwable(failure(Expected(Printed("expected")), Actual(Printed("actual"))), 14.milliseconds))
+         } shouldBe "\ntestcity[testFailed name='my test case' message='expected:<expected> but was:<actual>' type='comparisonFailure' actual='actual' expected='expected' duration='14']\n"
       }
    }
 }

--- a/kotest-runner/kotest-runner-console/src/jvmTest/kotlin/com/sksamuel/kotest/runner/console/TeamCityMessagesTest.kt
+++ b/kotest-runner/kotest-runner-console/src/jvmTest/kotlin/com/sksamuel/kotest/runner/console/TeamCityMessagesTest.kt
@@ -1,0 +1,52 @@
+package com.sksamuel.kotest.runner.console
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.console.TeamCityMessages
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+
+@OptIn(ExperimentalTime::class)
+class TeamCityMessagesTest : ShouldSpec({
+
+   should("escape brackets in messages") {
+      val msg = TeamCityMessages.testFailed("testcity", "escape brackets")
+         .message("expected:<[foo]> but was:<[bar]>")
+         .duration(67.milliseconds)
+         .toString()
+      msg shouldBe """testcity[testFailed name='escape brackets' message='expected:<|[foo|]> but was:<|[bar|]>' duration='67']"""
+   }
+
+   should("escape quotes") {
+      val msg = TeamCityMessages.testFailed("testcity", "escape quotes")
+         .message("foo'bar")
+         .duration(67.milliseconds)
+         .toString()
+      msg shouldBe """testcity[testFailed name='escape quotes' message='foo|'bar' duration='67']"""
+   }
+
+   should("escape new lines") {
+      val msg = TeamCityMessages.testFailed("testcity", "escape brackets")
+         .message(
+            """
+qweqwe
+ewr
+ret
+"""
+         )
+         .duration(67.milliseconds)
+         .toString()
+      msg shouldBe """testcity[testFailed name='escape brackets' message='qweqwe|newr|nret' duration='67']"""
+   }
+
+   should("support comparison values") {
+      val msg = TeamCityMessages.testFailed("testcity", "support comparison values")
+         .type("comparisonFailure")
+         .message("test failed")
+         .actual("act")
+         .expected("exp")
+         .duration(44.milliseconds)
+         .toString()
+      msg shouldBe """testcity[testFailed name='support comparison values' type='comparisonFailure' message='test failed' actual='act' expected='exp' duration='44']"""
+   }
+})


### PR DESCRIPTION
Supporting escaping of quotes, brackets and newlines in team city service messages and updated errors to use comparisonType when applicable.
Also added location hint for specs