### PR TITLE
Fix IncorrectDereferenceException when calling assertions on backgrond thread on native

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -2,7 +2,5 @@ package io.kotest.assertions
 
 import kotlin.native.concurrent.ThreadLocal
 
-actual val errorCollector: ErrorCollector = NativeErrorCollector
-
 @ThreadLocal
-object NativeErrorCollector : BasicErrorCollector()
+actual val errorCollector: ErrorCollector = BasicErrorCollector()

--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/counter.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/counter.kt
@@ -2,7 +2,5 @@ package io.kotest.assertions
 
 import kotlin.native.concurrent.ThreadLocal
 
-actual val assertionCounter: AssertionCounter = NativeAssertionCounter
-
 @ThreadLocal
-object NativeAssertionCounter : BasicAssertionCounter()
+actual val assertionCounter: AssertionCounter = BasicAssertionCounter()

--- a/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/reflection.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/reflection.kt
@@ -1,3 +1,6 @@
 package io.kotest.mpp
 
+import kotlin.native.concurrent.SharedImmutable
+
+@SharedImmutable
 actual val reflection: Reflection = BasicReflection

--- a/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/stacktraces.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/stacktraces.kt
@@ -1,3 +1,7 @@
 package io.kotest.mpp
 
+import kotlin.native.concurrent.SharedImmutable
+
+
+@SharedImmutable
 actual val stacktraces: StackTraces = BasicStackTraces

--- a/kotest-tests/kotest-tests-native/build.gradle.kts
+++ b/kotest-tests/kotest-tests-native/build.gradle.kts
@@ -1,0 +1,74 @@
+plugins {
+   kotlin("multiplatform")
+}
+
+repositories {
+   mavenCentral()
+}
+
+
+repositories {
+   mavenCentral()
+}
+
+kotlin {
+   targets {
+      linuxX64()
+      mingwX64()
+      macosX64()
+      tvos()
+//      watchos()
+      iosX64()
+      iosArm64()
+      iosArm32()
+   }
+
+   sourceSets {
+      val commonTest by getting {
+         dependencies {
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
+            implementation(project(Projects.AssertionsCore))
+         }
+      }
+
+      val nativeTest by creating {
+         dependsOn(commonTest)
+      }
+
+      val macosX64Test by getting {
+         dependsOn(nativeTest)
+      }
+
+      val mingwX64Test by getting {
+         dependsOn(nativeTest)
+      }
+
+      val linuxX64Test by getting {
+         dependsOn(nativeTest)
+      }
+
+      val iosX64Test by getting {
+         dependsOn(nativeTest)
+      }
+
+      val iosArm64Test by getting {
+         dependsOn(nativeTest)
+      }
+
+      val iosArm32Test by getting {
+         dependsOn(nativeTest)
+      }
+
+//      val watchosTest by getting {
+//         dependsOn(nativeTest)
+//      }
+
+      val tvosTest by getting {
+         dependsOn(nativeTest)
+      }
+   }
+}
+
+
+apply(from = "../../nopublish.gradle")

--- a/kotest-tests/kotest-tests-native/src/nativeTest/kotlin/io/kotest/NativeThreadingTest.kt
+++ b/kotest-tests/kotest-tests-native/src/nativeTest/kotlin/io/kotest/NativeThreadingTest.kt
@@ -1,0 +1,77 @@
+package io.kotest
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.data.blocking.forAll
+import io.kotest.data.row
+import io.kotest.matchers.ints.beEven
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import kotlin.native.concurrent.TransferMode.SAFE
+import kotlin.native.concurrent.Worker
+import kotlin.native.concurrent.freeze
+import kotlin.test.Test
+
+
+class NativeThreadingTest {
+   @Test
+   fun testShouldBe() = threadedTest {
+      1 shouldBe 1
+   }
+
+   @Test
+   fun testShouldWithMatcher() = threadedTest {
+      2 should beEven()
+   }
+
+   @Test
+   fun testForAll() = threadedTest {
+      forAll(
+         row(4, 5),
+         row(3, 6)
+      ) { a, b ->
+         a + b shouldBe 9
+      }
+   }
+
+   @Test
+   fun testSoftAssert() = threadedTest {
+      assertSoftly {
+         "a" shouldBe "a"
+         "b" shouldBe "b"
+      }
+   }
+
+   @Test
+   fun testShouldThrow() = threadedTest {
+      shouldThrow<IllegalArgumentException> {
+         require(false)
+      }
+   }
+
+   @Test
+   fun testStackTraces() = threadedTest {
+      shouldThrow<AssertionError> {
+         forAll(
+            row(4, 5),
+            row(3, 6)
+         ) { a, b ->
+            a + b shouldBe 0
+         }
+      }
+   }
+
+   // https://jakewharton.com/litmus-testing-kotlins-many-memory-models/
+   private fun threadedTest(body: () -> Unit) {
+      // Run once on the main thread
+      body()
+
+      // Run again on a background thread
+      body.freeze()
+      val worker = Worker.start()
+      val future = worker.execute(SAFE, { body }) {
+         runCatching(it)
+      }
+      future.result.getOrThrow()
+   }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -97,6 +97,7 @@ include("kotest-tests:kotest-tests-tagextension")
 include("kotest-tests:kotest-tests-timeout")
 include("kotest-tests:kotest-tests-timeout-sysprop")
 include("kotest-tests:kotest-tests-multiname-test-name-sysprop")
+include("kotest-tests:kotest-tests-native")
 
 //include("kotest-examples:kotest-examples-jvm")
 //include("kotest-examples:kotest-examples-allure")


### PR DESCRIPTION
This commit adds a test that runs basic assertions on a background thread on kotlin native. Prior to this commit, that test would fail because not all top-level `val`s are annotated with `@SharedImmutable` or `@ThreadLocal`. I annotated all top-level `val`s I found in `dektopMain` sourceSets, which fixes the errors.