### PR TITLE
tempdir: Delete temporary directories recursively

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
@@ -6,7 +6,7 @@ import java.io.File
 fun TestConfiguration.tempdir(prefix: String? = null, suffix: String? = null): File {
    val dir = kotlin.io.path.createTempDirectory(prefix ?: javaClass.name).toFile()
    afterSpec {
-      dir.delete()
+      dir.deleteRecursively()
    }
    return dir
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
@@ -3,10 +3,10 @@ package io.kotest.engine.spec
 import io.kotest.core.TestConfiguration
 import java.io.File
 
-fun TestConfiguration.tempdir(prefix: String? = javaClass.name, suffix: String? = null): File {
-   val dir = kotlin.io.path.createTempDirectory(prefix ?: "tmp")
+fun TestConfiguration.tempdir(prefix: String? = null, suffix: String? = null): File {
+   val dir = kotlin.io.path.createTempDirectory(prefix ?: javaClass.name).toFile()
    afterSpec {
-      dir.toFile().delete()
+      dir.delete()
    }
-   return dir.toFile()
+   return dir
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempfile.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempfile.kt
@@ -2,10 +2,9 @@ package io.kotest.engine.spec
 
 import io.kotest.core.TestConfiguration
 import java.io.File
-import java.nio.file.Files
 
-fun TestConfiguration.tempfile(prefix: String? = javaClass.name, suffix: String? = ".tmp"): File {
-   val file = Files.createTempFile(prefix, suffix).toFile()
+fun TestConfiguration.tempfile(prefix: String? = null, suffix: String? = null): File {
+   val file = kotlin.io.path.createTempFile(prefix ?: javaClass.name, suffix).toFile()
    afterSpec {
       file.delete()
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/TempDirTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/TempDirTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.file.shouldNotExist
 
 class TempDirTest : FunSpec({
 
-   val dir = tempdir()
+   val dir = tempdir().apply { resolve("test.txt").writeText("This is a test file.") }
 
    test("temp directory should be deleted after spec") {
       dir.shouldExist()


### PR DESCRIPTION
While delete() works on directories, they must be empty for delete() to
succeed. However, temporary directories should be deleted recursively,
including any contained files and / or subdirectories.