### PR TITLE
Fix native publishing.

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: Run windows tests
         if: matrix.os == 'windows-latest'
-        run: ./gradlew nativeTest
+        run: ./gradlew mingwX64Test
 
       - name: Run macOS tests
         if: matrix.os == 'macOS-latest'
-        run: ./gradlew nativeTest
+        run: ./gradlew macosX64Test
 
       - name: Bundle the build report
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                fetch-depth: 0
 
          -  name: deploy to sonatype snapshots
-            run: ./gradlew publishNativePublicationToDeployRepository
+            run: ./gradlew publishMacosX64PublicationToDeployRepository
             env:
                OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
                OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -88,7 +88,7 @@ jobs:
                fetch-depth: 0
 
          -  name: deploy to sonatype snapshots
-            run: ./gradlew publishNativePublicationToDeployRepository
+            run: ./gradlew publishMingwX64PublicationToDeployRepository
             env:
                OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
                OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,6 +20,7 @@ systemProp.org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=756m -XX:+HeapDumpOnOu
 org.gradle.internal.publish.checksums.insecure=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 kotlin.native.disableCompilerDaemon=true
+kotlin.native.ignoreDisabledTargets=true
 systemProp.kotlin.native.disableCompilerDaemon=true
 
 android.useAndroidX=true

--- a/kotest-assertions/kotest-assertions-core/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-core/build.gradle.kts
@@ -26,10 +26,17 @@ kotlin {
             }
          }
       }
-      when {
-         Ci.os.isMacOsX -> macosX64("native")
-         Ci.os.isWindows -> mingwX64("native")
-         else -> linuxX64("native")
+
+      linuxX64()
+      mingwX64()
+      macosX64()
+
+      if (Ci.ideaActive) {
+         when {
+            Ci.os.isMacOsX -> macosX64("native")
+            Ci.os.isWindows -> mingwX64("native")
+            Ci.os.isLinux -> linuxX64("native")
+         }
       }
    }
 
@@ -84,9 +91,12 @@ kotlin {
          }
       }
 
-      val nativeMain by getting {
-         dependsOn(commonMain)
-         dependencies {
+      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+
+      listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
+         val sourceSet = get(it)
+         sourceSet.dependsOn(nativeMain)
+         sourceSet.dependencies {
             implementation(Libs.Coroutines.coreNative)
          }
       }

--- a/kotest-assertions/kotest-assertions-shared/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-shared/build.gradle.kts
@@ -26,10 +26,17 @@ kotlin {
             }
          }
       }
-      when {
-         Ci.os.isMacOsX -> macosX64("native")
-         Ci.os.isWindows -> mingwX64("native")
-         else -> linuxX64("native")
+
+      linuxX64()
+      mingwX64()
+      macosX64()
+
+      if (Ci.ideaActive) {
+         when {
+            Ci.os.isMacOsX -> macosX64("native")
+            Ci.os.isWindows -> mingwX64("native")
+            Ci.os.isLinux -> linuxX64("native")
+         }
       }
    }
 
@@ -80,9 +87,12 @@ kotlin {
          }
       }
 
-      val nativeMain by getting {
-         dependsOn(commonMain)
-         dependencies {
+      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+
+      listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
+         val sourceSet = get(it)
+         sourceSet.dependsOn(nativeMain)
+         sourceSet.dependencies {
             implementation(Libs.Coroutines.coreNative)
          }
       }

--- a/kotest-fp/build.gradle.kts
+++ b/kotest-fp/build.gradle.kts
@@ -25,10 +25,17 @@ kotlin {
             }
          }
       }
-      when {
-         Ci.os.isMacOsX -> macosX64("native")
-         Ci.os.isWindows -> mingwX64("native")
-         else -> linuxX64("native")
+
+      linuxX64()
+      mingwX64()
+      macosX64()
+
+      if (Ci.ideaActive) {
+         when {
+            Ci.os.isMacOsX -> macosX64("native")
+            Ci.os.isWindows -> mingwX64("native")
+            Ci.os.isLinux -> linuxX64("native")
+         }
       }
    }
 
@@ -62,8 +69,14 @@ kotlin {
          }
       }
 
-      val nativeMain by getting {
-         dependsOn(commonMain)
+      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+
+      listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
+         val sourceSet = get(it)
+         sourceSet.dependsOn(nativeMain)
+         sourceSet.dependencies {
+            implementation(Libs.Coroutines.coreNative)
+         }
       }
    }
 }

--- a/kotest-mpp/build.gradle.kts
+++ b/kotest-mpp/build.gradle.kts
@@ -29,10 +29,17 @@ kotlin {
             }
          }
       }
-      when {
-         Ci.os.isMacOsX -> macosX64("native")
-         Ci.os.isWindows -> mingwX64("native")
-         else -> linuxX64("native")
+
+      linuxX64()
+      mingwX64()
+      macosX64()
+
+      if (Ci.ideaActive) {
+         when {
+            Ci.os.isMacOsX -> macosX64("native")
+            Ci.os.isWindows -> mingwX64("native")
+            Ci.os.isLinux -> linuxX64("native")
+         }
       }
    }
 
@@ -69,9 +76,12 @@ kotlin {
          }
       }
 
-      val nativeMain by getting {
-         dependsOn(commonMain)
-         dependencies {
+      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+
+      listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
+         val sourceSet = get(it)
+         sourceSet.dependsOn(nativeMain)
+         sourceSet.dependencies {
             implementation(Libs.Coroutines.coreNative)
          }
       }


### PR DESCRIPTION
Currently, native code is unusable because only one native target is defined. Each build job will overwrite the artifacts of previous jobs.

This PR fixes this by defining a separate target for each platform. The targets each depend on a common "native" source set, so they all use the same code. When running in IntelliJ, the "native" source set is defined to be the current platform so that the code is treated as native rather than common code.