### PR TITLE
combinatorial edgecases for bind

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bind.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bind.kt
@@ -1,77 +1,46 @@
 package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
+import io.kotest.property.Exhaustive
 import io.kotest.property.Gen
 
-fun <A, B, T : Any> Arb.Companion.bind(genA: Gen<A>, genB: Gen<B>, bindFn: (A, B) -> T): Arb<T> = arb {
-   val iterA = genA.generate(it).iterator()
-   val iterB = genB.generate(it).iterator()
-   generateSequence {
-      val a = iterA.next()
-      val b = iterB.next()
-      bindFn(a.value, b.value)
-   }
-}
+fun <A, B, T> Arb.Companion.bind(genA: Gen<A>, genB: Gen<B>, bindFn: (A, B) -> T): Arb<T> =
+   genA.bind(genB, bindFn)
 
-fun <A, B, C, T : Any> Arb.Companion.bind(
+fun <A, B, C, T> Arb.Companion.bind(
    genA: Gen<A>,
    genB: Gen<B>,
    genC: Gen<C>,
    bindFn: (A, B, C) -> T
-): Arb<T> = arb {
-   val iterA = genA.generate(it).iterator()
-   val iterB = genB.generate(it).iterator()
-   val iterC = genC.generate(it).iterator()
-   generateSequence {
-      val a = iterA.next()
-      val b = iterB.next()
-      val c = iterC.next()
-      bindFn(a.value, b.value, c.value)
-   }
+): Arb<T> = genA.bind(genB).bind(genC).map { (ab, c) ->
+   val (a, b) = ab
+   bindFn(a, b, c)
 }
 
-fun <A, B, C, D, T : Any> Arb.Companion.bind(
+fun <A, B, C, D, T> Arb.Companion.bind(
    genA: Gen<A>, genB: Gen<B>, genC: Gen<C>, genD: Gen<D>,
    bindFn: (A, B, C, D) -> T
-): Arb<T> = arb {
-   val iterA = genA.generate(it).iterator()
-   val iterB = genB.generate(it).iterator()
-   val iterC = genC.generate(it).iterator()
-   val iterD = genD.generate(it).iterator()
-   generateSequence {
-      val a = iterA.next()
-      val b = iterB.next()
-      val c = iterC.next()
-      val d = iterD.next()
-      bindFn(a.value, b.value, c.value, d.value)
-   }
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).map { (abc, d) ->
+   val (ab, c) = abc
+   val (a, b) = ab
+   bindFn(a, b, c, d)
 }
 
-fun <A, B, C, D, E, T : Any> Arb.Companion.bind(
+fun <A, B, C, D, E, T> Arb.Companion.bind(
    genA: Gen<A>,
    genB: Gen<B>,
    genC: Gen<C>,
    genD: Gen<D>,
    genE: Gen<E>,
    bindFn: (A, B, C, D, E) -> T
-): Arb<T> = arb {
-   val iterA = genA.generate(it).iterator()
-   val iterB = genB.generate(it).iterator()
-   val iterC = genC.generate(it).iterator()
-   val iterD = genD.generate(it).iterator()
-   val iterE = genE.generate(it).iterator()
-   generateSequence {
-      val a = iterA.next()
-      val b = iterB.next()
-      val c = iterC.next()
-      val d = iterD.next()
-      val e = iterE.next()
-      bindFn(a.value, b.value, c.value, d.value, e.value)
-   }
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).bind(genE).map { (abcd, e) ->
+   val (abc, d) = abcd
+   val (ab, c) = abc
+   val (a, b) = ab
+   bindFn(a, b, c, d, e)
 }
 
-
-fun <A, B, C, D, E, F, T : Any> Arb.Companion.bind(
+fun <A, B, C, D, E, F, T> Arb.Companion.bind(
    genA: Gen<A>,
    genB: Gen<B>,
    genC: Gen<C>,
@@ -79,26 +48,15 @@ fun <A, B, C, D, E, F, T : Any> Arb.Companion.bind(
    genE: Gen<E>,
    genF: Gen<F>,
    bindFn: (A, B, C, D, E, F) -> T
-): Arb<T> = arb {
-   val iterA = genA.generate(it).iterator()
-   val iterB = genB.generate(it).iterator()
-   val iterC = genC.generate(it).iterator()
-   val iterD = genD.generate(it).iterator()
-   val iterE = genE.generate(it).iterator()
-   val iterF = genF.generate(it).iterator()
-   generateSequence {
-      val a = iterA.next()
-      val b = iterB.next()
-      val c = iterC.next()
-      val d = iterD.next()
-      val e = iterE.next()
-      val f = iterF.next()
-      bindFn(a.value, b.value, c.value, d.value, e.value, f.value)
-   }
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).bind(genE).bind(genF).map { (abcde, f) ->
+   val (abcd, e) = abcde
+   val (abc, d) = abcd
+   val (ab, c) = abc
+   val (a, b) = ab
+   bindFn(a, b, c, d, e, f)
 }
 
-
-fun <A, B, C, D, E, F, G, T : Any> Arb.Companion.bind(
+fun <A, B, C, D, E, F, G, T> Arb.Companion.bind(
    genA: Gen<A>,
    genB: Gen<B>,
    genC: Gen<C>,
@@ -107,22 +65,95 @@ fun <A, B, C, D, E, F, G, T : Any> Arb.Companion.bind(
    genF: Gen<F>,
    genG: Gen<G>,
    bindFn: (A, B, C, D, E, F, G) -> T
-): Arb<T> = arb {
-   val seqA = genA.generate(it).iterator()
-   val seqB = genB.generate(it).iterator()
-   val seqC = genC.generate(it).iterator()
-   val seqD = genD.generate(it).iterator()
-   val seqE = genE.generate(it).iterator()
-   val seqF = genF.generate(it).iterator()
-   val seqG = genG.generate(it).iterator()
-   generateSequence {
-      val a = seqA.next()
-      val b = seqB.next()
-      val c = seqC.next()
-      val d = seqD.next()
-      val e = seqE.next()
-      val f = seqF.next()
-      val g = seqG.next()
-      bindFn(a.value, b.value, c.value, d.value, e.value, f.value, g.value)
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).bind(genE).bind(genF).bind(genG).map { (abcdef, g) ->
+   val (abcde, f) = abcdef
+   val (abcd, e) = abcde
+   val (abc, d) = abcd
+   val (ab, c) = abc
+   val (a, b) = ab
+   bindFn(a, b, c, d, e, f, g)
+}
+
+fun <A, B, C, D, E, F, G, H, T> Arb.Companion.bind(
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   bindFn: (A, B, C, D, E, F, G, H) -> T
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).bind(genE).bind(genF).bind(genG).bind(genH).map { (abcdefg, h) ->
+   val (abcdef, g) = abcdefg
+   val (abcde, f) = abcdef
+   val (abcd, e) = abcde
+   val (abc, d) = abcd
+   val (ab, c) = abc
+   val (a, b) = ab
+   bindFn(a, b, c, d, e, f, g, h)
+}
+
+fun <A, B, C, D, E, F, G, H, I, T> Arb.Companion.bind(
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   genI: Gen<I>,
+   bindFn: (A, B, C, D, E, F, G, H, I) -> T
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).bind(genE).bind(genF).bind(genG).bind(genH).bind(genI)
+   .map { (abcdefgh, i) ->
+      val (abcdefg, h) = abcdefgh
+      val (abcdef, g) = abcdefg
+      val (abcde, f) = abcdef
+      val (abcd, e) = abcde
+      val (abc, d) = abcd
+      val (ab, c) = abc
+      val (a, b) = ab
+      bindFn(a, b, c, d, e, f, g, h, i)
+   }
+
+fun <A, B, C, D, E, F, G, H, I, J, T> Arb.Companion.bind(
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   genI: Gen<I>,
+   genJ: Gen<J>,
+   bindFn: (A, B, C, D, E, F, G, H, I, J) -> T
+): Arb<T> = genA.bind(genB).bind(genC).bind(genD).bind(genE).bind(genF).bind(genG).bind(genH).bind(genI).bind(genJ)
+   .map { (abcdefghi, j) ->
+      val (abcdefgh, i) = abcdefghi
+      val (abcdefg, h) = abcdefgh
+      val (abcdef, g) = abcdefg
+      val (abcde, f) = abcdef
+      val (abcd, e) = abcde
+      val (abc, d) = abcd
+      val (ab, c) = abc
+      val (a, b) = ab
+      bindFn(a, b, c, d, e, f, g, h, i, j)
+   }
+
+fun <A, B, C> Gen<A>.bind(other: Gen<B>, fn: (A, B) -> C): Arb<C> {
+   val arb = when (this) {
+      is Arb -> this
+      is Exhaustive -> this.toArb()
+   }
+
+   return arb.flatMap { a ->
+      when (other) {
+         is Arb -> other.map { fn(a, it) }
+         is Exhaustive -> other.toArb().map { fn(a, it) }
+      }
    }
 }
+
+fun <A, B> Gen<A>.bind(other: Gen<B>): Arb<Pair<A, B>> = this.bind(other, ::Pair)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bind.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bind.kt
@@ -142,7 +142,7 @@ fun <A, B, C, D, E, F, G, H, I, J, T> Arb.Companion.bind(
       bindFn(a, b, c, d, e, f, g, h, i, j)
    }
 
-fun <A, B, C> Gen<A>.bind(other: Gen<B>, fn: (A, B) -> C): Arb<C> {
+private fun <A, B, C> Gen<A>.bind(other: Gen<B>, fn: (A, B) -> C): Arb<C> {
    val arb = when (this) {
       is Arb -> this
       is Exhaustive -> this.toArb()
@@ -156,4 +156,4 @@ fun <A, B, C> Gen<A>.bind(other: Gen<B>, fn: (A, B) -> C): Arb<C> {
    }
 }
 
-fun <A, B> Gen<A>.bind(other: Gen<B>): Arb<Pair<A, B>> = this.bind(other, ::Pair)
+private fun <A, B> Gen<A>.bind(other: Gen<B>): Arb<Pair<A, B>> = this.bind(other, ::Pair)

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BindTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.property.arbitrary
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.comparables.beGreaterThan
 import io.kotest.matchers.comparables.beLessThan
@@ -17,6 +18,7 @@ import io.kotest.property.arbitrary.negativeInts
 import io.kotest.property.arbitrary.positiveInts
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.take
+import io.kotest.property.arbitrary.withEdgecases
 import io.kotest.property.checkAll
 import io.kotest.matchers.doubles.beGreaterThan as gtd
 
@@ -111,6 +113,268 @@ class BindTest : StringSpec({
          .shouldHaveAtLeastSize(100)
    }
 
+
+   "Arb.bind(a,b,c,d,e,f) should generate distinct values" {
+      val arbA = Arb.string()
+      val arbB = Arb.string()
+      val arbC = Arb.string()
+      val arbD = Arb.string()
+      val arbE = Arb.string()
+      val arbF = Arb.string()
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF) { a, b, c, d, e, f -> "$a$b$c$d$e$f" }.take(1000).toSet()
+         .shouldHaveAtLeastSize(100)
+   }
+
+   "Arb.bind(a,b,c,d,e,f,g) should generate distinct values" {
+      val arbA = Arb.string()
+      val arbB = Arb.string()
+      val arbC = Arb.string()
+      val arbD = Arb.string()
+      val arbE = Arb.string()
+      val arbF = Arb.string()
+      val arbG = Arb.string()
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG) { a, b, c, d, e, f, g -> "$a$b$c$d$e$f$g" }.take(1000).toSet()
+         .shouldHaveAtLeastSize(100)
+   }
+
+   "Arb.bind(a,b,c,d,e,f,g,h) should generate distinct values" {
+      val arbA = Arb.string()
+      val arbB = Arb.string()
+      val arbC = Arb.string()
+      val arbD = Arb.string()
+      val arbE = Arb.string()
+      val arbF = Arb.string()
+      val arbG = Arb.string()
+      val arbH = Arb.string()
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG, arbH) { a, b, c, d, e, f, g, h -> "$a$b$c$d$e$f$g$h" }
+         .take(1000).toSet().shouldHaveAtLeastSize(100)
+   }
+
+   "Arb.bind(a,b,c,d,e,f,g,h,i) should generate distinct values" {
+      val arbA = Arb.string()
+      val arbB = Arb.string()
+      val arbC = Arb.string()
+      val arbD = Arb.string()
+      val arbE = Arb.string()
+      val arbF = Arb.string()
+      val arbG = Arb.string()
+      val arbH = Arb.string()
+      val arbI = Arb.string()
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG, arbH, arbI) { a, b, c, d, e, f, g, h, i ->
+         "$a$b$c$d$e$f$g$h$i"
+      }.take(1000).toSet().shouldHaveAtLeastSize(100)
+   }
+
+   "Arb.bind(a,b,c,d,e,f,g,h,i,j) should generate distinct values" {
+      val arbA = Arb.string()
+      val arbB = Arb.string()
+      val arbC = Arb.string()
+      val arbD = Arb.string()
+      val arbE = Arb.string()
+      val arbF = Arb.string()
+      val arbG = Arb.string()
+      val arbH = Arb.string()
+      val arbI = Arb.string()
+      val arbJ = Arb.string()
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG, arbH, arbI, arbJ) { a, b, c, d, e, f, g, h, i, j ->
+         "$a$b$c$d$e$f$g$h$i$j"
+      }.take(1000).toSet().shouldHaveAtLeastSize(100)
+   }
+
+   "Arb.bind(a,b) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      Arb.bind(arbA, arbB) { a, b -> a + b }.edgecases() shouldContainExactlyInAnyOrder listOf(
+         "aa",
+         "ab"
+      )
+   }
+
+   "Arb.bind(a,b,c) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      Arb.bind(arbA, arbB, arbC) { a, b, c -> a + b + c }.edgecases() shouldContainExactlyInAnyOrder listOf(
+         "aaa",
+         "aab",
+         "aba",
+         "abb",
+      )
+   }
+
+   "Arb.bind(a,b,c,d) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      Arb.bind(arbA, arbB, arbC, arbD) { a, b, c, d -> "$a$b$c$d" }.edgecases() shouldContainExactlyInAnyOrder listOf(
+         "aaaa",
+         "aaba",
+         "abaa",
+         "abba",
+         "aaab",
+         "aabb",
+         "abab",
+         "abbb"
+      )
+   }
+
+   "Arb.bind(a,b,c,d,e) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      val arbE = Arb.string().withEdgecases("a", "b")
+      Arb.bind(arbA, arbB, arbC, arbD, arbE) { a, b, c, d, e -> "$a$b$c$d$e" }
+         .edgecases() shouldContainExactlyInAnyOrder listOf(
+         "aaaaa",
+         "aabaa",
+         "abaaa",
+         "abbaa",
+         "aaaba",
+         "aabba",
+         "ababa",
+         "abbba",
+         "aaaab",
+         "aabab",
+         "abaab",
+         "abbab",
+         "aaabb",
+         "aabbb",
+         "ababb",
+         "abbbb"
+      )
+   }
+
+
+   "Arb.bind(a,b,c,d,e,f) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a", "b")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      val arbE = Arb.string().withEdgecases("a", "b")
+      val arbF = Arb.string().withEdgecases("a", "b")
+      val expectedEdgecases =
+         arbA.edgecases()
+            .product(arbB.edgecases(), String::plus)
+            .product(arbC.edgecases(), String::plus)
+            .product(arbD.edgecases(), String::plus)
+            .product(arbE.edgecases(), String::plus)
+            .product(arbF.edgecases(), String::plus)
+
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF) { a, b, c, d, e, f -> "$a$b$c$d$e$f" }
+         .edgecases() shouldContainExactlyInAnyOrder expectedEdgecases
+   }
+
+
+   "Arb.bind(a,b,c,d,e,f,g) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a", "b")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      val arbE = Arb.string().withEdgecases("a", "b")
+      val arbF = Arb.string().withEdgecases("a", "b")
+      val arbG = Arb.string().withEdgecases("a", "b")
+      val expectedEdgecases =
+         arbA.edgecases()
+            .product(arbB.edgecases(), String::plus)
+            .product(arbC.edgecases(), String::plus)
+            .product(arbD.edgecases(), String::plus)
+            .product(arbE.edgecases(), String::plus)
+            .product(arbF.edgecases(), String::plus)
+            .product(arbG.edgecases(), String::plus)
+
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG) { a, b, c, d, e, f, g -> "$a$b$c$d$e$f$g" }
+         .edgecases() shouldContainExactlyInAnyOrder expectedEdgecases
+   }
+
+
+   "Arb.bind(a,b,c,d,e,f,g,h) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a", "b")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      val arbE = Arb.string().withEdgecases("a", "b")
+      val arbF = Arb.string().withEdgecases("a", "b")
+      val arbG = Arb.string().withEdgecases("a", "b")
+      val arbH = Arb.string().withEdgecases("a", "b")
+      val expectedEdgecases =
+         arbA.edgecases()
+            .product(arbB.edgecases(), String::plus)
+            .product(arbC.edgecases(), String::plus)
+            .product(arbD.edgecases(), String::plus)
+            .product(arbE.edgecases(), String::plus)
+            .product(arbF.edgecases(), String::plus)
+            .product(arbG.edgecases(), String::plus)
+            .product(arbH.edgecases(), String::plus)
+
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG, arbH) { a, b, c, d, e, f, g, h -> "$a$b$c$d$e$f$g$h" }
+         .edgecases() shouldContainExactlyInAnyOrder expectedEdgecases
+   }
+
+   "Arb.bind(a,b,c,d,e,f,g,h,i) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a", "b")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      val arbE = Arb.string().withEdgecases("a", "b")
+      val arbF = Arb.string().withEdgecases("a", "b")
+      val arbG = Arb.string().withEdgecases("a", "b")
+      val arbH = Arb.string().withEdgecases("a", "b")
+      val arbI = Arb.string().withEdgecases("a", "b")
+      val expectedEdgecases =
+         arbA.edgecases()
+            .product(arbB.edgecases(), String::plus)
+            .product(arbC.edgecases(), String::plus)
+            .product(arbD.edgecases(), String::plus)
+            .product(arbE.edgecases(), String::plus)
+            .product(arbF.edgecases(), String::plus)
+            .product(arbG.edgecases(), String::plus)
+            .product(arbH.edgecases(), String::plus)
+            .product(arbI.edgecases(), String::plus)
+
+      Arb.bind(
+         arbA,
+         arbB,
+         arbC,
+         arbD,
+         arbE,
+         arbF,
+         arbG,
+         arbH,
+         arbI
+      ) { a, b, c, d, e, f, g, h, i -> "$a$b$c$d$e$f$g$h$i" }
+         .edgecases() shouldContainExactlyInAnyOrder expectedEdgecases
+   }
+
+   "Arb.bind(a,b,c,d,e,f,g,h,i,j) should compute the cartesian product of edgecases" {
+      val arbA = Arb.string().withEdgecases("a", "b")
+      val arbB = Arb.string().withEdgecases("a", "b")
+      val arbC = Arb.string().withEdgecases("a", "b")
+      val arbD = Arb.string().withEdgecases("a", "b")
+      val arbE = Arb.string().withEdgecases("a", "b")
+      val arbF = Arb.string().withEdgecases("a", "b")
+      val arbG = Arb.string().withEdgecases("a", "b")
+      val arbH = Arb.string().withEdgecases("a", "b")
+      val arbI = Arb.string().withEdgecases("a", "b")
+      val arbJ = Arb.string().withEdgecases("a", "b")
+      val expectedEdgecases =
+         arbA.edgecases()
+            .product(arbB.edgecases(), String::plus)
+            .product(arbC.edgecases(), String::plus)
+            .product(arbD.edgecases(), String::plus)
+            .product(arbE.edgecases(), String::plus)
+            .product(arbF.edgecases(), String::plus)
+            .product(arbG.edgecases(), String::plus)
+            .product(arbH.edgecases(), String::plus)
+            .product(arbI.edgecases(), String::plus)
+            .product(arbJ.edgecases(), String::plus)
+
+      Arb.bind(arbA, arbB, arbC, arbD, arbE, arbF, arbG, arbH, arbI, arbJ) { a, b, c, d, e, f, g, h, i, j ->
+         "$a$b$c$d$e$f$g$h$i$j"
+      }.edgecases() shouldContainExactlyInAnyOrder expectedEdgecases
+   }
+
    "Arb.reflectiveBind" {
       val arb = Arb.bind<Wobble>()
       arb.take(10).toList().size shouldBe 10
@@ -118,3 +382,10 @@ class BindTest : StringSpec({
 })
 
 data class Wobble(val a: String, val b: Boolean, val c: Int, val d: Double, val e: Float)
+
+private fun <A, B, C> List<A>.product(listB: List<B>, fn: (A, B) -> C): List<C> =
+   this.flatMap { a ->
+      listB.map { b ->
+         fn(a, b)
+      }
+   }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FlatMapTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FlatMapTest.kt
@@ -2,15 +2,41 @@ package com.sksamuel.kotest.property.arbitrary
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.take
+import io.kotest.property.arbitrary.withEdgecases
 
 class FlatMapTest : FunSpec() {
    init {
-      test("Arb.flatMap") {
+      test("Arb.flatMap should compute the cartesian product of each arb's edgecases") {
+         val arbPair = Arb.int(1..10).withEdgecases(1, 2).flatMap { a ->
+            Arb.double().withEdgecases(1.0, 2.0).flatMap { b ->
+               Arb.string().withEdgecases("foo", "bar").map { c ->
+                  a to b to c
+               }
+            }
+         }
+
+         arbPair.edgecases() shouldContainExactlyInAnyOrder listOf(
+            1 to 1.0 to "foo",
+            1 to 1.0 to "bar",
+            1 to 2.0 to "foo",
+            1 to 2.0 to "bar",
+            2 to 1.0 to "foo",
+            2 to 1.0 to "bar",
+            2 to 2.0 to "foo",
+            2 to 2.0 to "bar",
+         )
+      }
+
+      test("Arb.flatMap should generate dependent Arb") {
          Arb.int(1..10).flatMap { Arb.int(1..it * it) }.take(15, RandomSource.seeded(3242344L))
             .toList() shouldContainExactly
             listOf(


### PR DESCRIPTION
Closes #1700 

Bind will now by default takes the cartesian product of the edgecases of each Arb. If one or more of the arbs have no edgecases, then the resulting Arb has no edgecases.

as `Arb.flatMap` does the cartesian product under the hood we can leverage flatMap to achieve the behaviour that we expect.
