### PR TITLE
Add existInOrder and should(Not)ExistInOrder matchers

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -42,6 +42,29 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
   )
 }
 
+fun <T> existInOrder(vararg ps: (T) -> Boolean): Matcher<Collection<T>?> = existInOrder(ps.asList())
+
+/**
+ * Assert that a collections contains a subsequence that matches the given subsequence of predicates, possibly with
+ * values in between.
+ */
+fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> = neverNullMatcher { actual ->
+   require(predicates.isNotEmpty()) { "predicates must not be empty" }
+
+   var subsequenceIndex = 0
+   val actualIterator = actual.iterator()
+
+   while (actualIterator.hasNext() && subsequenceIndex < predicates.size) {
+      if (predicates[subsequenceIndex](actualIterator.next())) subsequenceIndex += 1
+   }
+
+   MatcherResult(
+      subsequenceIndex == predicates.size,
+      { "${actual.show().value} did not match the predicates ${predicates.show().value} in order" },
+      { "${actual.show().value} should not match the predicates ${predicates.show().value} in order" }
+   )
+}
+
 fun <T> haveSize(size: Int): Matcher<Collection<T>> = haveSizeMatcher(size)
 
 fun <T> singleElement(t: T): Matcher<Collection<T>> = object : Matcher<Collection<T>> {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -422,6 +422,14 @@ infix fun <T> Array<T>.shouldNotContainInOrder(expected: Array<T>) = asList().sh
 infix fun <T> Array<T>.shouldNotContainInOrder(expected: List<T>) = asList().shouldNotContainInOrder(expected)
 infix fun <T> List<T>.shouldNotContainInOrder(expected: List<T>) = this shouldNot containsInOrder(expected)
 
+fun <T> Array<T>.shouldExistInOrder(vararg ps: (T) -> Boolean) = asList().shouldExistInOrder(ps.toList())
+fun <T> List<T>.shouldExistInOrder(vararg ps: (T) -> Boolean) = this.shouldExistInOrder(ps.toList())
+infix fun <T> Array<T>.shouldExistInOrder(expected: List<(T) -> Boolean>) = asList().shouldExistInOrder(expected)
+infix fun <T> List<T>.shouldExistInOrder(expected: List<(T) -> Boolean>) = this should existInOrder(expected)
+infix fun <T> Array<T>.shouldNotExistInOrder(expected: Array<(T) -> Boolean>) = asList().shouldNotExistInOrder(expected.asList())
+infix fun <T> Array<T>.shouldNotExistInOrder(expected: List<(T) -> Boolean>) = asList().shouldNotExistInOrder(expected)
+infix fun <T> List<T>.shouldNotExistInOrder(expected: List<(T) -> Boolean>) = this shouldNot existInOrder(expected)
+
 fun <T> Array<T>.shouldBeEmpty() = asList().shouldBeEmpty()
 fun <T> Collection<T>.shouldBeEmpty() = this should beEmpty()
 fun <T> Array<T>.shouldNotBeEmpty() = asList().shouldNotBeEmpty()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -599,6 +599,47 @@ class CollectionMatchersTest : WordSpec() {
          }
       }
 
+      "existInOrder" should {
+         "test that a collection matches the predicates in the given order, duplicates permitted" {
+            val col = listOf(1, 1, 2, 2, 3, 3)
+
+            col should existInOrder(
+               { it == 1 },
+               { it == 2 },
+               { it == 3 }
+            )
+            col should existInOrder({ it == 1 })
+
+            shouldThrow<AssertionError> {
+               col should existInOrder(
+                  { it == 1 },
+                  { it == 2 },
+                  { it == 6 }
+               )
+            }
+
+            shouldThrow<AssertionError> {
+               col should existInOrder({ it == 4 })
+            }
+
+            shouldThrow<AssertionError> {
+               col should existInOrder(
+                  { it == 2 },
+                  { it == 1 },
+                  { it == 3 }
+               )
+            }
+         }
+         "work with unsorted collections" {
+            val actual = listOf(5, 3, 1, 2, 4, 2)
+            actual should existInOrder(
+               { it == 3 },
+               { it == 2 },
+               { it == 2 }
+            )
+         }
+      }
+
       "startWith" should {
          "test that a list starts with the given collection" {
             val col = listOf(1, 2, 3, 4, 5)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.collections.containNull
 import io.kotest.matchers.collections.containOnlyNulls
 import io.kotest.matchers.collections.containsInOrder
 import io.kotest.matchers.collections.endWith
+import io.kotest.matchers.collections.existInOrder
 import io.kotest.matchers.collections.haveElementAt
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.collections.monotonicallyDecreasing


### PR DESCRIPTION
### Description of the Change

This PR adds the `existInOrder` matcher and accompanying extension functions. Let me know if I need to target this at another branch.

### Motivation

There is currently no built-in way to match an ordered sequence of predicates against a collection.

### Verification Process

I added unit tests based on the `containsInOrder` tests, with the exception that I did not add a `print errors unambiguously` test because this matcher operates on predicates, so there isn't a "clean" way to print the predicate.

### Applicable Issues

Closes #1460.
