### PR TITLE
#1587 Improve error message for should contain when key is present

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -1,5 +1,7 @@
 package io.kotest.matchers.maps
 
+import io.kotest.fp.getOrElse
+import io.kotest.fp.toOption
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.Diff
@@ -37,8 +39,10 @@ fun <V> haveValues(vararg values: V): Matcher<Map<*, V>> = object : Matcher<Map<
 
 fun <K, V> contain(key: K, v: V): Matcher<Map<K, V>> = object : Matcher<Map<K, V>> {
   override fun test(value: Map<K, V>) = MatcherResult(value[key] == v,
-    "Map should contain mapping $key=$v but was $value",
+    "Map should contain mapping $key=$v but was ${buildActualValue(value)}",
     "Map should not contain mapping $key=$v but was $value")
+
+   private fun buildActualValue(map: Map<K, V>) = map[key].toOption().map { "$key=$it" }.getOrElse(map)
 }
 
 fun <K, V> containAll(expected: Map<K, V>): Matcher<Map<K, V>> =

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -1,5 +1,7 @@
 package io.kotest.matchers.maps
 
+import io.kotest.fp.getOrElse
+import io.kotest.fp.toOption
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -8,9 +10,11 @@ import io.kotest.matchers.shouldNot
 fun <K, V> mapcontain(key: K, v: V) = object : Matcher<Map<K, V>> {
    override fun test(value: Map<K, V>) = MatcherResult(
       value[key] == v,
-      "Map should contain mapping $key=$v but was $value",
+      "Map should contain mapping $key=$v but was ${buildActualValue(value)}",
       "Map should not contain mapping $key=$v but was $value"
    )
+
+   private fun buildActualValue(map: Map<K, V>) = map[key].toOption().map { "$key=$it" }.getOrElse(map)
 }
 
 fun <K, V> Map<K, V>.shouldContain(key: K, value: V) = this should mapcontain(key, value)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -60,8 +60,14 @@ class MapMatchersTest : WordSpec() {
             map shouldContain (1 to "a")
             map shouldNotContain (3 to "A")
             shouldThrow<AssertionError> {
+               map.shouldContain(1, "c")
+            }.message.shouldBe("Map should contain mapping 1=c but was 1=a")
+            shouldThrow<AssertionError> {
+               map.shouldContain(4, "e")
+            }.message.shouldBe("Map should contain mapping 4=e but was {1=a, 2=b}")
+            shouldThrow<AssertionError> {
                map should contain(2, "a")
-            }
+            }.message.shouldBe("Map should contain mapping 2=a but was 2=b")
          }
       }
 


### PR DESCRIPTION
- when the key is found with different value show the conflict
- when no key is found for the expected key, show the entire map