### PR TITLE
Improved output of eventually #1775

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-shared/build.gradle.kts
@@ -111,7 +111,7 @@ kotlin {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
    kotlinOptions.jvmTarget = "1.8"
-   kotlinOptions.apiVersion = "1.3"
+   kotlinOptions.apiVersion = "1.4"
 }
 
 tasks.named<Test>("jvmTest") {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/Eventually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/Eventually.kt
@@ -44,15 +44,28 @@ suspend fun <T, E : Throwable> eventually(
             throw e
          if (firstError == null)
             firstError = e
-         lastError = e
+         else
+            lastError = e
       }
       times++
       delay(poll.toLongMilliseconds())
    }
-   val underlyingCause =
-      if (lastError == null) "" else "; first cause was ${firstError?.message}; last cause was ${lastError.message}"
+
+   val sb = StringBuilder()
+   sb.appendLine("Eventually block failed after ${duration}; attempted $times time(s); $poll delay between attempts")
+   sb.appendLine()
+
+   if (firstError != null) {
+      sb.appendLine("The first error was caused by: ${firstError.message}")
+      sb.appendLine(firstError.stackTraceToString())
+   }
+
+   if (lastError != null) {
+      sb.appendLine("The last error was caused by: ${lastError.message}")
+      sb.appendLine(lastError.stackTraceToString())
+   }
+
    throw failure(
-      "Test failed after ${duration.toLongMilliseconds()}ms; attempted $times times$underlyingCause",
-      lastError
+      sb.toString()
    )
 }


### PR DESCRIPTION
Output now looks like:

```
  java.lang.AssertionError: "Eventually block failed after 100ms; attempted 4 time(s); 25.0ms delay between attempts
  
  The first error was caused by: first
  java.lang.AssertionError: first
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1$11$invokeSuspend$$inlined$shouldThrow$lambda$1.invokeSuspend(EventuallyTest.kt:103)
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1$11$invokeSuspend$$inlined$shouldThrow$lambda$1.invoke(EventuallyTest.kt)
  	at io.kotest.assertions.timing.EventuallyKt.eventually-RI63U9M(Eventually.kt:39)
  	at io.kotest.assertions.timing.EventuallyKt.eventually-D5N0EJY(Eventually.kt:13)
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1$11.invokeSuspend(EventuallyTest.kt:100)
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1$11.invoke(EventuallyTest.kt)
  	at io.kotest.core.spec.style.scopes.WordSpecShouldScope$invoke$2.invokeSuspend(WordSpecShouldScope.kt:67)
  	at io.kotest.core.spec.style.scopes.WordSpecShouldScope$invoke$2.invoke(WordSpecShouldScope.kt)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2$1.invokeSuspend(executions.kt:13)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2$1.invoke(executions.kt)
  	at io.kotest.core.internal.ExecutionsKt.wrapTestWithGlobalAssert(executions.kt:39)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2.invokeSuspend(executions.kt:12)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2.invoke(executions.kt)
  	at io.kotest.core.internal.ExecutionsKt$wrapTestWithAssertionModeCheck$2.invokeSuspend(executions.kt:25)
  	at io.kotest.core.internal.ExecutionsKt$wrapTestWithAssertionModeCheck$2.invoke(executions.kt)
  	at io.kotest.core.internal.AssertionsCheckKt.executeWithAssertionsCheck(assertionsCheck.kt:25)
  	at io.kotest.core.internal.ExecutionsKt.wrapTestWithAssertionModeCheck(executions.kt:24)
  	at io.kotest.core.internal.ExecutionsKt.executeWithBehaviours(executions.kt:11)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3$1.invokeSuspend(TestCaseExecutor.kt:222)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3$1.invoke(TestCaseExecutor.kt)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
  	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:194)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3.invokeSuspend(TestCaseExecutor.kt:216)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3.invoke(TestCaseExecutor.kt)
  	at io.kotest.mpp.ReplayKt.replay(replay.kt:18)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1.invokeSuspend(TestCaseExecutor.kt:211)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1.invoke(TestCaseExecutor.kt)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:102)
  	at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:120)
  	at kotlinx.coroutines.TimeoutKt.withTimeout(Timeout.kt:37)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1.invokeSuspend(TestCaseExecutor.kt:210)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1.invoke(TestCaseExecutor.kt)
  	at io.kotest.engine.ExecutorExecutionContext$executeWithTimeoutInterruption$$inlined$suspendCoroutine$lambda$2.invokeSuspend(ExecutorExecutionContext.kt:56)
  	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
  	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
  	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
  	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
  	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
  	at io.kotest.engine.ExecutorExecutionContext.executeWithTimeoutInterruption(ExecutorExecutionContext.kt:55)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2.invokeSuspend(TestCaseExecutor.kt:209)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2.invoke(TestCaseExecutor.kt)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:102)
  	at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:120)
  	at kotlinx.coroutines.TimeoutKt.withTimeout(Timeout.kt:37)
  	at io.kotest.core.internal.TestCaseExecutor.executeAndWait(TestCaseExecutor.kt:207)
  	at io.kotest.core.internal.TestCaseExecutor.invokeTestCase(TestCaseExecutor.kt:176)
  	at io.kotest.core.internal.TestCaseExecutor.executeActiveTest(TestCaseExecutor.kt:145)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1$1.invokeSuspend(TestCaseExecutor.kt:83)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1$1.invoke(TestCaseExecutor.kt)
  	at io.kotest.core.internal.TestCaseExecutor.executeIfActive(TestCaseExecutor.kt:109)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1.invokeSuspend(TestCaseExecutor.kt:83)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1.invoke(TestCaseExecutor.kt)
  	at io.kotest.core.internal.TestCaseExecutor.intercept(TestCaseExecutor.kt:97)
  	at io.kotest.core.internal.TestCaseExecutor.execute(TestCaseExecutor.kt:63)
  	at io.kotest.engine.runners.SingleInstanceSpecRunner.runTest(SingleInstanceSpecRunner.kt:73)
  	at io.kotest.engine.runners.SingleInstanceSpecRunner$Context.registerTestCase(SingleInstanceSpecRunner.kt:51)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3$1$contextp$1.registerTestCase(TestCaseExecutor.kt:219)
  	at io.kotest.core.test.TestContext$DefaultImpls.registerTestCase(TestContext.kt:40)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3$1$contextp$1.registerTestCase(TestCaseExecutor.kt:217)
  	at io.kotest.core.spec.style.scopes.ContainerScope$DefaultImpls.addTest(ContainerScope.kt:77)
  	at io.kotest.core.spec.style.scopes.WordSpecShouldScope.addTest(WordSpecShouldScope.kt:24)
  	at io.kotest.core.spec.style.scopes.ContainerScope$DefaultImpls.addTest(ContainerScope.kt:63)
  	at io.kotest.core.spec.style.scopes.WordSpecShouldScope.addTest(WordSpecShouldScope.kt:24)
  	at io.kotest.core.spec.style.scopes.WordSpecShouldScope.invoke(WordSpecShouldScope.kt:67)
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1.invokeSuspend(EventuallyTest.kt:97)
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1.invoke(EventuallyTest.kt)
  	at io.kotest.core.spec.style.scopes.WordSpecRootScope$should$1.invokeSuspend(WordSpecRootScope.kt:12)
  	at io.kotest.core.spec.style.scopes.WordSpecRootScope$should$1.invoke(WordSpecRootScope.kt)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2$1.invokeSuspend(executions.kt:13)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2$1.invoke(executions.kt)
  	at io.kotest.core.internal.ExecutionsKt.wrapTestWithGlobalAssert(executions.kt:39)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2.invokeSuspend(executions.kt:12)
  	at io.kotest.core.internal.ExecutionsKt$executeWithBehaviours$2.invoke(executions.kt)
  	at io.kotest.core.internal.ExecutionsKt.wrapTestWithAssertionModeCheck(executions.kt:23)
  	at io.kotest.core.internal.ExecutionsKt.executeWithBehaviours(executions.kt:11)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3$1.invokeSuspend(TestCaseExecutor.kt:222)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3$1.invoke(TestCaseExecutor.kt)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(Undispatched.kt:91)
  	at kotlinx.coroutines.CoroutineScopeKt.coroutineScope(CoroutineScope.kt:194)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3.invokeSuspend(TestCaseExecutor.kt:216)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1$3.invoke(TestCaseExecutor.kt)
  	at io.kotest.mpp.ReplayKt.replay(replay.kt:18)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1.invokeSuspend(TestCaseExecutor.kt:211)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1$1.invoke(TestCaseExecutor.kt)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:102)
  	at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:120)
  	at kotlinx.coroutines.TimeoutKt.withTimeout(Timeout.kt:37)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1.invokeSuspend(TestCaseExecutor.kt:210)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2$1.invoke(TestCaseExecutor.kt)
  	at io.kotest.engine.ExecutorExecutionContext$executeWithTimeoutInterruption$$inlined$suspendCoroutine$lambda$2.invokeSuspend(ExecutorExecutionContext.kt:56)
  	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
  	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
  	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
  	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
  	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
  	at io.kotest.engine.ExecutorExecutionContext.executeWithTimeoutInterruption(ExecutorExecutionContext.kt:55)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2.invokeSuspend(TestCaseExecutor.kt:209)
  	at io.kotest.core.internal.TestCaseExecutor$executeAndWait$2.invoke(TestCaseExecutor.kt)
  	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:102)
  	at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:120)
  	at kotlinx.coroutines.TimeoutKt.withTimeout(Timeout.kt:37)
  	at io.kotest.core.internal.TestCaseExecutor.executeAndWait(TestCaseExecutor.kt:207)
  	at io.kotest.core.internal.TestCaseExecutor.invokeTestCase(TestCaseExecutor.kt:176)
  	at io.kotest.core.internal.TestCaseExecutor.executeActiveTest(TestCaseExecutor.kt:145)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1$1.invokeSuspend(TestCaseExecutor.kt:83)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1$1.invoke(TestCaseExecutor.kt)
  	at io.kotest.core.internal.TestCaseExecutor.executeIfActive(TestCaseExecutor.kt:109)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1.invokeSuspend(TestCaseExecutor.kt:83)
  	at io.kotest.core.internal.TestCaseExecutor$intercept$innerExecute$1.invoke(TestCaseExecutor.kt)
  	at io.kotest.core.internal.TestCaseExecutor.intercept(TestCaseExecutor.kt:97)
  	at io.kotest.core.internal.TestCaseExecutor.execute(TestCaseExecutor.kt:63)
  	at io.kotest.engine.runners.SingleInstanceSpecRunner.runTest(SingleInstanceSpecRunner.kt:73)
  	at io.kotest.engine.runners.SingleInstanceSpecRunner$execute$2$invokeSuspend$$inlined$invoke$lambda$1.invokeSuspend(SingleInstanceSpecRunner.kt:83)
  	at io.kotest.engine.runners.SingleInstanceSpecRunner$execute$2$invokeSuspend$$inlined$invoke$lambda$1.invoke(SingleInstanceSpecRunner.kt)
  	at io.kotest.engine.spec.SpecRunner$runParallel$$inlined$map$lambda$1$1.invokeSuspend(SpecRunner.kt:53)
  	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
  	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
  	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
  	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
  	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
  	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
  	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
  	at io.kotest.engine.spec.SpecRunner$runParallel$$inlined$map$lambda$1.run(SpecRunner.kt:52)
  	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  	at java.base/java.lang.Thread.run(Thread.java:834)
  
  The last error was caused by: last
  java.lang.AssertionError: last
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1$11$invokeSuspend$$inlined$shouldThrow$lambda$1.invokeSuspend(EventuallyTest.kt:105)
  	at com.sksamuel.kotest.assertions.timing.EventuallyTest$1$11$invokeSuspend$$inlined$shouldThrow$lambda$1.invoke(EventuallyTest.kt)
  	at io.kotest.assertions.timing.EventuallyKt.eventually-RI63U9M(Eventually.kt:39)
  	at io.kotest.assertions.timing.EventuallyKt$eventually$4.invokeSuspend(Eventually.kt)
  	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
  	at kotlinx.coroutines.DispatchedTaskKt.resume(DispatchedTask.kt:176)
  	at kotlinx.coroutines.DispatchedTaskKt.dispatch(DispatchedTask.kt:111)
  	at kotlinx.coroutines.CancellableContinuationImpl.dispatchResume(CancellableContinuationImpl.kt:308)
  	at kotlinx.coroutines.CancellableContinuationImpl.resumeImpl(CancellableContinuationImpl.kt:318)
  	at kotlinx.coroutines.CancellableContinuationImpl.resumeUndispatched(CancellableContinuationImpl.kt:400)
```