### PR TITLE
#1488 Makes ContainerScope extends CoroutineScope

### DIFF
--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecScope.kt
@@ -29,7 +29,7 @@ interface BehaviorSpecScope : RootScope {
    private fun addGiven(name: String, xdisabled: Boolean, test: suspend GivenScope.() -> Unit) {
       val testName = createTestName("Given: ", name)
       registration().addContainerTest(testName, xdisabled) {
-         GivenScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         GivenScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
@@ -3,18 +3,14 @@ package io.kotest.core.spec.style.scopes
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.AfterTest
 import io.kotest.core.spec.BeforeTest
-import io.kotest.core.test.Description
-import io.kotest.core.test.TestCase
-import io.kotest.core.test.TestCaseConfig
-import io.kotest.core.test.TestContext
-import io.kotest.core.test.TestResult
-import io.kotest.core.test.TestType
+import io.kotest.core.test.*
 import io.kotest.fp.Tuple2
+import kotlinx.coroutines.CoroutineScope
 
 /**
  * Contains methods used by container levels tests - such as adding before / after test callbacks.
  */
-interface ContainerScope {
+interface ContainerScope : CoroutineScope {
 
    /**
     * Returns the [Description] for the test that defined this scope.

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeScope.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.createTestName
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A context that allows tests to be registered using the syntax:
@@ -24,7 +25,8 @@ class DescribeScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend fun describe(name: String, test: suspend DescribeScope.() -> Unit) {
@@ -34,7 +36,8 @@ class DescribeScope(
             this@DescribeScope.description.append(testName),
             this@DescribeScope.lifecycle,
             this,
-            this@DescribeScope.defaultConfig
+            this@DescribeScope.defaultConfig,
+            this@DescribeScope.coroutineContext
          ).test()
       }
    }
@@ -46,7 +49,8 @@ class DescribeScope(
             this@DescribeScope.description.append(testName),
             this@DescribeScope.lifecycle,
             this,
-            this@DescribeScope.defaultConfig
+            this@DescribeScope.defaultConfig,
+            this@DescribeScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecScope.kt
@@ -15,7 +15,7 @@ interface DescribeSpecScope : RootScope {
    fun describe(name: String, test: suspend DescribeScope.() -> Unit) {
       val testName = createTestName("Describe: ", name)
       registration().addContainerTest(testName, xdisabled = false) {
-         DescribeScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         DescribeScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectScope.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.createTestName
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A context that allows tests to be registered using the syntax:
@@ -25,7 +26,8 @@ class ExpectScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend fun context(name: String, test: suspend ExpectScope.() -> Unit) {
@@ -35,7 +37,8 @@ class ExpectScope(
             this@ExpectScope.description.append(testName),
             this@ExpectScope.lifecycle,
             this,
-            this@ExpectScope.defaultConfig
+            this@ExpectScope.defaultConfig,
+            this@ExpectScope.coroutineContext
          ).test()
       }
    }
@@ -47,7 +50,8 @@ class ExpectScope(
             this@ExpectScope.description.append(testName),
             this@ExpectScope.lifecycle,
             this,
-            this@ExpectScope.defaultConfig
+            this@ExpectScope.defaultConfig,
+            this@ExpectScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecScope.kt
@@ -11,14 +11,14 @@ interface ExpectSpecScope : RootScope {
    fun context(name: String, test: suspend ExpectScope.() -> Unit) {
       val testName = createTestName("Context: ", name)
       registration().addContainerTest(testName, xdisabled = false) {
-         ExpectScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         ExpectScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 
    fun xcontext(name: String, test: suspend ExpectScope.() -> Unit) {
       val testName = createTestName("Context: ", name)
       registration().addContainerTest(testName, xdisabled = true) {
-         ExpectScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         ExpectScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureScope.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.createTestName
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A scope that allows tests to be registered using the syntax:
@@ -25,7 +26,8 @@ class FeatureScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend fun feature(name: String, test: suspend FeatureScope.() -> Unit) {
@@ -35,7 +37,8 @@ class FeatureScope(
             this@FeatureScope.description.append(testName),
             this@FeatureScope.lifecycle,
             this,
-            this@FeatureScope.defaultConfig
+            this@FeatureScope.defaultConfig,
+            this@FeatureScope.coroutineContext
          ).test()
       }
    }
@@ -47,7 +50,8 @@ class FeatureScope(
             this@FeatureScope.description.append(testName),
             this@FeatureScope.lifecycle,
             this,
-            this@FeatureScope.defaultConfig
+            this@FeatureScope.defaultConfig,
+            this@FeatureScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecScope.kt
@@ -17,7 +17,7 @@ interface FeatureSpecScope : RootScope {
    fun addFeature(name: String, xdisabled: Boolean, test: suspend FeatureScope.() -> Unit) {
       val testName = createTestName("Feature: ", name)
       registration().addContainerTest(testName, xdisabled = xdisabled) {
-         FeatureScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         FeatureScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeScope.kt
@@ -6,6 +6,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -13,7 +14,8 @@ class FreeScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend infix operator fun String.minus(test: suspend FreeScope.() -> Unit) {
@@ -22,7 +24,8 @@ class FreeScope(
             this@FreeScope.description.append(this@minus),
             this@FreeScope.lifecycle,
             this,
-            this@FreeScope.defaultConfig
+            this@FreeScope.defaultConfig,
+            this@FreeScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecScope.kt
@@ -13,7 +13,7 @@ interface FreeSpecScope : RootScope {
    // eg, "this test" - { } // adds a container test
    infix operator fun String.minus(test: suspend FreeScope.() -> Unit) {
       registration().addContainerTest(this, xdisabled = false) {
-         FreeScope(description().append(this@minus), lifecycle(), this, defaultConfig()).test()
+         FreeScope(description().append(this@minus), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContextScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContextScope.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.KotestDsl
 import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A scope that allows tests to be registered using the syntax:
@@ -18,7 +19,8 @@ class FunSpecContextScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    /**
@@ -30,7 +32,8 @@ class FunSpecContextScope(
             this@FunSpecContextScope.description.append(name),
             this@FunSpecContextScope.lifecycle,
             this,
-            this@FunSpecContextScope.defaultConfig
+            this@FunSpecContextScope.defaultConfig,
+            this@FunSpecContextScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecScope.kt
@@ -9,7 +9,7 @@ interface FunSpecScope : RootScope {
     */
    fun context(name: String, test: suspend FunSpecContextScope.() -> Unit) {
       registration().addContainerTest(name, xdisabled = false) {
-         FunSpecContextScope(description().append(name), lifecycle(), this, defaultConfig()).test()
+         FunSpecContextScope(description().append(name), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/GivenScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/GivenScope.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.createTestName
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A context that allows tests to be registered using the syntax:
@@ -28,7 +29,8 @@ class GivenScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend fun And(name: String, test: suspend GivenScope.() -> Unit) = addAnd(name, test, xdisabled = false)
@@ -42,7 +44,8 @@ class GivenScope(
             this@GivenScope.description.append(testName),
             this@GivenScope.lifecycle,
             this,
-            this@GivenScope.defaultConfig
+            this@GivenScope.defaultConfig,
+            this@GivenScope.coroutineContext
          ).test()
       }
    }
@@ -58,7 +61,8 @@ class GivenScope(
             this@GivenScope.description.append(testName),
             this@GivenScope.lifecycle,
             this,
-            this@GivenScope.defaultConfig
+            this@GivenScope.defaultConfig,
+            this@GivenScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContextScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContextScope.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.createTestName
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A scope that allows tests to be registered using the syntax:
@@ -19,7 +20,8 @@ class ShouldSpecContextScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    /**
@@ -31,7 +33,8 @@ class ShouldSpecContextScope(
             this@ShouldSpecContextScope.description.append(name),
             this@ShouldSpecContextScope.lifecycle,
             this,
-            this@ShouldSpecContextScope.defaultConfig
+            this@ShouldSpecContextScope.defaultConfig,
+            this@ShouldSpecContextScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecScope.kt
@@ -24,7 +24,7 @@ interface ShouldSpecScope : RootScope {
     */
    fun context(name: String, test: suspend ShouldSpecContextScope.() -> Unit) {
       registration().addContainerTest(name, xdisabled = false) {
-         ShouldSpecContextScope(description().append(name), lifecycle(), this, defaultConfig()).test()
+         ShouldSpecContextScope(description().append(name), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WhenScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WhenScope.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.createTestName
+import kotlin.coroutines.CoroutineContext
 
 /**
  * A context that allows tests to be registered using the syntax:
@@ -24,7 +25,8 @@ class WhenScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend fun And(name: String, test: suspend WhenScope.() -> Unit) = addAnd(name, test, xdisabled = false)
@@ -38,7 +40,8 @@ class WhenScope(
             this@WhenScope.description.append(testName),
             this@WhenScope.lifecycle,
             this,
-            this@WhenScope.defaultConfig
+            this@WhenScope.defaultConfig,
+            this@WhenScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecScope.kt
@@ -9,14 +9,14 @@ interface WordSpecScope : RootScope {
    infix fun String.should(test: suspend WordSpecShouldScope.() -> Unit) {
       val testName = "$this should"
       registration().addContainerTest(testName, xdisabled = false) {
-         WordSpecShouldScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         WordSpecShouldScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 
    infix fun String.xshould(test: suspend WordSpecShouldScope.() -> Unit) {
       val testName = "$this should"
       registration().addContainerTest(testName, xdisabled = true) {
-         WordSpecShouldScope(description().append(testName), lifecycle(), this, defaultConfig()).test()
+         WordSpecShouldScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).test()
       }
    }
 
@@ -26,7 +26,7 @@ interface WordSpecScope : RootScope {
    private fun addWhenContext(name: String, init: suspend WordSpecWhenScope.() -> Unit) {
       val testName = "$name when"
       registration().addContainerTest(testName, xdisabled = false) {
-         WordSpecWhenScope(description().append(testName), lifecycle(), this, defaultConfig()).init()
+         WordSpecWhenScope(description().append(testName), lifecycle(), this, defaultConfig(), this.coroutineContext).init()
       }
    }
 }

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldScope.kt
@@ -7,6 +7,7 @@ import io.kotest.core.test.Description
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -22,7 +23,8 @@ class WordSpecShouldScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    @OptIn(ExperimentalTime::class)

--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenScope.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.KotestDsl
 import io.kotest.core.test.Description
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
+import kotlin.coroutines.CoroutineContext
 
 @Suppress("FunctionName")
 @KotestDsl
@@ -11,7 +12,8 @@ class WordSpecWhenScope(
    override val description: Description,
    override val lifecycle: Lifecycle,
    override val testContext: TestContext,
-   override val defaultConfig: TestCaseConfig
+   override val defaultConfig: TestCaseConfig,
+   override val coroutineContext: CoroutineContext
 ) : ContainerScope {
 
    suspend infix fun String.Should(test: suspend WordSpecShouldScope.() -> Unit) = addShould(this, test, false)
@@ -25,7 +27,8 @@ class WordSpecWhenScope(
             this@WordSpecWhenScope.description.append(testName),
             this@WordSpecWhenScope.lifecycle,
             this,
-            this@WordSpecWhenScope.defaultConfig
+            this@WordSpecWhenScope.defaultConfig,
+            this@WordSpecWhenScope.coroutineContext
          ).test()
       }
    }

--- a/kotest-examples/kotest-examples-javascript/package-lock.json
+++ b/kotest-examples/kotest-examples-javascript/package-lock.json
@@ -459,9 +459,9 @@
       }
     },
     "mocha": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/behavior/BehaviorSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/behavior/BehaviorSpecTest.kt
@@ -5,6 +5,8 @@ import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicInteger
 
 class BehaviorSpecTest : BehaviorSpec() {
@@ -145,6 +147,19 @@ class BehaviorSpecTest : BehaviorSpec() {
                xwhen("should be ignored") {
                   error("boom")
                }
+            }
+         }
+      }
+
+      given("something delay in given scope") {
+         launch { delay(1) }
+         `when`("something delay in when scope") {
+            launch { delay(1) }
+            and("something delay in when scope provided by and") {
+               launch { delay(1) }
+            }
+            then("one should be one") {
+               1 shouldBe 1
             }
          }
       }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/feature/FeatureSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/feature/FeatureSpecTest.kt
@@ -2,28 +2,37 @@ package com.sksamuel.kotest.specs.feature
 
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.matchers.ints.shouldBeLessThan
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class FeatureSpecTest : FeatureSpec() {
 
-  init {
+   init {
 
-     feature("a feature") {
-        scenario("can execute a scenario") {
-           1.shouldBeLessThan(4)
-        }
-        xscenario("should be ignored") {
-           error("Boom")
-        }
-     }
+      feature("a feature") {
+         scenario("can execute a scenario") {
+            1.shouldBeLessThan(4)
+         }
+         xscenario("should be ignored") {
+            error("Boom")
+         }
+      }
 
-     xfeature("should be ignored") {
-        error("Boom")
-     }
+      xfeature("should be ignored") {
+         error("Boom")
+      }
 
-     xfeature("should be ignored 2") {
-        scenario("should be ignored") {
-           error("Boom")
-        }
-     }
-  }
+      xfeature("should be ignored 2") {
+         scenario("should be ignored") {
+            error("Boom")
+         }
+      }
+
+      feature("a feature with coroutine in feature scope") {
+         launch { delay(1) }
+         scenario("a dummy scenario") {
+
+         }
+      }
+   }
 }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/freespec/FreeSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/freespec/FreeSpecTest.kt
@@ -3,35 +3,47 @@ package com.sksamuel.kotest.specs.freespec
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Suppress("OverridingDeprecatedMember", "DEPRECATION")
 class FreeSpecTest : FreeSpec() {
 
-  private var count = 0
+   private var count = 0
 
-  override fun afterSpec(spec: Spec) {
-    count shouldBe 3
-  }
+   override fun afterSpec(spec: Spec) {
+      count shouldBe 3
+   }
 
-  init {
+   init {
 
-    "context a" - {
-      "b1" - {
-        "c" {
-          count += 1
-        }
+      "context a" - {
+         "b1" - {
+            "c" {
+               count += 1
+            }
+         }
+         "b2" - {
+            "d" {
+               count += 2
+            }
+         }
       }
-      "b2" - {
-        "d" {
-          count += 2
-        }
+
+      "context with coroutine in free scope" - {
+         launch { delay(1) }
+         "another context with coroutine in free scope" - {
+            launch { delay(1) }
+            "a dummy test" {
+
+            }
+         }
       }
-    }
 
 
-    "params" - {
-      "support config".config(enabled = true) {
+      "params" - {
+         "support config".config(enabled = true) {
+         }
       }
-    }
-  }
+   }
 }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/funspec/FunSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/funspec/FunSpecTest.kt
@@ -8,6 +8,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldNotBeBlank
 import io.kotest.matchers.string.shouldStartWith
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.nio.file.Paths
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
@@ -42,6 +44,13 @@ class FunSpecTest : FunSpec() {
             test("wibble") {
                "hello".shouldHaveLength(5)
             }
+         }
+      }
+
+      context("a context with coroutine in fun spec context scope") {
+         launch { delay(1) }
+         test("a dummy test") {
+
          }
       }
    }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/shouldspec/ShouldSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/shouldspec/ShouldSpecTest.kt
@@ -2,28 +2,37 @@ package com.sksamuel.kotest.specs.shouldspec
 
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.ints.shouldBeLessThan
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
 @OptIn(ExperimentalTime::class)
 class ShouldSpecTest : ShouldSpec() {
 
-  init {
-     context("a context") {
-        should("a test") {
-           1.shouldBeLessThan(2)
-        }
-        should("a test with config").config(enabled = true, timeout = 12321.milliseconds) {
-           1.shouldBeLessThan(2)
-        }
-        context("a nested context") {
-           should("a test") {
-              1.shouldBeLessThan(2)
-           }
-        }
-        should("a test without a parent context") {
-           1.shouldBeLessThan(2)
-        }
-    }
-  }
+   init {
+      context("a context") {
+         should("a test") {
+            1.shouldBeLessThan(2)
+         }
+         should("a test with config").config(enabled = true, timeout = 12321.milliseconds) {
+            1.shouldBeLessThan(2)
+         }
+         context("a nested context") {
+            should("a test") {
+               1.shouldBeLessThan(2)
+            }
+         }
+         should("a test without a parent context") {
+            1.shouldBeLessThan(2)
+         }
+      }
+      context("a context with delay in child coroutine") {
+         launch { delay(1) }
+         should("a test") {
+            1.shouldBeLessThan(2)
+         }
+      }
+
+   }
 }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/wordspec/WordSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/wordspec/WordSpecTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.kotest.specs.wordspec
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlin.time.ExperimentalTime
 import kotlin.time.milliseconds
 
@@ -32,6 +34,15 @@ class WordSpecTest : WordSpec() {
             }
          }
 
+      }
+      "a context with coroutine in word spec when scope" When {
+         launch { delay(1) }
+         "a context with coroutine in word spec should scope" Should {
+            launch { delay(1) }
+            "a dummy test" {
+
+            }
+         }
       }
    }
 }


### PR DESCRIPTION
This PR makes ContainerScope extends CoroutineScope which enable user to launch a coroutine in ContainerScopes such as ExpectScope, WhenScope, ShouldSpecContextScope etc.