### PR TITLE
#1864 Makes scenario create test instead of container test

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureScope.kt
@@ -61,11 +61,11 @@ class FeatureScope(
    }
 
    suspend fun scenario(name: String, test: suspend TestContext.() -> Unit) {
-      addContainerTest(createTestName("Scenario: ", name, false), xdisabled = false, test = test)
+      addTest(createTestName("Scenario: ", name, false), xdisabled = false, test = test)
    }
 
    suspend fun xscenario(name: String, test: suspend TestContext.() -> Unit) {
-      addContainerTest(createTestName("Scenario: ", name, false), xdisabled = true, test = test)
+      addTest(createTestName("Scenario: ", name, false), xdisabled = true, test = test)
    }
 
    fun scenario(name: String): TestWithConfigBuilder {

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/FeatureSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/FeatureSpecEngineKitTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.runner.junit5
 
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.AssertionMode
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.shouldBe
 import org.junit.platform.engine.discovery.DiscoverySelectors.selectClass
@@ -119,6 +120,23 @@ class FeatureSpecEngineKitTest : FunSpec({
             )
          }
    }
+
+   test("verify failure on zero assertion and strict assertion mode enable") {
+      EngineTestKit
+         .engine("kotest")
+         .selectors(selectClass(FeatureSpecWithZeroAssertions::class.java))
+         .configurationParameter("allow_private", "true")
+         .execute()
+         .allEvents().apply {
+            failed().shouldHaveNames("no assertion")
+            succeeded().shouldHaveNames(
+               "one dummy assertion",
+               "assertion mode",
+               "com.sksamuel.kotest.runner.junit5.FeatureSpecWithZeroAssertions",
+               "Kotest"
+            )
+         }
+   }
 })
 
 private class FeatureSpecHappyPathSample : FeatureSpec() {
@@ -192,4 +210,18 @@ private class FeatureSpecSample : FeatureSpec() {
          }
       }
    }
+}
+
+private class FeatureSpecWithZeroAssertions : FeatureSpec() {
+   init {
+
+       feature("assertion mode") {
+          scenario("no assertion") {}
+          scenario("one dummy assertion") {
+             1 shouldBe 1
+          }
+       }
+   }
+
+   override fun assertionMode() = AssertionMode.Error
 }


### PR DESCRIPTION
Since we do not provides any other function inside `scenario` block to register a `test case` neither do we can call `scenario` inside `scenario` block, so it makes sense for `scenario` function to register a `test` instead of `container test`. As a result of that kotest will be able to fail test when assertion mode is `error` and there is no assertion inside `scenario` block.

closes #1864