### PR TITLE
Update documentation to include JSON module

### DIFF
--- a/docs/matchers/json.md
+++ b/docs/matchers/json.md
@@ -1,6 +1,6 @@
 Json Matchers
 =============
-
+Matchers for JSON are provided by the `kotest-assertions-json` module.
 
 
 | JSON | For convenience, JSONs are simply strings |


### PR DESCRIPTION
The documentation does not mention that the JSON matches are in the JSON module.