### PR TITLE
Deprecates `isolation` variable; Adds `isolationMode`

### DIFF
--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -8,6 +8,7 @@ import io.kotest.core.runtime.executeSpec
 import io.kotest.core.sourceRef
 import io.kotest.core.test.*
 import io.kotest.fp.Tuple2
+import kotlin.js.JsName
 
 abstract class Spec : TestConfiguration(), SpecConfigurationMethods {
 
@@ -40,11 +41,19 @@ abstract class Spec : TestConfiguration(), SpecConfigurationMethods {
          .map { RootTest(it.value, it.index) }
    }
 
+
+   @Deprecated(
+      "This var was replaced by [isolationMode]. Use it instead",
+      ReplaceWith("isolationMode")
+   )
+   var isolation: IsolationMode? = null
+
    /**
     * Sets the [IsolationMode] used by the test engine when running tests in this spec.
     * If left null, then the project default is applied.
     */
-   var isolation: IsolationMode? = null
+   @JsName("isolationModeJs")
+   var isolationMode: IsolationMode? = null
 
    /**
     * Sets the [TestCaseOrder] to control the order of execution of root level tests in this spec.
@@ -135,7 +144,7 @@ fun Spec.resolvedTestCaseOrder() =
    this.testOrder ?: this.testCaseOrder() ?: Project.testCaseOrder()
 
 fun Spec.resolvedIsolationMode() =
-   this.isolation ?: this.isolationMode() ?: Project.isolationMode()
+   this.isolationMode ?: this.isolation ?: this.isolationMode() ?: Project.isolationMode()
 
 /**
  * Orders the collection of [TestCase]s based on the provided [TestCaseOrder].

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/leaf/FreeSpecInstancePerLeafTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/leaf/FreeSpecInstancePerLeafTest.kt
@@ -29,7 +29,7 @@ class FreeSpecInstancePerLeafTest : FreeSpec({
       buffer shouldBe "abcabdaefghgi"
    }
 
-   isolation = IsolationMode.InstancePerLeaf
+   isolationMode = IsolationMode.InstancePerLeaf
 
    val count = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/leaf/FunSpecInstancePerLeafTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/leaf/FunSpecInstancePerLeafTest.kt
@@ -13,7 +13,7 @@ class FunSpecInstancePerLeafTest : FunSpec({
       buffer.shouldBe("abc")
    }
 
-   isolation = IsolationMode.InstancePerLeaf
+   isolationMode = IsolationMode.InstancePerLeaf
 
    val counter = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/leaf/StringSpecInstancePerLeafTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/leaf/StringSpecInstancePerLeafTest.kt
@@ -13,7 +13,7 @@ class StringSpecInstancePerLeafTest : StringSpec({
       buffer.shouldBe("abc")
    }
 
-   isolation = IsolationMode.InstancePerLeaf
+   isolationMode = IsolationMode.InstancePerLeaf
 
    val counter = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/AfterTestExceptionTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/AfterTestExceptionTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.specs.isolation.test
 
+import io.kotest.core.engine.SpecExecutor
+import io.kotest.core.engine.TestEngineListener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.*
 import io.kotest.core.test.TestCase
@@ -7,11 +9,9 @@ import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestStatus
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.kotest.core.engine.TestEngineListener
-import io.kotest.core.engine.SpecExecutor
 
 private class BehaviorSpecWithAfterTestError : BehaviorSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
@@ -24,7 +24,7 @@ private class BehaviorSpecWithAfterTestError : BehaviorSpec({
 })
 
 private class FunSpecWithAfterTestError : FunSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
@@ -32,7 +32,7 @@ private class FunSpecWithAfterTestError : FunSpec({
 })
 
 private class StringSpecWithAfterTestError : StringSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
@@ -40,7 +40,7 @@ private class StringSpecWithAfterTestError : StringSpec({
 })
 
 private class ShouldSpecWithAfterTestError : ShouldSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
@@ -48,14 +48,14 @@ private class ShouldSpecWithAfterTestError : ShouldSpec({
 })
 
 private class DescribeSpecWithAfterTestError : DescribeSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
 })
 
 private class FeatureSpecWithAfterTestError : FeatureSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
@@ -65,14 +65,14 @@ private class FeatureSpecWithAfterTestError : FeatureSpec({
 })
 
 private class ExpectSpecWithAfterTestError : ExpectSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
 })
 
 private class FreeSpecWithAfterTestError : FreeSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }
@@ -80,7 +80,7 @@ private class FreeSpecWithAfterTestError : FreeSpec({
 })
 
 private class WordSpecWithAfterTestError : WordSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    afterTest {
       error("boom")
    }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/BeforeTestExceptionTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/BeforeTestExceptionTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.specs.isolation.test
 
+import io.kotest.core.engine.SpecExecutor
+import io.kotest.core.engine.TestEngineListener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.*
 import io.kotest.core.test.TestCase
@@ -7,11 +9,9 @@ import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestStatus
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.kotest.matchers.types.shouldBeInstanceOf
-import io.kotest.core.engine.TestEngineListener
-import io.kotest.core.engine.SpecExecutor
 
 private class BehaviorSpecWithBeforeTestError : BehaviorSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
@@ -24,7 +24,7 @@ private class BehaviorSpecWithBeforeTestError : BehaviorSpec({
 })
 
 private class FunSpecWithBeforeTestError : FunSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
@@ -32,7 +32,7 @@ private class FunSpecWithBeforeTestError : FunSpec({
 })
 
 private class StringSpecWithBeforeTestError : StringSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
@@ -40,7 +40,7 @@ private class StringSpecWithBeforeTestError : StringSpec({
 })
 
 private class ShouldSpecWithBeforeTestError : ShouldSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
@@ -48,14 +48,14 @@ private class ShouldSpecWithBeforeTestError : ShouldSpec({
 })
 
 private class DescribeSpecWithBeforeTestError : DescribeSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
 })
 
 private class FeatureSpecWithBeforeTestError : FeatureSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
@@ -65,14 +65,14 @@ private class FeatureSpecWithBeforeTestError : FeatureSpec({
 })
 
 private class ExpectSpecWithBeforeTestError : ExpectSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
 })
 
 private class FreeSpecWithBeforeTestError : FreeSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }
@@ -80,7 +80,7 @@ private class FreeSpecWithBeforeTestError : FreeSpec({
 })
 
 private class WordSpecWithBeforeTestError : WordSpec({
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    beforeTest {
       error("boom")
    }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/BehaviorSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/BehaviorSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class BehaviorSpecInstancePerTestTest : BehaviorSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    val count = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/DescribeSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/DescribeSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class DescribeSpecInstancePerTestTest : DescribeSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    val counter = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/ExpectSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/ExpectSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class ExpectSpecInstancePerTestTest : ExpectSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    val counter = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/FeatureSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/FeatureSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class FeatureSpecInstancePerTestTest : FeatureSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    val count = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/FreeSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/FreeSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class FreeSpecInstancePerTestTest : FreeSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    val count = AtomicInteger(0)
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/FunSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/FunSpecInstancePerTestTest.kt
@@ -22,7 +22,7 @@ class FunSpecInstancePerTestTest : FunSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    var count = 0
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/ShouldSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/ShouldSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class ShouldSpecInstancePerTestTest : ShouldSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
    val counter = AtomicInteger(0)
 
    context("a") {

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/StringSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/StringSpecInstancePerTestTest.kt
@@ -22,7 +22,7 @@ class StringSpecInstancePerTestTest : StringSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    var count = 0
 

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/WordSpecInstancePerTestTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/isolation/test/WordSpecInstancePerTestTest.kt
@@ -23,7 +23,7 @@ class WordSpecInstancePerTestTest : WordSpec({
       tests.add(it.a.name)
    }
 
-   isolation = IsolationMode.InstancePerTest
+   isolationMode = IsolationMode.InstancePerTest
 
    val count = AtomicInteger(0)
 


### PR DESCRIPTION
With this commit, I've deprecated the `isolation` spec variable, in favour of a variable that's closer to the `isolationMode()` function.

Closes #1418