### PR TITLE
Fix first failure in `beforeTest` blocks

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/lifecycle.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/lifecycle.kt
@@ -68,16 +68,15 @@ suspend fun TestCase.invokeAllBeforeTestCallbacks(): Try<TestCase> =
    }.fold({
       Try.Failure(it)
    }, { listeners ->
-      Try {
-         listeners.forEach {
+      listeners.map {
+         Try {
             if (type == TestType.Container) it.beforeContainer(this)
             if (type == TestType.Test) it.beforeEach(this)
             it.beforeAny(this)
             it.beforeTest(this)
+            this
          }
-
-         this
-      }
+      }.find { it.isFailure() } ?: Try { this }
    })
 
 /**

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DiscoveryTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DiscoveryTest.kt
@@ -37,7 +37,7 @@ class DiscoveryTest : FunSpec({
          .build()
       val engine = KotestJunitPlatformTestEngine()
       val descriptor = engine.discover(req, UniqueId.forEngine("testengine"))
-      descriptor.classes.size shouldBe 23
+      descriptor.classes.size shouldBe 24
    }
 
    test("kotest should return classes if request has no included or excluded test engines") {
@@ -48,7 +48,7 @@ class DiscoveryTest : FunSpec({
          .build()
       val engine = KotestJunitPlatformTestEngine()
       val descriptor = engine.discover(req, UniqueId.forEngine("testengine"))
-      descriptor.classes.size shouldBe 23
+      descriptor.classes.size shouldBe 24
    }
 
    test("kotest should support include package name filter") {

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/InvokeAllBeforeTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/InvokeAllBeforeTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.kotest.runner.junit5
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.junit.platform.engine.discovery.DiscoverySelectors
+import org.junit.platform.testkit.engine.EngineTestKit
+
+class InvokeAllBeforeTest : FunSpec ({
+   test("should execute all beforeTest's blocks, if we have some errors in it") {
+      EngineTestKit
+         .engine("kotest")
+         .selectors(DiscoverySelectors.selectClass(ErrorInBeforeTest::class.java))
+         .configurationParameter("allow_private", "true")
+         .execute()
+
+      ErrorInBeforeTest.count shouldBe 2 //because we failed on beforeTest - we didn't execute the 'some test'
+   }
+
+})
+
+private class ErrorInBeforeTest : FreeSpec() {
+   companion object {
+      var count = 0
+   }
+
+   init {
+      beforeTest { throw RuntimeException("First Error") }
+      beforeTest { count += 1 }
+      beforeAny { count += 1 }
+      beforeAny { throw RuntimeException("Second Error") }
+      "some case" { count += 1 }
+   }
+}


### PR DESCRIPTION
The same problem, but with `beforeTest`: https://github.com/kotest/kotest/pull/1724