### PR TITLE
Use the class name as the default prefix for temporary files / dirs

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
@@ -3,7 +3,7 @@ package io.kotest.engine.spec
 import io.kotest.core.TestConfiguration
 import java.io.File
 
-fun TestConfiguration.tempdir(prefix: String? = null, suffix: String? = null): File {
+fun TestConfiguration.tempdir(prefix: String? = javaClass.name, suffix: String? = null): File {
    val dir = createTempDir(prefix ?: "tmp", suffix)
    afterSpec {
       dir.delete()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempfile.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempfile.kt
@@ -4,7 +4,7 @@ import io.kotest.core.TestConfiguration
 import java.io.File
 import java.nio.file.Files
 
-fun TestConfiguration.tempfile(prefix: String? = null, suffix: String? = ".tmp"): File {
+fun TestConfiguration.tempfile(prefix: String? = javaClass.name, suffix: String? = ".tmp"): File {
    val file = Files.createTempFile(prefix, suffix).toFile()
    afterSpec {
       file.delete()


### PR DESCRIPTION
This way left-over files / dir can be easier associated to the test /
spec that created them.

Resolves #2136.