### PR TITLE
Make line break error message compatible with IntelliJ diff

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -53,6 +53,7 @@ import io.kotest.matchers.string.shouldNotHaveLengthBetween
 import io.kotest.matchers.string.shouldNotHaveLengthIn
 import io.kotest.matchers.string.shouldNotHaveSameLengthAs
 import io.kotest.matchers.string.shouldNotMatch
+import org.opentest4j.AssertionFailedError
 
 class StringMatchersTest : FreeSpec() {
    init {
@@ -83,8 +84,10 @@ class StringMatchersTest : FreeSpec() {
          "should show diff when newline count differs" {
             shouldThrow<AssertionError> {
                "a\nb" shouldBe "a\n\nb"
-            }.message shouldBe """expected: a\n\nb but was: a\nb
-(contents match, but line-breaks differ; output has been escaped to show line-breaks)"""
+            }.message shouldBe """
+               |(contents match, but line-breaks differ; output has been escaped to show line-breaks)
+               |expected:<a\n\nb> but was:<a\nb>
+               """.trimMargin()
          }
       }
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/StringEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/StringEq.kt
@@ -1,13 +1,8 @@
 package io.kotest.assertions.eq
 
-import io.kotest.assertions.Actual
-import io.kotest.assertions.AssertionsConfig
-import io.kotest.assertions.Expected
-import io.kotest.assertions.diffLargeString
-import io.kotest.assertions.failure
+import io.kotest.assertions.*
 import io.kotest.assertions.show.Printed
 import io.kotest.assertions.show.show
-import io.kotest.mpp.sysprop
 
 /**
  * An [Eq] implementation for String's that generates diffs for errors when the string inputs
@@ -26,8 +21,13 @@ object StringEq : Eq<String> {
    override fun equals(actual: String, expected: String): Throwable? {
       return when {
          actual == expected -> null
-         equalIgnoringWhitespace(actual, expected) ->
-            failure("expected: ${escapeLineBreaks(expected)} but was: ${escapeLineBreaks(actual)}\n(contents match, but line-breaks differ; output has been escaped to show line-breaks)")
+         equalIgnoringWhitespace(actual, expected) -> {
+            failure(
+               Expected(Printed(escapeLineBreaks(expected))),
+               Actual(Printed(escapeLineBreaks(actual))),
+               "(contents match, but line-breaks differ; output has been escaped to show line-breaks)\n"
+            )
+         }
          useDiff(expected, actual) -> diff(expected, actual)
          else -> failure(Expected(expected.show()), Actual(actual.show()))
       }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/StringEqTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/StringEqTest.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.shouldBe
 
 class StringEqTest : FunSpec({
    test("string eq should highlight line break diffs") {
-      StringEq.equals("foo\nbar\r", "\r\nfoo\nbar\r\n")?.message shouldBe """expected: \r\nfoo\nbar\r\n but was: foo\nbar\r
-(contents match, but line-breaks differ; output has been escaped to show line-breaks)"""
+      StringEq.equals("foo\nbar\r", "\r\nfoo\nbar\r\n")?.message shouldBe """
+         |(contents match, but line-breaks differ; output has been escaped to show line-breaks)
+         |expected:<\r\nfoo\nbar\r\n> but was:<foo\nbar\r>
+         """.trimMargin()
    }
 })


### PR DESCRIPTION
This commit slightly changes the error message shown when a string differs from its expected value only based on line endings. The message now works with IntelliJ's visual diff, but still shows the line endings escaped in logs.