### PR TITLE
Added SpringTestExtension to expose test context managers #1956

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/build.gradle.kts
+++ b/kotest-extensions/kotest-extensions-spring/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
             implementation(kotlin("reflect"))
             implementation(Libs.Spring.context)
             implementation(Libs.Spring.test)
+            implementation(Libs.Coroutines.coreJvm)
             implementation(Libs.Bytebuddy.bytebuddy)
          }
       }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
@@ -1,0 +1,114 @@
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package io.kotest.extensions.spring
+
+import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.internal.KotestEngineSystemProperties
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.core.test.TestType
+import io.kotest.mpp.sysprop
+import io.kotest.spring.SpringTestLifecycleMode
+import kotlinx.coroutines.withContext
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.modifier.Visibility
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.implementation.FixedValue
+import org.springframework.test.context.TestContextManager
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+class SpringTestContextCoroutineContextElement(val value: TestContextManager) : AbstractCoroutineContextElement(Key) {
+   companion object Key : CoroutineContext.Key<SpringTestContextCoroutineContextElement>
+}
+
+/**
+ * Returns the [TestContextManager] from a test or spec.
+ */
+suspend fun testContextManager(): TestContextManager =
+   coroutineContext[SpringTestContextCoroutineContextElement]?.value
+      ?: error("No TestContextManager defined in this coroutine context")
+
+val SpringExtension = SpringTestExtension(SpringTestLifecycleMode.Test)
+
+class SpringTestExtension(private val mode: SpringTestLifecycleMode) : TestCaseExtension, SpecExtension {
+
+   var ignoreSpringListenerOnFinalClassWarning: Boolean = false
+
+   override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+      val context = TestContextManager(spec::class.java)
+      withContext(SpringTestContextCoroutineContextElement(context)) {
+         testContextManager().beforeTestClass()
+         testContextManager().prepareTestInstance(spec)
+         execute(spec)
+         testContextManager().afterTestClass()
+      }
+   }
+
+   override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
+      if (testCase.isApplicable()) {
+         testContextManager().beforeTestMethod(testCase.spec, method(testCase))
+         testContextManager().beforeTestExecution(testCase.spec, method(testCase))
+      }
+      val result = execute(testCase)
+      if (testCase.isApplicable()) {
+         testContextManager().afterTestMethod(testCase.spec, method(testCase), null as Throwable?)
+         testContextManager().afterTestExecution(testCase.spec, method(testCase), null as Throwable?)
+      }
+      return result
+   }
+
+   /**
+    * Returns true if this test case should have the spring lifecycle methods applied
+    */
+   private fun TestCase.isApplicable() = (mode == SpringTestLifecycleMode.Root && description.isRootTest()) ||
+      (mode == SpringTestLifecycleMode.Test && type == TestType.Test)
+
+   /**
+    * Generates a fake [Method] for the given [TestCase].
+    *
+    * Check https://github.com/kotest/kotest/issues/950#issuecomment-524127221
+    * for a in-depth explanation. Too much to write here
+    */
+   private fun method(testCase: TestCase): Method {
+      val klass = testCase.spec::class.java
+
+      return if (Modifier.isFinal(klass.modifiers)) {
+         if (!ignoreFinalWarning) {
+            println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
+         }
+         // the method here must exist since we can't add our own
+         this@SpringTestExtension::class.java.methods.firstOrNull { it.name == "intercept" }
+            ?: error("Could not find method 'intercept' to attach spring lifecycle methods to")
+      } else {
+         val methodName = methodName(testCase)
+         val fakeSpec = ByteBuddy()
+            .subclass(klass)
+            .defineMethod(methodName, String::class.java, Visibility.PUBLIC)
+            .intercept(FixedValue.value("Foo"))
+            .make()
+            .load(this::class.java.classLoader, ClassLoadingStrategy.Default.CHILD_FIRST)
+            .loaded
+         fakeSpec.getMethod(methodName)
+      }
+   }
+
+   /**
+    * Generates a fake method name for the given [TestCase].
+    * The method name is taken from the test case path.
+    */
+   internal fun methodName(testCase: TestCase): String {
+      return testCase.description.testPath().value.replace("[^a-zA-Z_0-9]".toRegex(), "_").let {
+         if (it.first().isLetter()) it else "_$it"
+      }
+   }
+
+   private val ignoreFinalWarning =
+      ignoreSpringListenerOnFinalClassWarning ||
+         !sysprop(KotestEngineSystemProperties.springIgnoreWarning, "false").toBoolean()
+}

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/spring/SpringListener.kt
@@ -132,8 +132,8 @@ object SpringAutowireConstructorExtension : ConstructorExtension {
          null
       } else {
          val manager = TestContextManager(clazz.java)
-         val ac = manager.testContext.applicationContext
-         ac.autowireCapableBeanFactory.autowire(clazz.java, AUTOWIRE_CONSTRUCTOR, true) as Spec
+         val context = manager.testContext.applicationContext
+         context.autowireCapableBeanFactory.autowire(clazz.java, AUTOWIRE_CONSTRUCTOR, true) as Spec
       }
    }
 }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTest.kt
@@ -1,0 +1,55 @@
+package io.kotest.extensions.spring
+
+import io.kotest.core.sourceRef
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.core.spec.toDescription
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestType
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.spring.Components
+import io.kotest.spring.UserService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [(Components::class)])
+class SpringExtensionTest : WordSpec() {
+
+   override fun extensions() = listOf(SpringExtension)
+
+   @Autowired
+   private var service: UserService? = null
+
+   init {
+      "SpringExtension" should {
+         "have autowired the service" {
+            service?.repository?.findUser()?.name shouldBe "system_user"
+         }
+         "make test context available in the coroutine context"{
+            testContextManager().shouldNotBeNull()
+         }
+         "generate applicable method name for a root test" {
+            SpringExtension.methodName(
+               TestCase(
+                  SpringExtensionTest::class.toDescription().appendTest("0foo__!!55@#woo"),
+                  this@SpringExtensionTest,
+                  {},
+                  sourceRef(),
+                  TestType.Test
+               )
+            ) shouldBe "_0foo____55__woo"
+         }
+         "generate applicable method name for a nested test" {
+            SpringExtension.methodName(
+               TestCase(
+                  SpringExtensionTest::class.toDescription().appendTest("0foo__!!55@#woo").appendTest("wibble%%wobble"),
+                  this@SpringExtensionTest,
+                  {},
+                  sourceRef(),
+                  TestType.Test
+               )
+            ) shouldBe "_0foo____55__woo____wibble__wobble"
+         }
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
@@ -1,28 +1,41 @@
 package io.kotest.core.extensions
 
-import io.kotest.core.test.TestCase
 import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
 import kotlin.reflect.KClass
 
 /**
- * Reusable spec extension that allows intercepting specs before they are executed.
- * The callback is invoked for each [Spec] that has been submitted for execution.
+ * Extension point that allows intercepting execution of specs.
  */
 interface SpecExtension : Extension {
 
    /**
-    * Intercepts execution of a [Spec].
+    * Intercepts a [Spec] before it has been instantiated.
     *
     * Implementations must invoke the process callback if they
     * wish this spec to be executed. If they want to skip
     * the tests in this spec they can elect not to invoke
     * the callback.
     *
-    * Once the process function returns, the execution of this
+    * Once the [process] function returns, the execution of this
     * [Spec] and all it's nested [TestCase]s are guaranteed
     * to have been completed.
     *
     * @param process callback function required to continue spec processing
     */
-   suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit)
+   suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
+      process()
+   }
+
+   /**
+    * Implementations must invoke the process callback if they
+    * wish this spec to be executed. If they want to skip
+    * the tests in this spec they can elect not to invoke
+    * the callback.
+    *
+    * Once the [execute] function returns, the execution of this
+    * [Spec] and all it's nested [TestCase]s are guaranteed
+    * to have been completed.
+    */
+   suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {}
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
@@ -37,5 +37,7 @@ interface SpecExtension : Extension {
     * [Spec] and all it's nested [TestCase]s are guaranteed
     * to have been completed.
     */
-   suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {}
+   suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+      execute(spec)
+   }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/SpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/SpecExecutor.kt
@@ -94,9 +94,10 @@ class SpecExecutor(private val listener: TestEngineListener) {
       when {
          remaining.isEmpty() -> run()
          else -> {
-            val rest = remaining.drop(1)
             remaining.first().intercept(spec::class) {
-               interceptSpec(spec, rest, run)
+               remaining.first().intercept(spec) {
+                  interceptSpec(spec, remaining.drop(1), run)
+               }
             }
          }
       }

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/AfterProjectListenerExceptionHandlingTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/AfterProjectListenerExceptionHandlingTest.kt
@@ -20,7 +20,7 @@ class AfterProjectListenerExceptionHandlingTest : FunSpec({
    test("an AfterProjectListenerException should add marker spec") {
       every { configuration.listeners() } returns listOf(
          object : ProjectListener {
-            override suspend fun afterProject() {WordSpecEngineKitTest
+            override suspend fun afterProject() {
                if (System.getenv("foo") == "true") error("too")
             }
          }

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/AfterProjectListenerExceptionHandlingTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/AfterProjectListenerExceptionHandlingTest.kt
@@ -2,7 +2,7 @@ package com.sksamuel.kotest.runner.junit5
 
 import io.kotest.core.config.configuration
 import io.kotest.core.listeners.ProjectListener
-import io.kotest.core.spec.DoNotParallelize
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.system.withEnvironment
 import io.mockk.every
@@ -11,7 +11,7 @@ import io.mockk.unmockkObject
 import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.testkit.engine.EngineTestKit
 
-@DoNotParallelize
+@Isolate
 class AfterProjectListenerExceptionHandlingTest : FunSpec({
 
    beforeTest { mockkObject(configuration) }
@@ -20,7 +20,7 @@ class AfterProjectListenerExceptionHandlingTest : FunSpec({
    test("an AfterProjectListenerException should add marker spec") {
       every { configuration.listeners() } returns listOf(
          object : ProjectListener {
-            override suspend fun afterProject() {
+            override suspend fun afterProject() {WordSpecEngineKitTest
                if (System.getenv("foo") == "true") error("too")
             }
          }

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/BeforeAfterProjectListenerExceptionHandlingTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/BeforeAfterProjectListenerExceptionHandlingTest.kt
@@ -2,7 +2,7 @@ package com.sksamuel.kotest.runner.junit5
 
 import io.kotest.core.config.configuration
 import io.kotest.core.listeners.ProjectListener
-import io.kotest.core.spec.DoNotParallelize
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.system.withEnvironment
 import io.mockk.every
@@ -11,7 +11,7 @@ import io.mockk.unmockkObject
 import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.testkit.engine.EngineTestKit
 
-@DoNotParallelize
+@Isolate
 class BeforeAfterProjectListenerExceptionHandlingTest : FunSpec({
 
    test("BeforeProjectListenerException and AfterProjectListenerException should add marker spec") {

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/BeforeProjectListenerExceptionHandlingTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/BeforeProjectListenerExceptionHandlingTest.kt
@@ -2,7 +2,7 @@ package com.sksamuel.kotest.runner.junit5
 
 import io.kotest.core.config.configuration
 import io.kotest.core.listeners.ProjectListener
-import io.kotest.core.spec.DoNotParallelize
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.system.withEnvironment
 import io.mockk.every
@@ -11,7 +11,7 @@ import io.mockk.unmockkObject
 import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.testkit.engine.EngineTestKit
 
-@DoNotParallelize
+@Isolate
 class BeforeProjectListenerExceptionHandlingTest : FunSpec({
 
    beforeTest { mockkObject(configuration) }

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
@@ -74,7 +74,7 @@ class WordSpecEngineKitTest : FunSpec({
                "a when container with a failing test when",
                "pass a test",
                "with a should container should",
-               "a when container when",BeforeAfterProjectListenerExceptionHandlingTest
+               "a when container when",
                "a failing container should",
                "com.sksamuel.kotest.runner.junit5.WordSpecSample",
                "Kotest",

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
@@ -74,7 +74,7 @@ class WordSpecEngineKitTest : FunSpec({
                "a when container with a failing test when",
                "pass a test",
                "with a should container should",
-               "a when container when",
+               "a when container when",BeforeAfterProjectListenerExceptionHandlingTest
                "a failing container should",
                "com.sksamuel.kotest.runner.junit5.WordSpecSample",
                "Kotest",

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/stringspec/StringSpecInstancePerTestOrderingTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/specs/stringspec/StringSpecInstancePerTestOrderingTest.kt
@@ -11,7 +11,7 @@ class StringSpecInstancePerTestOrderingTest : StringSpec() {
       var string = ""
    }
 
-   override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerTest
+   override fun isolationMode() = IsolationMode.InstancePerTest
 
    private var uniqueCount = AtomicInteger(0)
 


### PR DESCRIPTION
This PR adds a new spring extension called SpringTestExtension intended as a long term replacement for the SpringListener.

This extension uses a new SpecExtension method to allow intercepting the coroutine context and placing the spring TestContestManager into that context.

Then users in their tests can call `testContextManager()` to retrieve a reference to that manager, and also call `manager.testContext` to get the context used.

Fixes #1956