### PR TITLE
Add functions for data tests with custom names

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/datatest/datatest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/datatest/datatest.kt
@@ -3,6 +3,7 @@ package io.kotest.core.datatest
 import io.kotest.assertions.failure
 import io.kotest.core.spec.style.scopes.ContainerScope
 import io.kotest.core.test.createTestName
+import kotlin.jvm.*
 
 suspend fun <T> ContainerScope.forNone(vararg data: Pair<String, T>, test: suspend (T) -> Unit) {
    data.forEach { (name, t) ->
@@ -42,6 +43,19 @@ suspend fun <T : Any> ContainerScope.forAll(vararg ts: T, test: suspend (T) -> U
    val idents = Identifiers()
    ts.forEach { t ->
       val name = idents.stableIdentifier(t)
+      addTest(createTestName(name), false) { test(t) }
+   }
+}
+
+@JvmName("forAllWithNames")
+suspend fun <T : Any> ContainerScope.forAll(data: List<Pair<String, T>>, test: suspend (T) -> Unit) {
+   data.forEach { (name, t) ->
+      addTest(createTestName(name), false) { test(t) }
+   }
+}
+
+suspend fun <T : Any> ContainerScope.forAll(vararg data: Pair<String, T>, test: suspend (T) -> Unit) {
+   data.forEach { (name, t) ->
       addTest(createTestName(name), false) { test(t) }
    }
 }


### PR DESCRIPTION
The [documentation](https://kotest.io/docs/framework/data-driven-testing.html#custom-test-names) shows the ability to assign custom names to data tests.
In `4.3.2` this is only possible with the `forNone` function so I added the `forAll` functions which accept custom names.