### PR TITLE
ISSUE-1573: Allow to disable SpringListener warning on a final class

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/build.gradle.kts
+++ b/kotest-extensions/kotest-extensions-spring/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
       val jvmMain by getting {
          dependencies {
             implementation(project(":kotest-core"))
+            implementation(project(":kotest-common"))
             implementation(project(Projects.AssertionsShared))
             implementation(kotlin("stdlib-jdk8"))
             implementation(kotlin("reflect"))

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
@@ -1,11 +1,12 @@
 package io.kotest.spring
 
-import io.kotest.core.test.TestCase
-import io.kotest.core.test.TestResult
-import io.kotest.core.spec.Spec
 import io.kotest.core.extensions.ConstructorExtension
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.AutoScan
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.mpp.sysprop
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.description.modifier.Visibility
 import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
@@ -20,7 +21,7 @@ import kotlin.reflect.full.primaryConstructor
 
 object SpringListener : TestListener {
 
-   var ignoreWarning: Boolean = false
+   var ignoreSpringListenerOnFinalClassWarning: Boolean = false
 
    // Each Spec needs its own context. However, this listener is a singleton, so we need
    // to keep this map to separate those contexts instead of making this class non-singleton, thus
@@ -58,7 +59,7 @@ object SpringListener : TestListener {
          val klass = this::class.java
 
          return if (Modifier.isFinal(klass.modifiers)) {
-            if (!ignoreWarning) {
+            if (!ignoreSpringListenerOnFinalClassWarning || !sysprop("kotest.listener.spring.ignore.warning").toBoolean()) {
                println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
             }
             this@SpringListener::class.java.getMethod("afterSpec", Spec::class.java, Continuation::class.java)

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
@@ -20,6 +20,8 @@ import kotlin.reflect.full.primaryConstructor
 
 object SpringListener : TestListener {
 
+   var ignoreWarning: Boolean = false
+
    // Each Spec needs its own context. However, this listener is a singleton, so we need
    // to keep this map to separate those contexts instead of making this class non-singleton, thus
    // breaking client code
@@ -56,7 +58,9 @@ object SpringListener : TestListener {
          val klass = this::class.java
 
          return if (Modifier.isFinal(klass.modifiers)) {
-            println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
+            if (!ignoreWarning) {
+               println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
+            }
             this@SpringListener::class.java.getMethod("afterSpec", Spec::class.java, Continuation::class.java)
          } else {
             val fakeSpec = ByteBuddy()

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
@@ -59,7 +59,7 @@ object SpringListener : TestListener {
          val klass = this::class.java
 
          return if (Modifier.isFinal(klass.modifiers)) {
-            if (!ignoreSpringListenerOnFinalClassWarning || !sysprop("kotest.listener.spring.ignore.warning").toBoolean()) {
+            if (!ignoreSpringListenerOnFinalClassWarning || !sysprop("kotest.listener.spring.ignore.warning", "false").toBoolean()) {
                println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
             }
             this@SpringListener::class.java.getMethod("afterSpec", Spec::class.java, Continuation::class.java)


### PR DESCRIPTION
Hi,

https://github.com/kotest/kotest/issues/1573
As discussed I've introduced `ignoreWarning` to provide possibility to disable warning about using SpringListener on final classes. I decided to go with the property instead of changing to object to class to not break current behaviour.

Thanks