### PR TITLE
Add DuplicateTestNameMode #2234

### DIFF
--- a/documentation/docs/framework/config_props.md
+++ b/documentation/docs/framework/config_props.md
@@ -93,5 +93,7 @@ object KotestEngineProperties {
     * Appends all tags associated with a test case to its display name.
     * */
    const val testNameAppendTags = "kotest.framework.testname.append.tags"
+
+   const val duplicateTestNameMode = "kotest.framework.testname.duplicate.mode"
 }
 ```

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Configuration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Configuration.kt
@@ -12,6 +12,7 @@ import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.test.AssertionMode
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.core.test.TestNameCase
@@ -260,6 +261,14 @@ class Configuration {
    var removeTestNameWhitespace: Boolean = false
 
    var testNameAppendTags: Boolean = false
+
+   /**
+    * Controls what to do when a duplicated test name is discovered.
+    * See possible settings in [DuplicateTestNameMode].
+    *
+    * Defaults to [Defaults.duplicateTestNameMode]
+    */
+   var duplicateTestNameMode: DuplicateTestNameMode = Defaults.duplicateTestNameMode
 
    /**
     * Returns all globally registered [Listener]s.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
@@ -3,6 +3,7 @@ package io.kotest.core.config
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.test.AssertionMode
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.core.test.TestNameCase
@@ -13,6 +14,8 @@ object Defaults {
    val testCaseConfig: TestCaseConfig = TestCaseConfig()
    val testCaseOrder: TestCaseOrder = TestCaseOrder.Sequential
    val isolationMode: IsolationMode = IsolationMode.SingleInstance
+   val duplicateTestNameMode: DuplicateTestNameMode = DuplicateTestNameMode.Warn
+
    const val specFailureFilePath: String = "./.kotest/spec_failures"
 
    const val parallelism: Int = 1

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineProperties.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineProperties.kt
@@ -83,4 +83,6 @@ object KotestEngineProperties {
     * Appends all tags associated with a test case to its display name.
     * */
    const val testNameAppendTags = "kotest.framework.testname.append.tags"
+
+   const val duplicateTestNameMode = "kotest.framework.testname.duplicate.mode"
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/DuplicateTestNameMode.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/DuplicateTestNameMode.kt
@@ -20,5 +20,5 @@ enum class DuplicateTestNameMode {
     * Silently adjusts the name of a test when a duplicate is discovered so that the name is unique.
     * The name is prepended with a counter, so a duplicated test `foo` would become `(1) foo`.
     */
-   None
+   Silent
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/DuplicateTestNameMode.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/DuplicateTestNameMode.kt
@@ -1,0 +1,24 @@
+package io.kotest.core.test
+
+enum class DuplicateTestNameMode {
+
+   /**
+    * Fails a test if it has the same name as another test.
+    *
+    * Tests names are compared using the full path, so a nested test `foo` inside a context `bar`, is
+    * considered to be a different test from a nested `foo` inside another context `baz`
+    */
+   Error,
+
+   /**
+    * Outputs a warning on a duplicated test name, and renames the test without failing.
+    * The name is prepended with a counter, so a duplicated test `foo` would become `(1) foo`.
+    */
+   Warn,
+
+   /**
+    * Silently adjusts the name of a test when a duplicate is discovered so that the name is unique.
+    * The name is prepended with a counter, so a duplicated test `foo` would become `(1) foo`.
+    */
+   None
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/Identifiers.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/Identifiers.kt
@@ -27,7 +27,7 @@ object Identifiers {
    fun uniqueTestName(name: String, testNames: Set<String>): String {
       if (!testNames.contains(name)) return name
       var n = 1
-      fun nextName() = "$name ($n)"
+      fun nextName() = "($n) $name"
       while (testNames.contains(nextName()))
          n++
       return nextName()

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/NestedTest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/NestedTest.kt
@@ -41,10 +41,12 @@ fun createNestedTest(
 
 /**
  * Returns a full [TestCase] from this nested test, attaching the nested test to the given spec.
+ *
+ * @param name override the name or can be null to use the original name
  */
-fun NestedTest.toTestCase(spec: Spec, parent: TestCase): TestCase {
+fun NestedTest.toTestCase(spec: Spec, parent: TestCase, name: DescriptionName.TestName? = null): TestCase {
    val testCase = TestCase(
-      description = parent.description.append(this.name, type),
+      description = parent.description.append(name ?: this.name, type),
       spec = spec,
       test = test,
       source = sourceRef,

--- a/kotest-framework/kotest-framework-api/src/jvmMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/jvmMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -10,6 +10,7 @@ import io.kotest.core.spec.IsolationMode
 import io.kotest.core.test.AssertionMode
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.core.test.TestCaseConfig
 import kotlin.reflect.KClass
 import kotlin.time.Duration
@@ -223,6 +224,12 @@ abstract class AbstractProjectConfig {
    open val testNameRemoveWhitespace: Boolean? = null
 
    open val testNameAppendTags: Boolean? = null
+
+   /**
+    * Controls what to do when a duplicated test name is discovered.
+    * See possible settings in [DuplicateTestNameMode].
+    */
+   open val duplicateTestNameMode: DuplicateTestNameMode? = null
 
    /**
     * Executed before the first test of the project, but after the

--- a/kotest-framework/kotest-framework-api/src/jvmTest/kotlin/io/kotest/core/test/IdentifiersTest.kt
+++ b/kotest-framework/kotest-framework-api/src/jvmTest/kotlin/io/kotest/core/test/IdentifiersTest.kt
@@ -7,10 +7,10 @@ class IdentifiersTest : FunSpec() {
    init {
       test("should make repeated names unique") {
          Identifiers.uniqueTestName("foo", emptySet()) shouldBe "foo"
-         Identifiers.uniqueTestName("foo", setOf("foo")) shouldBe "foo (1)"
-         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)")) shouldBe "foo (2)"
-         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)", "foo (2)")) shouldBe "foo (3)"
-         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1")) shouldBe "foo (1)"
+         Identifiers.uniqueTestName("foo", setOf("foo")) shouldBe "(1) foo (1)"
+         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)")) shouldBe "(2) foo"
+         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)", "(2) foo")) shouldBe "(3) foo"
+         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1")) shouldBe "(1) foo"
       }
    }
 }

--- a/kotest-framework/kotest-framework-api/src/jvmTest/kotlin/io/kotest/core/test/IdentifiersTest.kt
+++ b/kotest-framework/kotest-framework-api/src/jvmTest/kotlin/io/kotest/core/test/IdentifiersTest.kt
@@ -7,7 +7,7 @@ class IdentifiersTest : FunSpec() {
    init {
       test("should make repeated names unique") {
          Identifiers.uniqueTestName("foo", emptySet()) shouldBe "foo"
-         Identifiers.uniqueTestName("foo", setOf("foo")) shouldBe "(1) foo (1)"
+         Identifiers.uniqueTestName("foo", setOf("foo")) shouldBe "(1) foo"
          Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)")) shouldBe "(2) foo"
          Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)", "(2) foo")) shouldBe "(3) foo"
          Identifiers.uniqueTestName("foo", setOf("foo", "foo (1")) shouldBe "(1) foo"

--- a/kotest-framework/kotest-framework-api/src/jvmTest/kotlin/io/kotest/core/test/IdentifiersTest.kt
+++ b/kotest-framework/kotest-framework-api/src/jvmTest/kotlin/io/kotest/core/test/IdentifiersTest.kt
@@ -8,9 +8,9 @@ class IdentifiersTest : FunSpec() {
       test("should make repeated names unique") {
          Identifiers.uniqueTestName("foo", emptySet()) shouldBe "foo"
          Identifiers.uniqueTestName("foo", setOf("foo")) shouldBe "(1) foo"
-         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)")) shouldBe "(2) foo"
-         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1)", "(2) foo")) shouldBe "(3) foo"
-         Identifiers.uniqueTestName("foo", setOf("foo", "foo (1")) shouldBe "(1) foo"
+         Identifiers.uniqueTestName("foo", setOf("foo", "(1) foo")) shouldBe "(2) foo"
+         Identifiers.uniqueTestName("foo", setOf("foo", "(1) foo", "(2) foo")) shouldBe "(3) foo"
+         Identifiers.uniqueTestName("foo", setOf("foo", "(1) foo")) shouldBe "(2) foo"
       }
    }
 }

--- a/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/EnumValueInDataClassNamingTest.kt
+++ b/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/EnumValueInDataClassNamingTest.kt
@@ -22,10 +22,10 @@ class EnumValueInDataClassNamingTest : FunSpec() {
       names shouldBe listOf(
          "PythTriple(a=Three, b=Four, c=Five)",
          "PythTriple(a=Four, b=Three, c=Five)",
-         "PythTriple(a=Four, b=Three, c=Five) (1)",
+         "(1) PythTriple(a=Four, b=Three, c=Five)",
          "data class with enum with field",
          "FooClass(a=Bar1, b=Bar2)",
-         "FooClass(a=Bar1, b=Bar2) (1)",
+         "(1) FooClass(a=Bar1, b=Bar2)",
          "data class with enum with class field"
       )
    }

--- a/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/tests.kt
+++ b/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/tests.kt
@@ -52,8 +52,8 @@ fun RootContext.registerRootTests(): MutableList<String> {
       )
    ) { a ->
       a % 2 shouldBe 0
-      if (a == 2) this.testCase.displayName shouldBe "a (2)"
-      if (a == 4) this.testCase.displayName shouldBe "b (2)"
+      if (a == 2) this.testCase.displayName shouldBe "(2) a"
+      if (a == 4) this.testCase.displayName shouldBe "(2) b"
    }
 
    forAll("p", "q") { a ->
@@ -121,8 +121,8 @@ suspend fun TestContext.registerContextTests(): MutableList<String> {
       )
    ) { a ->
       a % 2 shouldBe 0
-      if (a == 2) this.testCase.displayName shouldBe "a (2)"
-      if (a == 4) this.testCase.displayName shouldBe "b (2)"
+      if (a == 2) this.testCase.displayName shouldBe "(2) a"
+      if (a == 4) this.testCase.displayName shouldBe "(2) b"
    }
 
    forAll("p", "q") { a ->

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io.kotest.engine/config/detect.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io.kotest.engine/config/detect.kt
@@ -8,6 +8,7 @@ import io.kotest.core.listeners.Listener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.test.AssertionMode
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.core.test.TestNameCase
@@ -48,7 +49,8 @@ data class DetectedProjectConfig(
    val includeTestScopeAffixes: Option<Boolean> = Option.None,
    val testNameCase: Option<TestNameCase> = Option.None,
    val testNameRemoveWhitespace: Option<Boolean> = Option.None,
-   val testNameAppendTags: Option<Boolean> = Option.None
+   val testNameAppendTags: Option<Boolean> = Option.None,
+   val duplicateTestNameMode: Option<DuplicateTestNameMode> = Option.None,
 )
 
 fun DetectedProjectConfig.merge(other: DetectedProjectConfig): DetectedProjectConfig {
@@ -75,7 +77,8 @@ fun DetectedProjectConfig.merge(other: DetectedProjectConfig): DetectedProjectCo
       includeTestScopeAffixes = this.includeTestScopeAffixes.orElse(other.includeTestScopeAffixes),
       testNameCase = this.testNameCase.orElse(other.testNameCase),
       testNameRemoveWhitespace = this.testNameRemoveWhitespace.orElse(other.testNameRemoveWhitespace),
-      testNameAppendTags = this.testNameAppendTags.orElse(other.testNameAppendTags)
+      testNameAppendTags = this.testNameAppendTags.orElse(other.testNameAppendTags),
+      duplicateTestNameMode = this.duplicateTestNameMode.orElse(other.duplicateTestNameMode),
    )
 }
 
@@ -118,4 +121,6 @@ fun DetectedProjectConfig.apply(configuration: Configuration) {
    testNameCase.forEach { configuration.testNameCase = it }
    testNameRemoveWhitespace.forEach { configuration.removeTestNameWhitespace = it }
    testNameAppendTags.forEach { configuration.testNameAppendTags = it }
+
+   duplicateTestNameMode.forEach { configuration.duplicateTestNameMode = it }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/LoadConfigFromClasspath.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/LoadConfigFromClasspath.kt
@@ -54,6 +54,7 @@ private fun AbstractProjectConfig.toDetectedConfig(): DetectedProjectConfig {
       invocationTimeout = invocationTimeout.toOption(),
       testCaseConfig = defaultTestCaseConfig.toOption(),
       includeTestScopeAffixes = includeTestScopePrefixes.toOption(),
+      duplicateTestNameMode = duplicateTestNameMode.toOption(),
       testNameCase = testNameCase.toOption(),
       testNameRemoveWhitespace = testNameRemoveWhitespace.toOption(),
       testNameAppendTags = testNameAppendTags.toOption()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/loadConfigFromSystemProperties.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/loadConfigFromSystemProperties.kt
@@ -3,6 +3,7 @@ package io.kotest.engine.config
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.test.AssertionMode
 import io.kotest.core.internal.KotestEngineProperties
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.fp.Option
 import io.kotest.fp.toOption
 import io.kotest.mpp.sysprop
@@ -36,6 +37,9 @@ internal fun globalAssertSoftly(): Option<Boolean> =
 internal fun testNameAppendTags(): Option<Boolean> =
    sysprop(KotestEngineProperties.testNameAppendTags).toOption().map { it.toUpperCase() == "TRUE" }
 
+internal fun duplicateTestNameMode(): Option<DuplicateTestNameMode> =
+   sysprop(KotestEngineProperties.testNameAppendTags).toOption().map { DuplicateTestNameMode.valueOf(it) }
+
 /**
  * Returns a [DetectedProjectConfig] which is built from system properties where supported.
  */
@@ -50,6 +54,7 @@ internal fun loadConfigFromSystemProperties(): DetectedProjectConfig {
       invocationTimeout = invocationTimeout(),
       testNameRemoveWhitespace = allowMultilineTestName(),
       globalAssertSoftly = globalAssertSoftly(),
-      testNameAppendTags = testNameAppendTags()
+      testNameAppendTags = testNameAppendTags(),
+      duplicateTestNameMode = duplicateTestNameMode(),
    )
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/script/ScriptExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/script/ScriptExecutor.kt
@@ -122,7 +122,7 @@ class ScriptExecutor(private val listener: TestEngineListener) {
       // in the single instance runner we execute each nested test as soon as they are registered
       override suspend fun registerTestCase(nested: NestedTest) {
          log("Nested test case discovered $nested")
-         val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+         val overrideName = handler.handle(nested.name)?.let { createTestName(it) }
          val nestedTestCase = nested.toTestCase(testCase.spec, testCase, overrideName)
          runTest(nestedTestCase, coroutineContext)
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/ConcurrentInstancePerLeafSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/ConcurrentInstancePerLeafSpecRunner.kt
@@ -1,7 +1,6 @@
 package io.kotest.engine.spec.runners
 
 import io.kotest.core.config.configuration
-import io.kotest.core.test.Identifiers
 import io.kotest.core.test.NestedTest
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
@@ -116,7 +115,7 @@ internal class ConcurrentInstancePerLeafSpecRunner(
 
             override suspend fun registerTestCase(nested: NestedTest) {
 
-               val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+               val overrideName = handler.handle(nested.name)?.let { createTestName(it) }
                val t = nested.toTestCase(test.spec, test, overrideName)
 
                when {

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerLeafSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerLeafSpecRunner.kt
@@ -1,30 +1,30 @@
 package io.kotest.engine.spec.runners
 
-import io.kotest.core.test.Identifiers
-import io.kotest.core.spec.Spec
-import io.kotest.core.test.Description
-import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
-import io.kotest.core.test.TestContext
-import io.kotest.core.test.TestResult
-import io.kotest.core.test.toTestCase
-import io.kotest.engine.spec.SpecRunner
-import io.kotest.engine.listener.TestEngineListener
-import io.kotest.engine.ExecutorExecutionContext
+import io.kotest.core.config.configuration
 import io.kotest.core.internal.TestCaseExecutor
+import io.kotest.core.spec.Spec
 import io.kotest.core.spec.invokeAfterSpec
 import io.kotest.core.spec.invokeBeforeSpec
 import io.kotest.core.spec.materializeAndOrderRootTests
+import io.kotest.core.test.Description
+import io.kotest.core.test.NestedTest
+import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestCaseExecutionListener
+import io.kotest.core.test.TestContext
+import io.kotest.core.test.TestResult
 import io.kotest.core.test.createTestName
+import io.kotest.core.test.toTestCase
+import io.kotest.engine.ExecutorExecutionContext
 import io.kotest.engine.launchers.TestLauncher
+import io.kotest.engine.listener.TestEngineListener
+import io.kotest.engine.spec.SpecRunner
+import io.kotest.engine.test.DuplicateTestNameHandler
 import io.kotest.engine.toTestResult
 import io.kotest.fp.Try
 import io.kotest.mpp.log
 import kotlinx.coroutines.coroutineScope
 import java.util.PriorityQueue
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.Comparator
 import kotlin.coroutines.CoroutineContext
 
 internal class InstancePerLeafSpecRunner(
@@ -102,17 +102,14 @@ internal class InstancePerLeafSpecRunner(
 
             var open = true
 
-            // names in the same scope
-            val namesInScope = mutableSetOf<String>()
+            private val handler = DuplicateTestNameHandler(configuration.duplicateTestNameMode)
 
             override val testCase: TestCase = test
             override val coroutineContext: CoroutineContext = this@coroutineScope.coroutineContext
             override suspend fun registerTestCase(nested: NestedTest) {
 
-               val uniqueName = Identifiers.uniqueTestName(nested.name.name, namesInScope)
-               namesInScope.add(uniqueName)
-
-               val t = nested.copy(name = createTestName(uniqueName)).toTestCase(test.spec, test)
+               val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+               val t = nested.toTestCase(test.spec, test, overrideName)
 
                // if this test is our target then we definitely run it
                // or if the test is on the path to our target we must run it

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerLeafSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerLeafSpecRunner.kt
@@ -108,7 +108,7 @@ internal class InstancePerLeafSpecRunner(
             override val coroutineContext: CoroutineContext = this@coroutineScope.coroutineContext
             override suspend fun registerTestCase(nested: NestedTest) {
 
-               val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+               val overrideName = handler.handle(nested.name)?.let { createTestName(it) }
                val t = nested.toTestCase(test.spec, test, overrideName)
 
                // if this test is our target then we definitely run it

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerTestSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerTestSpecRunner.kt
@@ -133,7 +133,7 @@ internal class InstancePerTestSpecRunner(
             override val coroutineContext: CoroutineContext = this@coroutineScope.coroutineContext
             override suspend fun registerTestCase(nested: NestedTest) {
 
-               val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+               val overrideName = handler.handle(nested.name)?.let { createTestName(it) }
                val t = nested.toTestCase(testCase.spec, testCase, overrideName)
 
                // if we are currently executing the target, then any registered tests are new, and we

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerTestSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerTestSpecRunner.kt
@@ -1,17 +1,25 @@
 package io.kotest.engine.spec.runners
 
-import io.kotest.core.test.Identifiers
+import io.kotest.core.config.configuration
 import io.kotest.core.internal.TestCaseExecutor
 import io.kotest.core.internal.resolvedThreads
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.invokeAfterSpec
 import io.kotest.core.spec.invokeBeforeSpec
 import io.kotest.core.spec.materializeAndOrderRootTests
-import io.kotest.core.test.*
+import io.kotest.core.test.NestedTest
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestCaseExecutionListener
+import io.kotest.core.test.TestContext
+import io.kotest.core.test.TestResult
+import io.kotest.core.test.TestType
+import io.kotest.core.test.createTestName
+import io.kotest.core.test.toTestCase
 import io.kotest.engine.ExecutorExecutionContext
 import io.kotest.engine.launchers.TestLauncher
 import io.kotest.engine.listener.TestEngineListener
 import io.kotest.engine.spec.SpecRunner
+import io.kotest.engine.test.DuplicateTestNameHandler
 import io.kotest.engine.toTestResult
 import io.kotest.fp.Try
 import io.kotest.mpp.log
@@ -119,16 +127,15 @@ internal class InstancePerTestSpecRunner(
       coroutineScope {
          val context = object : TestContext {
 
-            val namesInScope = mutableSetOf<String>()
+            private val handler = DuplicateTestNameHandler(configuration.duplicateTestNameMode)
 
             override val testCase: TestCase = test
             override val coroutineContext: CoroutineContext = this@coroutineScope.coroutineContext
             override suspend fun registerTestCase(nested: NestedTest) {
 
-               val uniqueName = Identifiers.uniqueTestName(nested.name.name, namesInScope)
-               namesInScope.add(uniqueName)
+               val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+               val t = nested.toTestCase(testCase.spec, testCase, overrideName)
 
-               val t = nested.copy(name = createTestName(uniqueName)).toTestCase(test.spec, test)
                // if we are currently executing the target, then any registered tests are new, and we
                // should begin execution of them in fresh specs
                // otherwise if the test is on the path we can continue in the same spec

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/SingleInstanceSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/SingleInstanceSpecRunner.kt
@@ -1,6 +1,6 @@
 package io.kotest.engine.spec.runners
 
-import io.kotest.core.test.Identifiers
+import io.kotest.core.config.configuration
 import io.kotest.core.internal.TestCaseExecutor
 import io.kotest.core.internal.resolvedThreads
 import io.kotest.core.spec.Spec
@@ -18,6 +18,7 @@ import io.kotest.engine.ExecutorExecutionContext
 import io.kotest.engine.launchers.TestLauncher
 import io.kotest.engine.listener.TestEngineListener
 import io.kotest.engine.spec.SpecRunner
+import io.kotest.engine.test.DuplicateTestNameHandler
 import io.kotest.engine.toTestResult
 import io.kotest.fp.Try
 import io.kotest.mpp.log
@@ -71,18 +72,13 @@ internal class SingleInstanceSpecRunner(
       override val coroutineContext: CoroutineContext,
    ) : TestContext {
 
-      // these are the tests inside this context, so we can track for duplicates
-      private val seen = mutableSetOf<String>()
+      private val handler = DuplicateTestNameHandler(configuration.duplicateTestNameMode)
 
       // in the single instance runner we execute each nested test as soon as they are registered
       override suspend fun registerTestCase(nested: NestedTest) {
          log("Nested test case discovered $nested")
-
-         val uniqueName = Identifiers.uniqueTestName(nested.name.name, seen)
-         seen.add(uniqueName)
-
-         val nested2 = if (uniqueName == nested.name.name) nested else nested.copy(name = createTestName(uniqueName))
-         val nestedTestCase = nested2.toTestCase(testCase.spec, testCase)
+         val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+         val nestedTestCase = nested.toTestCase(testCase.spec, testCase, overrideName)
          runTest(nestedTestCase, coroutineContext)
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/SingleInstanceSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/SingleInstanceSpecRunner.kt
@@ -77,7 +77,7 @@ internal class SingleInstanceSpecRunner(
       // in the single instance runner we execute each nested test as soon as they are registered
       override suspend fun registerTestCase(nested: NestedTest) {
          log("Nested test case discovered $nested")
-         val overrideName = handler.handle(testCase)?.let { createTestName(it) }
+         val overrideName = handler.handle(nested.name)?.let { createTestName(it) }
          val nestedTestCase = nested.toTestCase(testCase.spec, testCase, overrideName)
          runTest(nestedTestCase, coroutineContext)
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/DuplicateTestNameHandler.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/DuplicateTestNameHandler.kt
@@ -1,8 +1,8 @@
 package io.kotest.engine.test
 
+import io.kotest.core.test.DescriptionName
 import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.core.test.Identifiers
-import io.kotest.core.test.TestCase
 
 /**
  * A handler for test names. Will track all test names used for a particular context.
@@ -14,21 +14,21 @@ class DuplicateTestNameHandler(private val mode: DuplicateTestNameMode) {
    private fun message(name: String): String =
       "Duplicated test name ${name}. To disable this message, set DuplicateTestNameMode to None."
 
-   fun handle(testCase: TestCase): String? {
-      val isUnique = names.add(testCase.description.name.name)
+   fun handle(name: DescriptionName.TestName): String? {
+      val isUnique = names.add(name.name)
       if (isUnique) return null
       return when (mode) {
-         DuplicateTestNameMode.Error -> error(message(testCase.displayName))
-         DuplicateTestNameMode.None -> makeUniqueName(testCase)
+         DuplicateTestNameMode.Error -> error(message(name.name))
+         DuplicateTestNameMode.Silent -> makeUniqueName(name.name)
          DuplicateTestNameMode.Warn -> {
-            println("WARN: " + message(testCase.displayName))
-            makeUniqueName(testCase)
+            println("WARN: " + message(name.name))
+            makeUniqueName(name.name)
          }
       }
    }
 
-   private fun makeUniqueName(testCase: TestCase): String {
-      val unique = Identifiers.uniqueTestName(testCase.description.name.name, names)
+   private fun makeUniqueName(name: String): String {
+      val unique = Identifiers.uniqueTestName(name, names)
       names.add(unique)
       return unique
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/DuplicateTestNameHandler.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/DuplicateTestNameHandler.kt
@@ -1,0 +1,35 @@
+package io.kotest.engine.test
+
+import io.kotest.core.test.DuplicateTestNameMode
+import io.kotest.core.test.Identifiers
+import io.kotest.core.test.TestCase
+
+/**
+ * A handler for test names. Will track all test names used for a particular context.
+ */
+class DuplicateTestNameHandler(private val mode: DuplicateTestNameMode) {
+
+   private val names = mutableSetOf<String>()
+
+   private fun message(name: String): String =
+      "Duplicated test name ${name}. To disable this message, set DuplicateTestNameMode to None."
+
+   fun handle(testCase: TestCase): String? {
+      val isUnique = names.add(testCase.description.name.name)
+      if (isUnique) return null
+      return when (mode) {
+         DuplicateTestNameMode.Error -> error(message(testCase.displayName))
+         DuplicateTestNameMode.None -> makeUniqueName(testCase)
+         DuplicateTestNameMode.Warn -> {
+            println("WARN: " + message(testCase.displayName))
+            makeUniqueName(testCase)
+         }
+      }
+   }
+
+   private fun makeUniqueName(testCase: TestCase): String {
+      val unique = Identifiers.uniqueTestName(testCase.description.name.name, names)
+      names.add(unique)
+      return unique
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/datatest/DataTestingRepeatedNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/datatest/DataTestingRepeatedNameTest.kt
@@ -38,9 +38,9 @@ class DataTestingRepeatedTestNameTest : FunSpec() {
             "Foo(name=sam)",
             "Foo(name=ham)",
             "Foo(name=sham)",
-            "Foo(name=sham) (1)",
-            "Foo(name=ham) (1)",
-            "Foo(name=ham) (2)",
+            "(1) Foo(name=sham)",
+            "(1) Foo(name=ham)",
+            "(2) Foo(name=ham)",
             "foo",
          )
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/describeSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/describeSpec.kt
@@ -1,22 +1,11 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.config.configuration
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class DescribeSpecDuplicateTestNameModeInfoTest(iso: IsolationMode) : DescribeSpec() {
-
-   private val previous = configuration.duplicateTestNameMode
-
    init {
-
-      beforeSpec {
-         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
-      }
-
       isolationMode = iso
       describe("foo") {
          it("woo") {}
@@ -40,18 +29,9 @@ abstract class DescribeSpecDuplicateTestNameModeInfoTest(iso: IsolationMode) : D
       context("goo") {
          this.testCase.displayName shouldBe "(2) goo"
       }
-
-      afterSpec {
-         configuration.duplicateTestNameMode = previous
-      }
    }
 }
 
-@Isolate // sets global values via configuration so must be isolated
 class DescribeSpecSingleInstanceDuplicateTestNameModeInfoTest : DescribeSpecDuplicateTestNameModeInfoTest(IsolationMode.SingleInstance)
-
-@Isolate // sets global values via configuration so must be isolated
 class DescribeSpecInstancePerLeafDuplicateTestNameModeInfoTest : DescribeSpecDuplicateTestNameModeInfoTest(IsolationMode.InstancePerLeaf)
-
-@Isolate // sets global values via configuration so must be isolated
 class DescribeSpecInstancePerTestDuplicateTestNameModeInfoTest : DescribeSpecDuplicateTestNameModeInfoTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/describeSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/describeSpec.kt
@@ -1,37 +1,57 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
-abstract class DescribeSpecDuplicateNameTest(iso: IsolationMode) : DescribeSpec() {
+abstract class DescribeSpecDuplicateTestNameModeInfoTest(iso: IsolationMode) : DescribeSpec() {
+
+   private val previous = configuration.duplicateTestNameMode
+
    init {
+
+      beforeSpec {
+         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
+      }
+
       isolationMode = iso
       describe("foo") {
          it("woo") {}
          it("woo") {
-            this.testCase.displayName shouldBe "woo (1)"
+            this.testCase.displayName shouldBe "(1) woo"
          }
          it("woo") {
-            this.testCase.displayName shouldBe "woo (2)"
+            this.testCase.displayName shouldBe "(2) woo"
          }
       }
       describe("foo") {
-         this.testCase.displayName shouldBe "foo (1)"
+         this.testCase.displayName shouldBe "(1) foo"
       }
       describe("foo") {
-         this.testCase.displayName shouldBe "foo (2)"
+         this.testCase.displayName shouldBe "(2) foo"
       }
       context("goo") {}
       context("goo") {
-         this.testCase.displayName shouldBe "goo (1)"
+         this.testCase.displayName shouldBe "(1) goo"
       }
       context("goo") {
-         this.testCase.displayName shouldBe "goo (2)"
+         this.testCase.displayName shouldBe "(2) goo"
+      }
+
+      afterSpec {
+         configuration.duplicateTestNameMode = previous
       }
    }
 }
 
-class DescribeSpecSingleInstanceDuplicateNameTest : DescribeSpecDuplicateNameTest(IsolationMode.SingleInstance)
-class DescribeSpecInstancePerLeafDuplicateNameTest : DescribeSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-class DescribeSpecInstancePerTestDuplicateNameTest : DescribeSpecDuplicateNameTest(IsolationMode.InstancePerTest)
+@Isolate // sets global values via configuration so must be isolated
+class DescribeSpecSingleInstanceDuplicateTestNameModeInfoTest : DescribeSpecDuplicateTestNameModeInfoTest(IsolationMode.SingleInstance)
+
+@Isolate // sets global values via configuration so must be isolated
+class DescribeSpecInstancePerLeafDuplicateTestNameModeInfoTest : DescribeSpecDuplicateTestNameModeInfoTest(IsolationMode.InstancePerLeaf)
+
+@Isolate // sets global values via configuration so must be isolated
+class DescribeSpecInstancePerTestDuplicateTestNameModeInfoTest : DescribeSpecDuplicateTestNameModeInfoTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/expectSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/expectSpec.kt
@@ -1,22 +1,46 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ExpectSpec
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
-abstract class ExpectSpecDuplicateNameTest(iso: IsolationMode) : ExpectSpec() {
+abstract class ExpectSpecDuplicateTest(iso: IsolationMode) : ExpectSpec() {
+
+   private val previous = configuration.duplicateTestNameMode
+
    init {
+
+      beforeSpec {
+         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
+      }
+
       isolationMode = iso
       context("foo") {
          expect("woo") {}
-         expect("woo") { this.testCase.displayName shouldBe "woo (1)" }
+         expect("woo") { this.testCase.displayName shouldBe "(1) woo" }
+         expect("woo") { this.testCase.displayName shouldBe "(2) woo" }
       }
       context("foo") {
-         this.testCase.displayName shouldBe "foo (1)"
+         this.testCase.displayName shouldBe "(1) foo"
+      }
+      context("foo") {
+         this.testCase.displayName shouldBe "(2) foo"
+      }
+
+      afterSpec {
+         configuration.duplicateTestNameMode = previous
       }
    }
 }
 
-class ExpectSpecSingleInstanceDuplicateNameTest : ExpectSpecDuplicateNameTest(IsolationMode.SingleInstance)
-class ExpectSpecInstancePerLeafDuplicateNameTest : ExpectSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-class ExpectSpecInstancePerTestDuplicateNameTest : ExpectSpecDuplicateNameTest(IsolationMode.InstancePerTest)
+@Isolate
+class ExpectSpecSingleInstanceDuplicateNameTest : ExpectSpecDuplicateTest(IsolationMode.SingleInstance)
+
+@Isolate
+class ExpectSpecInstancePerLeafDuplicateNameTest : ExpectSpecDuplicateTest(IsolationMode.InstancePerLeaf)
+
+@Isolate
+class ExpectSpecInstancePerTestDuplicateNameTest : ExpectSpecDuplicateTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/expectSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/expectSpec.kt
@@ -1,22 +1,11 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.config.configuration
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ExpectSpec
-import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class ExpectSpecDuplicateTest(iso: IsolationMode) : ExpectSpec() {
-
-   private val previous = configuration.duplicateTestNameMode
-
    init {
-
-      beforeSpec {
-         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
-      }
-
       isolationMode = iso
       context("foo") {
          expect("woo") {}
@@ -29,18 +18,9 @@ abstract class ExpectSpecDuplicateTest(iso: IsolationMode) : ExpectSpec() {
       context("foo") {
          this.testCase.displayName shouldBe "(2) foo"
       }
-
-      afterSpec {
-         configuration.duplicateTestNameMode = previous
-      }
    }
 }
 
-@Isolate
 class ExpectSpecSingleInstanceDuplicateNameTest : ExpectSpecDuplicateTest(IsolationMode.SingleInstance)
-
-@Isolate
 class ExpectSpecInstancePerLeafDuplicateNameTest : ExpectSpecDuplicateTest(IsolationMode.InstancePerLeaf)
-
-@Isolate
 class ExpectSpecInstancePerTestDuplicateNameTest : ExpectSpecDuplicateTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/featureSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/featureSpec.kt
@@ -1,22 +1,11 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.config.configuration
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FeatureSpec
-import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class FeatureSpecDuplicateNameTest(iso: IsolationMode) : FeatureSpec() {
-
-   private val previous = configuration.duplicateTestNameMode
-
    init {
-
-      beforeSpec {
-         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
-      }
-
       isolationMode = iso
       feature("foo") {
          scenario("woo") {}
@@ -25,18 +14,9 @@ abstract class FeatureSpecDuplicateNameTest(iso: IsolationMode) : FeatureSpec() 
       }
       feature("foo") { this.testCase.displayName shouldBe "(1) foo" }
       feature("foo") { this.testCase.displayName shouldBe "(2) foo" }
-
-      afterSpec {
-         configuration.duplicateTestNameMode = previous
-      }
    }
 }
 
-@Isolate // sets global values via configuration so must be isolated
 class FeatureSpecSingleInstanceDuplicateNameTest : FeatureSpecDuplicateNameTest(IsolationMode.SingleInstance)
-
-@Isolate // sets global values via configuration so must be isolated
 class FeatureSpecInstancePerLeafDuplicateNameTest : FeatureSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-
-@Isolate // sets global values via configuration so must be isolated
 class FeatureSpecInstancePerTestDuplicateNameTest : FeatureSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/featureSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/featureSpec.kt
@@ -1,24 +1,42 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FeatureSpec
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class FeatureSpecDuplicateNameTest(iso: IsolationMode) : FeatureSpec() {
+
+   private val previous = configuration.duplicateTestNameMode
+
    init {
+
+      beforeSpec {
+         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
+      }
+
       isolationMode = iso
       feature("foo") {
          scenario("woo") {}
-         scenario("woo") {
-            this.testCase.displayName shouldBe "woo (1)"
-         }
+         scenario("woo") { this.testCase.displayName shouldBe "(1) woo" }
+         scenario("woo") { this.testCase.displayName shouldBe "(2) woo" }
       }
-      feature("foo") {
-         this.testCase.displayName shouldBe "foo (1)"
+      feature("foo") { this.testCase.displayName shouldBe "(1) foo" }
+      feature("foo") { this.testCase.displayName shouldBe "(2) foo" }
+
+      afterSpec {
+         configuration.duplicateTestNameMode = previous
       }
    }
 }
 
+@Isolate // sets global values via configuration so must be isolated
 class FeatureSpecSingleInstanceDuplicateNameTest : FeatureSpecDuplicateNameTest(IsolationMode.SingleInstance)
+
+@Isolate // sets global values via configuration so must be isolated
 class FeatureSpecInstancePerLeafDuplicateNameTest : FeatureSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
+
+@Isolate // sets global values via configuration so must be isolated
 class FeatureSpecInstancePerTestDuplicateNameTest : FeatureSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/freespec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/freespec.kt
@@ -1,22 +1,11 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.config.configuration
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class FreeSpecDuplicateNameTest(iso: IsolationMode) : FreeSpec() {
-
-   private val previous = configuration.duplicateTestNameMode
-
    init {
-
-      beforeSpec {
-         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
-      }
-
       isolationMode = iso
 
       "foo" { }
@@ -40,18 +29,9 @@ abstract class FreeSpecDuplicateNameTest(iso: IsolationMode) : FreeSpec() {
       "woo" - {
          this.testCase.displayName shouldBe "(2) woo"
       }
-
-      afterSpec {
-         configuration.duplicateTestNameMode = previous
-      }
    }
 }
 
-@Isolate // sets global values via configuration so must be isolated
 class FreeSpecSingleInstanceDuplicateNameTest : FreeSpecDuplicateNameTest(IsolationMode.SingleInstance)
-
-@Isolate // sets global values via configuration so must be isolated
 class FreeSpecInstancePerLeafDuplicateNameTest : FreeSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-
-@Isolate // sets global values via configuration so must be isolated
 class FreeSpecInstancePerTestDuplicateNameTest : FreeSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/freespec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/freespec.kt
@@ -1,32 +1,57 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class FreeSpecDuplicateNameTest(iso: IsolationMode) : FreeSpec() {
 
+   private val previous = configuration.duplicateTestNameMode
+
    init {
+
+      beforeSpec {
+         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
+      }
+
       isolationMode = iso
 
       "foo" { }
-      "foo" {
-         this.testCase.displayName shouldBe "foo (1)"
-      }
+      "foo" { this.testCase.displayName shouldBe "(1) foo" }
+      "foo" { this.testCase.displayName shouldBe "(2) foo" }
 
       "woo" - {
          "goo" { }
          "goo" {
-            this.testCase.displayName shouldBe "goo (1)"
+            this.testCase.displayName shouldBe "(1) goo"
+         }
+         "goo" {
+            this.testCase.displayName shouldBe "(2) goo"
          }
       }
 
       "woo" - {
-         this.testCase.displayName shouldBe "woo (1)"
+         this.testCase.displayName shouldBe "(1) woo"
+      }
+
+      "woo" - {
+         this.testCase.displayName shouldBe "(2) woo"
+      }
+
+      afterSpec {
+         configuration.duplicateTestNameMode = previous
       }
    }
 }
 
+@Isolate // sets global values via configuration so must be isolated
 class FreeSpecSingleInstanceDuplicateNameTest : FreeSpecDuplicateNameTest(IsolationMode.SingleInstance)
+
+@Isolate // sets global values via configuration so must be isolated
 class FreeSpecInstancePerLeafDuplicateNameTest : FreeSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
+
+@Isolate // sets global values via configuration so must be isolated
 class FreeSpecInstancePerTestDuplicateNameTest : FreeSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/funSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/funSpec.kt
@@ -1,23 +1,11 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.config.configuration
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class FunSpecDuplicateNameTest(iso: IsolationMode) : FunSpec() {
-
-   private val previous = configuration.duplicateTestNameMode
-
-
    init {
-
-      beforeSpec {
-         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
-      }
-
       isolationMode = iso
       context("wobble") {
          test("wibble") { }
@@ -26,19 +14,10 @@ abstract class FunSpecDuplicateNameTest(iso: IsolationMode) : FunSpec() {
       }
       context("wobble") { this.testCase.displayName shouldBe "(1) wobble" }
       context("wobble") { this.testCase.displayName shouldBe "(2) wobble" }
-
-      afterSpec {
-         configuration.duplicateTestNameMode = previous
-      }
    }
 }
 
-@Isolate // sets global values via configuration so must be isolated
 class FunSpecSingleInstanceDuplicateNameTest : FunSpecDuplicateNameTest(IsolationMode.SingleInstance)
-
-@Isolate // sets global values via configuration so must be isolated
 class FunSpecInstancePerLeafDuplicateNameTest : FunSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-
-@Isolate // sets global values via configuration so must be isolated
 class FunSpecInstancePerTestDuplicateNameTest : FunSpecDuplicateNameTest(IsolationMode.InstancePerTest)
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/funSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/funSpec.kt
@@ -1,25 +1,44 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class FunSpecDuplicateNameTest(iso: IsolationMode) : FunSpec() {
+
+   private val previous = configuration.duplicateTestNameMode
+
+
    init {
+
+      beforeSpec {
+         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
+      }
+
       isolationMode = iso
       context("wobble") {
          test("wibble") { }
-         test("wibble") {
-            this.testCase.displayName shouldBe "wibble (1)"
-         }
+         test("wibble") { this.testCase.displayName shouldBe "(1) wibble" }
+         test("wibble") { this.testCase.displayName shouldBe "(2) wibble" }
       }
-      context("wobble") {
-         this.testCase.displayName shouldBe "wobble (1)"
+      context("wobble") { this.testCase.displayName shouldBe "(1) wobble" }
+      context("wobble") { this.testCase.displayName shouldBe "(2) wobble" }
+
+      afterSpec {
+         configuration.duplicateTestNameMode = previous
       }
    }
 }
 
+@Isolate // sets global values via configuration so must be isolated
 class FunSpecSingleInstanceDuplicateNameTest : FunSpecDuplicateNameTest(IsolationMode.SingleInstance)
+
+@Isolate // sets global values via configuration so must be isolated
 class FunSpecInstancePerLeafDuplicateNameTest : FunSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
+
+@Isolate // sets global values via configuration so must be isolated
 class FunSpecInstancePerTestDuplicateNameTest : FunSpecDuplicateNameTest(IsolationMode.InstancePerTest)
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/shouldSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/shouldSpec.kt
@@ -1,6 +1,5 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
@@ -18,11 +17,6 @@ abstract class ShouldSpecDuplicateNameTest(iso: IsolationMode) : ShouldSpec() {
    }
 }
 
-@Isolate // sets global values via configuration so must be isolated
 class ShouldSpecSingleInstanceDuplicateNameTest : ShouldSpecDuplicateNameTest(IsolationMode.SingleInstance)
-
-@Isolate // sets global values via configuration so must be isolated
 class ShouldSpecInstancePerLeafDuplicateNameTest : ShouldSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-
-@Isolate // sets global values via configuration so must be isolated
 class ShouldSpecInstancePerTestDuplicateNameTest : ShouldSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/shouldSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/shouldSpec.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
@@ -9,16 +10,19 @@ abstract class ShouldSpecDuplicateNameTest(iso: IsolationMode) : ShouldSpec() {
       isolationMode = iso
       context("foo") {
          should("woo") {}
-         should("woo") {
-            this.testCase.displayName shouldBe "woo (1)"
-         }
+         should("woo") { this.testCase.displayName shouldBe "(1) woo" }
+         should("woo") { this.testCase.displayName shouldBe "(2) woo" }
       }
-      context("foo") {
-         this.testCase.displayName shouldBe "foo (1)"
-      }
+      context("foo") { this.testCase.displayName shouldBe "(1) foo" }
+      context("foo") { this.testCase.displayName shouldBe "(2) foo" }
    }
 }
 
+@Isolate // sets global values via configuration so must be isolated
 class ShouldSpecSingleInstanceDuplicateNameTest : ShouldSpecDuplicateNameTest(IsolationMode.SingleInstance)
+
+@Isolate // sets global values via configuration so must be isolated
 class ShouldSpecInstancePerLeafDuplicateNameTest : ShouldSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
+
+@Isolate // sets global values via configuration so must be isolated
 class ShouldSpecInstancePerTestDuplicateNameTest : ShouldSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/stringSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/stringSpec.kt
@@ -1,39 +1,18 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
-import io.kotest.core.config.configuration
-import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class StringSpecDuplicateNameTest(iso: IsolationMode) : StringSpec() {
-
-   private val previous = configuration.duplicateTestNameMode
-
    init {
-
-      beforeSpec {
-         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
-      }
-
       isolationMode = iso
-
       "foo" {}
       "foo" { this.testCase.displayName shouldBe "(1) foo" }
       "foo" { this.testCase.displayName shouldBe "(2) foo" }
-
-      afterSpec {
-         configuration.duplicateTestNameMode = previous
-      }
    }
 }
 
-@Isolate // sets global values via configuration so must be isolated
 class StringSpecSingleInstanceDuplicateNameTest : StringSpecDuplicateNameTest(IsolationMode.SingleInstance)
-
-@Isolate // sets global values via configuration so must be isolated
 class StringSpecInstancePerLeafDuplicateNameTest : StringSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
-
-@Isolate // sets global values via configuration so must be isolated
 class StringSpecInstancePerTestDuplicateNameTest : StringSpecDuplicateNameTest(IsolationMode.InstancePerTest)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/stringSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/duplicatedname/stringSpec.kt
@@ -1,19 +1,39 @@
 package com.sksamuel.kotest.engine.spec.duplicatedname
 
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.test.DuplicateTestNameMode
 import io.kotest.matchers.shouldBe
 
 abstract class StringSpecDuplicateNameTest(iso: IsolationMode) : StringSpec() {
+
+   private val previous = configuration.duplicateTestNameMode
+
    init {
+
+      beforeSpec {
+         configuration.duplicateTestNameMode = DuplicateTestNameMode.Silent
+      }
+
       isolationMode = iso
+
       "foo" {}
-      "foo" {
-         this.testCase.displayName shouldBe "foo (1)"
+      "foo" { this.testCase.displayName shouldBe "(1) foo" }
+      "foo" { this.testCase.displayName shouldBe "(2) foo" }
+
+      afterSpec {
+         configuration.duplicateTestNameMode = previous
       }
    }
 }
 
+@Isolate // sets global values via configuration so must be isolated
 class StringSpecSingleInstanceDuplicateNameTest : StringSpecDuplicateNameTest(IsolationMode.SingleInstance)
+
+@Isolate // sets global values via configuration so must be isolated
 class StringSpecInstancePerLeafDuplicateNameTest : StringSpecDuplicateNameTest(IsolationMode.InstancePerLeaf)
+
+@Isolate // sets global values via configuration so must be isolated
 class StringSpecInstancePerTestDuplicateNameTest : StringSpecDuplicateNameTest(IsolationMode.InstancePerTest)


### PR DESCRIPTION
Closes #2234 

I've added `DuplicateTestNameMode` which allows us to have an error (current behavior), a warning (outputs a message saying dup name, renames test), or none (no warning, renames test).

The renamed tests are like `foo` => `(1) foo` and so on.

I've set default to warning.