### PR TITLE
Added the annotation and sysprop for filtering spec class instantiation

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/SpecClassFilter.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/SpecClassFilter.kt
@@ -1,0 +1,7 @@
+package io.kotest.core.filter
+
+interface SpecClassFilter: Filter {
+
+}
+
+annotation class SpecClassExecutionFilter(val filter: String)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineSystemProperties.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineSystemProperties.kt
@@ -61,4 +61,6 @@ object KotestEngineSystemProperties {
    *  If set -> filter testCases by this severity level and higher, else running all
    */
    const val severityPrefix = "kotest.framework.test.severity"
+
+   const val specClassExecutionFilter = "kotest.framework.spec.class.filter"
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngine.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngine.kt
@@ -3,6 +3,7 @@ package io.kotest.engine
 import io.kotest.core.Tags
 import io.kotest.core.config.configuration
 import io.kotest.core.filter.TestFilter
+import io.kotest.core.internal.isActive
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.afterProject
 import io.kotest.core.spec.beforeProject
@@ -133,7 +134,7 @@ class KotestEngine(private val config: KotestEngineConfig) {
          parallelism,
          NamedThreadFactory("kotest-engine-%d")
       )
-      specs.forEach { klass ->
+      specs.filter { it.isActive(it.qualifiedName) }.forEach { klass ->
          executor.submit {
             runBlocking {
                specExecutor.execute(klass)


### PR DESCRIPTION
For filtering we need to add the annotation SpecClassExecutionFilter w value -> and use 'kotest.framework.spec.class.filter' with list. example: some,something