### PR TITLE
Update Gradle dependencies docs removing unnecessary -jvm suffix

### DIFF
--- a/doc/extensions.md
+++ b/doc/extensions.md
@@ -46,7 +46,7 @@ The ```kotest-assertions-ktor-jvm``` extension provides response matchers for a 
 To add Ktor matchers, add the following dependency to your project
 
 ```groovy
-testImplementation("io.kotest:kotest-assertions-ktor-jvm:${version}")
+testImplementation("io.kotest:kotest-assertions-ktor:${version}")
 ```
 
 Usage:
@@ -123,7 +123,7 @@ The [Koin DI Framework](https://insert-koin.io/) can be used with Kotest through
 
 To add the listener to your project, add the depency to your project:
 ```groovy
-testImplementation("io.kotest:kotest-extensions-koin-jvm:${version}")
+testImplementation("io.kotest:kotest-extensions-koin:${version}")
 ```
 
 With the dependency added, we can use Koin in our tests!
@@ -151,7 +151,7 @@ class KotestAndKoin : FunSpec(), KoinTest {
 To add this module to project you need spcify following in your `build.gradle`:
 
 ```groovy
-testImplementation 'io.kotest:kotest-extensions-robolectric-jvm:<version>'
+testImplementation 'io.kotest:kotest-extensions-robolectric:<version>'
 ```
 With this dependency added you should add extensions to your project config. For example if you have no such config yet it would look like
 
@@ -178,7 +178,7 @@ This extension is a wrapper over [kotlin-compile-testing](https://github.com/tsc
 To add the compilation matcher, add the following dependency to your project
 
 ```groovy
-testImplementation("io.kotest:kotest-assertions-compiler-jvm:${version}")
+testImplementation("io.kotest:kotest-assertions-compiler:${version}")
 ```
 
 Usage:

--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -10,7 +10,7 @@ Sometimes this is available with less complex integrations, such as using [Liste
 The Mutation Testing tool [Pitest](https://pitest.org/) is integrated via plugin with Kotest. After [configuring](https://gradle-pitest-plugin.solidsoft.info/) the Pitest extension, add the Kotest Plugin dependency to your dependencies as well:
 
 ```kotlin
-    testImplementation("io.kotest:kotest-plugins-pitest-jvm:<version>")
+    testImplementation("io.kotest:kotest-plugins-pitest:<version>")
 ```
 
 After doing that, tell Pitest that we're going to use the `Kotest` as a `testPlugin`:

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -57,9 +57,9 @@ test {
 }
 
 dependencies {
-  testImplementation 'io.kotest:kotest-runner-junit5-jvm:<version>' // for kotest framework
-  testImplementation 'io.kotest:kotest-assertions-core-jvm:<version>' // for kotest core jvm assertions
-  testImplementation 'io.kotest:kotest-property-jvm:<version>' // for kotest property test
+  testImplementation 'io.kotest:kotest-runner-junit5:<version>' // for kotest framework
+  testImplementation 'io.kotest:kotest-assertions-core:<version>' // for kotest core jvm assertions
+  testImplementation 'io.kotest:kotest-property:<version>' // for kotest property test
 }
 ```
 
@@ -77,9 +77,9 @@ android.testOptions {
 }
 
 dependencies {
-    testImplementation 'io.kotest:kotest-runner-junit5-jvm:<version>' // for kotest framework
-    testImplementation 'io.kotest:kotest-assertions-core-jvm:<version>' // for kotest core jvm assertions
-    testImplementation 'io.kotest:kotest-property-jvm:<version>' // for kotest property test
+    testImplementation 'io.kotest:kotest-runner-junit5:<version>' // for kotest framework
+    testImplementation 'io.kotest:kotest-assertions-core:<version>' // for kotest core jvm assertions
+    testImplementation 'io.kotest:kotest-property:<version>' // for kotest property test
 }
 ```
 
@@ -96,9 +96,9 @@ tasks.withType<Test> {
 }
 
 dependencies {
-  testImplementation("io.kotest:kotest-runner-junit5-jvm:<version>") // for kotest framework
-  testImplementation("io.kotest:kotest-assertions-core-jvm:<version>") // for kotest core jvm assertions
-  testImplementation("io.kotest:kotest-property-jvm:<version>") // for kotest property test
+  testImplementation("io.kotest:kotest-runner-junit5:<version>") // for kotest framework
+  testImplementation("io.kotest:kotest-assertions-core:<version>") // for kotest core jvm assertions
+  testImplementation("io.kotest:kotest-property:<version>") // for kotest property test
 }
 ```
 


### PR DESCRIPTION
Related issue: #1638 