### PR TITLE
Upgrade arrow to 0.13.1

### DIFF
--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -16,11 +16,8 @@ object Libs {
    }
 
    object Arrow {
-      private const val version = "0.11.0"
+      private const val version = "0.13.1"
       const val core = "io.arrow-kt:arrow-core:$version"
-      const val fx = "io.arrow-kt:arrow-fx:$version"
-      const val syntax = "io.arrow-kt:arrow-syntax:$version"
-      const val validation = "io.arrow-kt:arrow-validation:$version"
    }
 
    object Ajalt {

--- a/kotest-property/kotest-property-arrow/src/jvmTest/kotlin/com/sksamuel/kotest/property/arrow/EitherTest.kt
+++ b/kotest-property/kotest-property-arrow/src/jvmTest/kotlin/com/sksamuel/kotest/property/arrow/EitherTest.kt
@@ -1,7 +1,7 @@
 package com.sksamuel.kotest.property.arrow
 
-import arrow.core.Left
-import arrow.core.Right
+import arrow.core.left
+import arrow.core.right
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.property.Arb
@@ -17,48 +17,48 @@ class EitherTest : FunSpec({
    test("Arb.either should generate both left and right") {
       val eithers = Arb.either(Arb.char('a'..'z'), Arb.int(1..10)).take(10, RandomSource.seeded(123456L)).toList()
       eithers shouldContainExactly listOf(
-         Left('h'),
-         Right(3),
-         Right(10),
-         Right(2),
-         Left('x'),
-         Left('s'),
-         Left('n'),
-         Left('t'),
-         Left('q'),
-         Right(2)
+         'h'.left(),
+         3.right(),
+         10.right(),
+         2.right(),
+         'x'.left(),
+         's'.left(),
+         'n'.left(),
+         't'.left(),
+         'q'.left(),
+         2.right()
       )
    }
 
    test("Arb.left should project arbitrary values to left") {
       val lefts = Arb.left(Arb.int(1..10)).take(10, RandomSource.seeded(123456L)).toList()
       lefts shouldContainExactly listOf(
-         Left(1),
-         Left(3),
-         Left(10),
-         Left(10),
-         Left(1),
-         Left(3),
-         Left(10),
-         Left(4),
-         Left(2),
-         Left(4)
+         1.left(),
+         3.left(),
+         10.left(),
+         10.left(),
+         1.left(),
+         3.left(),
+         10.left(),
+         4.left(),
+         2.left(),
+         4.left()
       )
    }
 
    test("Arb.right should project arbitrary values to right") {
       val rights = Arb.right(Arb.int(1..10)).take(10, RandomSource.seeded(123456L)).toList()
       rights shouldContainExactly listOf(
-         Right(1),
-         Right(3),
-         Right(10),
-         Right(10),
-         Right(1),
-         Right(3),
-         Right(10),
-         Right(4),
-         Right(2),
-         Right(4)
+         1.right(),
+         3.right(),
+         10.right(),
+         10.right(),
+         1.right(),
+         3.right(),
+         10.right(),
+         4.right(),
+         2.right(),
+         4.right()
       )
    }
 })

--- a/kotest-property/kotest-property-arrow/src/jvmTest/kotlin/com/sksamuel/kotest/property/arrow/NonEmptyListTest.kt
+++ b/kotest-property/kotest-property-arrow/src/jvmTest/kotlin/com/sksamuel/kotest/property/arrow/NonEmptyListTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.property.arrow
 
-import arrow.core.NonEmptyList
+import arrow.core.nonEmptyListOf
 import io.kotest.assertions.throwables.shouldThrowMessage
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -25,24 +25,24 @@ class NonEmptyListTest : FunSpec({
       Arb.nel(Arb.constant("a"), 1..5)
          .take(3, RandomSource.seeded(123123L))
          .toList() shouldContainExactly listOf(
-         NonEmptyList.of("a", "a"),
-         NonEmptyList.of("a", "a"),
-         NonEmptyList.of("a", "a", "a", "a")
+         nonEmptyListOf("a", "a"),
+         nonEmptyListOf("a", "a"),
+         nonEmptyListOf("a", "a", "a", "a")
       )
    }
 
    test("Arb.nel should generate NonEmptyList") {
       val expected = listOf(
-         NonEmptyList.of(1, 4),
-         NonEmptyList.of(8, 1, 5, 6),
-         NonEmptyList.of(3, 1, 7, 3),
-         NonEmptyList.of(3, 9, 2),
-         NonEmptyList.of(4, 8),
-         NonEmptyList.of(9),
-         NonEmptyList.of(1, 1, 7, 3, 2),
-         NonEmptyList.of(7, 1, 4),
-         NonEmptyList.of(5, 4, 1, 4),
-         NonEmptyList.of(6, 6, 4, 6)
+         nonEmptyListOf(1, 4),
+         nonEmptyListOf(8, 1, 5, 6),
+         nonEmptyListOf(3, 1, 7, 3),
+         nonEmptyListOf(3, 9, 2),
+         nonEmptyListOf(4, 8),
+         nonEmptyListOf(9),
+         nonEmptyListOf(1, 1, 7, 3, 2),
+         nonEmptyListOf(7, 1, 4),
+         nonEmptyListOf(5, 4, 1, 4),
+         nonEmptyListOf(6, 6, 4, 6)
       )
 
       Arb.nel(Arb.int(1..10), 1..5)

--- a/kotest-property/kotest-property-arrow/src/jvmTest/kotlin/com/sksamuel/kotest/property/arrow/OptionTest.kt
+++ b/kotest-property/kotest-property-arrow/src/jvmTest/kotlin/com/sksamuel/kotest/property/arrow/OptionTest.kt
@@ -1,7 +1,7 @@
 package com.sksamuel.kotest.property.arrow
 
-import arrow.core.None
-import arrow.core.Some
+import arrow.core.none
+import arrow.core.some
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.property.Arb
@@ -15,36 +15,36 @@ import io.kotest.property.arrow.some
 class OptionTest : FunSpec({
    test("Arb.some should apply arbitrary values to some") {
       Arb.some(Arb.int(1..10)).take(10, RandomSource.seeded(123456L)).toList() shouldContainExactly listOf(
-         Some(1),
-         Some(3),
-         Some(10),
-         Some(10),
-         Some(1),
-         Some(3),
-         Some(10),
-         Some(4),
-         Some(2),
-         Some(4)
+         1.some(),
+         3.some(),
+         10.some(),
+         10.some(),
+         1.some(),
+         3.some(),
+         10.some(),
+         4.some(),
+         2.some(),
+         4.some()
       )
    }
 
    test("Arb.none should always yield none") {
       Arb.none<Int>().take(10, RandomSource.seeded(123456L)).toList() shouldContainExactly
-         generateSequence { None }.take(10).toList()
+         generateSequence { none<Int>() }.take(10).toList()
    }
 
    test("Arb.option should apply arbitrary values to an option which may be empty") {
       Arb.option(Arb.int(1..10)).take(10, RandomSource.seeded(123456L)).toList() shouldContainExactly listOf(
-         Some(1),
-         None,
-         None,
-         Some(4),
-         None,
-         None,
-         Some(7),
-         Some(6),
-         None,
-         Some(2)
+         1.some(),
+         none(),
+         none(),
+         4.some(),
+         none(),
+         none(),
+         7.some(),
+         6.some(),
+         none(),
+         2.some()
       )
    }
 })


### PR DESCRIPTION
updating arrow deps and cleaning up unused ones. note that this is only used in `kotest-property-arrow`.