### PR TITLE
add data class backed data tests that execute in a separate scope

### DIFF
--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeScope.kt
@@ -52,4 +52,12 @@ class FreeScope(
       invocationTimeout,
       test
    )
+
+   suspend fun <T> forAll(testCases: Map<String, T>, testfn: suspend (FreeScope).(T) -> Unit) {
+      testCases.forEach { entry ->
+         entry.key - {
+            testfn(this, entry.value)
+         }
+      }
+   }
 }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/freespec/FreeSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/freespec/FreeSpecTest.kt
@@ -45,5 +45,21 @@ class FreeSpecTest : FreeSpec() {
          "support config".config(enabled = true) {
          }
       }
+
+      "for all" - {
+         data class TestCase(val string: String, val length: Int)
+         forAll(
+            mapOf(
+               "zero" to TestCase(string = "", length = 0),
+               "one" to TestCase(string = "a", length = 1)
+            )
+         ) {
+            it.string.length shouldBe it.length
+
+            "sub" - {
+               it.string.length shouldBe it.length
+            }
+         }
+      }
    }
 }


### PR DESCRIPTION
Fixes #1537

I'll add documentation once the feature is accepted.