### PR TITLE
#1860 Fixes shrinkage not getting used in property tests

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -27,7 +27,7 @@ fun <A> arbitrary(edgecases: List<A>, fn: (RandomSource) -> A): Arb<A> = object 
 fun <A> arbitrary(edgecases: List<A>, shrinker: Shrinker<A>, fn: (RandomSource) -> A): Arb<A> = object : Arb<A>() {
    override fun edgecases(): List<A> = edgecases
    override fun sample(rs: RandomSource): Sample<A> = sampleOf(fn(rs), shrinker)
-   override fun values(rs: RandomSource): Sequence<Sample<A>> = generateSequence { Sample(fn(rs)) }
+   override fun values(rs: RandomSource): Sequence<Sample<A>> = generateSequence { sampleOf(fn(rs), shrinker) }
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ShrinkingTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ShrinkingTest.kt
@@ -10,7 +10,7 @@ import io.kotest.property.checkAll
 
 class ShrinkingTest : FunSpec() {
    init {
-      test("!shrinking should show the exception raised by the shrunk values") {
+      test("shrinking should show the exception raised by the shrunk values") {
 
          val stdout = captureStandardOut {
             shouldThrowAny {


### PR DESCRIPTION
closes: #1860 