### PR TITLE
Fix beforeTest/afterTest only being executed for immediate child scopes

### DIFF
--- a/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
+++ b/kotest-core/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
@@ -56,7 +56,7 @@ interface ContainerScope : CoroutineScope {
    fun beforeTest(f: BeforeTest) {
       lifecycle.addListener(object : TestListener {
          override suspend fun beforeTest(testCase: TestCase) {
-            if (description.isParentOf(testCase.description)) f(testCase)
+            if (description.isAncestorOf(testCase.description)) f(testCase)
          }
       })
    }
@@ -67,7 +67,7 @@ interface ContainerScope : CoroutineScope {
    fun afterTest(f: AfterTest) {
       lifecycle.addListener(object : TestListener {
          override suspend fun afterTest(testCase: TestCase, result: TestResult) {
-            if (description.isParentOf(testCase.description)) f(Tuple2(testCase, result))
+            if (description.isAncestorOf(testCase.description)) f(Tuple2(testCase, result))
          }
       })
    }

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/behavior/BehaviorSpecNestedBeforeAfterTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/behavior/BehaviorSpecNestedBeforeAfterTest.kt
@@ -55,6 +55,16 @@ class BehaviorSpecNestedBeforeAfterTest : BehaviorSpec({
             a = "resetme"
          }
       }
+      `when`("h") {
+         then("i") {
+            a shouldBe "n" // from the outer before
+            a = "resetme"
+         }
+         then("k") {
+            a shouldBe "n"
+            a = "resetme"
+         }
+      }
    }
 
    afterSpec {

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/describe/DescribeSpecNestedBeforeAfterTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/describe/DescribeSpecNestedBeforeAfterTest.kt
@@ -30,6 +30,17 @@ class DescribeSpecNestedBeforeAfterTest : DescribeSpec({
          a shouldBe "n"
          a = "resetme"
       }
+
+      describe("bar") {
+         it("f") {
+            a shouldBe "n" // from the outer before
+            a = "resetme"
+         }
+         it("g") {
+            a shouldBe "n"
+            a = "resetme"
+         }
+      }
    }
 
    afterSpec {

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/funspec/FunSpecNestedBeforeAfterTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/funspec/FunSpecNestedBeforeAfterTest.kt
@@ -46,6 +46,17 @@ class FunSpecNestedBeforeAfterTest : FunSpec({
       test("b") {
          a shouldBe "wobble"
       }
+
+      context("fizz") {
+         test("a") {
+            a shouldBe "wobble" // from the outer before
+            a = "resetme"
+         }
+         test("b") {
+            a shouldBe "wobble"
+            a = "resetme"
+         }
+      }
    }
 
    afterSpec {


### PR DESCRIPTION
## Description

Fixes #1574.

Normally `beforeTest` and `afterTest` in the `*Scope` classes need to be executed for every test case of every child scope, no matter how deeply nested they are.

Currently, this only happens if the parent of the test case in question is the immediate parent (verified via `description.isParentOf(testCase.description)`). The problem is that this needs to be executed even if the parent is an ancestor and not just an immediate parent.

## Fix
Changed the `ContainerScope` to execute `beforeTest` and `afterTest` if the scope is an ancestor of the test case in question, not just a parent.


## Tests
Extended the three test classes that verify `beforeTest` / `afterTest` to include tests that verify the behaviour in question. The added tests would fail without this fix.