### PR TITLE
Use the SPDX compliant license identifier "Apache-2.0" in POM files

### DIFF
--- a/publish-mpp.gradle.kts
+++ b/publish-mpp.gradle.kts
@@ -65,7 +65,7 @@ publishing {
 
             licenses {
                license {
-                  name.set("The Apache 2.0 License")
+                  name.set("Apache-2.0")
                   url.set("https://opensource.org/licenses/Apache-2.0")
                }
             }


### PR DESCRIPTION
Using an SPDX compliant license identifier makes it easier for other
tools to correctly determine the license of this project.

See: https://spdx.org/licenses/