### PR TITLE
add a shouldTimeout for async calls

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
@@ -5,8 +5,6 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
-import kotlinx.coroutines.withTimeout
-import kotlinx.coroutines.TimeoutCancellationException
 
 fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A) {
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
@@ -42,3 +42,20 @@ fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: () -> A) {
     throw failure("Expected test to timeout for $timeout/$unit")
   }
 }
+
+/**
+ * Verify that an asynchronous call should timeout
+ */
+suspend fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: suspend () -> A) {
+   val timedOut = try {
+      withTimeout(unit.toMillis(timeout)) {
+         thunk()
+         false
+      }
+   } catch (t: TimeoutCancellationException) {
+      true
+   }
+   if (!timedOut) {
+      throw failure("Expected test to timeout for $timeout/$unit")
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
@@ -45,19 +45,3 @@ fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: () -> A) {
   }
 }
 
-/**
- * Verify that an asynchronous call should timeout
- */
-suspend fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: suspend () -> A) {
-   val timedOut = try {
-      withTimeout(unit.toMillis(timeout)) {
-         thunk()
-         false
-      }
-   } catch (t: TimeoutCancellationException) {
-      true
-   }
-   if (!timedOut) {
-      throw failure("Expected test to timeout for $timeout/$unit")
-   }
-}

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
@@ -5,6 +5,8 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.TimeoutCancellationException
 
 fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A) {
 

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/async/timeout.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/async/timeout.kt
@@ -1,0 +1,32 @@
+package io.kotest.assertions.async
+
+import io.kotest.assertions.failure
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+suspend fun <A> shouldTimeout(duration: Duration, thunk: suspend () -> A) =
+   shouldTimeout(duration.toLongMilliseconds(), TimeUnit.MILLISECONDS, thunk)
+
+suspend fun <A> shouldTimeout(duration: java.time.Duration, thunk: suspend () -> A) =
+   shouldTimeout(duration.toMillis(), TimeUnit.MILLISECONDS, thunk)
+
+/**
+ * Verify that an asynchronous call should timeout
+ */
+suspend fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: suspend () -> A) {
+   val timedOut = try {
+      withTimeout(unit.toMillis(timeout)) {
+         thunk()
+         false
+      }
+   } catch (t: TimeoutCancellationException) {
+      true
+   }
+   if (!timedOut) {
+      throw failure("Expected test to timeout for $timeout/$unit")
+   }
+}

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/async/TimeoutTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/async/TimeoutTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.kotest.assertions.async
+
+import io.kotest.assertions.async.shouldTimeout
+import io.kotest.assertions.shouldFail
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.delay
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.time.ExperimentalTime
+import kotlin.time.milliseconds
+
+@ExperimentalTime
+class TimeoutTest : FunSpec({
+   test("shouldTimeout should pass if a coroutine takes longer than the given timeout") {
+      shouldTimeout(Duration.ofMillis(5)) {
+         delay(10)
+      }
+      shouldTimeout(5.milliseconds) {
+         delay(10)
+      }
+      shouldTimeout(5, TimeUnit.MILLISECONDS) {
+         delay(10)
+      }
+   }
+   test("shouldTimeout should fail if a coroutine finishes before the timeout") {
+      shouldFail {
+         shouldTimeout(Duration.ofMillis(5)) {
+            delay(1)
+         }
+      }
+      shouldFail {
+         shouldTimeout(5.milliseconds) {
+            delay(1)
+         }
+      }
+      shouldFail {
+         shouldTimeout(5, TimeUnit.MILLISECONDS) {
+            delay(1)
+         }
+      }
+   }
+})


### PR DESCRIPTION
Found myself wanting to verify that an async call timed out, so wrote this up which seems to work.  I had planned on adding tests, but noticed nothing in the concurrent package seemed to (or I missed them)--happy to write some, just let me know.

Fixes https://github.com/kotest/kotest/issues/1447