### PR TITLE
Added per project listener for testcontainers

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
@@ -5,6 +5,7 @@ import org.testcontainers.lifecycle.Startable
 
 fun <T : Startable> T.perTest(): StartablePerTestListener<T> = StartablePerTestListener<T>(this)
 fun <T : Startable> T.perSpec(): StartablePerSpecListener<T> = StartablePerSpecListener<T>(this)
+fun <T : Startable> T.perProject(containerName: String): StartablePerProjectListener<T> = StartablePerProjectListener<T>(this, containerName)
 
 fun <T : Startable> TestConfiguration.configurePerTest(startable: T): T {
    listener(StartablePerTestListener(startable))
@@ -13,5 +14,10 @@ fun <T : Startable> TestConfiguration.configurePerTest(startable: T): T {
 
 fun <T : Startable> TestConfiguration.configurePerSpec(startable: T): T {
    listener(StartablePerSpecListener(startable))
+   return startable
+}
+
+fun <T : Startable> TestConfiguration.configurePerProject(startable: T, containerName: String): T {
+   listener(StartablePerProjectListener(startable, containerName))
    return startable
 }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
@@ -1,0 +1,50 @@
+package io.kotest.extensions.testcontainers
+
+import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.testcontainers.lifecycle.Startable
+
+/**
+ * [StartablePerProjectListener] starts the given [startable] before execution of all specs
+ * and stops after execution of all specs.
+ *
+ * [startable] can any of [GenericContainer] [DockerComposeContainer] [LocalStackContainer] etc.
+ *
+ * This listener should be used when you want to use a single container for all tests in project.
+ *
+ * @see
+ * [StartablePerTestListener]
+ * */
+
+class StartablePerProjectListener<T : Startable>(val startable: T, val containerName: String) : TestListener, ProjectListener {
+   override val name = containerName
+   private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)
+
+   override suspend fun beforeProject() {
+      withContext(Dispatchers.IO) {
+         startable.start()
+      }
+   }
+
+   override suspend fun beforeTest(testCase: TestCase) {
+      withContext(Dispatchers.IO) {
+         testLifecycleAwareListener.beforeTest(testCase)
+      }
+   }
+
+   override suspend fun afterProject() {
+      withContext(Dispatchers.IO) {
+         startable.stop()
+      }
+   }
+
+   override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+      withContext(Dispatchers.IO) {
+         testLifecycleAwareListener.afterTest(testCase, result)
+      }
+   }
+}

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmTest/kotlin/io/kotest/extensions/testcontainers/StartableTestLifecycleAwareTest.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmTest/kotlin/io/kotest/extensions/testcontainers/StartableTestLifecycleAwareTest.kt
@@ -16,6 +16,6 @@ class StartableTestLifecycleAwareTest : StringSpec({
 
    "beforeTestCount for second test should be two" {
       startableTestLifecycleAwareForPerTest.testDescriptions shouldHaveSize 2
-      startableTestLifecycleAwareForPerTest.testDescriptions shouldHaveSize 2
+      startableTestLifecycleAwareForPerSpec.testDescriptions shouldHaveSize 2
    }
 })


### PR DESCRIPTION
If we need the singleton container for all tests - we need to use `beforeProject` and `afterProject` for start and stop container.