### PR TITLE
Add new matcher for map containAnyKeys containAnyValues closes #1697

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -37,6 +37,24 @@ fun <V> haveValues(vararg values: V): Matcher<Map<*, V>> = object : Matcher<Map<
   }
 }
 
+fun <K> containAnyKeys(vararg keys: K): Matcher<Map<K, Any?>> = object : Matcher<Map<K, Any?>> {
+   override fun test(value: Map<K, Any?>): MatcherResult {
+      val passed = keys.any { value.containsKey(it) }
+      return MatcherResult(passed,
+         "Map did not contain any of the keys ${keys.joinToString(", ")}",
+         "Map should not contain any of the keys ${keys.joinToString(", ")}")
+   }
+}
+
+fun <V> containAnyValues(vararg values: V): Matcher<Map<*, V>> = object : Matcher<Map<*, V>> {
+   override fun test(value: Map<*, V>): MatcherResult {
+      val passed = values.any { value.containsValue(it) }
+      return MatcherResult(passed,
+         "Map did not contain any of the values ${values.joinToString(", ")}",
+         "Map should not contain any of the values ${values.joinToString(", ")}")
+   }
+}
+
 fun <K, V> contain(key: K, v: V): Matcher<Map<K, V>> = object : Matcher<Map<K, V>> {
   override fun test(value: Map<K, V>) = MatcherResult(value[key] == v,
     "Map should contain mapping $key=$v but was ${buildActualValue(value)}",

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -41,11 +41,14 @@ infix fun <K, V> Map<K, V>.shouldHaveSize(size: Int) = this should haveSize(size
 
 fun <K, V> Map<K, V>.shouldHaveKeys(vararg keys: K) = this should haveKeys(*keys)
 fun <K, V> Map<K, V>.shouldContainKeys(vararg keys: K) = this should haveKeys(*keys)
+fun <K, V> Map<K, V>.shouldContainAnyKeysOf(vararg keys: K) = this should containAnyKeys(*keys)
 fun <K, V> Map<K, V>.shouldNotHaveKeys(vararg keys: K) = this shouldNot haveKeys(*keys)
 fun <K, V> Map<K, V>.shouldNotContainKeys(vararg keys: K) = this shouldNot haveKeys(*keys)
 
+
 fun <K, V> Map<K, V>.shouldHaveValues(vararg values: V) = this should haveValues(*values)
 fun <K, V> Map<K, V>.shouldContainValues(vararg values: V) = this should haveValues(*values)
+fun <K, V> Map<K, V>.shouldContainAnyValuesOf(vararg values: V) = this should containAnyValues(*values)
 fun <K, V> Map<K, V>.shouldNotHaveValues(vararg values: V) = this shouldNot haveValues(*values)
 fun <K, V> Map<K, V>.shouldNotContainValues(vararg values: V) = this shouldNot haveValues(*values)
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -113,6 +113,37 @@ class MapMatchersTest : WordSpec() {
          }
       }
 
+      "containAnyKeys" should {
+       "test that a map contains any of the given keys"{
+          val map = mapOf("a" to 1, "b" to 2, "c" to 3)
+          map should containAnyKeys("a","x","y")
+          map should containAnyKeys("a","b","c")
+          map should containAnyKeys("a","b")
+          map.shouldContainAnyKeysOf("a","c")
+          shouldThrow<AssertionError>{
+             map should containAnyKeys("x","y","z")
+          }
+         shouldThrow<AssertionError>{
+            map.shouldContainAnyKeysOf("x","y")
+         }
+       }
+      }
+
+      "containAnyValues" should {
+         "test that a map contains any of the given values"{
+            val map = mapOf("a" to 1, "b" to 2, "c" to 3)
+            map should containAnyValues(1,23,24)
+            map should containAnyValues(1,2,3)
+            map should containAnyValues(3,2)
+            map.shouldContainAnyValuesOf(2,3)
+            shouldThrow<AssertionError>{
+               map should containAnyValues(9,8,7)
+            }
+            shouldThrow<AssertionError>{
+               map.shouldContainAnyValuesOf(4,5)
+            }
+         }
+      }
       "containAll" should {
          "test that a map contains all given pairs" {
             val map = mapOf(Pair(1, "a"), Pair(2, "b"), Pair(3, "c"))


### PR DESCRIPTION
Add new matchers closes #1697 
`Map.shouldContainAnyKeyOf(a,b,...)` // contains one of more of the keys
`Map.shouldContainAnyValueOf(a, b, ...)` // contains one or more of the values