### PR TITLE
update function signature for Arb.bind/5

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bind.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bind.kt
@@ -48,7 +48,11 @@ fun <A, B, C, D, T : Any> Arb.Companion.bind(
 }
 
 fun <A, B, C, D, E, T : Any> Arb.Companion.bind(
-   genA: Arb<A>, genB: Arb<B>, genC: Arb<C>, genD: Arb<D>, genE: Arb<E>,
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
    bindFn: (A, B, C, D, E) -> T
 ): Arb<T> = arb {
    val iterA = genA.generate(it).iterator()


### PR DESCRIPTION
It requires Arbs instead of Gens, must be a mistake since there's no reason to restrict it.