### PR TITLE
Fix issues of passing vararg to another function in containsInOrder

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -27,8 +27,8 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
    )
 }
 
-fun <T> Iterable<T>.shouldContainInOrder(vararg ts: T) = toList().shouldContainInOrder(ts)
-fun <T> Array<T>.shouldContainInOrder(vararg ts: T) = asList().shouldContainInOrder(ts)
+fun <T> Iterable<T>.shouldContainInOrder(vararg ts: T) = toList().shouldContainInOrder(*ts)
+fun <T> Array<T>.shouldContainInOrder(vararg ts: T) = asList().shouldContainInOrder(*ts)
 fun <T> List<T>.shouldContainInOrder(vararg ts: T) = this.shouldContainInOrder(ts.toList())
 infix fun <T> Iterable<T>.shouldContainInOrder(expected: List<T>) = toList().shouldContainInOrder(expected)
 infix fun <T> Array<T>.shouldContainInOrder(expected: List<T>) = asList().shouldContainInOrder(expected)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.matchers.collections
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containsInOrder
+import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.throwable.shouldHaveMessage
 
@@ -41,6 +42,14 @@ class InOrderTest : WordSpec() {
   1,
   2
 ] in order""")
+         }
+         "support iterables with vararg" {
+            val actual = listOf(1, 2, 3, 4, 5).asIterable()
+            actual.shouldContainInOrder(2, 3, 4)
+         }
+         "support arrays with vararg" {
+            val actual = arrayOf(1, 2, 3, 4, 5)
+            actual.shouldContainInOrder(2, 3, 4)
          }
       }
    }


### PR DESCRIPTION
This PR has the aim of fixing issues of containsInOrder extensions. These extensions has passed vararg to another function not using spread operator. Please let me know if any further actions is required.