### PR TITLE
Adjust Exhaustive default iterations

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
@@ -3,6 +3,7 @@
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
+import io.kotest.property.PropertyTesting.computeDefaultIteration
 import io.kotest.property.arbitrary.default
 import io.kotest.property.internal.proptest
 
@@ -14,7 +15,7 @@ suspend fun<A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = proptest<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
+): PropertyContext = proptest<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
 
 suspend fun<A, B, C, D, E, F> checkAll(
    config: PropTestConfig,
@@ -25,7 +26,7 @@ suspend fun<A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = checkAll<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, genD, genE, genF, property)
+): PropertyContext = checkAll<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
 
 suspend fun<A, B, C, D, E, F> checkAll(
    iterations: Int,
@@ -120,7 +121,7 @@ suspend fun<A, B, C, D, E, F> forAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = forAll<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
+) = forAll<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
 suspend fun<A, B, C, D, E, F> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -131,7 +132,7 @@ suspend fun<A, B, C, D, E, F> forAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = forAll<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, genD, genE, genF, property)
+) = forAll<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
 
 suspend fun<A, B, C, D, E, F> forAll(
    iterations: Int,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -9,6 +9,17 @@ object PropertyTesting {
    var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
    var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
    var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", "1000").toInt()
+
+   @PublishedApi
+   internal fun computeDefaultIteration(vararg gen: Gen<*>): Int {
+      var iterations = defaultIterationCount
+      gen.forEach {
+         if(it is Exhaustive<*> && it.minIterations() > iterations) {
+            iterations = it.minIterations()
+         }
+      }
+      return iterations
+   }
 }
 
 data class PropTest(

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
@@ -3,6 +3,7 @@
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
+import io.kotest.property.PropertyTesting.computeDefaultIteration
 import io.kotest.property.arbitrary.default
 import io.kotest.property.internal.proptest
 import kotlin.jvm.JvmName
@@ -13,7 +14,7 @@ suspend fun <A> Gen<A>.checkAll(property: suspend PropertyContext.(A) -> Unit) =
 suspend fun <A> checkAll(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = proptest(PropertyTesting.defaultIterationCount, genA, PropTestConfig(), property)
+): PropertyContext = proptest(computeDefaultIteration(genA), genA, PropTestConfig(), property)
 
 @JvmName("checkAllExt")
 suspend fun <A> Gen<A>.checkAll(iterations: Int, property: suspend PropertyContext.(A) -> Unit) =
@@ -33,7 +34,7 @@ suspend fun <A> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = proptest(PropertyTesting.defaultIterationCount, genA, config, property)
+): PropertyContext = proptest(computeDefaultIteration(genA), genA, config, property)
 
 @JvmName("checkAllExt")
 suspend fun <A> Gen<A>.checkAll(
@@ -92,7 +93,7 @@ suspend fun <A> Gen<A>.forAll(property: PropertyContext.(A) -> Boolean) =
 suspend fun <A> forAll(
    genA: Gen<A>,
    property: PropertyContext.(A) -> Boolean
-) = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), genA, property)
+) = forAll(computeDefaultIteration(genA), PropTestConfig(), genA, property)
 
 
 @JvmName("checkAllExt")
@@ -113,7 +114,7 @@ suspend fun <A> forAll(
    config: PropTestConfig,
    genA: Gen<A>,
    property: PropertyContext.(A) -> Boolean
-) = forAll(PropertyTesting.defaultIterationCount, config, genA, property)
+) = forAll(computeDefaultIteration(genA), config, genA, property)
 
 @JvmName("checkAllExt")
 suspend fun <A> Gen<A>.forAll(iterations: Int, config: PropTestConfig, property: PropertyContext.(A) -> Boolean) =

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
@@ -3,6 +3,7 @@
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
+import io.kotest.property.PropertyTesting.computeDefaultIteration
 import io.kotest.property.arbitrary.default
 import io.kotest.property.internal.proptest
 
@@ -10,14 +11,14 @@ suspend fun <A, B> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Unit
-): PropertyContext = proptest<A, B>(PropertyTesting.defaultIterationCount, genA, genB, PropTestConfig(), property)
+): PropertyContext = proptest<A, B>(computeDefaultIteration(genA, genB), genA, genB, PropTestConfig(), property)
 
 suspend fun <A, B> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Unit
-): PropertyContext = checkAll<A, B>(PropertyTesting.defaultIterationCount, config, genA, genB, property)
+): PropertyContext = checkAll<A, B>(computeDefaultIteration(genA, genB), config, genA, genB, property)
 
 suspend fun <A, B> checkAll(
    iterations: Int,
@@ -94,14 +95,14 @@ suspend fun <A, B> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Boolean
-) = forAll<A, B>(PropertyTesting.defaultIterationCount, PropTestConfig(), genA, genB, property)
+) = forAll<A, B>(computeDefaultIteration(genA, genB), PropTestConfig(), genA, genB, property)
 
 suspend fun <A, B> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Boolean
-) = forAll<A, B>(PropertyTesting.defaultIterationCount, config, genA, genB, property)
+) = forAll<A, B>(computeDefaultIteration(genA, genB), config, genA, genB, property)
 
 suspend fun <A, B> forAll(
    iterations: Int,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest3.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest3.kt
@@ -11,7 +11,7 @@ suspend fun <A, B, C> checkAll(
    genB: Gen<B>,
    genC: Gen<C>,
    property: suspend PropertyContext.(A, B, C) -> Unit
-): PropertyContext = proptest<A, B, C>(PropertyTesting.defaultIterationCount, genA, genB, genC, PropTestConfig(), property)
+): PropertyContext = proptest<A, B, C>(PropertyTesting.computeDefaultIteration(genA, genB, genC), genA, genB, genC, PropTestConfig(), property)
 
 suspend fun <A, B, C> checkAll(
    config: PropTestConfig,
@@ -19,7 +19,7 @@ suspend fun <A, B, C> checkAll(
    genB: Gen<B>,
    genC: Gen<C>,
    property: suspend PropertyContext.(A, B, C) -> Unit
-): PropertyContext = checkAll<A, B, C>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, property)
+): PropertyContext = checkAll<A, B, C>(PropertyTesting.computeDefaultIteration(genA, genB, genC), config, genA, genB, genC, property)
 
 suspend fun <A, B, C> checkAll(
    iterations: Int,
@@ -93,7 +93,7 @@ suspend fun <A, B, C> forAll(
    genB: Gen<B>,
    genC: Gen<C>,
    property: suspend PropertyContext.(A, B, C) -> Boolean
-) = forAll<A, B, C>(PropertyTesting.defaultIterationCount, PropTestConfig(), genA, genB, genC, property)
+) = forAll<A, B, C>(PropertyTesting.computeDefaultIteration(genA, genB, genC), PropTestConfig(), genA, genB, genC, property)
 
 suspend fun <A, B, C> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -101,7 +101,7 @@ suspend fun <A, B, C> forAll(
    genB: Gen<B>,
    genC: Gen<C>,
    property: suspend PropertyContext.(A, B, C) -> Boolean
-) = forAll<A, B, C>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, property)
+) = forAll<A, B, C>(PropertyTesting.computeDefaultIteration(genA, genB, genC), config, genA, genB, genC, property)
 
 suspend fun <A, B, C> forAll(
    iterations: Int,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
@@ -3,6 +3,7 @@
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
+import io.kotest.property.PropertyTesting.computeDefaultIteration
 import io.kotest.property.arbitrary.default
 import io.kotest.property.internal.proptest
 
@@ -12,7 +13,7 @@ suspend fun<A, B, C, D> checkAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Unit
-): PropertyContext = proptest<A, B, C, D>(PropertyTesting.defaultIterationCount, genA, genB, genC, genD, PropTestConfig(), property)
+): PropertyContext = proptest<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), genA, genB, genC, genD, PropTestConfig(), property)
 
 suspend fun<A, B, C, D> checkAll(
    config: PropTestConfig,
@@ -21,7 +22,7 @@ suspend fun<A, B, C, D> checkAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Unit
-): PropertyContext = checkAll<A, B, C, D>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, genD, property)
+): PropertyContext = checkAll<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), config, genA, genB, genC, genD, property)
 
 suspend fun<A, B, C, D> checkAll(
    iterations: Int,
@@ -102,7 +103,7 @@ suspend fun<A, B, C, D> forAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
-) = forAll<A, B, C, D>(PropertyTesting.defaultIterationCount, PropTestConfig(), genA, genB, genC, genD, property)
+) = forAll<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), PropTestConfig(), genA, genB, genC, genD, property)
 
 suspend fun<A, B, C, D> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -111,7 +112,7 @@ suspend fun<A, B, C, D> forAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
-) = forAll<A, B, C, D>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, genD, property)
+) = forAll<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), config, genA, genB, genC, genD, property)
 
 suspend fun<A, B, C, D> forAll(
    iterations: Int,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest5.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest5.kt
@@ -3,6 +3,7 @@
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
+import io.kotest.property.PropertyTesting.computeDefaultIteration
 import io.kotest.property.arbitrary.default
 import io.kotest.property.internal.proptest
 
@@ -13,7 +14,7 @@ suspend fun<A, B, C, D, E> checkAll(
    genD: Gen<D>,
    genE: Gen<E>,
    property: suspend PropertyContext.(A, B, C, D, E) -> Unit
-): PropertyContext = proptest<A, B, C, D, E>(PropertyTesting.defaultIterationCount, genA, genB, genC, genD, genE, PropTestConfig(), property)
+): PropertyContext = proptest<A, B, C, D, E>(computeDefaultIteration(genA, genB, genC, genD, genE), genA, genB, genC, genD, genE, PropTestConfig(), property)
 
 suspend fun<A, B, C, D, E> checkAll(
    config: PropTestConfig,
@@ -23,7 +24,7 @@ suspend fun<A, B, C, D, E> checkAll(
    genD: Gen<D>,
    genE: Gen<E>,
    property: suspend PropertyContext.(A, B, C, D, E) -> Unit
-): PropertyContext = checkAll<A, B, C, D, E>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, genD, genE, property)
+): PropertyContext = checkAll<A, B, C, D, E>(computeDefaultIteration(genA, genB, genC, genD, genE), config, genA, genB, genC, genD, genE, property)
 
 suspend fun<A, B, C, D, E> checkAll(
    iterations: Int,
@@ -111,7 +112,7 @@ suspend fun<A, B, C, D, E> forAll(
    genD: Gen<D>,
    genE: Gen<E>,
    property: suspend PropertyContext.(A, B, C, D, E) -> Boolean
-) = forAll<A, B, C, D, E>(PropertyTesting.defaultIterationCount, PropTestConfig(), genA, genB, genC, genD, genE, property)
+) = forAll<A, B, C, D, E>(computeDefaultIteration(genA, genB, genC, genD, genE), PropTestConfig(), genA, genB, genC, genD, genE, property)
 
 suspend fun<A, B, C, D, E> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -121,7 +122,7 @@ suspend fun<A, B, C, D, E> forAll(
    genD: Gen<D>,
    genE: Gen<E>,
    property: suspend PropertyContext.(A, B, C, D, E) -> Boolean
-) = forAll<A, B, C, D, E>(PropertyTesting.defaultIterationCount, config, genA, genB, genC, genD, genE, property)
+) = forAll<A, B, C, D, E>(computeDefaultIteration(genA, genB, genC, genD, genE), config, genA, genB, genC, genD, genE, property)
 
 suspend fun<A, B, C, D, E> forAll(
    iterations: Int,

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ConfigTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ConfigTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.kotest.property
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.PropertyTesting
+import io.kotest.property.PropertyTesting.computeDefaultIteration
+import io.kotest.property.arbitrary.string
+import io.kotest.property.exhaustive.exhaustive
+
+class ConfigTest : FunSpec({
+
+   test("Calculate default iterations arb") {
+      computeDefaultIteration(Arb.string()) shouldBe PropertyTesting.defaultIterationCount
+   }
+
+   test("Calculate default iterations exhaustive") {
+      computeDefaultIteration(bigExhaustive) shouldBe 10_000
+      computeDefaultIteration(mediumExhaustive) shouldBe 5_000
+      computeDefaultIteration(bigExhaustive, mediumExhaustive, Arb.string()) shouldBe 10_000
+   }
+})
+
+private val bigExhaustive = exhaustive(List(10_000) { it })
+private val mediumExhaustive = exhaustive(List(5_000) { it })

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/IterationsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/IterationsTest.kt
@@ -1,0 +1,17 @@
+package com.sksamuel.kotest.property.exhaustive
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.property.checkAll
+import io.kotest.property.exhaustive.exhaustive
+
+class IterationsTest : ShouldSpec({
+
+   should("calculate min iterations to be at least the minimum for an exhaustive") {
+      val items = List(10_000) { it }
+
+      exhaustive(items).checkAll {
+         // If all of these execute, the exhaustive could infer the minimum iterations
+      }
+   }
+
+})


### PR DESCRIPTION
This commit aims to change how we calculate the default iterations for a given gen. When dealing with Arbs, it's ok to assume a number, as any iterations can be used for an Arb.

However, when talking about Exhaustives, the default iterations might not be enough for them to execute, and thus they fail.

I changed how we compute that default to assume that Exhaustives should have at least their min iterations as default iterations.

Fixes #1456