### PR TITLE
Fix Small Typo in "Isolation Mode" Docs

### DIFF
--- a/documentation/docs/framework/isolation_mode.md
+++ b/documentation/docs/framework/isolation_mode.md
@@ -34,7 +34,7 @@ class MyTestClass : WordSpec() {
 ## Single Instance
 
 The default isolation mode is `SingleInstance` whereby one instance of the Spec class is created and then each test case
-is exected in turn until all tests have completed.
+is executed in turn until all tests have completed.
 
 For example, in the following spec, the same id would be printed three times as the same instance is used for all tests.
 


### PR DESCRIPTION
Hello,

I was reading the documentation for isolation mode and I found "exected" in the place of what I believe should be "executed". I thought about contributing with this small fix. If this is not a typo, I apologize for opening a PR for this. 🙂

Thanks,
Hugo