### PR TITLE
add groovy and kotlin syntax highlighting to docusaurus

### DIFF
--- a/documentation/docs/assertions/android_matchers.md
+++ b/documentation/docs/assertions/android_matchers.md
@@ -9,7 +9,7 @@ slug: android-matchers.html
 This page lists all current Android matchers in Kotest. These are additional to the default [matchers](matchers.md) and are specific to Android.
 
 To use them, it's required to add an extra dependency to your project:
-```
+```kotlin
 implementation("io.kotest:kotest-assertions-android:VERSION")
 ```
 

--- a/documentation/docs/framework/styles.md
+++ b/documentation/docs/framework/styles.md
@@ -429,7 +429,7 @@ Just add the `@Test` annotation to any function defined in the spec class.
 
 You can also add annotations to execute something before tests/specs and after tests/specs, similarly to JUnit's
 
-```
+```kotlin
 @BeforeAll / @BeforeClass
 @BeforeEach / @Before
 @AfterAll / @AfterClass

--- a/documentation/docs/framework/tags.md
+++ b/documentation/docs/framework/tags.md
@@ -156,7 +156,7 @@ class MyTestClass : FunSpec({
 To use System Properties (-Dx=y), your gradle must be configured to propagate them to the test executors, and an extra configuration must be added to your tests:
 
 Groovy:
-```
+```groovy
 test {
     //... Other configurations ...
     systemProperties = System.properties
@@ -164,7 +164,7 @@ test {
 ```
 
 Kotlin Gradle DSL:
-```
+```kotlin
 val test by tasks.getting(Test::class) {
     // ... Other configurations ...
     systemProperties = System.getProperties().map { it.key.toString() to it.value }.toMap()

--- a/documentation/docs/quick_start.mdx
+++ b/documentation/docs/quick_start.mdx
@@ -44,7 +44,7 @@ For Gradle 4.6 and higher this is as simple as adding `useJUnitPlatform()` insid
 
 If you are using Gradle + Groovy then:
 
-```
+```groovy
 test {
    useJUnitPlatform()
 }
@@ -52,7 +52,7 @@ test {
 
 Or if you are using Gradle + Kotlin then:
 
-```
+```kotlin
 tasks.withType<Test> {
    useJUnitPlatform()
 }
@@ -60,7 +60,7 @@ tasks.withType<Test> {
 
 And then the dependency:
 
-```
+```groovy
 testImplementation 'io.kotest:kotest-runner-junit5:$version'
 ```
 
@@ -69,14 +69,14 @@ testImplementation 'io.kotest:kotest-runner-junit5:$version'
 
 Add the following dependency to your commonTest dependencies block:
 
-```
+```groovy
 implementation 'io.kotest:kotest-framework-engine:$version'
 ```
 
 
 Alternatively, add the dependency to the Javascript specific target.
 
-```
+```kotlin
 kotlin {
    targets {
       js {
@@ -124,7 +124,7 @@ And then add the Kotest JUnit5 runner to your dependencies section.
 Kotest on Android uses the [JUnit Platform](https://junit.org/junit5/docs/current/user-guide/#running-tests-build-gradle) gradle plugin.
 This requires configuring the android test options block in your build file and then adding the Kotest junit5 runner dependency.
 
-```
+```kotlin
 android.testOptions {
    unitTests.all {
       useJUnitPlatform()
@@ -132,7 +132,7 @@ android.testOptions {
 }
 ```
 
-```
+```groovy
 dependencies {
    testImplementation 'io.kotest:kotest-runner-junit5:version'
 }
@@ -194,13 +194,13 @@ Add the following dependency to your build.
 
 Add the following dependency to your commonTest dependencies block:
 
-```
+```groovy
 implementation 'io.kotest:kotest-assertions-core:$version'
 ```
 
 Alternatively, add the dependency to a specific target. For example, we could add to the Javascript target only.
 
-```
+```kotlin
 kotlin {
    targets {
       js {
@@ -251,7 +251,7 @@ The property test framework is supported on all targets.
 
 Add the following dependency to your build:
 
-```
+```groovy
 testImplementation 'io.kotest:kotest-property:$version'
 ```
 
@@ -275,14 +275,14 @@ Add the following dependency to your build.
 
 Add the following dependency to your commonTest dependencies block:
 
-```
+```groovy
 implementation 'io.kotest:kotest-property:$version'
 ```
 
 
 Alternatively, add the dependency to a specific target. For example, we could add to the Javascript target only.
 
-```
+```kotlin
 kotlin {
    targets {
       js {

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -81,6 +81,9 @@ module.exports = {
          ],
          copyright: `Copyright © ${new Date().getFullYear()} Kotest, Inc. Built with Docusaurus.`,
       },
+      prism: {
+         additionalLanguages: ['kotlin', 'groovy'],
+      },
    },
    presets: [
       [


### PR DESCRIPTION
also added language tags in a handful of places where they were missing

fixes #1914

Original                  |   Updated
:------------------------:|:------------------------:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/9890900/102305490-ded87680-3f25-11eb-90e4-d051fe5d3697.png">|<img width="521" alt="image" src="https://user-images.githubusercontent.com/9890900/102305517-f152b000-3f25-11eb-87c0-7987461d4052.png">
