### PR TITLE
New map assertions shouldNotContainAnyKeysOf() shouldNotContainAnyValuesOf()  #1769

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -44,13 +44,14 @@ fun <K, V> Map<K, V>.shouldContainKeys(vararg keys: K) = this should haveKeys(*k
 fun <K, V> Map<K, V>.shouldContainAnyKeysOf(vararg keys: K) = this should containAnyKeys(*keys)
 fun <K, V> Map<K, V>.shouldNotHaveKeys(vararg keys: K) = this shouldNot haveKeys(*keys)
 fun <K, V> Map<K, V>.shouldNotContainKeys(vararg keys: K) = this shouldNot haveKeys(*keys)
-
+fun <K, V> Map<K, V>.shouldNotContainAnyKeysOf(vararg keys: K) = this shouldNot containAnyKeys(*keys)
 
 fun <K, V> Map<K, V>.shouldHaveValues(vararg values: V) = this should haveValues(*values)
 fun <K, V> Map<K, V>.shouldContainValues(vararg values: V) = this should haveValues(*values)
 fun <K, V> Map<K, V>.shouldContainAnyValuesOf(vararg values: V) = this should containAnyValues(*values)
 fun <K, V> Map<K, V>.shouldNotHaveValues(vararg values: V) = this shouldNot haveValues(*values)
 fun <K, V> Map<K, V>.shouldNotContainValues(vararg values: V) = this shouldNot haveValues(*values)
+fun <K, V> Map<K, V>.shouldNotContainAnyValuesOf(vararg values: V) = this shouldNot containAnyValues(*values)
 
 fun <K, V> Map<K, V>.shouldBeEmpty() = this should beEmpty()
 fun <K, V> Map<K, V>.shouldNotBeEmpty() = this shouldNot beEmpty()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -114,33 +114,39 @@ class MapMatchersTest : WordSpec() {
       }
 
       "containAnyKeys" should {
-       "test that a map contains any of the given keys"{
-          val map = mapOf("a" to 1, "b" to 2, "c" to 3)
-          map should containAnyKeys("a","x","y")
-          map should containAnyKeys("a","b","c")
-          map should containAnyKeys("a","b")
-          map.shouldContainAnyKeysOf("a","c")
-          shouldThrow<AssertionError>{
-             map should containAnyKeys("x","y","z")
-          }
-         shouldThrow<AssertionError>{
-            map.shouldContainAnyKeysOf("x","y")
+         "test that a map contains any of the given keys"{
+            val map = mapOf("a" to 1, "b" to 2, "c" to 3)
+            map should containAnyKeys("a", "x", "y")
+            map should containAnyKeys("a", "b", "c")
+            map should containAnyKeys("a", "b")
+            map.shouldContainAnyKeysOf("a", "c")
+            shouldThrow<AssertionError> {
+               map should containAnyKeys("x", "y", "z")
+            }
+            shouldThrow<AssertionError> {
+               map.shouldContainAnyKeysOf("x", "y")
+            }
+            shouldThrow<AssertionError> {
+               map.shouldNotContainAnyKeysOf("a", "y")
+            }
          }
-       }
       }
 
       "containAnyValues" should {
          "test that a map contains any of the given values"{
             val map = mapOf("a" to 1, "b" to 2, "c" to 3)
-            map should containAnyValues(1,23,24)
-            map should containAnyValues(1,2,3)
-            map should containAnyValues(3,2)
-            map.shouldContainAnyValuesOf(2,3)
-            shouldThrow<AssertionError>{
-               map should containAnyValues(9,8,7)
+            map should containAnyValues(1, 23, 24)
+            map should containAnyValues(1, 2, 3)
+            map should containAnyValues(3, 2)
+            map.shouldContainAnyValuesOf(2, 3)
+            shouldThrow<AssertionError> {
+               map should containAnyValues(9, 8, 7)
             }
-            shouldThrow<AssertionError>{
-               map.shouldContainAnyValuesOf(4,5)
+            shouldThrow<AssertionError> {
+               map.shouldContainAnyValuesOf(4, 5)
+            }
+            shouldThrow<AssertionError> {
+               map.shouldNotContainAnyValuesOf(1,5)
             }
          }
       }


### PR DESCRIPTION
closes #1769 

Map.shouldNotContainAnyKeysOf("a","b") // does not contain any of the keys specified
Map.shouldNotContainAnyValuesOf(1,2,3) // does not contain any of the values specified

