### PR TITLE
Added annotation and sysprop for filtering spec class instantiation

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/Filter.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/Filter.kt
@@ -1,3 +1,6 @@
 package io.kotest.core.filter
 
+
 interface Filter
+
+annotation class SpecClassExecutionFilter(val filter: String)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineSystemProperties.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineSystemProperties.kt
@@ -61,4 +61,6 @@ object KotestEngineSystemProperties {
    *  If set -> filter testCases by this severity level and higher, else running all
    */
    const val severityPrefix = "kotest.framework.test.severity"
+
+   const val specClassExecutionFilter = "kotest.framework.spec.class.filter"
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/active.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/active.kt
@@ -1,6 +1,7 @@
 package io.kotest.core.internal
 
 import io.kotest.core.config.configuration
+import io.kotest.core.filter.SpecClassExecutionFilter
 import io.kotest.core.filter.TestFilter
 import io.kotest.core.filter.TestFilterResult
 import io.kotest.core.test.TestCase
@@ -11,9 +12,12 @@ import io.kotest.core.internal.tags.activeTags
 import io.kotest.core.internal.tags.allTags
 import io.kotest.core.internal.tags.isActive
 import io.kotest.core.internal.tags.parse
+import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCaseSeverityLevel
+import io.kotest.mpp.annotation
 import io.kotest.mpp.log
 import io.kotest.mpp.sysprop
+import kotlin.reflect.KClass
 
 /**
  * Returns true if the given [TestCase] is active.
@@ -76,6 +80,18 @@ fun TestCase.isActive(): Boolean {
       ?: TestCaseSeverityLevel.valueOf("NORMAL").isEnabled()
    if(!severityEnabled) {
       log("${description.testPath()} is disabled by severityLevel")
+      return false
+   }
+
+   return true
+}
+
+fun KClass<out Spec>.isActive(): Boolean {
+
+   val currentFilter = this.annotation<SpecClassExecutionFilter>()
+   val enabledByFilter = ( currentFilter != null && (sysprop(KotestEngineSystemProperties.specClassExecutionFilter) as List<String>)?.let { it.contains(currentFilter?.filter) } )
+   if(!enabledByFilter) {
+      log("${this.qualifiedName} is disabled by specClassFilter")
       return false
    }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngine.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngine.kt
@@ -3,6 +3,7 @@ package io.kotest.engine
 import io.kotest.core.Tags
 import io.kotest.core.config.configuration
 import io.kotest.core.filter.TestFilter
+import io.kotest.core.internal.isActive
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.afterProject
 import io.kotest.core.spec.beforeProject
@@ -133,7 +134,7 @@ class KotestEngine(private val config: KotestEngineConfig) {
          parallelism,
          NamedThreadFactory("kotest-engine-%d")
       )
-      specs.forEach { klass ->
+      specs.filter { it.isActive() }.forEach { klass ->
          executor.submit {
             runBlocking {
                specExecutor.execute(klass)


### PR DESCRIPTION
For filtering we need to add the annotation SpecClassExecutionFilter w value -> and use 'kotest.framework.spec.class.filter' for list. example: [desc,something]