### PR TITLE
Fix withEnvironment() to be case-insensitve on Windows

### DIFF
--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt
@@ -61,7 +61,12 @@ inline fun <T> withEnvironment(environment: Pair<String, String?>, mode: Overrid
  * already changed, the result is inconsistent, as the System Environment Map is a single map.
  */
 inline fun <T> withEnvironment(environment: Map<String, String?>, mode: OverrideMode = SetOrError, block: () -> T): T {
-   val originalEnvironment = System.getenv().toMap() // Using to map to guarantee it's not modified
+   val isWindows = "windows" in System.getProperty("os.name").orEmpty()
+   val originalEnvironment = if (isWindows) {
+      System.getenv().toSortedMap(String.CASE_INSENSITIVE_ORDER)
+   } else {
+      System.getenv()
+   }
 
    setEnvironmentMap(mode.override(originalEnvironment, environment))
 


### PR DESCRIPTION
On Windows, environment variables names are case-insensitive. The
OverrideMode in withEnvironment() did not take this into account before.
Instead of making OverrideMode itself conditionally ignore case, simply
let it operate on a map with case-insensitive keys on Windows.

Note that the original comment about using "toMap()" was bogus, as all
consumers of "originalEnvironment" anyway already take an immutable map as
their parameter.