### PR TITLE
fix Arb.set hanging when underlying arb cardinality was insufficient

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/collections.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/collections.kt
@@ -39,14 +39,18 @@ fun <T> Arb.Companion.of(vararg collection: T): Arb<T> = element(*collection)
 fun <A> Arb.Companion.set(gen: Gen<A>, range: IntRange = 0..100): Arb<Set<A>> {
    check(!range.isEmpty())
    check(range.first >= 0)
+   val maxIterations = 1000
    return arbitrary {
       val genIter = gen.generate(it).iterator()
       val targetSize = it.random.nextInt(range)
       val set = mutableSetOf<A>()
-      while (set.size < targetSize && genIter.hasNext()) {
+      var iterations = 0
+      while (iterations++ < maxIterations && set.size < targetSize && genIter.hasNext()) {
          set.add(genIter.next().value)
       }
-      check(set.size == targetSize)
+      check(set.size == targetSize) {
+         "the target size requirement of $targetSize could not be satisfied after $maxIterations consecutive samples"
+      }
       set
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveAtMostSize
@@ -9,7 +10,9 @@ import io.kotest.property.Exhaustive
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.list
+import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.set
+import io.kotest.property.arbitrary.single
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.constant
 import io.kotest.property.forAll
@@ -24,6 +27,13 @@ class CollectionsTest : FunSpec({
    test("Arb.set should not include empty edgecases as first sample") {
       val numGen = Arb.set(Arb.int(), 1..10)
       forAll(1, numGen) { it.isNotEmpty() }
+   }
+
+   test("Arb.set should throw when underlying arb cardinality is lower than expected set cardinality") {
+      val arbUnderlying = Arb.of("foo", "bar", "baz")
+      shouldThrowAny {
+         Arb.set(arbUnderlying, 5..100).single()
+      }
    }
 
    test("Arb.list should return lists of underlying generators") {


### PR DESCRIPTION
fixes #1931 