### PR TITLE
Add missing highlights in documentation

### DIFF
--- a/doc/matchers/ktor.md
+++ b/doc/matchers/ktor.md
@@ -12,7 +12,7 @@ The following matchers are used when testing via the ktor server testkit.
 | ---------- | --- |
 | `shouldHaveStatus(HttpStatusCode)`        | Tests that the response had the given http status code    |
 | `shouldHaveContent(content)`              | Tests that the response has the given body     |
-| `shouldHaveContentType(ContentType)       | Tests that the response has the given Content Type     |
+| `shouldHaveContentType(ContentType)`       | Tests that the response has the given Content Type     |
 | `shouldHaveHeader(name, value)`           | Tests that the response included the given name=value header     |
 | `shouldHaveCookie(name, value)`           | Tests that the response included the given cookie     |
 
@@ -23,6 +23,6 @@ The following matchers can be used against responses from the ktor http client.
 | Matcher | Description    |
 | ---------- | --- |
 | `shouldHaveStatus(HttpStatusCode)`        | Tests that the response had the given http status code    |
-| `shouldHaveContentType(ContentType)       | Tests that the response has the given Content Type     |
+| `shouldHaveContentType(ContentType)`       | Tests that the response has the given Content Type     |
 | `shouldHaveHeader(name, value)`           | Tests that the response included the given name=value header     |
 | `shouldHaveVersion(HttpProtocolVersion)`  | Tests that the response used the given protocol version     |

--- a/documentation/docs/quick_start.mdx
+++ b/documentation/docs/quick_start.mdx
@@ -121,7 +121,7 @@ And then add the Kotest JUnit5 runner to your dependencies section.
    </TabItem>
    <TabItem value="Android">
 
-:::info 
+:::info
 Currently, only JVM tests are officially supported in Kotest. Experimental support for instrumented and Robolectric tests is currently under work.
 
 The following steps enable Kotest to be used for unit and integration tests, where the Android framework is not needed or is mocked that usually reside in the
@@ -178,7 +178,7 @@ For example, the JDBC matchers only work for JVM since JDBC is a Java library.
 
 Add the following dependency to your build:
 
-```
+```groovy
 testImplementation 'io.kotest:kotest-assertions-core:$version'
 ```
 


### PR DESCRIPTION
Also, it seems to me the `Edit this page` (bottom of the page) is broken on all pages. Couldn't find which configuration drives its value but whenever I click on it shows a `Not Found` message.