### PR TITLE
fixes "ListShrinker in action"

### DIFF
--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ListShrinkerTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ListShrinkerTest.kt
@@ -102,7 +102,7 @@ class ListShrinkerTest : FunSpec() {
             checkAll(PropTestConfig(seed = 123132), Arb.list(Arb.int(0..100))) { list ->
                list.shouldHaveAtMostSize(3)
             }
-         }.message.shouldContain("Arg 0: [0, 1, 51, 24")
+         }.message.shouldContain("Shrink result (after 90 shrinks) => [0, 1, 51, 24]")
       }
    }
 }


### PR DESCRIPTION
"ListShrinker in action" did not test for shrink-result

Question, do we want the number of shrinks hardcoded?
This will fail on an improvement and is not the thing being tested.
The other option would be to test for "=>" but that means that it can never be used for something else then the final result.

The best option (I think) would be  to create an util-function which would test for the final result, so we could call something like:

```
 test("ListShrinker in action") {
         shouldThrowAny {
            checkAll(PropTestConfig(seed = 123132), Arb.list(Arb.int(0..100))) { list ->
               list.shouldHaveAtMostSize(3)
            }
         }.message should containShrinkResult("[0, 1, 51, 24]")
      }
```

Or "shouldmatch" with an util function.
(I'm not that familiar with regex, though)