### PR TITLE
Fix and remove double negative in empty directory assertions

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -15,9 +15,9 @@ private fun File.safeList(): List<String> = this.list()?.toList() ?: emptyList()
 private fun File.safeListFiles(): List<File> = this.listFiles()?.toList() ?: emptyList()
 private fun File.safeListFiles(filter: FileFilter): List<File> = this.listFiles(filter)?.toList() ?: emptyList()
 
-fun File.shouldBeNonEmptyDirectory() = this should beNonEmptyDirectory()
-fun File.shouldNotBeNonEmptyDirectory() = this shouldNot beNonEmptyDirectory()
-fun beNonEmptyDirectory(): Matcher<File> = object : Matcher<File> {
+fun File.shouldBeEmptyDirectory() = this should beEmptyDirectory()
+fun File.shouldNotBeEmptyDirectory() = this shouldNot beEmptyDirectory()
+fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
   override fun test(value: File): MatcherResult = MatcherResult(value.isDirectory && value.safeList().isEmpty(), "$value should be a non empty directory", "$value should not be a non empty directory")
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -15,6 +15,11 @@ private fun File.safeList(): List<String> = this.list()?.toList() ?: emptyList()
 private fun File.safeListFiles(): List<File> = this.listFiles()?.toList() ?: emptyList()
 private fun File.safeListFiles(filter: FileFilter): List<File> = this.listFiles(filter)?.toList() ?: emptyList()
 
+@Deprecated(message ="checks if a directory is empty", replaceWith = ReplaceWith("shouldBeEmptyDirectory()"))
+fun File.shouldBeNonEmptyDirectory() = this shouldNot beEmptyDirectory()
+@Deprecated(message ="checks if a directory is not empty", replaceWith = ReplaceWith("shouldNotBeEmptyDirectory()"))
+fun File.shouldNotBeNonEmptyDirectory() = this should beEmptyDirectory()
+
 fun File.shouldBeEmptyDirectory() = this should beEmptyDirectory()
 fun File.shouldNotBeEmptyDirectory() = this shouldNot beEmptyDirectory()
 fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
@@ -3,7 +3,7 @@ package io.kotest.matchers.paths
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.file.beLarger
-import io.kotest.matchers.file.beNonEmptyDirectory
+import io.kotest.matchers.file.beEmptyDirectory
 import io.kotest.matchers.file.containNFiles
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -121,8 +121,8 @@ fun beExecutable(): Matcher<Path> = object : Matcher<Path> {
 infix fun Path.shouldContainNFiles(n: Int) = this.toFile() shouldBe containNFiles(n)
 infix fun Path.shouldNotContainNFiles(n: Int) = this.toFile() shouldNotBe containNFiles(n)
 
-fun Path.shouldBeNonEmptyDirectory() = this.toFile() should beNonEmptyDirectory()
-fun Path.shouldNotBeNonEmptyDirectory() = this.toFile() shouldNot beNonEmptyDirectory()
+fun Path.shouldBeEmptyDirectory() = this.toFile() should beEmptyDirectory()
+fun Path.shouldNotBeEmptyDirectory() = this.toFile() shouldNot beEmptyDirectory()
 
 fun Path.shouldBeHidden() = this should beHidden()
 fun Path.shouldNotBeHidden() = this shouldNot beHidden()

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
@@ -121,6 +121,11 @@ fun beExecutable(): Matcher<Path> = object : Matcher<Path> {
 infix fun Path.shouldContainNFiles(n: Int) = this.toFile() shouldBe containNFiles(n)
 infix fun Path.shouldNotContainNFiles(n: Int) = this.toFile() shouldNotBe containNFiles(n)
 
+@Deprecated(message ="checks if a directory is empty", replaceWith = ReplaceWith("shouldBeEmptyDirectory()"))
+fun Path.shouldBeNonEmptyDirectory() = this.toFile() shouldNot beEmptyDirectory()
+@Deprecated(message ="checks if a directory is not empty", replaceWith = ReplaceWith("shouldBeNonEmptyDirectory()"))
+fun Path.shouldNotBeNonEmptyDirectory() = this.toFile() should beEmptyDirectory()
+
 fun Path.shouldBeEmptyDirectory() = this.toFile() should beEmptyDirectory()
 fun Path.shouldNotBeEmptyDirectory() = this.toFile() shouldNot beEmptyDirectory()
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/file/FileMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/file/FileMatchersTest.kt
@@ -11,6 +11,8 @@ import io.kotest.matchers.file.haveExtension
 import io.kotest.matchers.file.shouldBeADirectory
 import io.kotest.matchers.file.shouldBeAFile
 import io.kotest.matchers.file.shouldBeAbsolute
+import io.kotest.matchers.file.shouldBeEmptyDirectory
+import io.kotest.matchers.file.shouldBeNonEmptyDirectory
 import io.kotest.matchers.file.shouldBeRelative
 import io.kotest.matchers.file.shouldBeSymbolicLink
 import io.kotest.matchers.file.shouldExist
@@ -18,13 +20,14 @@ import io.kotest.matchers.file.shouldHaveExtension
 import io.kotest.matchers.file.shouldHaveParent
 import io.kotest.matchers.file.shouldNotBeADirectory
 import io.kotest.matchers.file.shouldNotBeAFile
+import io.kotest.matchers.file.shouldNotBeEmptyDirectory
+import io.kotest.matchers.file.shouldNotBeNonEmptyDirectory
 import io.kotest.matchers.file.shouldNotBeSymbolicLink
 import io.kotest.matchers.file.shouldNotExist
 import io.kotest.matchers.file.shouldNotHaveExtension
 import io.kotest.matchers.file.shouldNotHaveParent
 import io.kotest.matchers.file.shouldStartWithPath
 import io.kotest.matchers.file.startWithPath
-import io.kotest.matchers.paths.shouldBeEmptyDirectory
 import io.kotest.matchers.paths.shouldBeLarger
 import io.kotest.matchers.paths.shouldBeSmaller
 import io.kotest.matchers.paths.shouldBeSymbolicLink
@@ -32,7 +35,6 @@ import io.kotest.matchers.paths.shouldContainFile
 import io.kotest.matchers.paths.shouldContainFileDeep
 import io.kotest.matchers.paths.shouldContainFiles
 import io.kotest.matchers.paths.shouldHaveParent
-import io.kotest.matchers.paths.shouldNotBeEmptyDirectory
 import io.kotest.matchers.paths.shouldNotBeSymbolicLink
 import io.kotest.matchers.paths.shouldNotContainFile
 import io.kotest.matchers.paths.shouldNotContainFileDeep
@@ -149,10 +151,17 @@ class FileMatchersTest : FunSpec() {
       }
     }
 
+    test("directory should be empty (deprecated)") {
+       val dir = Files.createTempDirectory("testdir").toFile()
+       dir.shouldNotBeNonEmptyDirectory()
+       dir.resolve("testfile.txt").writeBytes(byteArrayOf(1, 2, 3))
+       dir.shouldBeNonEmptyDirectory()
+    }
+
     test("directory should be empty") {
-       val dir = Files.createTempDirectory("testdir")
+       val dir = Files.createTempDirectory("testdir").toFile()
        dir.shouldBeEmptyDirectory()
-       Files.write(dir.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
+       dir.resolve("testfile.txt").writeBytes(byteArrayOf(1, 2, 3))
        dir.shouldNotBeEmptyDirectory()
     }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/file/FileMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/file/FileMatchersTest.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.file.shouldNotHaveExtension
 import io.kotest.matchers.file.shouldNotHaveParent
 import io.kotest.matchers.file.shouldStartWithPath
 import io.kotest.matchers.file.startWithPath
+import io.kotest.matchers.paths.shouldBeEmptyDirectory
 import io.kotest.matchers.paths.shouldBeLarger
 import io.kotest.matchers.paths.shouldBeSmaller
 import io.kotest.matchers.paths.shouldBeSymbolicLink
@@ -31,6 +32,7 @@ import io.kotest.matchers.paths.shouldContainFile
 import io.kotest.matchers.paths.shouldContainFileDeep
 import io.kotest.matchers.paths.shouldContainFiles
 import io.kotest.matchers.paths.shouldHaveParent
+import io.kotest.matchers.paths.shouldNotBeEmptyDirectory
 import io.kotest.matchers.paths.shouldNotBeSymbolicLink
 import io.kotest.matchers.paths.shouldNotContainFile
 import io.kotest.matchers.paths.shouldNotContainFileDeep
@@ -145,6 +147,13 @@ class FileMatchersTest : FunSpec() {
       shouldThrow<AssertionError> {
         dir shouldBe aFile()
       }
+    }
+
+    test("directory should be empty") {
+       val dir = Files.createTempDirectory("testdir")
+       dir.shouldBeEmptyDirectory()
+       Files.write(dir.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
+       dir.shouldNotBeEmptyDirectory()
     }
 
     test("directory contains file matching predicate") {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
@@ -1,0 +1,20 @@
+package com.sksamuel.kotest.matchers.paths
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.paths.shouldBeEmptyDirectory
+import io.kotest.matchers.paths.shouldNotBeEmptyDirectory
+import java.nio.file.Files
+
+@Suppress("BlockingMethodInNonBlockingContext")
+class PathMatchersTest : FunSpec() {
+
+  init {
+
+     test("directory should be empty") {
+       val path = Files.createTempDirectory("testdir").toAbsolutePath()
+       path.shouldBeEmptyDirectory()
+       Files.write(path.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
+       path.shouldNotBeEmptyDirectory()
+     }
+  }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
@@ -2,7 +2,9 @@ package com.sksamuel.kotest.matchers.paths
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.paths.shouldBeEmptyDirectory
+import io.kotest.matchers.paths.shouldBeNonEmptyDirectory
 import io.kotest.matchers.paths.shouldNotBeEmptyDirectory
+import io.kotest.matchers.paths.shouldNotBeNonEmptyDirectory
 import java.nio.file.Files
 
 @Suppress("BlockingMethodInNonBlockingContext")
@@ -10,11 +12,18 @@ class PathMatchersTest : FunSpec() {
 
   init {
 
-     test("directory should be empty") {
-       val path = Files.createTempDirectory("testdir").toAbsolutePath()
-       path.shouldBeEmptyDirectory()
+    test("directory should be empty (deprecated)") {
+       val path = Files.createTempDirectory("testdir")
+       path.shouldNotBeNonEmptyDirectory()
        Files.write(path.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
-       path.shouldNotBeEmptyDirectory()
-     }
+       path.shouldBeNonEmptyDirectory()
+    }
+
+    test("directory should be empty") {
+      val path = Files.createTempDirectory("testdir")
+      path.shouldBeEmptyDirectory()
+      Files.write(path.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
+      path.shouldNotBeEmptyDirectory()
+    }
   }
 }


### PR DESCRIPTION
Current (reversed) situation:
File.shouldBeNonEmptyDirectory to check if a directory is empty
File.shouldNotBeNonEmptyDirectory to check if a directory is not empty

I suggest removing the negation in the name, leading to:
File.shouldBeEmptyDirectory to check if a directory is empty
File.shouldNotBeEmptyDirectory to check if a directory is not empty
and
Path.shouldBeEmptyDirectory to check if a directory is empty
Path.shouldNotBeEmptyDirectory to check if a directory is not empty