### PR TITLE
#1705 Adds an arbitrary to generate BigDecimal

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
@@ -1,0 +1,14 @@
+package io.kotest.property.arbitrary
+
+import io.kotest.property.Arb
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+fun Arb.Companion.bigDecimal() = Arb.double().map { it.toBigDecimal() }
+
+fun Arb.Companion.bigDecimal(scale: Int, roundingMode: RoundingMode) = bigDecimal().map { it.setScale(scale, roundingMode) }
+
+fun Arb.Companion.bigDecimal(min: BigDecimal, max: BigDecimal): Arb<BigDecimal> {
+   return bigDecimal().filter { it in min..max }
+}
+

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -4,6 +4,7 @@ import io.kotest.property.Arb
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.lang.reflect.WildcardType
+import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -45,7 +46,8 @@ actual inline fun <reified A> targetDefaultForClass(): Arb<A>? {
       A::class == LocalDate::class -> Arb.localDate() as Arb<A>
       A::class == LocalDateTime::class -> Arb.localDateTime() as Arb<A>
       A::class == LocalTime::class -> Arb.localTime() as Arb<A>
-      A::class == Period::class -> Arb.period()as Arb<A>
+      A::class == Period::class -> Arb.period() as Arb<A>
+      A::class == BigDecimal::class -> Arb.bigDecimal() as Arb<A>
       else -> null
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.kotest.property.arbitrary
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.arbitrary.take
+import io.kotest.property.checkAll
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+class BigDecimalTest : FunSpec({
+   test("Arb.bigDecimal(min, max) should generate bigDecimal between given range") {
+      val min = BigDecimal.valueOf(Double.MIN_VALUE)
+      val max = BigDecimal.valueOf(Double.MAX_VALUE)
+
+      Arb.bigDecimal(min, max).take(1_00_000).forAll {
+         (it >= min && it <= max) shouldBe true
+      }
+   }
+
+   test("Arb.bigDecimal(scale, rounding) should generate bigDecimal of given scale") {
+      Arb.bigDecimal(4, RoundingMode.CEILING).take(1_00_000).forAll {
+         assertSoftly {
+            it.scale() shouldBe 4
+         }
+      }
+   }
+})


### PR DESCRIPTION
This pull request adds two method in companion object of `Arbs`.
`.bigDecimal()` => It generates Arb of BigDecimal and internally uses Arbs.double() 
`.bidDecimal(scale, roundingMode)`  => It generates Arb of BigDecimal having given scale and rounding mode.

Added the BigDecimal Arb in targetDefaultForClassName as well.

side note: I did't find any test for `targetDefaultForClassName.kt` , did i missed out something, or we do not have test for that, and is that intensional or a miss.