### PR TITLE
Fixes Arb.bigdecimal getting hanged for min and max value which other than Double min and max

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
@@ -14,7 +14,11 @@ private val bigDecimalEdgecases = listOf(
 
 fun Arb.Companion.bigDecimal(): Arb<BigDecimal> {
    return arbitrary(bigDecimalEdgecases) {
-      BigDecimal(it.random.nextInt() * it.random.nextDouble())
+      if (it.random.nextInt() % 2 == 0) {
+         BigDecimal(it.random.nextLong()) * BigDecimal(it.random.nextDouble())
+      } else {
+         BigDecimal(it.random.nextInt()) * BigDecimal(it.random.nextDouble())
+      }
    }
 }
 

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
@@ -4,9 +4,22 @@ import io.kotest.property.Arb
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-fun Arb.Companion.bigDecimal() = Arb.double().map { it.toBigDecimal() }
+private val bigDecimalEdgecases = listOf(
+   BigDecimal(0.0),
+   BigDecimal(1.0),
+   BigDecimal(-1.0),
+   BigDecimal("1e-300"),
+   BigDecimal("-1e-300"),
+)
 
-fun Arb.Companion.bigDecimal(scale: Int, roundingMode: RoundingMode) = bigDecimal().map { it.setScale(scale, roundingMode) }
+fun Arb.Companion.bigDecimal(): Arb<BigDecimal> {
+   return arbitrary(bigDecimalEdgecases) {
+      BigDecimal(it.random.nextInt() * it.random.nextDouble())
+   }
+}
+
+fun Arb.Companion.bigDecimal(scale: Int, roundingMode: RoundingMode) =
+   bigDecimal().map { it.setScale(scale, roundingMode) }
 
 fun Arb.Companion.bigDecimal(min: BigDecimal, max: BigDecimal): Arb<BigDecimal> {
    return bigDecimal().filter { it in min..max }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
@@ -3,13 +3,14 @@ package com.sksamuel.kotest.property.arbitrary
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
+import io.kotest.matchers.concurrent.shouldCompleteWithin
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigDecimal
 import io.kotest.property.arbitrary.take
-import io.kotest.property.checkAll
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.util.concurrent.TimeUnit
 
 class BigDecimalTest : FunSpec({
    test("Arb.bigDecimal(min, max) should generate bigDecimal between given range") {
@@ -25,6 +26,13 @@ class BigDecimalTest : FunSpec({
       Arb.bigDecimal(4, RoundingMode.CEILING).take(1_00_000).forAll {
          assertSoftly {
             it.scale() shouldBe 4
+         }
+      }
+   }
+
+   test("Arb.bigDecimal(min, max) for large value should complete with in few seconds") {
+      shouldCompleteWithin(5, TimeUnit.SECONDS) {
+         Arb.bigDecimal(BigDecimal.valueOf(-100_000.00), BigDecimal.valueOf(100_000.00)).take(100).forEach { _ ->
          }
       }
    }


### PR DESCRIPTION
Earlier we were using `Arb.double` under to generate BigDecimal but since `Arb.double` generate only values between `Double.MAX_VALUE` and `Double.MIN_VALUE`, the `Arb.bigDecimal` was getting hanged if the supplied rannge is beyond  `Double.MAX_VALUE` and `Double.MIN_VALUE`.

I have no experience in data driven test, so not sure how the Shrinker will work for BigDecimal.

closes: #2132 