### PR TITLE
Implement Exhaustive.merge for two gens with a common supertype.

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/Exhaustive.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/Exhaustive.kt
@@ -22,29 +22,11 @@ fun <A> List<A>.exhaustive(): Exhaustive<A> = object : Exhaustive<A>() {
  * In other words, if genA provides 1,2,3 and genB provides 7,8,9 then the merged
  * gen would output 1,7,2,8,3,9.
  *
- * The supplied gen must be a subtype of the type of this gen.
- *
- * @param other the arg to merge with this one
- * @return the merged arg.
- */
-
-fun <A, B : A> Exhaustive<A>.merge(other: Exhaustive<B>): Exhaustive<A> = object : Exhaustive<A>() {
-   override val values: List<A> = this@merge.values.zip(other.values).flatMap { listOf(it.first, it.second) }
-}
-
-/**
- * Returns a new [Exhaustive] which will merge the values from this Exhaustive and the values of
- * the supplied Exhaustive together, taking one from each in turn.
- *
- * In other words, if genA provides 1,2,3 and genB provides 7,8,9 then the merged
- * gen would output 1,7,2,8,3,9.
- *
  * The supplied gen and this gen must have a common supertype.
  *
  * @param other the arg to merge with this one
  * @return the merged arg.
  */
-
 fun <A, B : A, C : A> Exhaustive<B>.merge(other: Exhaustive<C>): Exhaustive<A> = object : Exhaustive<A>() {
    override val values: List<A> = this@merge.values.zip(other.values).flatMap { listOf(it.first, it.second) }
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/Exhaustive.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/Exhaustive.kt
@@ -32,6 +32,22 @@ fun <A, B : A> Exhaustive<A>.merge(other: Exhaustive<B>): Exhaustive<A> = object
    override val values: List<A> = this@merge.values.zip(other.values).flatMap { listOf(it.first, it.second) }
 }
 
+/**
+ * Returns a new [Exhaustive] which will merge the values from this Exhaustive and the values of
+ * the supplied Exhaustive together, taking one from each in turn.
+ *
+ * In other words, if genA provides 1,2,3 and genB provides 7,8,9 then the merged
+ * gen would output 1,7,2,8,3,9.
+ *
+ * The supplied gen and this gen must have a common supertype.
+ *
+ * @param other the arg to merge with this one
+ * @return the merged arg.
+ */
+
+fun <A, B : A, C : A> Exhaustive<B>.merge(other: Exhaustive<C>): Exhaustive<A> = object : Exhaustive<A>() {
+   override val values: List<A> = this@merge.values.zip(other.values).flatMap { listOf(it.first, it.second) }
+}
 
 /**
  * Returns a new [Exhaustive] which takes its elements from the receiver and filters them using the supplied

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/MergeTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/MergeTest.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.kotest.property.exhaustive
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.exhaustive.exhaustive
+import io.kotest.property.exhaustive.merge
+
+private sealed class Common {
+   internal data class Foo(val value: Int) : Common()
+   internal data class Bar(val value: Int) : Common()
+}
+
+class MergeTest : FunSpec({
+   test("merge two exhaustive gens where one is a subtype of the other") {
+      listOf(1, 2, 3).exhaustive().merge(listOf(4, 5, 6).exhaustive()).values shouldBe listOf(1, 4, 2, 5, 3, 6)
+   }
+
+   test("merge two exhaustive gens where neither is a subtype of the other") {
+      val firstGen = listOf(Common.Foo(1), Common.Foo(2), Common.Foo(3)).exhaustive()
+      val secondGen = listOf(Common.Bar(4), Common.Bar(5), Common.Bar(6)).exhaustive()
+      firstGen.merge(secondGen).values shouldBe listOf(
+         Common.Foo(1),
+         Common.Bar(4),
+         Common.Foo(2),
+         Common.Bar(5),
+         Common.Foo(3),
+         Common.Bar(6)
+      )
+   }
+})


### PR DESCRIPTION
### Description of the Change

This PR implements the example code from #1497 for merging two `Exhaustive` gens with a common supertype.

### Applicable Issues

Closes #1497.
