### PR TITLE
:bug: improved the json assert error messages so intellij recognizes them as a diff

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -23,8 +23,8 @@ fun matchJson(expected: String?) = object : Matcher<String?> {
 
     return MatcherResult(
       actualJson == expectedJson,
-      "expected: $expectedJson but was: $actualJson",
-      "expected not to match with: $expectedJson but match: $actualJson"
+      "expected:<$expectedJson> but was:<$actualJson>",
+      "expected not to match with:<$expectedJson> but was:<$actualJson>"
     )
   }
 }
@@ -47,8 +47,8 @@ fun matchJsonResource(resource: String) = object : Matcher<String?> {
 
     return MatcherResult(
       actualJson == expectedJson,
-      "expected: $expectedJson but was: $actualJson",
-      "expected not to match with: $expectedJson but match: $actualJson"
+      "expected:<$expectedJson> but was:<$actualJson>",
+      "expected not to match with:<$expectedJson> but was:<$actualJson>"
     )
   }
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonAssertionsTest.kt
@@ -59,11 +59,11 @@ class JsonAssertionsTest : StringSpec({
   "should return correct error message on failure" {
     shouldThrow<AssertionError> {
       json1 shouldMatchJson json3
-    }.message shouldBe """expected: {"location":"chicago","name":"sam"} but was: {"name":"sam","location":"london"}"""
+    }.message shouldBe """expected:<{"location":"chicago","name":"sam"}> but was:<{"name":"sam","location":"london"}>"""
 
     shouldThrow<AssertionError> {
       json1 shouldNotMatchJson json2
-    }.message shouldBe """expected not to match with: {"location":"london","name":"sam"} but match: {"name":"sam","location":"london"}"""
+    }.message shouldBe """expected not to match with:<{"location":"london","name":"sam"}> but was:<{"name":"sam","location":"london"}>"""
   }
 
   "test json path" {
@@ -131,7 +131,7 @@ class JsonAssertionsTest : StringSpec({
 
     shouldThrow<AssertionError> {
       testJson2.shouldMatchJsonResource("/json1.json")
-    }.message shouldBe """expected: {"name":"sam","location":"chicago"} but was: {"name":"sam","location":"london"}"""
+    }.message shouldBe """expected:<{"name":"sam","location":"chicago"}> but was:<{"name":"sam","location":"london"}>"""
 
     shouldThrow<AssertionError> { null shouldMatchJsonResource "/json1.json" }
 


### PR DESCRIPTION
ok, this is a follow up to the issues #1106 and #1112.

The message format is still not correct and is not recognized by intellij as something that should go inside a diff dialog.

I've updated the error messages so it is really recognized. This seems to be the pattern that IntelliJ is expecting:

https://github.com/JetBrains/intellij-community/blob/master/java/java-runtime/src/com/intellij/rt/execution/testFrameworks/AbstractExpectedPatterns.java