### PR TITLE
Added spring listener lifecycle mode #1643

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/spring/SpringRootLifecycleModeTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/spring/SpringRootLifecycleModeTest.kt
@@ -1,0 +1,55 @@
+package io.kotest.spring
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.test.context.TestContext
+import org.springframework.test.context.TestExecutionListener
+import org.springframework.test.context.TestExecutionListeners
+
+@TestExecutionListeners(value = [SpringRootExecutionListener::class])
+class SpringRootLifecycleModeTest : DescribeSpec() {
+   init {
+
+      listener(SpringTestListener(SpringTestLifecycleMode.Root))
+
+      beforeSpec {
+         before shouldBe 0
+      }
+
+      describe("the outer scope should be initialized by the spring listener") {
+         before shouldBe 1
+         it("inner scope should have no effect") {
+            before shouldBe 1
+            after shouldBe 0
+         }
+         after shouldBe 0
+      }
+
+      describe("the outer scope should be initialized by the spring listener part 2") {
+         before shouldBe 2
+         it("inner scope should have no effect") {
+            before shouldBe 2
+            after shouldBe 1
+         }
+         after shouldBe 1
+      }
+
+      afterSpec {
+         after shouldBe 2
+      }
+   }
+}
+
+private var before = 0
+private var after = 0
+
+private class SpringRootExecutionListener : TestExecutionListener {
+
+   override fun beforeTestMethod(testContext: TestContext) {
+      before++
+   }
+
+   override fun afterTestMethod(testContext: TestContext) {
+      after++
+   }
+}

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/spring/SpringTestLifecycleModeTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/spring/SpringTestLifecycleModeTest.kt
@@ -1,0 +1,55 @@
+package io.kotest.spring
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.test.context.TestContext
+import org.springframework.test.context.TestExecutionListener
+import org.springframework.test.context.TestExecutionListeners
+
+@TestExecutionListeners(value = [SpringTestExecutionListener::class])
+class SpringTestLifecycleModeTest : DescribeSpec() {
+   init {
+
+      listener(SpringTestListener(SpringTestLifecycleMode.Test))
+
+      beforeSpec {
+         before shouldBe 0
+      }
+
+      describe("an outer scope should not be initialized by the spring listener") {
+         before shouldBe 0
+         it("but the inner scope should be") {
+            before shouldBe 1
+            after shouldBe 0
+         }
+         after shouldBe 1
+      }
+
+      describe("an outer scope should not be initialized by the spring listener part 2") {
+         before shouldBe 1
+         it("but the inner scope should be") {
+            before shouldBe 2
+            after shouldBe 1
+         }
+         after shouldBe 2
+      }
+
+      afterSpec {
+         after shouldBe 2
+      }
+   }
+}
+
+private var before = 0
+private var after = 0
+
+private class SpringTestExecutionListener : TestExecutionListener {
+
+   override fun beforeTestMethod(testContext: TestContext) {
+      before++
+   }
+
+   override fun afterTestMethod(testContext: TestContext) {
+      after++
+   }
+}


### PR DESCRIPTION
Closes #1643

Expands the SpringListener (in a backwards compatible way) to allow for setting a lifecycle mode. This flag controls when the spring beforeTestMethod / afterTestMethod functions are invoked.

Since the spring test support expects tests to be methods, for nested specs we need to either invoke at the root test scope, or the leaf test scope. The flag supports both options.

By using this flag, @DataJpaTest can be configured to work with nested test styles by setting up the listener like this:

`listener(SpringTestListener(SpringTestLifecycleMode.Test))`