### PR TITLE
Enhances email arb; Creates domain arb

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/domain.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/domain.kt
@@ -1,0 +1,164 @@
+package io.kotest.property.arbitrary
+
+import io.kotest.property.Arb
+
+/**
+ * Generates random domains
+ *
+ * https://en.wikipedia.org/wiki/Domain_name#Domain_name_syntax
+ * https://whogohost.com/host/knowledgebase/308/Valid-Domain-Name-Characters.html
+ */
+fun Arb.Companion.domain(
+   tlds: List<String> = top120TLDs,
+   labelArb: Arb<String> = _labelArb
+): Arb<String> = arbitrary { rs ->
+   val amountOfLabels = rs.random.nextInt(1, 4)
+
+   val labels = labelArb.take(amountOfLabels).joinToString(separator = ".", postfix = ".")
+
+   labels + tlds.random(rs.random)
+}
+
+private val _labelArb = arbitrary {
+   buildString(63) {
+      append(validCharsArb.filter { it != '-' }.single(it))
+
+      append(validCharsArb.take(it.random.nextInt(0, 61), it).joinToString(""))
+
+      append(validCharsArb.filter { it != '-' }.single(it))
+
+      if(length >= 4) {
+         if(get(2) == '-' && get(3) == '-') {
+            set(3, validCharsArb.filter { it != '-' }.single(it))
+         }
+      }
+   }
+}
+
+private val validCharsArb = arbitrary { (('a'..'z') + ('A'..'Z') + ('0'..'9') + '-').random(it.random) }
+
+/**
+ * https://www.scoutdns.com/100-most-popular-tlds-by-google-index/
+ */
+private val top120TLDs = listOf(
+   "com",
+   "net",
+   "org",
+   "jp",
+   "de",
+   "uk",
+   "fr",
+   "br",
+   "it",
+   "ru",
+   "es",
+   "me",
+   "gov",
+   "pl",
+   "ca",
+   "au",
+   "cn",
+   "co",
+   "in",
+   "nl",
+   "edu",
+   "info",
+   "eu",
+   "ch",
+   "id",
+   "at",
+   "kr",
+   "cz",
+   "mx",
+   "be",
+   "tv",
+   "se",
+   "tr",
+   "tw",
+   "al",
+   "ua",
+   "ir",
+   "vn",
+   "cl",
+   "sk",
+   "ly",
+   "cc",
+   "to",
+   "no",
+   "fi",
+   "us",
+   "pt",
+   "dk",
+   "ar",
+   "hu",
+   "tk",
+   "gr",
+   "il",
+   "news",
+   "ro",
+   "my",
+   "biz",
+   "ie",
+   "za",
+   "nz",
+   "sg",
+   "ee",
+   "th",
+   "io",
+   "xyz",
+   "pe",
+   "bg",
+   "hk",
+   "rs",
+   "lt",
+   "link",
+   "ph",
+   "club",
+   "si",
+   "site",
+   "mobi",
+   "by",
+   "cat",
+   "wiki",
+   "la",
+   "ga",
+   "xxx",
+   "cf",
+   "hr",
+   "ng",
+   "jobs",
+   "online",
+   "kz",
+   "ug",
+   "gq",
+   "ae",
+   "is",
+   "lv",
+   "pro",
+   "fm",
+   "tips",
+   "ms",
+   "sa",
+   "app",
+   "lat",
+   "pk",
+   "ws",
+   "top",
+   "xn--p1ai",
+   "pw",
+   "ai",
+   "kw",
+   "ml",
+   "su",
+   "lu",
+   "nu",
+   "ec",
+   "uy",
+   "az",
+   "ma",
+   "st",
+   "asia",
+   "im",
+   "am",
+   "email",
+)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/emails.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/emails.kt
@@ -1,10 +1,12 @@
 package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
+import io.kotest.property.Gen
 import io.kotest.property.azstring
 import kotlin.random.nextInt
 
-fun Arb.Companion.email(usernameSize: IntRange = 3..10, domainSize: IntRange = 3..10): Arb<String> {
+@Deprecated("This function is deprecated and will be replaced. To be removed in 4.5")
+fun Arb.Companion.email(usernameSize: IntRange = 3..10, domainSize: IntRange): Arb<String> {
    val tlds = listOf("com", "net", "gov", "co.uk", "jp", "nl", "ru", "de", "com.br", "it", "pl", "io")
    return arbitrary {
       val tld = tlds.random(it.random)
@@ -15,4 +17,34 @@ fun Arb.Companion.email(usernameSize: IntRange = 3..10, domainSize: IntRange = 3
       } else username
       "$usernamep@$domain.$tld"
    }
+}
+
+fun Arb.Companion.email(
+   localPartGen: Gen<String> = emailLocalPart(),
+   domainGen: Gen<String> = domain()
+) = bind(localPartGen, domainGen) { localPart, domain -> "$localPart@$domain" }
+
+/**
+ * https://en.wikipedia.org/wiki/Email_address#Local-part
+ *
+ * If unquoted, it may use any of these ASCII characters:
+ * - uppercase and lowercase Latin letters A to Z and a to z
+ * - digits 0 to 9
+ * - printable characters !#$%&'*+-/=?^_`{|}~
+ * - dot ., provided that it is not the first or last character and provided also that it does not appear consecutively
+ * (e.g., John..Doe@example.com is not allowed)
+ */
+fun Arb.Companion.emailLocalPart(): Arb<String> = arbitrary { rs ->
+   val possibleChars = ('A'..'Z') + ('a'..'z') + ('0'..'9') + """!#$%&'*+-/=?^_`{|}~.""".toList()
+   val firstAndLastChars = possibleChars - '.'
+   val size = rs.random.nextInt(1..64)
+
+   val str = if (size <= 2) {
+      List(size) { firstAndLastChars.random(rs.random) }.joinToString("")
+   } else {
+      firstAndLastChars.random(rs.random) +
+         List(size - 2) { possibleChars.random(rs.random) }.joinToString("") +
+         firstAndLastChars.random(rs.random)
+   }
+   str.replace("\\.+".toRegex(), ".")
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DomainArbTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DomainArbTest.kt
@@ -1,0 +1,90 @@
+package com.sksamuel.kotest.property.arbitrary
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldHaveMaxLength
+import io.kotest.matchers.string.shouldNotEndWith
+import io.kotest.matchers.string.shouldNotStartWith
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.domain
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.checkAll
+import java.nio.charset.StandardCharsets
+
+class DomainArbTest : ShouldSpec({
+   should("Generate domains with the most common TLDs by default") {
+      val tlds = mutableListOf<String>()
+      Arb.domain().checkAll(iterations = 10_000) {
+         tlds += it.substringAfterLast(".")
+      }
+
+      tlds shouldContainAll listOf("com", "net", "org")
+   }
+
+   should("Only generate domains with selected TLDs") {
+      Arb.domain(tlds = listOf("abc")).checkAll {
+         it shouldEndWith ".abc"
+      }
+   }
+
+   should("Generate domains with 2 to 4 labels") {
+      val generatedLevels = mutableSetOf<Int>()
+      Arb.domain().checkAll(iterations = 10_000) {
+         generatedLevels += it.split(".").size
+      }
+
+      generatedLevels shouldBe setOf(2, 3, 4)
+   }
+
+   should("Never exceed 253 characters") {
+      Arb.domain().checkAll {
+         it shouldHaveMaxLength 253
+      }
+   }
+
+   should("Not have labels exceeding 63 characters") {
+      Arb.domain().checkAll {
+         it.split(".").forAll { it shouldHaveMaxLength 63 }
+      }
+   }
+
+   should("Have only ASCII characters") {
+      Arb.domain().checkAll {
+         StandardCharsets.US_ASCII.newEncoder().canEncode(it)
+      }
+   }
+
+   should("Eventually generate domains with all valid characters") {
+      val generatedLetters = mutableSetOf<Char>()
+
+      Arb.domain().checkAll(iterations = 10_000) {
+         generatedLetters += it.toList()
+      }
+
+      (generatedLetters - '.') shouldBe (('a'..'z') + ('A'..'Z') + ('0'..'9') + '-').toSet()
+   }
+
+   should("Never start with a hyphen") {
+      Arb.domain().checkAll(iterations = 100_000) {
+         it shouldNotStartWith "-"
+      }
+   }
+
+   should("Never end with a hyphen") {
+      Arb.domain().checkAll(iterations = 100_000) {
+         it shouldNotEndWith "-"
+      }
+   }
+
+   // https://whogohost.com/host/knowledgebase/308/Valid-Domain-Name-Characters.html
+   // 2021-01-05
+   should("Never contain a double dash in the 3rd and 4th positions") {
+      Arb.domain().filter { it.length >= 4 }.checkAll(iterations = 100_000) {
+         it.substring(2, 4) shouldNotBe "--"
+      }
+   }
+})

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/EmailArbTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/EmailArbTest.kt
@@ -1,23 +1,60 @@
 package com.sksamuel.kotest.property.arbitrary
 
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldHaveLengthBetween
+import io.kotest.matchers.string.shouldMatch
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldNotEndWith
+import io.kotest.matchers.string.shouldNotStartWith
 import io.kotest.property.Arb
-import io.kotest.property.PropTestConfig
 import io.kotest.property.arbitrary.email
+import io.kotest.property.arbitrary.emailLocalPart
 import io.kotest.property.checkAll
 
-class EmailArbTest : FunSpec({
+class EmailArbTest : ShouldSpec({
 
-   test("emails happy path") {
-      checkAll(1, PropTestConfig(seed = 1289312), Arb.email()) { e ->
-         e.shouldBe("xxkm@regk.nl")
+   should("Generate only right format emails") {
+      checkAll(Arb.email()) {
+         it.shouldMatch(".+\\@.+\\..+")   // Simple regex only to get a feeling of what we're generating
       }
-      checkAll(1, PropTestConfig(seed = 8934575), Arb.email()) { e ->
-         e.shouldBe("ghnnq@dbagstxjkc.com.br")
+   }
+
+   should("Generate emails with up to 320 characters") {
+      Arb.email().checkAll {
+         it.shouldHaveLengthBetween(3, 320)
       }
-      checkAll(1, PropTestConfig(seed = 487643), Arb.email(usernameSize = 8..8)) { e ->
-         e.shouldBe("thst.wycb@svpgz.gov")
+   }
+
+   context("Local Part") {
+      should("Generate email with all possible characters for local parts") {
+         val chars = sortedSetOf<Char>()
+         Arb.emailLocalPart().checkAll(iterations = 10_000) {
+            chars += it.substringBefore('@').toList()
+         }
+         chars shouldContainExactlyInAnyOrder (('a'..'z') + ('A'..'Z') + ('0'..'9') + """!#$%&'*+-/=?^_`{|}~.""".toList())
+      }
+
+      should("Never generate emails with dot at the start or at the end") {
+         Arb.emailLocalPart().checkAll {
+            it shouldNotStartWith "."
+            it shouldNotEndWith "."
+         }
+      }
+
+      should("Never generate two dots in a row") {
+         Arb.emailLocalPart().checkAll {
+            it shouldNotContain ".."
+         }
+      }
+
+      should("Generate with length ranging from 1 to 64") {
+         val sizes = sortedSetOf<Int>()
+         Arb.emailLocalPart().checkAll {
+            sizes += it.length
+         }
+         sizes shouldBe (1..64).toSortedSet()
       }
    }
 })


### PR DESCRIPTION
This commit will improve how we generate random emails, in a way that it
 will become closer to real email addresses.

 In addition, this commit also creates a Domain arbitrary. Originally
 used only in emails, generating random valid domains can be useful for
 many usecases.

 Closes #1941
 Closes #1969