### PR TITLE
#1932 Set assertion mode back to hard even in case any exception is thrown from assertion block

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyFailureTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyFailureTest.kt
@@ -1,0 +1,26 @@
+package com.sksamuel.kotest.matchers
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.lang.AssertionError
+
+class AssertSoftlyFailureTest : StringSpec() {
+   init {
+      "a test which will throw exception from assertSoftly block"{
+         shouldThrowAny {
+            assertSoftly {
+               throw Exception()
+            }
+         }
+      }
+
+      "a test which does not uses assertSoftly so here we should get assertion error" {
+         shouldThrow<AssertionError> {
+            1 shouldBe 0
+         }
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/assertSoftly.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/assertSoftly.kt
@@ -21,8 +21,11 @@ inline fun <T> assertSoftly(assertions: () -> T): T {
    // outermost verifyAll block
    if (errorCollector.getCollectionMode() == ErrorCollectionMode.Soft) return assertions()
    errorCollector.setCollectionMode(ErrorCollectionMode.Soft)
-   return assertions().apply {
-      // set the collection mode back to the default
+   return try {
+      assertions()
+   } finally {
+      // In case if any exception is thrown from assertions block setting errorCollectionMode back to hard
+      // so that it won't remain soft for others tests. See https://github.com/kotest/kotest/issues/1932
       errorCollector.setCollectionMode(ErrorCollectionMode.Hard)
       errorCollector.throwCollectedErrors()
    }


### PR DESCRIPTION
Currently in case if any exception is getting thrown from assertion block of `assertSoftly` the errorCollection mode was not changing back to `hard` as result any assertion error in subsequent test were not getting reported. This PR make sure that even in case of exception the assertion mode is get set back to `hard` so that subsequent test does not effected by current test.

Fixes #1932