### PR TITLE
Eventually: Merge listener and predicate and improve consistency

### DIFF
--- a/doc/nondeterministic.md
+++ b/doc/nondeterministic.md
@@ -44,8 +44,8 @@ class MyTests : ShouldSpec() {
 
 #### Exceptions
 
-By default, `eventually` will ignore any AssertionError thrown inside the function,
-while any others will then immediately fail the test.
+By default, `eventually` ignores AssertionErrors thrown inside the function
+while any other Throwable will immediately fail the test.
 
 You can also tell `eventually` to ignore other exceptions:
 Let's assume that our example from before throws a `UserNotFoundException` when the user is not found in the database.
@@ -64,7 +64,8 @@ class MyTests : ShouldSpec() {
 }
 ```
 
-**ATTENTION**: `eventually` currently does not works well within `assertSoftly`, since assertions aren't thrown normally in there:
+**ATTENTION**: `eventually` currently does not work well within `assertSoftly`,
+since assertions aren't thrown normally in there:
 
 ```kotlin
 class MyTests : ShouldSpec() {

--- a/doc/nondeterministic.md
+++ b/doc/nondeterministic.md
@@ -18,11 +18,10 @@ Or you can roll a loop and sleep and retry and sleep and retry, but this is just
 Another common approach is to use countdown latches and this works fine if you are able to inject the latches in the appropriate places but it isn't always
 possible to have the code under test trigger a latch.
 
+### Usage
+
 As an alternative, Kotest provides the `eventually` function which will periodically
 test the code until it either passes, or the timeout is reached. This is perfect for nondeterministic code.
-
-
-### Examples
 
 #### Simple example
 
@@ -45,16 +44,13 @@ class MyTests : ShouldSpec() {
 
 #### Exceptions
 
-By default, `eventually` will ignore any exception that is thrown inside the function (note, that means it won't catch `Error`).
-If you want to be more specific, you can tell `eventually` to ignore specific exceptions and any others will immediately fail the test.
+By default, `eventually` will ignore any AssertionError thrown inside the function,
+while any others will then immediately fail the test.
 
-Let's assume that our example from before throws a `UserNotFoundException` while the user is not found in the database.
+You can also tell `eventually` to ignore other exceptions:
+Let's assume that our example from before throws a `UserNotFoundException` when the user is not found in the database.
 It will eventually return the user when the message is processed by the system.
-
-In this scenario, we can explicitly skip the exception that we expect to happen until the test passed, but any other exceptions would
-not be ignored. Note, this example is similar to the former, but if there was some other error, say a ConnectionException for example, this would cause
-the eventually block to immediately exit with a failure message.
-
+However, if there is another error, `eventually` will fail immediately.
 
 ```kotlin
 class MyTests : ShouldSpec() {
@@ -68,18 +64,17 @@ class MyTests : ShouldSpec() {
 }
 ```
 
-**ATTENTION**: `eventually` does not works well with `assertSoftly`. In `assertSoftly` if an `eventually` fails any
-assertion followed by it won't be executed. Example:
+**ATTENTION**: `eventually` currently does not works well within `assertSoftly`, since assertions aren't thrown normally in there:
 
 ```kotlin
 class MyTests : ShouldSpec() {
   init {
     should("some test with eventually inside assert softly") {
-      assertSoftly{
+      assertSoftly {
         eventually(1.seconds) {
           1 shouldBe 2
         }
-        1 shouldBe 2 // Never get executed.
+        1 shouldBe 2 // Never gets executed
       }
     }
   }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
@@ -224,7 +224,7 @@ class EventuallyTest : WordSpec() {
 
          "fail tests that fail a predicate" {
             shouldThrow<AssertionError> {
-               eventually(1.seconds, predicate = { it == 2 }) {
+               eventually(1.seconds, predicate = { (result) -> result == 2 }) {
                   1
                }
             }
@@ -278,7 +278,7 @@ class EventuallyTest : WordSpec() {
             }.message
 
             message.shouldContain("Eventually block failed after Infinity")
-            message.shouldContain("attempted 2 time(s)")
+            message.shouldContain("attempted 2 times")
          }
 
          "override assertion to hard assertion before executing assertion and reset it after executing" {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/NondeterministicHelpers.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/NondeterministicHelpers.kt
@@ -2,5 +2,6 @@ package io.kotest.assertions
 
 typealias SuspendingProducer<T> = suspend () -> T
 
-
+/** @return empty string when count is one, otherwise a single 's'. */
+fun plural_s(count: Int) = if(count == 1) "" else "s"
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -29,7 +29,7 @@ suspend fun <T> retry(
    timeout: Duration,
    delay: Duration = 1.seconds,
    multiplier: Int = 1,
-   f: suspend () -> T
+   f: SuspendingProducer<T>
 ): T = retry(maxRetry, timeout, delay, multiplier, Exception::class, f)
 
 
@@ -55,7 +55,7 @@ suspend fun <T, E : Throwable> retry(
    delay: Duration = 1.seconds,
    multiplier: Int = 1,
    exceptionClass: KClass<E>,
-   f: suspend () -> T
+   f: SuspendingProducer<T>
 ): T {
    val mark = TimeSource.Monotonic.markNow()
    val end = mark.plus(timeout)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/continually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/continually.kt
@@ -51,8 +51,8 @@ data class Continually<T> (
 @Deprecated("Use continually with an interval, using Duration based poll is deprecated",
    ReplaceWith("continually(duration, poll.fixed(), f = f)", "io.kotest.assertions.until.fixed")
 )
-suspend fun <T> continually(duration: Duration, poll: Duration, f: suspend () -> T) =
+suspend fun <T> continually(duration: Duration, poll: Duration, f: SuspendingProducer<T>) =
    continually(duration, poll.fixed(), f = f)
 
-suspend fun <T> continually(duration: Duration, interval: Interval = 10.milliseconds.fixed(), f: suspend () -> T) =
+suspend fun <T> continually(duration: Duration, interval: Interval = 10.milliseconds.fixed(), f: SuspendingProducer<T>) =
    Continually<T>(duration, interval).invoke(f)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
@@ -13,33 +13,46 @@ import kotlin.time.TimeSource
 import kotlin.time.milliseconds
 
 /**
- * Runs a function until it doesn't throw as long as the specified duration hasn't passed
+ * Runs function [f] until it doesn't throw, as long as the specified [duration] hasn't passed.
+ * @return the result of [f] or fails if [f] never completed without throwing
  */
 suspend fun <T> eventually(duration: Duration, f: suspend () -> T): T =
-   eventually(EventuallyConfig(duration = duration, exceptionClass = Throwable::class), f = f)
+   eventually(EventuallyConfig(duration), f = f)
 
+/**
+ * Runs function [f] with the specified [interval] until it doesn't throw, as long as the specified [duration] hasn't passed.
+ * @return the result of [f] or fails if [f] never completed without throwing
+ */
 suspend fun <T : Any> eventually(
    duration: Duration,
    interval: Interval,
    f: suspend () -> T
 ): T = eventually(EventuallyConfig(duration, interval), f = f)
 
+/**
+ * Runs function [f] until it matches [predicate], as long as the specified [duration] hasn't passed.
+ */
 suspend fun <T> eventually(
    duration: Duration,
    interval: Interval,
    predicate: EventuallyPredicate<T>,
    f: suspend () -> T,
-): T = eventually(EventuallyConfig(duration = duration, interval), predicate = predicate, f = f)
+): T = eventually(EventuallyConfig(duration, interval), predicate = predicate, f = f)
 
+/**
+ * Runs function [f] with the specified [interval] until it doesn't throw, as long as the specified [duration] hasn't passed.
+ * @param listener will be notified at every iteration
+ * @return the result of [f] or fails if [f] never completed without throwing
+ */
 suspend fun <T> eventually(
    duration: Duration,
    interval: Interval,
    listener: EventuallyListener<T>,
    f: suspend () -> T,
-): T = eventually(EventuallyConfig(duration = duration, interval), listener = listener, f = f)
+): T = eventually(EventuallyConfig(duration, interval), listener = listener, f = f)
 
 suspend fun <T> eventually(duration: Duration, poll: Duration, f: suspend () -> T): T =
-   eventually(EventuallyConfig(duration = duration, interval = poll.fixed(), exceptionClass = Throwable::class), f = f)
+   eventually(EventuallyConfig(duration = duration, interval = poll.fixed()), f = f)
 
 /**
  * Runs a function until it doesn't throw the specified exception as long as the specified duration hasn't passed
@@ -49,13 +62,16 @@ suspend fun <T> eventually(duration: Duration, exceptionClass: KClass<out Throwa
 
 /**
  * Runs a function until the following constraints are eventually met:
- * the optional [predicate] must be satisfied, defaults to true
- * the optional [duration] has not passed now, defaults to [Duration.INFINITE]
- * the number of iterations does not exceed the optional [retries], defaults to [Int.MAX_VALUE]
+ * - the optional [predicate] must be satisfied, defaults to true
+ * - the optional [duration] has not passed now, defaults to [Duration.INFINITE]
+ * - the number of iterations does not exceed the optional [retries], defaults to [Int.MAX_VALUE]
  *
- * [eventually] will catch the specified optional [exceptionClass] and (or when not specified) [AssertionError], defaults to [Throwable]
- * [eventually] will delay the specified [interval] between iterations, defaults to 25 [milliseconds]
- * [eventually] will pass the resulting value and state (see [EventuallyState]) into the optional [listener]
+ * eventually will
+ * - catch the specified optional [exceptionClass] and (or when not specified) [AssertionError]
+ * - delay the specified [interval] between iterations, defaults to 25 [milliseconds]
+ * - pass the resulting value and state (see [EventuallyState]) into the optional [listener]
+ *
+ * @return the first accepted result of [f]
  */
 suspend fun <T> eventually(
    duration: Duration = Duration.INFINITE,
@@ -68,8 +84,8 @@ suspend fun <T> eventually(
 ): T = eventually(EventuallyConfig(duration, interval, retries, exceptionClass), predicate, listener, f)
 
 /**
- * Runs a function until it doesn't throw and the result satisfies the predicate as long as the specified duration hasn't passed
- * and uses [EventuallyConfig] to control the duration, interval, listener, retries, and exceptionClass.
+ * Runs a function until it doesn't throw and the result satisfies the predicate, as long as the specified duration hasn't passed.
+ * @param config controls the duration, interval, listener, retries, and exceptionClass
  */
 suspend fun <T> eventually(
    config: EventuallyConfig,

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
@@ -1,6 +1,8 @@
 package io.kotest.assertions.until
 
+import io.kotest.assertions.SuspendingProducer
 import io.kotest.assertions.failure
+import io.kotest.assertions.plural_s
 import kotlin.time.Duration
 import kotlin.time.TimeSource
 import kotlin.time.seconds
@@ -71,7 +73,7 @@ suspend fun until(patience: PatienceConfig, f: suspend () -> Boolean) =
 suspend fun <T> until(
    duration: Duration,
    predicate: suspend (T) -> Boolean,
-   f: suspend () -> T
+   f: SuspendingProducer<T>
 ): T = until(duration, interval = 1.seconds.fixed(), predicate = predicate, f = f)
 
 /**
@@ -86,7 +88,7 @@ suspend fun <T> until(
    duration: Duration,
    interval: Interval,
    predicate: suspend (T) -> Boolean,
-   f: suspend () -> T
+   f: SuspendingProducer<T>
 ): T = until(duration = duration, interval = interval, predicate = predicate, listener = {}, f = f)
 
 /**
@@ -103,7 +105,7 @@ suspend fun <T> until(
 suspend fun <T> until(
    patience: PatienceConfig,
    predicate: suspend (T) -> Boolean,
-   f: suspend () -> T
+   f: SuspendingProducer<T>
 ): T = until(duration = patience.duration, interval = patience.interval, predicate = predicate, listener = {}, f = f)
 
 @Deprecated("Simply move the listener code into the predicate code. Will be removed in 4.7 or 5.0")
@@ -112,7 +114,7 @@ suspend fun <T> until(
    interval: Interval = 1.seconds.fixed(),
    predicate: suspend (T) -> Boolean,
    listener: UntilListener<T>,
-   f: suspend () -> T
+   f: SuspendingProducer<T>
 ): T {
 
    val start = TimeSource.Monotonic.markNow()
@@ -130,6 +132,6 @@ suspend fun <T> until(
    }
 
    val runtime = start.elapsedNow()
-   val message = "Until block failed after ${runtime}; attempted $times time(s); $interval delay between attempts"
+   val message = "Until block failed after ${runtime}; attempted $times time${plural_s(times)}; $interval delay between attempts"
    throw failure(message)
 }

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
@@ -143,6 +143,7 @@ private class WordSpecSample : WordSpec({
 
    "a failing container" should {
       throw RuntimeException()
+      @Suppress("UNREACHABLE_CODE")
       "not reach this test" {}
    }
 })

--- a/kotest-tests/kotest-tests-concurrency-tests/src/jvmTest/kotlin/com/sksamuel/kotest/tests/concurrency/ConcurrentTestsSingleInstanceTest.kt
+++ b/kotest-tests/kotest-tests-concurrency-tests/src/jvmTest/kotlin/com/sksamuel/kotest/tests/concurrency/ConcurrentTestsSingleInstanceTest.kt
@@ -38,6 +38,7 @@ class ConcurrentTestsSingleInstanceTest : FunSpec() {
    override fun afterSpec(spec: Spec) {
       val end = System.currentTimeMillis()
       // total of delays is 1500 but should run concurrently
+      // FIXME this regularly fails
       (end - start).shouldBeLessThan(1000)
       befores.shouldHaveLength(4)
       // beforeTest should be called in declaration order

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/core/runtime/parallel/InstancePerLeafTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/core/runtime/parallel/InstancePerLeafTest.kt
@@ -21,9 +21,8 @@ private val externalMultipleThreadCounter =
    PersistentThreadLocal<Int>()
 
 class SpecThreadInstancePerLeafTest : FunSpec({
-
    isolationMode = IsolationMode.InstancePerLeaf
-   threads = 3
+   concurrency = 3
 
    val internalThreadCounter =
       PersistentThreadLocal<Int>()


### PR DESCRIPTION
Some shorthands didn't catch exceptions, others did, this was really confusing. It seems sensible to me like this - always catch by default unless there is a predicate, since it otherwise never re-runs, which is kinda useless.