### PR TITLE
Change `beEqualToIgnoringFields` api to avoid runtime crashes

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -30,9 +30,7 @@ import kotlin.reflect.jvm.isAccessible
  * firstFoo shouldBe secondFoo // Assertion fails, `equals` is false!
  * ```
  *
- * Note:
- * 1) Throws [IllegalArgumentException] in case [properties] parameter is not provided.
- * 2) Throws [IllegalArgumentException] if [properties] contains any non public property
+ * Note: Throws [IllegalArgumentException] if [properties] contains any non public property
  *
  */
 fun <T : Any> T.shouldBeEqualToUsingFields(other: T, vararg properties: KProperty<*>) {
@@ -58,9 +56,7 @@ fun <T : Any> T.shouldBeEqualToUsingFields(other: T, vararg properties: KPropert
  * firstFoo.shouldNotBeEqualToUsingFields(secondFoo, Foo::description) // Assertion passes
  *
  * ```
- * Note:
- * 1) Throws [IllegalArgumentException] in case [properties] parameter is not provided.
- * 2) Throws [IllegalArgumentException] if [properties] contains any non public property
+ * Note: Throws [IllegalArgumentException] if [properties] contains any non public property
  *
  *
  * @see [beEqualToUsingFields]
@@ -137,10 +133,9 @@ fun <T : Any> beEqualToUsingFields(other: T, vararg fields: KProperty<*>): Match
  * firstFoo shouldBe secondFoo // Assertion fails, `equals` is false!
  * ```
  *
- * Note: Throws [IllegalArgumentException] in case [properties] parameter is not provided.
  */
-fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, vararg properties: KProperty<*>) {
-   this should beEqualToIgnoringFields(other = other, ignorePrivateFields = true, fields = *properties)
+fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, property: KProperty<*>, vararg others: KProperty<*>) {
+   this should beEqualToIgnoringFields(other = other, ignorePrivateFields = true, property = property, others = others)
 }
 
 /**
@@ -166,11 +161,20 @@ fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, vararg properties: KProp
  * firstFoo shouldBe secondFoo // Assertion fails, `equals` is false!
  * ```
  *
- * Note: Throws [IllegalArgumentException] in case [properties] parameter is not provided.
  */
 
-fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, ignorePrivateFields: Boolean, vararg properties: KProperty<*>) {
-   this should beEqualToIgnoringFields(other = other, ignorePrivateFields = ignorePrivateFields, fields = *properties)
+fun <T : Any> T.shouldBeEqualToIgnoringFields(
+   other: T,
+   ignorePrivateFields: Boolean,
+   property: KProperty<*>,
+   vararg others: KProperty<*>,
+) {
+   this should beEqualToIgnoringFields(
+      other = other,
+      ignorePrivateFields = ignorePrivateFields,
+      property = property,
+      others = others
+   )
 }
 
 /**
@@ -193,8 +197,13 @@ fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, ignorePrivateFields: Boo
  * ```
  *
  */
-fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, vararg properties: KProperty<*>) =
-   this shouldNot beEqualToIgnoringFields(other = other, ignorePrivateFields = true, fields = *properties)
+fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, property: KProperty<*>, vararg others: KProperty<*>) =
+   this shouldNot beEqualToIgnoringFields(
+      other = other,
+      ignorePrivateFields = true,
+      property = property,
+      others = others,
+   )
 
 
 /**
@@ -219,8 +228,18 @@ fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, vararg properties: KP
  * ```
  *
  */
-fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, ignorePrivateFields: Boolean, vararg properties: KProperty<*>) =
-   this shouldNot beEqualToIgnoringFields(other = other, ignorePrivateFields = ignorePrivateFields, fields = *properties)
+fun <T : Any> T.shouldNotBeEqualToIgnoringFields(
+   other: T,
+   ignorePrivateFields: Boolean,
+   property: KProperty<*>,
+   vararg others: KProperty<*>
+) =
+   this shouldNot beEqualToIgnoringFields(
+      other = other,
+      ignorePrivateFields = ignorePrivateFields,
+      property = property,
+      others = others,
+   )
 
 /**
  * Matcher that compares values without using specific fields
@@ -249,13 +268,12 @@ fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, ignorePrivateFields: 
 fun <T : Any> beEqualToIgnoringFields(
    other: T,
    ignorePrivateFields: Boolean,
-   vararg fields: KProperty<*>
+   property: KProperty<*>,
+   vararg others: KProperty<*>
 ): Matcher<T> = object : Matcher<T> {
-   init {
-      require(fields.isNotEmpty()) { "At-least one field must be ignored when checking for equality" }
-   }
 
    override fun test(value: T): MatcherResult {
+      val fields = listOf(property) + others
       val fieldNames = fields.map { it.name }
       val fieldsExcludingGivenFields = value::class.memberProperties
          .filterNot { fieldNames.contains(it.name) }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
@@ -54,12 +54,6 @@ class ReflectionKtTest : FunSpec() {
          }.message shouldBe "Foo(a=sammy, b=13, c=true) should be equal to Foo(a=stef, b=13, c=false) ignoring fields [c]; Failed for [a: sammy != stef]"
       }
 
-      test("shouldBeEqualToIgnoringFields should throw exception when no field is mentioned") {
-         assertThrows<IllegalArgumentException>("At-least one field is required to be mentioned to be ignore for checking the equality") {
-            Foo("sammy", 23, false).shouldBeEqualToIgnoringFields(Foo("danny", 23, false))
-         }
-      }
-
       test("shouldBeEqualToIgnoringFields should compare equality for class having private fields") {
          val car1 = Car("C1", 10000, 430)
          val car2 = Car("C1", 123423, 123)


### PR DESCRIPTION
Fixes #2179
If I'm not mistaken that break backwards compatibility as I'm changing public api. So if someone used named parameters - it would fail

I also improved related `beEqualToUsingFields` documentation as it is allowed not to pass any `properties`