### PR TITLE
not null matcher should show the value that was meant to be null, closes #1942

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
@@ -101,6 +101,6 @@ fun beNull() = object : Matcher<Any?> {
   override fun test(value: Any?): MatcherResult {
     val passed = value == null
 
-    return MatcherResult(passed, "Expected value to be null, but was not-null.", "Expected value to not be null, but was null.")
+    return MatcherResult(passed, "Expected value to be null, but was $value.", "Expected value to be $value, but was null.")
   }
 }


### PR DESCRIPTION
https://github.com/kotest/kotest/blob/757529896b9d117240b281e69926953022d6ca9d/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt#L104

closes #1942