### PR TITLE
Fixed issues 1435  Add before and after test listeners to property ba…

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -17,7 +17,7 @@ data class PropTest(
    val maxFailure: Int = 0,
    val shrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000),
    val iterations: Int? = null,
-   val listeners: MutableList<PropTestListener> = mutableListOf()
+   val listeners: List<PropTestListener> = listOf()
 )
 
 fun PropTest.toPropTestConfig() =
@@ -36,25 +36,8 @@ data class PropTestConfig(
    val maxFailure: Int = 0,
    val shrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000),
    val iterations: Int? = null,
-   val listeners: MutableList<PropTestListener> = mutableListOf()
-) {
-   fun beforeTest(before: suspend () -> Unit) {
-      listeners.add(object : PropTestListener {
-         override suspend fun beforeTest() {
-            before()
-            super.beforeTest()
-         }
-      })
-   }
-   fun afterTest(after: suspend () -> Unit) {
-      listeners.add(object : PropTestListener {
-         override suspend fun afterTest() {
-            after()
-            super.afterTest()
-         }
-      })
-   }
-}
+   val listeners: List<PropTestListener> = listOf()
+)
 
 interface PropTestListener {
    suspend fun beforeTest(): Unit = Unit

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -16,7 +16,8 @@ data class PropTest(
    val minSuccess: Int = Int.MAX_VALUE,
    val maxFailure: Int = 0,
    val shrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000),
-   val iterations: Int? = null
+   val iterations: Int? = null,
+   val listeners: MutableList<PropTestListener> = mutableListOf()
 )
 
 fun PropTest.toPropTestConfig() =
@@ -25,7 +26,8 @@ fun PropTest.toPropTestConfig() =
       minSuccess = minSuccess,
       maxFailure = maxFailure,
       iterations = iterations,
-      shrinkingMode = shrinkingMode
+      shrinkingMode = shrinkingMode,
+      listeners = listeners
    )
 
 data class PropTestConfig(
@@ -33,5 +35,28 @@ data class PropTestConfig(
    val minSuccess: Int = Int.MAX_VALUE,
    val maxFailure: Int = 0,
    val shrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000),
-   val iterations: Int? = null
-)
+   val iterations: Int? = null,
+   val listeners: MutableList<PropTestListener> = mutableListOf()
+) {
+   fun beforeTest(before: suspend () -> Unit) {
+      listeners.add(object : PropTestListener {
+         override suspend fun beforeTest() {
+            before()
+            super.beforeTest()
+         }
+      })
+   }
+   fun afterTest(after: suspend () -> Unit) {
+      listeners.add(object : PropTestListener {
+         override suspend fun afterTest() {
+            after()
+            super.afterTest()
+         }
+      })
+   }
+}
+
+interface PropTestListener {
+   suspend fun beforeTest(): Unit = Unit
+   suspend fun afterTest(): Unit = Unit
+}

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
@@ -23,9 +23,11 @@ suspend fun <A> proptest(
       .take(iterations)
       .forEach { a ->
          val shrinkfn = shrinkfn<A>(a, property, config.shrinkingMode)
+         config.listeners.forEach { it.beforeTest() }
          test(context, config, shrinkfn, listOf(a.value), random.seed) {
             context.property(a.value)
          }
+         config.listeners.forEach { it.afterTest() }
       }
    context.checkMaxSuccess(config, random.seed)
    return context
@@ -51,9 +53,11 @@ suspend fun <A, B> proptest(
       .take(iterations)
       .forEach { (a, b) ->
          val shrinkfn = shrinkfn<A, B>(a, b, property, config.shrinkingMode)
+         config.listeners.forEach { it.beforeTest() }
          test(context, config, shrinkfn, listOf(a.value, b.value), random.seed) {
             context.property(a.value, b.value)
          }
+         config.listeners.forEach { it.afterTest() }
       }
 
    context.checkMaxSuccess(config, random.seed)
@@ -81,9 +85,11 @@ suspend fun <A, B, C> proptest(
       .forEach { (ab, c) ->
          val (a, b) = ab
          val shrinkfn = shrinkfn<A, B, C>(a, b, c, property, config.shrinkingMode)
+         config.listeners.forEach { it.beforeTest() }
          test(context, config, shrinkfn, listOf(a.value, b.value, c.value), random.seed) {
             context.property(a.value, b.value, c.value)
          }
+         config.listeners.forEach { it.afterTest() }
       }
 
    context.checkMaxSuccess(config, random.seed)
@@ -114,9 +120,11 @@ suspend fun <A, B, C, D> proptest(
          val (ab, c) = abc
          val (a, b) = ab
          val shrinkfn = shrinkfn(a, b, c, d, property, config.shrinkingMode)
+         config.listeners.forEach { it.beforeTest() }
          test(context, config, shrinkfn, listOf(a.value, b.value, c.value, d.value), random.seed) {
             context.property(a.value, b.value, c.value, d.value)
          }
+         config.listeners.forEach { it.afterTest() }
       }
 
    context.checkMaxSuccess(config, random.seed)
@@ -156,9 +164,11 @@ suspend fun <A, B, C, D, E> proptest(
          val (ab, c) = abc
          val (a, b) = ab
          val shrinkfn = shrinkfn(a, b, c, d, e, property, config.shrinkingMode)
+         config.listeners.forEach { it.beforeTest() }
          test(context, config, shrinkfn, listOf(a.value, b.value, c.value, d.value, e.value), random.seed) {
             context.property(a.value, b.value, c.value, d.value, e.value)
          }
+         config.listeners.forEach { it.afterTest() }
       }
    context.checkMaxSuccess(config, random.seed)
    return context
@@ -200,9 +210,11 @@ suspend fun <A, B, C, D, E, F> proptest(
          val (ab, c) = abc
          val (a, b) = ab
          val shrinkfn = shrinkfn(a, b, c, d, e, f, property, config.shrinkingMode)
+         config.listeners.forEach { it.beforeTest() }
          test(context, config, shrinkfn, listOf(a.value, b.value, c.value, d.value, e.value, f.value), random.seed) {
             context.property(a.value, b.value, c.value, d.value, e.value, f.value)
          }
+         config.listeners.forEach { it.afterTest() }
       }
    context.checkMaxSuccess(config, random.seed)
    return context

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropListenersTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropListenersTest.kt
@@ -18,15 +18,16 @@ class PropListenersTest : FunSpec({
       total = 0
    }
 
-   val propConfig = PropTestConfig().apply {
-      beforeTest {
+   val propConfig = PropTestConfig(listeners = listOf(object : PropTestListener {
+      override suspend fun beforeTest() {
          previous = current
          ++current
       }
-      afterTest {
+
+      override suspend fun afterTest() {
          ++total
       }
-   }
+   }))
 
    test("checkAll calls listener for param A") {
       val context = checkAll(10, propConfig, Arb.string()) {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropListenersTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropListenersTest.kt
@@ -1,0 +1,125 @@
+package com.sksamuel.kotest.property
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.*
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.string
+
+class PropListenersTest : FunSpec({
+   var previous = -1
+   var current = 0
+   var total = 0
+
+   beforeTest {
+      previous = -1
+      current = 0
+      total = 0
+   }
+
+   val propConfig = PropTestConfig().apply {
+      beforeTest {
+         previous = current
+         ++current
+      }
+      afterTest {
+         ++total
+      }
+   }
+
+   test("checkAll calls listener for param A") {
+      val context = checkAll(10, propConfig, Arb.string()) {
+         current shouldBe (previous + 1)
+         total shouldBe previous
+      }
+      previous shouldBe 9
+      current shouldBe 10
+      total shouldBe 10
+   }
+
+   test("checkAll calls listener for params A, B") {
+      val context = checkAll(
+         10,
+         propConfig,
+         Arb.string(),
+         Arb.int()
+      ) { _, _ ->
+         current shouldBe (previous + 1)
+         total shouldBe previous
+      }
+      previous shouldBe 9
+      current shouldBe 10
+      total shouldBe 10
+   }
+
+   test("checkAll calls listener for params A, B, C") {
+      val context = checkAll(
+         10,
+         propConfig,
+         Arb.string(),
+         Arb.string(),
+         Arb.int()
+      ) { _, _, _ ->
+         current shouldBe (previous + 1)
+         total shouldBe previous
+      }
+      previous shouldBe 9
+      current shouldBe 10
+      total shouldBe 10
+   }
+
+   test("checkAll calls listener for params A, B, C, D") {
+      val context = checkAll(
+         10,
+         propConfig,
+         Arb.string(),
+         Arb.int(),
+         Arb.string(),
+         Arb.int()
+      ) { _, _, _, _ ->
+         current shouldBe (previous + 1)
+         total shouldBe previous
+      }
+      previous shouldBe 9
+      current shouldBe 10
+      total shouldBe 10
+   }
+
+   test("checkAll calls listener for params A, B, C, D, E") {
+      val context = checkAll(
+         10,
+         propConfig,
+         Arb.string(),
+         Arb.int(),
+         Arb.string(),
+         Arb.string(),
+         Arb.int()
+      ) { _, _, _, _, _ ->
+         current shouldBe (previous + 1)
+         total shouldBe previous
+      }
+      previous shouldBe 9
+      current shouldBe 10
+      total shouldBe 10
+   }
+
+   test("checkAll calls listener for params A, B, C, D, E, F") {
+      val context = checkAll(
+         10,
+         propConfig,
+         Arb.string(),
+         Arb.int(),
+         Arb.string(),
+         Arb.int(),
+         Arb.string(),
+         Arb.int()
+      ) { _, _, _, _, _, _ ->
+         current shouldBe (previous + 1)
+         total shouldBe previous
+      }
+      previous shouldBe 9
+      current shouldBe 10
+      total shouldBe 10
+   }
+})


### PR DESCRIPTION
Add listeners to property base tests. You can add before and after for each iteration of the test.
See the file PropListenersTest for example how to use it. 
https://github.com/kotest/kotest/issues/1435