### PR TITLE
Fix running native tests from IntelliJ

### DIFF
--- a/kotest-assertions/kotest-assertions-core/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-core/build.gradle.kts
@@ -30,14 +30,6 @@ kotlin {
       linuxX64()
       mingwX64()
       macosX64()
-
-      if (Ci.ideaActive) {
-         when {
-            Ci.os.isMacOsX -> macosX64("native")
-            Ci.os.isWindows -> mingwX64("native")
-            Ci.os.isLinux -> linuxX64("native")
-         }
-      }
    }
 
    targets.all {
@@ -91,7 +83,7 @@ kotlin {
          }
       }
 
-      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+      val nativeMain = create("nativeMain")
 
       listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
          val sourceSet = get(it)

--- a/kotest-assertions/kotest-assertions-shared/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-shared/build.gradle.kts
@@ -30,14 +30,6 @@ kotlin {
       linuxX64()
       mingwX64()
       macosX64()
-
-      if (Ci.ideaActive) {
-         when {
-            Ci.os.isMacOsX -> macosX64("native")
-            Ci.os.isWindows -> mingwX64("native")
-            Ci.os.isLinux -> linuxX64("native")
-         }
-      }
    }
 
    targets.all {
@@ -87,7 +79,7 @@ kotlin {
          }
       }
 
-      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+      val nativeMain = create("nativeMain")
 
       listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
          val sourceSet = get(it)

--- a/kotest-fp/build.gradle.kts
+++ b/kotest-fp/build.gradle.kts
@@ -29,14 +29,6 @@ kotlin {
       linuxX64()
       mingwX64()
       macosX64()
-
-      if (Ci.ideaActive) {
-         when {
-            Ci.os.isMacOsX -> macosX64("native")
-            Ci.os.isWindows -> mingwX64("native")
-            Ci.os.isLinux -> linuxX64("native")
-         }
-      }
    }
 
    targets.all {
@@ -69,7 +61,7 @@ kotlin {
          }
       }
 
-      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+      val nativeMain = create("nativeMain")
 
       listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
          val sourceSet = get(it)

--- a/kotest-mpp/build.gradle.kts
+++ b/kotest-mpp/build.gradle.kts
@@ -33,14 +33,6 @@ kotlin {
       linuxX64()
       mingwX64()
       macosX64()
-
-      if (Ci.ideaActive) {
-         when {
-            Ci.os.isMacOsX -> macosX64("native")
-            Ci.os.isWindows -> mingwX64("native")
-            Ci.os.isLinux -> linuxX64("native")
-         }
-      }
    }
 
    targets.all {
@@ -76,7 +68,7 @@ kotlin {
          }
       }
 
-      val nativeMain = if (Ci.ideaActive) get("nativeMain") else create("nativeMain")
+      val nativeMain = create("nativeMain")
 
       listOf("macosX64Main", "linuxX64Main", "mingwX64Main").forEach {
          val sourceSet = get(it)


### PR DESCRIPTION
I think the issue stems from a module providing multiple tasks with the same native target platform, which only happened when running from IntelliJ.

This PR removes the IntelliJ check, instead using the same configuration as when running from gradle.

The downside to this change is that IntelliJ will treat the `nativeMain` source set as common code, and will report a lot of incorrect errors when editing those files. You can work around that by temporarily renaming the `nativeMain` directory to `linuxX64Main` and syncing gradle, then changing the name back before commiting. 

This is very much not ideal, but it does allow us to support K/N, and since there's not much code in `nativeMain`, you might find this compromise acceptable.

If not, here are two other potential paths forward:

1. Remove the `nativeMain` source set entirely and copy its contents once for each of the three native targets. This causes duplicated code, and I don't think IntelliJ will correctly highlight code for targets that aren't supported on whatever OS you're running on.
2. Give up on native support for now. Remove all targets except `linuxX64`, and rename `nativeMain` to `linuxX64Main`. This would allow us to keep maintaining the native code until the new version of the Kotlin MPP comes out.

Let me know if you'd prefer either of those options (or something I haven't considered).

Fixes #1468