### PR TITLE
Support nullable arguments for JSON matchers (fix #1504)

### DIFF
--- a/doc/matchers.md
+++ b/doc/matchers.md
@@ -82,12 +82,12 @@ For Android-specific matchers, take a look [here](android_matchers.md)
 | `str.shouldStartWith("prefix")` | Asserts that the string starts with the given prefix. The prefix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
 | `str.shouldBeEqualIgnoringCase(other)` | Asserts that the string is equal to another string ignoring case. |
 
-| JSON ||
+| JSON | For convenience, JSONs are simply strings |
 | -------- | ---- |
-| `str.shouldMatchJson(json)` | Asserts that the JSON is equal to another JSON ignoring properties' order and formatting. |
-| `str.shouldContainJsonKey("$.key")` | Asserts that the JSON contains a `key`. |
-| `str.shouldContainJsonKeyValue("$.key", "value")` | Asserts that the JSON contains a `key` with a specific `value`. |
-| `str.shouldMatchJsonResource("/file.json")` | Asserts that the JSON is equal to the existing `/file.json` ignoring properties' order and formatting. |
+| `str?.shouldMatchJson(json?)` | Asserts that the JSON is equal to another JSON ignoring properties' order and formatting. |
+| `str?.shouldContainJsonKey("$.json.path")` | Asserts that the JSON contains a JSON path. |
+| `str?.shouldContainJsonKeyValue("$.json.path", value)` | Asserts that the JSON contains a JSON path with a specific `value`. |
+| `str?.shouldMatchJsonResource("/file.json")` | Asserts that the JSON is equal to the existing `/file.json` ignoring properties' order and formatting. |
 
 | Integers ||
 | -------- | ---- |

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -8,74 +8,104 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 private val mapper by lazy { ObjectMapper().registerKotlinModule() }
 
-infix fun String.shouldMatchJson(json: String) = this should matchJson(json)
-infix fun String.shouldNotMatchJson(json: String) = this shouldNot matchJson(json)
-fun matchJson(json: String) = object : Matcher<String> {
+infix fun String?.shouldMatchJson(expected: String?) = this should matchJson(expected)
+infix fun String?.shouldNotMatchJson(expected: String?) = this shouldNot matchJson(expected)
+fun matchJson(expected: String?) = object : Matcher<String?> {
 
-  override fun test(value: String): MatcherResult {
-
-    val actualJson = mapper.readTree(value)
-    val expectedJson = mapper.readTree(json)
+  override fun test(value: String?): MatcherResult {
+    val actualJson = value?.let(mapper::readTree)
+    val expectedJson = expected?.let(mapper::readTree)
 
     return MatcherResult(
-        actualJson == expectedJson,
-        "expected: $expectedJson but was: $actualJson",
-        "expected not to match with: $expectedJson but match: $actualJson"
+      actualJson == expectedJson,
+      "expected: $expectedJson but was: $actualJson",
+      "expected not to match with: $expectedJson but match: $actualJson"
     )
   }
 }
 
-infix fun String.shouldMatchJsonResource(resource: String) = this should matchJsonResource(resource)
+@OptIn(ExperimentalContracts::class)
+infix fun String?.shouldMatchJsonResource(resource: String) {
+  contract {
+    returns() implies (this@shouldMatchJsonResource != null)
+  }
+
+  this should matchJsonResource(resource)
+}
+
 infix fun String.shouldNotMatchJsonResource(resource: String) = this shouldNot matchJsonResource(resource)
+fun matchJsonResource(resource: String) = object : Matcher<String?> {
 
-fun matchJsonResource(resource: String) = object : Matcher<String> {
-  override fun test(value: String): MatcherResult {
-
-    val actualJson = mapper.readTree(value)
+  override fun test(value: String?): MatcherResult {
+    val actualJson = value?.let(mapper::readTree)
     val expectedJson = mapper.readTree(this.javaClass.getResourceAsStream(resource))
 
     return MatcherResult(
-        actualJson == expectedJson,
-        "expected: $expectedJson but was: $actualJson",
-        "expected not to match with: $expectedJson but match: $actualJson"
+      actualJson == expectedJson,
+      "expected: $expectedJson but was: $actualJson",
+      "expected not to match with: $expectedJson but match: $actualJson"
     )
   }
 }
 
-infix fun String.shouldContainJsonKey(path: String) = this should containJsonKey(path)
+@OptIn(ExperimentalContracts::class)
+infix fun String?.shouldContainJsonKey(path: String) {
+  contract {
+    returns() implies (this@shouldContainJsonKey != null)
+  }
+
+  this should containJsonKey(path)
+}
+
 infix fun String.shouldNotContainJsonKey(path: String) = this shouldNot containJsonKey(path)
-fun containJsonKey(path: String) = object : Matcher<String> {
+fun containJsonKey(path: String) = object : Matcher<String?> {
 
-  override fun test(value: String): MatcherResult {
-
-    val sub = if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
+  override fun test(value: String?): MatcherResult {
+    val sub = when (value) {
+      null -> value
+      else -> if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
+    }
 
     val passed = try {
-      JsonPath.read<String>(value, path) != null
+      value != null && JsonPath.read<String>(value, path) != null
     } catch (t: PathNotFoundException) {
       false
     }
 
     return MatcherResult(
-        passed,
-        "$sub should contain the path $path",
-        "$sub should not contain the path $path"
+      passed,
+      "$sub should contain the path $path",
+      "$sub should not contain the path $path"
     )
   }
 }
 
-fun <T> String.shouldContainJsonKeyValue(path: String, value: T) = this should containJsonKeyValue(path, value)
+@OptIn(ExperimentalContracts::class)
+fun <T> String?.shouldContainJsonKeyValue(path: String, value: T) {
+  contract {
+    returns() implies (this@shouldContainJsonKeyValue != null)
+  }
+
+  this should containJsonKeyValue(path, value)
+}
+
 fun <T> String.shouldNotContainJsonKeyValue(path: String, value: T) = this shouldNot containJsonKeyValue(path, value)
-fun <T> containJsonKeyValue(path: String, t: T) = object : Matcher<String> {
-  override fun test(value: String): MatcherResult {
-    val sub = if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
+fun <T> containJsonKeyValue(path: String, t: T) = object : Matcher<String?> {
+  override fun test(value: String?): MatcherResult {
+    val sub = when (value) {
+      null -> value
+      else -> if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
+    }
+
     return MatcherResult(
-        JsonPath.read<T>(value, path) == t,
-        "$sub should contain the element $path = $t",
-        "$sub should not contain the element $path = $t"
+      value != null && JsonPath.read<T>(value, path) == t,
+      "$sub should contain the element $path = $t",
+      "$sub should not contain the element $path = $t"
     )
   }
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.tests.json
 
+import io.kotest.assertions.asClue
 import io.kotest.assertions.json.shouldContainJsonKey
 import io.kotest.assertions.json.shouldContainJsonKeyValue
 import io.kotest.assertions.json.shouldMatchJson
@@ -44,6 +45,14 @@ class JsonAssertionsTest : StringSpec({
   "test json equality" {
     json1.shouldMatchJson(json2)
     json1.shouldNotMatchJson(json3)
+
+    null.shouldMatchJson(null)
+    null.shouldNotMatchJson(json1)
+    json1.shouldNotMatchJson(null)
+
+    shouldThrow<AssertionError> { null.shouldNotMatchJson(null) }
+    shouldThrow<AssertionError> { null.shouldMatchJson(json1) }
+    shouldThrow<AssertionError> { json1.shouldMatchJson(null) }
   }
 
   "should return correct error message on failure" {
@@ -71,6 +80,16 @@ class JsonAssertionsTest : StringSpec({
     "store": {
         "book": [
             {... should contain the path ${'$'}.store.table"""
+
+    shouldThrow<AssertionError> { null.shouldContainJsonKey("abc") }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
+
+      val nullableJson: String? = """{"data": "value"}"""
+      nullableJson.shouldContainJsonKey("data")
+      use(nullableJson)
+    }
   }
 
   "test json key value" {
@@ -87,6 +106,16 @@ class JsonAssertionsTest : StringSpec({
     "store": {
         "book": [
             {... should contain the element ${'$'}.store.book[1].author = JK Rowling"""
+
+    shouldThrow<AssertionError> { null.shouldContainJsonKeyValue("ab", "cd") }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
+
+      val nullableJson: String? = """{"data": "value"}"""
+      nullableJson.shouldContainJsonKeyValue("data", "value")
+      use(nullableJson)
+    }
   }
 
   "test json match by resource" {
@@ -100,5 +129,15 @@ class JsonAssertionsTest : StringSpec({
     shouldThrow<AssertionError> {
       testJson2.shouldMatchJsonResource("/json1.json")
     }.message shouldBe """expected: {"name":"sam","location":"chicago"} but was: {"name":"sam","location":"london"}"""
+
+    shouldThrow<AssertionError> { null shouldMatchJsonResource "/json1.json" }
+
+    "contract should work".asClue {
+      fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
+
+      val nullableJson: String? = testJson1
+      nullableJson.shouldMatchJsonResource("/json1.json")
+      use(nullableJson)
+    }
   }
 })


### PR DESCRIPTION
I've decided to split that huge #1318 PR to some smaller ones. Here I've added support for nulls and updated documentation a bit.

This resolves #1504.

@klesniewski ^^