### PR TITLE
#2016 Update Eq to check data class assertion first before throwable assertion

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/Eq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/Eq.kt
@@ -25,7 +25,6 @@ fun <T : Any?> eq(actual: T, expected: T): Throwable? {
       actual != null && expected == null && actual != expected -> expectedIsNull(actual)
       actual != null && expected != null -> when {
          actual is Map<*, *> && expected is Map<*, *> -> MapEq.equals(actual, expected)
-         actual is Throwable && expected is Throwable -> ThrowableEq.equals(actual, expected)
          actual is Regex && expected is Regex -> RegexEq.equals(actual, expected)
          actual is String && expected is String -> StringEq.equals(actual, expected)
          actual is Number && expected is Number -> NumberEq.equals(actual, expected)
@@ -33,6 +32,7 @@ fun <T : Any?> eq(actual: T, expected: T): Throwable? {
             IterableEq.equals(IterableEq.asIterable(actual), IterableEq.asIterable(expected))
          }
          shouldShowDataClassDiff(actual, expected) -> DataClassEq.equals(actual as Any, expected as Any)
+         actual is Throwable && expected is Throwable -> ThrowableEq.equals(actual, expected)
          else -> DefaultEq.equals(actual as Any, expected as Any)
       }
       else -> null

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
@@ -1,11 +1,14 @@
 package com.sksamuel.kotest.eq
 
 import io.kotest.assertions.eq.isDataClassInstance
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotStartWith
 import io.kotest.matchers.string.shouldStartWith
 import org.junit.jupiter.api.assertThrows
+import java.lang.AssertionError
 
 data class DataClass1(val a: Int, val b: Float)
 data class DataClass2(val x: Int, val y: Float, val z: DataClass1)
@@ -120,6 +123,15 @@ class DataClassEqTest : StringSpec({
 
       throwable.message shouldNotStartWith "data class diff"
    }
+
+   "Data class assertion should applied on data class which extends throwable" {
+      shouldNotThrow<AssertionError> {
+         CustomException("abc") shouldBe CustomException("abc")
+      }
+      shouldThrow<AssertionError> {
+         CustomException("abc") shouldBe CustomException("efg")
+      }
+   }
 })
 
 class `DataClassEq AssertionConfig Tests` : StringSpec({
@@ -136,3 +148,5 @@ class `DataClassEq AssertionConfig Tests` : StringSpec({
       throwable.message shouldBe "expected:<DataClass1(a=2, b=3.5)> but was:<DataClass1(a=1, b=3.4)>"
    }
 })
+
+data class CustomException(private val value: String) : Exception()


### PR DESCRIPTION
In case of throwable we check only message field and actual type class,
in case if a data class extends throwable, it make more sense to do data
class assertion instead of only doing message field equality check.

closes: #2016 