### PR TITLE
#1563 Bug fix for Android API < 26 Instrumented Tests. ClassNotFoundException

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/show/FileShow.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/show/FileShow.kt
@@ -1,0 +1,7 @@
+package io.kotest.assertions.show
+
+import java.io.File
+
+object FileShow : Show<File> {
+  override fun show(a: File): Printed = a.path.printed()
+}

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/show/platformShow.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/show/platformShow.kt
@@ -1,9 +1,49 @@
 @file:JvmName("platformjvm")
 package io.kotest.assertions.show
 
-import java.nio.file.Path
+import kotlin.reflect.KClass
 
-actual fun <A : Any> platformShow(a: A): Show<A>? = when (a) {
-   is Path -> PathShow as Show<A>
-   else -> null
+/**
+ * Return a [Show] based on available runtime classes.
+ * Ex. A standard Java 8 JVM will have the 'java.nio.file.Path'
+ * type while certain versions of the Android JVM will not.
+ *
+ * Uses reflection to check for the available classes
+ * to avoid a runtime [ClassNotFoundException] when
+ * called on a JVM platform that may not have the
+ * required compiled types.
+ *
+ * @return [PathShow] if [A] is a 'java.nio.file.Path',
+ * or [FileShow] if [A] is `java.io.File`,
+ * or `null` otherwise.
+ */
+actual fun <A : Any> platformShow(a: A): Show<A>? = when {
+  javaNioPathKlass()?.isInstance(a) ?: false -> PathShow as Show<A>
+  javaIoFileKlass()?.isInstance(a) ?: false -> FileShow as Show<A>
+  else -> null
+}
+
+private fun javaNioPathKlass(): KClass<*>? = try {
+  /*
+   * There is no KClass reflection API to find a
+   * class by string so the Java Class Reflection
+   * API must be used.
+   * See https://youtrack.jetbrains.com/issue/KT-10440
+   */
+  Class.forName("java.nio.file.Path").kotlin
+} catch (_: ClassNotFoundException) {
+  // ignore Path as it may not exist on Android.
+  null
+}
+
+private fun javaIoFileKlass(): KClass<*>? = try {
+  /*
+   * There is no KClass reflection API to find a
+   * class by string so the Java Class Reflection
+   * API must be used.
+   * See https://youtrack.jetbrains.com/issue/KT-10440
+   */
+  Class.forName("java.io.File").kotlin
+} catch (_: ClassNotFoundException) {
+  null
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/show/FileShowTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/show/FileShowTest.kt
@@ -1,0 +1,12 @@
+package com.sksamuel.kotest.show
+
+import io.kotest.assertions.show.show
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.io.File
+
+class FileShowTest : FunSpec({
+  test("Show should support File") {
+    File("/a/b/c").show().value shouldBe "/a/b/c"
+  }
+})

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/show/ShowTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/show/ShowTest.kt
@@ -6,6 +6,8 @@ import io.kotest.assertions.show.printed
 import io.kotest.assertions.show.show
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.io.File
+import java.nio.file.Paths
 
 class ShowTest : FunSpec() {
    init {
@@ -35,6 +37,8 @@ class ShowTest : FunSpec() {
       test("Detect show for any") {
          13.show().value shouldBe "13"
          true.show().value shouldBe "true"
+         File("/a/b/c").show().value shouldBe "/a/b/c"
+         Paths.get("/a/b/c").show().value shouldBe "/a/b/c"
       }
 
       test("detect show for boolean") {


### PR DESCRIPTION
#1563 Bug fix for Android API < 26 Instrumented Tests. The referenced type `java.nio.file.Path` does not exist on Android JVMs for versions < 26 which results in Android Instrumented Tests failing while running on an Android Device. 

This PR checks for the `java.nio.file.Path` type via pure reflection to support the existing PathShow object and adds support for `java.io.File` as well. 

An existing UNCHECKED_CAST warning is still present and a new one is added to support the different types via reflection.