### PR TITLE
Avoid creating extra lambdas in blocking forAll

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll1.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll1.kt
@@ -10,11 +10,11 @@ import io.kotest.mpp.reflection
 fun <A> forAll(vararg rows: Row1<A>, testfn: (A) -> Unit) {
    val params = reflection.paramNames(testfn) ?: emptyList<String>()
    val paramA = params.getOrElse(0) { "a" }
-   table(headers(paramA), *rows).forAll { a -> testfn(a) }
+   table(headers(paramA), *rows).forAll(testfn)
 }
 
 fun <A> forNone(vararg rows: Row1<A>, testfn: (A) -> Unit) {
    val params = reflection.paramNames(testfn) ?: emptyList<String>()
    val paramA = params.getOrElse(0) { "a" }
-   table(headers(paramA), *rows).forNone { a -> testfn(a) }
+   table(headers(paramA), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll2.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll2.kt
@@ -11,12 +11,12 @@ fun <A, B> forAll(vararg rows: Row2<A, B>, testfn: (A, B) -> Unit) {
    val params = reflection.paramNames(testfn) ?: emptyList<String>()
    val paramA = params.getOrElse(0) { "a" }
    val paramB = params.getOrElse(1) { "b" }
-   table(headers(paramA, paramB), *rows).forAll { a, b -> testfn(a, b) }
+   table(headers(paramA, paramB), *rows).forAll(testfn)
 }
 
 fun <A, B> forNone(vararg rows: Row2<A, B>, testfn: (A, B) -> Unit) {
    val params = reflection.paramNames(testfn) ?: emptyList<String>()
    val paramA = params.getOrElse(0) { "a" }
    val paramB = params.getOrElse(1) { "b" }
-   table(headers(paramA, paramB), *rows).forNone { a, b -> testfn(a, b) }
+   table(headers(paramA, paramB), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll3.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll3.kt
@@ -12,7 +12,7 @@ fun <A, B, C> forAll(vararg rows: Row3<A, B, C>, testfn: (A, B, C) -> Unit) {
    val paramA = params.getOrElse(0) { "a" }
    val paramB = params.getOrElse(1) { "b" }
    val paramC = params.getOrElse(2) { "c" }
-   table(headers(paramA, paramB, paramC), *rows).forAll { A, B, C -> testfn(A, B, C) }
+   table(headers(paramA, paramB, paramC), *rows).forAll(testfn)
 }
 
 fun <A, B, C> forNone(vararg rows: Row3<A, B, C>, testfn: (A, B, C) -> Unit) {
@@ -20,5 +20,5 @@ fun <A, B, C> forNone(vararg rows: Row3<A, B, C>, testfn: (A, B, C) -> Unit) {
    val paramA = params.getOrElse(0) { "a" }
    val paramB = params.getOrElse(1) { "b" }
    val paramC = params.getOrElse(2) { "c" }
-   table(headers(paramA, paramB, paramC), *rows).forNone { A, B, C -> testfn(A, B, C) }
+   table(headers(paramA, paramB, paramC), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll4.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll4.kt
@@ -13,7 +13,7 @@ fun <A, B, C, D> forAll(vararg rows: Row4<A, B, C, D>, testfn: (A, B, C, D) -> U
    val paramB = params.getOrElse(1) { "b" }
    val paramC = params.getOrElse(2) { "c" }
    val paramD = params.getOrElse(2) { "d" }
-   table(headers(paramA, paramB, paramC, paramD), *rows).forAll { A, B, C, D -> testfn(A, B, C, D) }
+   table(headers(paramA, paramB, paramC, paramD), *rows).forAll(testfn)
 }
 
 fun <A, B, C, D> forNone(vararg rows: Row4<A, B, C, D>, testfn: (A, B, C, D) -> Unit) {
@@ -22,5 +22,5 @@ fun <A, B, C, D> forNone(vararg rows: Row4<A, B, C, D>, testfn: (A, B, C, D) -> 
    val paramB = params.getOrElse(1) { "b" }
    val paramC = params.getOrElse(2) { "c" }
    val paramD = params.getOrElse(2) { "d" }
-   table(headers(paramA, paramB, paramC, paramD), *rows).forNone { A, B, C, D -> testfn(A, B, C, D) }
+   table(headers(paramA, paramB, paramC, paramD), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll5.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll5.kt
@@ -14,7 +14,7 @@ fun <A, B, C, D, E> forAll(vararg rows: Row5<A, B, C, D, E>, testfn: (A, B, C, D
    val paramC = params.getOrElse(2) { "c" }
    val paramD = params.getOrElse(3) { "d" }
    val paramE = params.getOrElse(4) { "e" }
-   table(headers(paramA, paramB, paramC, paramD, paramE), *rows).forAll { A, B, C, D, E -> testfn(A, B, C, D, E) }
+   table(headers(paramA, paramB, paramC, paramD, paramE), *rows).forAll(testfn)
 }
 
 fun <A, B, C, D, E> forNone(vararg rows: Row5<A, B, C, D, E>, testfn: (A, B, C, D, E) -> Unit) {
@@ -24,5 +24,5 @@ fun <A, B, C, D, E> forNone(vararg rows: Row5<A, B, C, D, E>, testfn: (A, B, C, 
    val paramC = params.getOrElse(2) { "c" }
    val paramD = params.getOrElse(3) { "d" }
    val paramE = params.getOrElse(4) { "e" }
-   table(headers(paramA, paramB, paramC, paramD, paramE), *rows).forNone { A, B, C, D, E -> testfn(A, B, C, D, E) }
+   table(headers(paramA, paramB, paramC, paramD, paramE), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll6.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll6.kt
@@ -15,9 +15,7 @@ fun <A, B, C, D, E, F> forAll(vararg rows: Row6<A, B, C, D, E, F>, testfn: (A, B
    val paramD = params.getOrElse(3) { "d" }
    val paramE = params.getOrElse(4) { "e" }
    val paramF = params.getOrElse(5) { "f" }
-   table(headers(paramA, paramB, paramC, paramD, paramE, paramF), *rows).forAll { A, B, C, D, E, F ->
-      testfn(A, B, C, D, E, F)
-   }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF), *rows).forAll(testfn)
 }
 
 fun <A, B, C, D, E, F> forNone(
@@ -31,7 +29,5 @@ fun <A, B, C, D, E, F> forNone(
    val paramD = params.getOrElse(3) { "d" }
    val paramE = params.getOrElse(4) { "e" }
    val paramF = params.getOrElse(5) { "f" }
-   table(headers(paramA, paramB, paramC, paramD, paramE, paramF), *rows).forNone { A, B, C, D, E, F ->
-      testfn(A, B, C, D, E, F)
-   }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll7.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll7.kt
@@ -19,9 +19,7 @@ fun <A, B, C, D, E, F, G> forAll(
    val paramE = params.getOrElse(4) { "e" }
    val paramF = params.getOrElse(5) { "f" }
    val paramG = params.getOrElse(6) { "g" }
-   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG), *rows).forAll { A, B, C, D, E, F, G ->
-      testfn(A, B, C, D, E, F, G)
-   }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG), *rows).forAll(testfn)
 }
 
 fun <A, B, C, D, E, F, G> forNone(
@@ -36,7 +34,5 @@ fun <A, B, C, D, E, F, G> forNone(
    val paramE = params.getOrElse(4) { "e" }
    val paramF = params.getOrElse(5) { "f" }
    val paramG = params.getOrElse(6) { "g" }
-   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG), *rows).forNone { A, B, C, D, E, F, G ->
-      testfn(A, B, C, D, E, F, G)
-   }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG), *rows).forNone(testfn)
 }


### PR DESCRIPTION
This is a very minor optimization that simplifies the code slightly and avoids allocating an extra lambda function. This optimization is already in place for the suspending versions of these functions.