### PR TITLE
Add Spec EnabledIf

### DIFF
--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/Reflection.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/Reflection.kt
@@ -36,6 +36,11 @@ interface Reflection {
     * Returns a list of the class member properties defined in the primary constructor, if supported.
     */
    fun <T : Any> primaryConstructorMembers(klass: KClass<T>) : List<Property>
+
+   /**
+    * Returns a new instan created from the no arg constructor, if supported
+    */
+   fun <T : Any> newInstanceNoArgConstructor(klass: KClass<T>) : T
 }
 
 object BasicReflection : Reflection {
@@ -44,6 +49,7 @@ object BasicReflection : Reflection {
    override fun <T : Any> isDataClass(kclass: KClass<T>): Boolean = false
    override fun paramNames(fn: Function<*>): List<String>? = null
    override fun <T : Any> primaryConstructorMembers(klass: KClass<T>): List<Property>  = emptyList()
+   override fun <T : Any> newInstanceNoArgConstructor(klass: KClass<T>): T = TODO("UNSUPPORTED")
 }
 
 /**
@@ -59,5 +65,7 @@ fun KClass<*>.bestName(): String = reflection.fqn(this) ?: simpleName ?: this.to
 inline fun <reified T> KClass<*>.annotation(): T? = reflection.annotations(this).filterIsInstance<T>().firstOrNull()
 
 inline fun <reified T> KClass<*>.hasAnnotation(): Boolean = reflection.annotations(this).filterIsInstance<T>().isNotEmpty()
+
+fun <T : Any> KClass<T>.newInstanceNoArgConstructor(): T = reflection.newInstanceNoArgConstructor(this)
 
 data class Property(val name: String, val call: (Any) -> Any?)

--- a/kotest-common/src/jvmMain/kotlin/io/kotest/mpp/reflection.kt
+++ b/kotest-common/src/jvmMain/kotlin/io/kotest/mpp/reflection.kt
@@ -32,6 +32,10 @@ object JvmReflection : Reflection {
          membersByName[param.name]?.let { callable -> Property(callable.name) { callable.call(it) } }
       }
    }
+
+   override fun <T : Any> newInstanceNoArgConstructor(klass: KClass<T>): T {
+      return klass.java.newInstance()
+   }
 }
 
 actual val reflection: Reflection = JvmReflection

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/specAnnotations.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/specAnnotations.kt
@@ -1,5 +1,8 @@
 package io.kotest.core.annotation
 
+import io.kotest.core.spec.Spec
+import kotlin.reflect.KClass
+
 /**
  * Attach tag to [io.kotest.core.spec.Spec] and a spec excluded by a tag expression won't be instantiated.
  * An unannotated spec will still be instantiated to order to check if root tests are included.
@@ -16,3 +19,17 @@ annotation class Tags(vararg val values: String)
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Ignored
+
+/**
+ * Attach to [io.kotest.core.spec.Spec], and the logic inside [enabledIf] will be executed
+ * to define if a Spec will be instantiated or executed.
+ * 
+ * [SpecEnabaledIf] must contain a no-arg constructor as it will be used via reflection.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EnabledIf(val enabledIf: KClass<out EnabledCondition>)
+
+interface EnabledCondition {
+    fun enabled(specKlass: KClass<out Spec>): Boolean
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io.kotest.engine/extensions/EnabledConditionSpecDiscoveryExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io.kotest.engine/extensions/EnabledConditionSpecDiscoveryExtension.kt
@@ -1,0 +1,22 @@
+package io.kotest.engine.extensions
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.extensions.DiscoveryExtension
+import io.kotest.core.spec.Spec
+import io.kotest.mpp.annotation
+import io.kotest.mpp.newInstanceNoArgConstructor
+import kotlin.reflect.KClass
+
+/**
+ * Filters out any [Spec] annotated with which @[EnabledIf] evaluates to false.
+ */
+object EnabledConditionSpecDiscoveryExtension : DiscoveryExtension {
+   override fun afterScan(classes: List<KClass<out Spec>>): List<KClass<out Spec>> {
+      return classes
+         .filterNot { !it.isEnabled() }
+   }
+
+   private fun <T : Spec> KClass<T>.isEnabled(): Boolean {
+      return annotation<EnabledIf>()?.enabledIf?.newInstanceNoArgConstructor()?.enabled(this) ?: true
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io.kotest.engine/extensions/IgnoredSpecDiscoveryExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io.kotest.engine/extensions/IgnoredSpecDiscoveryExtension.kt
@@ -7,10 +7,11 @@ import io.kotest.mpp.hasAnnotation
 import kotlin.reflect.KClass
 
 /**
- * Filters out any [Spec] annotated with @[Ignored].
+ * Filters out any [Spec] annotated with @[Ignored]
  */
 object IgnoredSpecDiscoveryExtension : DiscoveryExtension {
    override fun afterScan(classes: List<KClass<out Spec>>): List<KClass<out Spec>> {
-      return classes.filterNot { it.hasAnnotation<Ignored>() }
+      return classes
+         .filterNot { it.hasAnnotation<Ignored>() }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/execute.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/execute.kt
@@ -7,6 +7,7 @@ import io.kotest.core.config.configuration
 import io.kotest.core.extensions.DiscoveryExtension
 import io.kotest.core.spec.Spec
 import io.kotest.engine.KotestEngineLauncher
+import io.kotest.engine.extensions.EnabledConditionSpecDiscoveryExtension
 import io.kotest.engine.extensions.IgnoredSpecDiscoveryExtension
 import io.kotest.engine.extensions.TagsExcludedDiscoveryExtension
 import io.kotest.engine.reporter.Reporter
@@ -72,6 +73,7 @@ private fun scan(packageName: String?): List<KClass<out Spec>> {
    val req = DiscoveryRequest(selectors = listOfNotNull(packageSelector))
    val extensions = listOf(
       IgnoredSpecDiscoveryExtension,
+      EnabledConditionSpecDiscoveryExtension,
       TagsExcludedDiscoveryExtension,
    ) + configuration.extensions().filterIsInstance<DiscoveryExtension>()
    val result = Discovery(extensions).discover(req)

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/annotation/SpecEnabledIfTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/annotation/SpecEnabledIfTest.kt
@@ -1,0 +1,23 @@
+package com.sksamuel.kotest.annotation
+
+import io.kotest.core.annotation.EnabledCondition
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import kotlin.reflect.KClass
+
+class MySpecDisabler : EnabledCondition {
+    override fun enabled(specKlass: KClass<out Spec>): Boolean {
+        return false
+    }
+}
+
+@EnabledIf(MySpecDisabler::class)
+class MyCompleteFailureSpec : FunSpec({
+    beforeSpec { throw RuntimeException() }
+    afterSpec { throw RuntimeException() }
+    
+    test("Should never run") {
+        throw RuntimeException()
+    }
+})


### PR DESCRIPTION
This commit adds the @EnabledIf annotation for specs. The way that Kotlin handles annotations isn't very fexible, and thus
using this annotation is verbose and repetitive. We must reference a class, as we can't reference just a single method as we do for
Test EnabledIf.

This currently only works on JVM, as does @Ignored.

Closes #1683