### PR TITLE
haveCauseOfType shows exception type instead of cause type

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
@@ -35,8 +35,8 @@ inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Thro
     null -> resultForThrowable(null)
     else -> MatcherResult(
       cause is T,
-      "Throwable cause should be of type ${T::class.bestName()}, but instead got ${cause::class.bestName()}",
-      "Throwable cause should not be of type ${T::class.bestName()}"
+      "Throwable cause should be of type ${T::class.bestName()} or it's descendant, but instead got ${cause::class.bestName()}",
+      "Throwable cause should not be of type ${T::class.bestName()} or it's descendant"
     )
   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import io.kotest.mpp.bestName
 
 infix fun Throwable.shouldHaveMessage(message: String) = this should haveMessage(message)
 infix fun Throwable.shouldNotHaveMessage(message: String) = this shouldNot haveMessage(message)
@@ -34,8 +35,8 @@ inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Thro
     null -> resultForThrowable(null)
     else -> MatcherResult(
       cause is T,
-      "Throwable cause should be of type ${T::class}, but instead got ${cause::class}",
-      "Throwable cause should not be of type ${T::class}"
+      "Throwable cause should be of type ${T::class.bestName()}, but instead got ${cause::class.bestName()}",
+      "Throwable cause should not be of type ${T::class.bestName()}"
     )
   }
 }
@@ -47,8 +48,8 @@ inline fun <reified T : Throwable> haveCauseOfType() = object : Matcher<Throwabl
     null -> resultForThrowable(null)
     else -> MatcherResult(
       cause::class == T::class,
-      "Throwable cause should be of type ${T::class}, but instead got ${cause::class}",
-      "Throwable cause should not be of type ${T::class}"
+      "Throwable cause should be of type ${T::class.bestName()}, but instead got ${cause::class.bestName()}",
+      "Throwable cause should not be of type ${T::class.bestName()}"
     )
   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
@@ -33,9 +33,9 @@ inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Thro
   override fun test(value: Throwable) = when {
     value.cause == null -> resultForThrowable(value.cause)
     else -> MatcherResult(
-        value.cause is T,
-        "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
-        "Throwable cause should be of type ${T::class}"
+      value.cause is T,
+      "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
+      "Throwable cause should not be of type ${T::class}"
     )
   }
 }
@@ -44,12 +44,12 @@ inline fun <reified T : Throwable> Throwable.shouldHaveCauseOfType() = this shou
 inline fun <reified T : Throwable> Throwable.shouldNotHaveCauseOfType() = this shouldNot haveCauseOfType<T>()
 inline fun <reified T : Throwable> haveCauseOfType() = object : Matcher<Throwable> {
   override fun test(value: Throwable) = when (value.cause) {
-      null -> resultForThrowable(value.cause)
-      else -> MatcherResult(
-         value.cause!!::class == T::class,
-         "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
-         "Throwable cause should be of type ${T::class}"
-      )
+    null -> resultForThrowable(value.cause)
+    else -> MatcherResult(
+      value.cause!!::class == T::class,
+      "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
+      "Throwable cause should not be of type ${T::class}"
+    )
   }
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
@@ -30,11 +30,11 @@ fun haveCause() = object : Matcher<Throwable> {
 inline fun <reified T : Throwable> Throwable.shouldHaveCauseInstanceOf() = this should haveCauseInstanceOf<T>()
 inline fun <reified T : Throwable> Throwable.shouldNotHaveCauseInstanceOf() = this shouldNot haveCauseInstanceOf<T>()
 inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Throwable> {
-  override fun test(value: Throwable) = when {
-    value.cause == null -> resultForThrowable(value.cause)
+  override fun test(value: Throwable) = when (val cause = value.cause) {
+    null -> resultForThrowable(null)
     else -> MatcherResult(
-      value.cause is T,
-      "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
+      cause is T,
+      "Throwable cause should be of type ${T::class}, but instead got ${cause::class}",
       "Throwable cause should not be of type ${T::class}"
     )
   }
@@ -43,11 +43,11 @@ inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Thro
 inline fun <reified T : Throwable> Throwable.shouldHaveCauseOfType() = this should haveCauseOfType<T>()
 inline fun <reified T : Throwable> Throwable.shouldNotHaveCauseOfType() = this shouldNot haveCauseOfType<T>()
 inline fun <reified T : Throwable> haveCauseOfType() = object : Matcher<Throwable> {
-  override fun test(value: Throwable) = when (value.cause) {
-    null -> resultForThrowable(value.cause)
+  override fun test(value: Throwable) = when (val cause = value.cause) {
+    null -> resultForThrowable(null)
     else -> MatcherResult(
-      value.cause!!::class == T::class,
-      "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
+      cause::class == T::class,
+      "Throwable cause should be of type ${T::class}, but instead got ${cause::class}",
       "Throwable cause should not be of type ${T::class}"
     )
   }
@@ -55,7 +55,7 @@ inline fun <reified T : Throwable> haveCauseOfType() = object : Matcher<Throwabl
 
 @PublishedApi
 internal fun resultForThrowable(value: Throwable?) = MatcherResult(
-    value != null,
-    "Throwable should have a cause",
-    "Throwable should not have a cause"
+  value != null,
+  "Throwable should have a cause",
+  "Throwable should not have a cause"
 )

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
@@ -34,7 +34,7 @@ inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Thro
     value.cause == null -> resultForThrowable(value.cause)
     else -> MatcherResult(
         value.cause is T,
-        "Throwable cause should be of type ${T::class}, but instead got ${value::class}",
+        "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
         "Throwable cause should be of type ${T::class}"
     )
   }
@@ -47,7 +47,7 @@ inline fun <reified T : Throwable> haveCauseOfType() = object : Matcher<Throwabl
       null -> resultForThrowable(value.cause)
       else -> MatcherResult(
          value.cause!!::class == T::class,
-         "Throwable cause should be of type ${T::class}, but instead got ${value::class}",
+         "Throwable cause should be of type ${T::class}, but instead got ${value.cause!!::class}",
          "Throwable cause should be of type ${T::class}"
       )
   }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/throwable/ThrowableMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/throwable/ThrowableMatchersTest.kt
@@ -99,7 +99,7 @@ class ThrowableMatchersTest : FreeSpec() {
       }
       "shouldNotHaveCauseOfType" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldNotHaveCauseOfType<IOException>()
-        shouldThrow<AssertionError> { CompleteTestException().shouldNotHaveCauseInstanceOf<FileNotFoundException>() }
+        shouldThrow<AssertionError> { CompleteTestException().shouldNotHaveCauseOfType<FileNotFoundException>() }
           .shouldHaveMessage("Throwable cause should not be of type java.io.FileNotFoundException")
       }
     }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/throwable/ThrowableMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/throwable/ThrowableMatchersTest.kt
@@ -57,34 +57,50 @@ class ThrowableMatchersTest : FreeSpec() {
         shouldThrow<IOException> { throw FileNotFoundException("this_file.txt not found") } shouldHaveMessage "this_file.txt not found"
         shouldThrow<TestException> { throw TestException() } shouldHaveMessage "This is a test exception"
         shouldThrow<CompleteTestException> { throw CompleteTestException() } shouldHaveMessage "This is a complete test exception"
+        shouldThrow<AssertionError> { TestException() shouldHaveMessage "random message" }
+          .shouldHaveMessage("Throwable should have message:\n\"random message\"\n\nActual was:\n\"This is a test exception\"")
       }
       "shouldNotHaveMessage" {
         shouldThrow<IOException> { throw FileNotFoundException("this_file.txt not found") } shouldNotHaveMessage "random message"
         shouldThrow<TestException> { throw TestException() } shouldNotHaveMessage "This is a complete test exception"
         shouldThrow<CompleteTestException> { throw CompleteTestException() } shouldNotHaveMessage "This is a test exception"
+        shouldThrow<AssertionError> { TestException() shouldNotHaveMessage "This is a test exception" }
+          .shouldHaveMessage("Throwable should not have message:\n\"This is a test exception\"")
       }
       "shouldHaveCause" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCause()
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCause {
           it shouldHaveMessage "file.txt not found"
         }
+        shouldThrow<AssertionError> { TestException().shouldHaveCause() }
+          .shouldHaveMessage("Throwable should have a cause")
       }
       "shouldNotHaveCause" {
         shouldThrow<TestException> { throw TestException() }.shouldNotHaveCause()
         shouldThrow<IOException> { throw FileNotFoundException("this_file.txt not found") }.shouldNotHaveCause()
+        shouldThrow<AssertionError> { CompleteTestException().shouldNotHaveCause() }
+          .shouldHaveMessage("Throwable should not have a cause")
       }
       "shouldHaveCauseInstanceOf" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCauseInstanceOf<FileNotFoundException>()
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCauseInstanceOf<IOException>()
+        shouldThrow<AssertionError> { CompleteTestException().shouldHaveCauseInstanceOf<RuntimeException>() }
+          .shouldHaveMessage("Throwable cause should be of type java.lang.RuntimeException, but instead got java.io.FileNotFoundException")
       }
       "shouldNotHaveCauseInstanceOf" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldNotHaveCauseInstanceOf<TestException>()
+        shouldThrow<AssertionError> { CompleteTestException().shouldNotHaveCauseInstanceOf<FileNotFoundException>() }
+          .shouldHaveMessage("Throwable cause should not be of type java.io.FileNotFoundException")
       }
       "shouldHaveCauseOfType" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCauseOfType<FileNotFoundException>()
+        shouldThrow<AssertionError> { CompleteTestException().shouldHaveCauseOfType<RuntimeException>() }
+          .shouldHaveMessage("Throwable cause should be of type java.lang.RuntimeException, but instead got java.io.FileNotFoundException")
       }
       "shouldNotHaveCauseOfType" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldNotHaveCauseOfType<IOException>()
+        shouldThrow<AssertionError> { CompleteTestException().shouldNotHaveCauseInstanceOf<FileNotFoundException>() }
+          .shouldHaveMessage("Throwable cause should not be of type java.io.FileNotFoundException")
       }
     }
     "shouldThrowExactly" - {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/throwable/ThrowableMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/throwable/ThrowableMatchersTest.kt
@@ -85,12 +85,12 @@ class ThrowableMatchersTest : FreeSpec() {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCauseInstanceOf<FileNotFoundException>()
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCauseInstanceOf<IOException>()
         shouldThrow<AssertionError> { CompleteTestException().shouldHaveCauseInstanceOf<RuntimeException>() }
-          .shouldHaveMessage("Throwable cause should be of type java.lang.RuntimeException, but instead got java.io.FileNotFoundException")
+          .shouldHaveMessage("Throwable cause should be of type java.lang.RuntimeException or it's descendant, but instead got java.io.FileNotFoundException")
       }
       "shouldNotHaveCauseInstanceOf" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldNotHaveCauseInstanceOf<TestException>()
         shouldThrow<AssertionError> { CompleteTestException().shouldNotHaveCauseInstanceOf<FileNotFoundException>() }
-          .shouldHaveMessage("Throwable cause should not be of type java.io.FileNotFoundException")
+          .shouldHaveMessage("Throwable cause should not be of type java.io.FileNotFoundException or it's descendant")
       }
       "shouldHaveCauseOfType" {
         shouldThrow<CompleteTestException> { throw CompleteTestException() }.shouldHaveCauseOfType<FileNotFoundException>()


### PR DESCRIPTION
`haveCauseOfType` shows the type of the exception itself, but not the type of the `cause` exception.