### PR TITLE
Adds a warning of non thread safety for withConstantNow in readme

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -462,6 +462,9 @@ Or, with a listener for all the tests:
   )
 ```
 
+**ATTENTION**: `withContantNow` and `ConstantNowTestListener` are very sensitive to race conditions. Using them, mocks the static method `now` which is global to the whole JVM instance,
+if you're using it while running test in parallel, the results may be inconsistent.
+
 
 
 


### PR DESCRIPTION
withConstantNow and ConstantNowTestListener are not thread safe, this
has been already documented in java doc, but not readme file.
Chances of people reading java doc is very less compare to Readme file.
Adding it to readme file will increase chances of people knowing about
its non thread safe nature beforehand.