### PR TITLE
Require one extra iteration to include one sample when kotest.proptest.arb.iterations.include.sample is enabled

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/Gen.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/Gen.kt
@@ -37,7 +37,7 @@ sealed class Gen<out A> {
     * Requesting a property test with fewer than this will result in an exception.
     */
    fun minIterations(): Int = when (this) {
-      is Arb -> if (PropertyTesting.requireAtLeastOneSampleForArbs) this.edgecases().size + 1 else this.edgecases().size
+      is Arb -> if (PropertyTesting.includeAtLeastOneSampleForArbs) this.edgecases().size + 1 else this.edgecases().size
       is Exhaustive -> this.values.size
    }
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/Gen.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/Gen.kt
@@ -37,7 +37,7 @@ sealed class Gen<out A> {
     * Requesting a property test with fewer than this will result in an exception.
     */
    fun minIterations(): Int = when (this) {
-      is Arb -> this.edgecases().size
+      is Arb -> if (PropertyTesting.requireAtLeastOneSampleForArbs) this.edgecases().size + 1 else this.edgecases().size
       is Exhaustive -> this.values.size
    }
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -10,6 +10,7 @@ object PropertyTesting {
    var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
    var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
    var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", "1000").toInt()
+   var requireAtLeastOneSampleForArbs: Boolean = sysprop("kotest.proptest.arb.require-at-least-one-sample", "false") == "true"
 }
 
 /**
@@ -34,12 +35,7 @@ fun computeDefaultIteration(vararg gens: Gen<*>): Int =
 fun calculateMinimumIterations(vararg gens: Gen<*>): Int {
    return when {
       gens.all { it is Exhaustive } -> gens.fold(1) { acc, gen -> gen.minIterations() * acc }
-      else -> gens.fold(0) { acc, gen ->
-         when (gen) {
-            is Exhaustive -> max(acc, gen.values.size)
-            is Arb -> max(acc, gen.edgecases().size)
-         }
-      }
+      else -> gens.fold(0) { acc, gen -> max(acc, gen.minIterations()) }
    }
 }
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -10,7 +10,7 @@ object PropertyTesting {
    var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
    var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
    var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", "1000").toInt()
-   var requireAtLeastOneSampleForArbs: Boolean = sysprop("kotest.proptest.arb.require-at-least-one-sample", "false") == "true"
+   var includeAtLeastOneSampleForArbs: Boolean = sysprop("kotest.proptest.arb.iterations.include.sample", "false") == "true"
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.Exhaustive
 import io.kotest.property.PropTestConfig
+import io.kotest.property.PropertyTesting
 import io.kotest.property.ShrinkingMode
+import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.exhaustive.constant
@@ -38,7 +40,7 @@ class ForAll2Test : FunSpec({
       context.failures() shouldBe 0
    }
 
-   test("should throw error if iteratons is less than min") {
+   test("should throw error if iterations is less than min") {
       shouldThrowAny {
          forAll(
             10,
@@ -46,6 +48,23 @@ class ForAll2Test : FunSpec({
             Exhaustive.longs(200L..300L)
          ) { a, b -> a + b == b + a }
       }.message shouldBe "Require at least 101 iterations to cover requirements"
+   }
+
+   context("when kotest.proptest.arb.require-at-least-one-sample is enabled") {
+      val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.requireAtLeastOneSampleForArbs
+      beforeTest { PropertyTesting.requireAtLeastOneSampleForArbs = true }
+      afterTest { PropertyTesting.requireAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs }
+
+      test("should throw error if iterations is less than min") {
+         val edgecases = { n: Int -> List(n) { it } }
+         shouldThrowAny {
+            forAll(
+               5,
+               arbitrary(edgecases(3)) { 1 },
+               arbitrary(edgecases(5)) { 1 }
+            ) { a, b -> a + b == b + a }
+         }.message shouldBe "Require at least 6 iterations to cover requirements"
+      }
    }
 
    test("forAll with mixed arbitrary and exhaustive") {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
@@ -50,10 +50,10 @@ class ForAll2Test : FunSpec({
       }.message shouldBe "Require at least 101 iterations to cover requirements"
    }
 
-   context("when kotest.proptest.arb.require-at-least-one-sample is enabled") {
-      val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.requireAtLeastOneSampleForArbs
-      beforeTest { PropertyTesting.requireAtLeastOneSampleForArbs = true }
-      afterTest { PropertyTesting.requireAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs }
+   context("when kotest.proptest.arb.iterations.include.sample is enabled") {
+      val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.includeAtLeastOneSampleForArbs
+      beforeTest { PropertyTesting.includeAtLeastOneSampleForArbs = true }
+      afterTest { PropertyTesting.includeAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs }
 
       test("should throw error if iterations is less than min") {
          val edgecases = { n: Int -> List(n) { it } }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForNoneTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForNoneTest.kt
@@ -49,10 +49,10 @@ class ForNoneTest : FunSpec({
       }.message shouldBe "Require at least 101 iterations to cover requirements"
    }
 
-   context("when kotest.proptest.arb.require-at-least-one-sample is enabled") {
-      val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.requireAtLeastOneSampleForArbs
-      beforeTest { PropertyTesting.requireAtLeastOneSampleForArbs = true }
-      afterTest { PropertyTesting.requireAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs }
+   context("when kotest.proptest.arb.iterations.include.sample is enabled") {
+      val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.includeAtLeastOneSampleForArbs
+      beforeTest { PropertyTesting.includeAtLeastOneSampleForArbs = true }
+      afterTest { PropertyTesting.includeAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs }
 
       test("should throw error if iterations is less than min") {
          val edgecases = { n: Int -> List(n) { it } }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/computeDefaultIerationsTest.kts
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/computeDefaultIerationsTest.kts
@@ -14,10 +14,24 @@ test("computeDefaultIteration should use default if larger than an arbs edge cas
    computeDefaultIteration(Arb.string()) shouldBe PropertyTesting.defaultIterationCount
 }
 
-test("computeDefaultIteration should use arbs edge cases if larger than default") {
+test("computeDefaultIteration should use arbs edge cases if larger than default " +
+   "iff kotest.proptest.arb.require-at-least-one-sample is disabled") {
    val edgecases = List(234234) { it }
    val arb = arbitrary(edgecases) { 1 }
    computeDefaultIteration(arb) shouldBe 234234
+}
+
+test("computeDefaultIteration should use arbs edge cases if larger than default " +
+   "iff kotest.proptest.arb.require-at-least-one-sample is enabled") {
+   val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.requireAtLeastOneSampleForArbs
+   PropertyTesting.requireAtLeastOneSampleForArbs = true
+   val edgecases = List(234234) { it }
+   val arb = arbitrary(edgecases) { 1 }
+   try {
+      computeDefaultIteration(arb) shouldBe 234234 + 1
+   } finally {
+      PropertyTesting.requireAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs
+   }
 }
 
 test("computeDefaultIteration should use exhaustive values") {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/computeDefaultIerationsTest.kts
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/computeDefaultIerationsTest.kts
@@ -15,22 +15,22 @@ test("computeDefaultIteration should use default if larger than an arbs edge cas
 }
 
 test("computeDefaultIteration should use arbs edge cases if larger than default " +
-   "iff kotest.proptest.arb.require-at-least-one-sample is disabled") {
+   "iff kotest.proptest.arb.iterations.include.sample is disabled") {
    val edgecases = List(234234) { it }
    val arb = arbitrary(edgecases) { 1 }
    computeDefaultIteration(arb) shouldBe 234234
 }
 
 test("computeDefaultIteration should use arbs edge cases if larger than default " +
-   "iff kotest.proptest.arb.require-at-least-one-sample is enabled") {
-   val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.requireAtLeastOneSampleForArbs
-   PropertyTesting.requireAtLeastOneSampleForArbs = true
+   "iff kotest.proptest.arb.iterations.include.sample is enabled") {
+   val defaultRequireAtLeastOneSampleForArbs = PropertyTesting.includeAtLeastOneSampleForArbs
+   PropertyTesting.includeAtLeastOneSampleForArbs = true
    val edgecases = List(234234) { it }
    val arb = arbitrary(edgecases) { 1 }
    try {
       computeDefaultIteration(arb) shouldBe 234234 + 1
    } finally {
-      PropertyTesting.requireAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs
+      PropertyTesting.includeAtLeastOneSampleForArbs = defaultRequireAtLeastOneSampleForArbs
    }
 }
 


### PR DESCRIPTION
In order to prevent breaking change I added new configuration property kotest.proptest.arb.require-at-least-one-sample. When this property is enabled `Gen.minIterations` includes at least one sample for Arb (edgecases.size + 1).

Fixes #1947 