### PR TITLE
Added inline version for intanceOf alias

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/types/TypeMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/types/TypeMatchers.kt
@@ -9,6 +9,8 @@ import kotlin.reflect.KClass
 // alias for beInstanceOf
 fun instanceOf(expected: KClass<*>): Matcher<Any?> = beInstanceOf(expected)
 
+inline fun <reified T : Any> instanceOf(): Matcher<Any?> = instanceOf(T::class)
+
 fun beInstanceOf(expected: KClass<*>): Matcher<Any?> = neverNullMatcher { value ->
   MatcherResult(
      expected.isInstance(value),

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/types/TypeMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/types/TypeMatchersTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.haveAnnotation
+import io.kotest.matchers.types.instanceOf
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.kotest.matchers.types.shouldBeTypeOf
@@ -52,19 +53,27 @@ class TypeMatchersTest : WordSpec() {
           val arrayList: List<Int> = arrayListOf(1, 2, 3)
 
           arrayList should beInstanceOf(ArrayList::class)
+          arrayList should beInstanceOf<ArrayList<*>>()
+          arrayList should instanceOf(ArrayList::class)
+          arrayList should instanceOf<ArrayList<*>>()
           arrayList.shouldBeInstanceOf<ArrayList<*>>()
 
           arrayList should beInstanceOf(List::class)
+          arrayList should beInstanceOf<List<*>>()
+          arrayList should instanceOf(List::class)
+          arrayList should instanceOf<List<*>>()
+          arrayList.shouldBeInstanceOf<List<*>>()
 
-          shouldThrow<AssertionError> {
-             arrayList should beInstanceOf(LinkedList::class)
-          }
+          shouldThrow<AssertionError> { arrayList should beInstanceOf(LinkedList::class) }
+          shouldThrow<AssertionError> { arrayList should beInstanceOf(LinkedList::class) }
+          shouldThrow<AssertionError> { arrayList should beInstanceOf<LinkedList<*>>() }
+          shouldThrow<AssertionError> { arrayList should instanceOf(LinkedList::class) }
+          shouldThrow<AssertionError> { arrayList should instanceOf<LinkedList<*>>() }
+          shouldThrow<AssertionError> { arrayList.shouldBeInstanceOf<LinkedList<*>>() }
 
           arrayList.shouldNotBeInstanceOf<LinkedList<*>>()
 
-          shouldThrow<AssertionError> {
-             arrayList.shouldNotBeInstanceOf<ArrayList<*>>()
-          }
+          shouldThrow<AssertionError> { arrayList.shouldNotBeInstanceOf<ArrayList<*>>() }
        }
 
        "use smart contracts to cast" {


### PR DESCRIPTION
Added a version of `instanceOf` that is inlined with a reified generic
type. This was done to remove the need for `::class` from the caller.
This type of function is already implemented for `beInstanceOf` and
`beOfType`. This commit just also adds it to `instanceOf`.

Also updated the tests to test every matcher, even aliases. I don't
suspect anyone would accidentally change the implementation of the
aliased functions, but you never know.

Fixes #1836