### PR TITLE
[doc] Fixed Get Started button color for dark theme

### DIFF
--- a/documentation/src/pages/styles.module.css
+++ b/documentation/src/pages/styles.module.css
@@ -40,6 +40,7 @@
 .heroSlogan {
    font-size: 60px;
    line-height: normal;
+   color: var(--ifm-color-white) !important;
 }
 
 
@@ -49,6 +50,7 @@
 
 .gettingStartedButton {
    background: #ffffff;
+   color: var(--ifm-color-gray-900) !important;
 }
 
 .gettingStartedButton:hover {


### PR DESCRIPTION
The Get started button text and the header text are changing their colour in the dark theme, but their background isn't, meaning their readability goes down (in the case of the button, the text gets completely unreadable).

Fixed that by assigning static colours to those classes.

|           | Before | After |
|--------|--------|-------|
| Light | ![localhost_3000_](https://user-images.githubusercontent.com/4479527/103094204-a8b98780-45f4-11eb-8742-4f6d1b67976c.png) | ![localhost_3000_ (2)](https://user-images.githubusercontent.com/4479527/103094260-d43c7200-45f4-11eb-87fc-44752b3a4a85.png) |
| Dark | ![localhost_3000_ (1)](https://user-images.githubusercontent.com/4479527/103094221-b66f0d00-45f4-11eb-936a-239e0f355c2a.png) | ![localhost_3000_ (3)](https://user-images.githubusercontent.com/4479527/103094274-ddc5da00-45f4-11eb-9d77-87802c6846dd.png) |