### PR TITLE
Switch edgecase default to 0.02

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -11,7 +11,7 @@ object PropertyTesting {
    var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
    var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
    var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", "1000").toInt()
-   var edgecasesGenerationProbability: Double = sysprop("kotest.proptest.arb.edgecases-generation-probability", "0.1").toDouble()
+   var edgecasesGenerationProbability: Double = sysprop("kotest.proptest.arb.edgecases-generation-probability", "0.02").toDouble()
    var edgecasesBindDeterminism: Double = sysprop("kotest.proptest.arb.edgecases-bind-determinism", "0.9").toDouble()
 }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ClassifyTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ClassifyTest.kt
@@ -15,7 +15,7 @@ class ClassifyTest : StringSpec() {
             classify(a == 0, "zero")
             classify(a % 2 == 0, "even number", "odd number")
             a + a == 2 * a
-         }.classifications() shouldBe mapOf("odd number" to 517, "even number" to 483, "zero" to 24)
+         }.classifications() shouldBe mapOf("odd number" to 507, "even number" to 493, "zero" to 9)
 
          forAll(PropTestConfig(seed = 1234), Arb.string()) { a ->
             classify(a.contains(" "), "has whitespace", "no whitespace")

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ListShrinkerTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ListShrinkerTest.kt
@@ -108,7 +108,7 @@ class ListShrinkerTest : FunSpec() {
             }
          }
          println(stdout)
-         stdout.shouldContain("Shrink result (after 51 shrinks) => [90, 86, 56, 1]")
+         stdout.shouldContain("Shrink result (after 51 shrinks) => [90, 86, 56, 34]")
       }
    }
 }


### PR DESCRIPTION
The current edgecase default of 10% seems high. With the default 1000 iterations, 100 would be edgecases.
This PR changes it to 2% giving us 20 over 1000.