### PR TITLE
Allow null clues

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
@@ -78,6 +78,12 @@ class ClueTest : FreeSpec({
          state shouldBe expected.toString()
       }
 
+      "clue can be nullable" {
+         val ex = shouldThrow<AssertionError> {
+            withClue(null) { 1 shouldBe 2 }
+         }
+         ex.message shouldBe "null\nexpected:<2> but was:<1>"
+      }
    }
    "asClue()" - {
       "should prepend clue to message with a newline" {
@@ -120,6 +126,13 @@ class ClueTest : FreeSpec({
             //after nesting, everything looks as before
             shouldThrow<AssertionError> {it.status shouldBe 200}.message shouldBe "HttpResponse(status=404, body=not found)\nexpected:<200> but was:<404>"
          }
+      }
+
+      "clue can be nullable" {
+         val ex = shouldThrow<AssertionError> {
+            null.asClue { 1 shouldBe 2 }
+         }
+         ex.message shouldBe "null\nexpected:<2> but was:<1>"
       }
    }
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
@@ -7,7 +7,7 @@ package io.kotest.assertions
  * @param thunk the code with assertions to be executed
  * @return the return value of the supplied [thunk]
  */
-inline fun <R> withClue(clue: Any, thunk: () -> R): R {
+inline fun <R> withClue(clue: Any?, thunk: () -> R): R {
    return clue.asClue { thunk() }
 }
 
@@ -18,7 +18,7 @@ inline fun <R> withClue(clue: Any, thunk: () -> R): R {
  * @param thunk the code with assertions to be executed
  * @return the return value of the supplied [thunk]
  */
-inline fun <R> withClue(clue: Lazy<Any>, thunk: () -> R): R {
+inline fun <R> withClue(clue: Lazy<Any?>, thunk: () -> R): R {
    try {
       errorCollector.pushClue { clue.value.toString() }
       return thunk()
@@ -34,9 +34,9 @@ inline fun <R> withClue(clue: Lazy<Any>, thunk: () -> R): R {
  * @param block the code with assertions to be executed
  * @return the return value of the supplied [block]
  */
-inline fun <T : Any, R> T.asClue(block: (T) -> R): R = withClue(lazy { this.toString() }) { block(this) }
+inline fun <T : Any?, R> T.asClue(block: (T) -> R): R = withClue(lazy { this.toString() }) { block(this) }
 
-inline fun <T : Any> Iterable<T>.forEachAsClue(action: (T) -> Unit) = forEach { element ->
+inline fun <T : Any?> Iterable<T>.forEachAsClue(action: (T) -> Unit) = forEach { element ->
    element.asClue {
       action(it)
    }


### PR DESCRIPTION
Fixes #1939.

Helpful for e.g. `foo.asClue { foo.shouldBeNull() }`