### PR TITLE
Fixed ByteArray generator not creating any values

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bytearrays.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bytearrays.kt
@@ -13,7 +13,7 @@ fun Arb.Companion.byteArrays(generateArrayLength: Gen<Int>, generateContents: Ar
    return arb { rs ->
       val lengths = generateArrayLength.generate(rs).iterator()
       val bytes = generateContents.values(rs).iterator()
-      sequence<ByteArray> {
+      generateSequence {
          val length = lengths.next().value
          ByteArray(length) { bytes.next().value }
       }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ByteArrayTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ByteArrayTest.kt
@@ -23,7 +23,7 @@ class ByteArrayTest : DescribeSpec() {
          }
          it("should populate random byte values") {
             Arb.byteArrays(Arb.constant(1000000), Arb.byte()).take(10).toList().forAll {
-               it.toSet().size shouldBe 255
+               it.toSet().size shouldBe 256
             }
          }
       }


### PR DESCRIPTION
Arb.byteArrays() was not working correctly and was creating a sequence
with no values.

The unit tests were still passing because the forAll inspector was being
run on an empty list and therefore wasn't actually testing any values.

This fixes #1608