### PR TITLE
Unfinished tests should error

### DIFF
--- a/kotest-common/src/commonMain/kotlin/io/kotest/fp/Try.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/fp/Try.kt
@@ -6,6 +6,7 @@ sealed class Try<out T> {
    data class Failure(val error: Throwable) : Try<Nothing>()
 
    companion object {
+      fun failure(error: String) = Failure(RuntimeException(error))
       operator fun invoke(t: Throwable): Try<Unit> = Failure(t)
       inline operator fun <T> invoke(f: () -> T): Try<T> = try {
          Success(f())

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerContext.kt
@@ -100,21 +100,25 @@ class DescribeSpecContainerContext(
       )
    }
 
-   fun it(name: String) =
-      TestWithConfigBuilder(
+   suspend fun it(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
+      return TestWithConfigBuilder(
          createTestName("It: ", name, false),
          testContext,
          testCase.spec.resolvedDefaultConfig(),
          xdisabled = false,
       )
+   }
 
-   fun xit(name: String) =
-      TestWithConfigBuilder(
+   suspend fun xit(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
+      return TestWithConfigBuilder(
          createTestName("It: ", name, false),
          testContext,
          testCase.spec.resolvedDefaultConfig(),
          xdisabled = true,
       )
+   }
 
    suspend fun it(name: String, test: suspend TestContext.() -> Unit) =
       registerTestCase(

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerContext.kt
@@ -98,7 +98,8 @@ class ExpectSpecContainerContext(
       )
    }
 
-   fun expect(name: String): TestWithConfigBuilder {
+   suspend fun expect(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
       return TestWithConfigBuilder(
          createTestName("Expect: ", name, false),
          testContext,
@@ -107,7 +108,8 @@ class ExpectSpecContainerContext(
       )
    }
 
-   fun xexpect(name: String): TestWithConfigBuilder {
+   suspend fun xexpect(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
       return TestWithConfigBuilder(
          createTestName("Expect: ", name, false),
          testContext,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerContext.kt
@@ -98,7 +98,8 @@ class FeatureSpecContainerContext(
       )
    }
 
-   fun scenario(name: String): TestWithConfigBuilder {
+   suspend fun scenario(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
       return TestWithConfigBuilder(
          createTestName("Scenario: ", name, false),
          testContext,
@@ -107,7 +108,8 @@ class FeatureSpecContainerContext(
       )
    }
 
-   fun xscenario(name: String): TestWithConfigBuilder {
+   suspend fun xscenario(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
       return TestWithConfigBuilder(
          createTestName("Scenario: ", name, false),
          testContext,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerContext.kt
@@ -92,14 +92,28 @@ class FunSpecContainerContext(
    /**
     * Adds a test case to this context, expecting config.
     */
-   fun test(name: String) =
-      TestWithConfigBuilder(createTestName(name), testContext, testCase.spec.resolvedDefaultConfig(), xdisabled = false)
+   suspend fun test(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
+      return TestWithConfigBuilder(
+         createTestName(name),
+         testContext,
+         testCase.spec.resolvedDefaultConfig(),
+         xdisabled = false
+      )
+   }
 
    /**
     * Adds a disabled test case to this context, expecting config.
     */
-   fun xtest(name: String) =
-      TestWithConfigBuilder(createTestName(name), testContext, testCase.spec.resolvedDefaultConfig(), xdisabled = true)
+   suspend fun xtest(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
+      return TestWithConfigBuilder(
+         createTestName(name),
+         testContext,
+         testCase.spec.resolvedDefaultConfig(),
+         xdisabled = true
+      )
+   }
 
    /**
     * Adds a test case to this context.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerContext.kt
@@ -86,21 +86,25 @@ class ShouldSpecContainerContext(
       true
    ) { ShouldSpecContainerContext(it) }
 
-   fun should(name: String) =
-      TestWithConfigBuilder(
+   suspend fun should(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
+      return TestWithConfigBuilder(
          createTestName("should ", name, false),
          testContext,
          testCase.spec.resolvedDefaultConfig(),
          xdisabled = false,
       )
+   }
 
-   fun xshould(name: String) =
-      TestWithConfigBuilder(
+   suspend fun xshould(name: String): TestWithConfigBuilder {
+      TestDslState.startTest(testContext.testCase.description.appendTest(name))
+      return TestWithConfigBuilder(
          createTestName("should ", name, false),
          testContext,
          testCase.spec.resolvedDefaultConfig(),
          xdisabled = true,
       )
+   }
 
    suspend fun should(name: String, test: suspend TestContext.() -> Unit) =
       registerTestCase(

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/TestWithConfigBuilder.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/TestWithConfigBuilder.kt
@@ -31,6 +31,9 @@ class TestWithConfigBuilder(
       severity: TestCaseSeverityLevel? = null,
       test: suspend TestContext.() -> Unit
    ) {
+
+      TestDslState.clear(context.testCase.description.appendTest(name))
+
       val derivedConfig = defaultTestConfig.deriveTestCaseConfig(
          enabled,
          tags,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
@@ -1,0 +1,33 @@
+package io.kotest.core.spec.style.scopes
+
+import io.kotest.core.test.Description
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
+
+object TestDslState {
+
+   private val started = mutableSetOf<String>()
+   private val mutex = Semaphore(1)
+
+   suspend fun startTest(name: Description.Test) = mutex.withPermit {
+      started.add(name.testPath().value)
+   }
+
+   suspend fun clear(name: Description.Test) = mutex.withPermit {
+      started.remove(name.testPath().value)
+   }
+
+   suspend fun checkState() = mutex.withPermit {
+      val unfinished = started.map { "Test was not fully defined: $it" }
+      if (unfinished.isNotEmpty())
+         error(unfinished.joinToString(", "))
+   }
+
+   suspend fun reset() {
+      mutex.withPermit {
+         started.clear()
+      }
+   }
+}
+
+

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngineLauncher.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngineLauncher.kt
@@ -1,13 +1,13 @@
 package io.kotest.engine
 
 import io.kotest.core.Tags
-import io.kotest.engine.listener.TestEngineListener
 import io.kotest.core.filter.TestFilter
 import io.kotest.core.spec.Spec
 import io.kotest.engine.config.ConfigManager
 import io.kotest.engine.listener.CompositeTestEngineListener
 import io.kotest.engine.listener.IsolationTestEngineListener
 import io.kotest.engine.listener.SynchronizedTestEngineListener
+import io.kotest.engine.listener.TestEngineListener
 import kotlinx.coroutines.runBlocking
 import kotlin.reflect.KClass
 import kotlin.script.templates.standard.ScriptTemplateWithArgs
@@ -33,7 +33,7 @@ class KotestEngineLauncher(
 
    constructor() : this(emptyList(), emptyList(), emptyList(), null, false, emptyList())
 
-   fun launch() {
+   fun launch(): EngineResult {
 
       if (listeners.isEmpty())
          error("Cannot launch a KotestEngine without at least one TestEngineListener")
@@ -51,13 +51,15 @@ class KotestEngineLauncher(
       val runner = KotestEngine(config)
       val plan = TestPlan(specs, scripts)
 
-      try {
+      return try {
          runBlocking { // blocks the calling thread while the engine runs
-            runner.execute(plan)
+            val result = runner.execute(plan)
             runner.cleanup()
+            result
          }
       } catch (e: Exception) {
          e.printStackTrace()
+         EngineResult(listOf(e))
       }
    }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/listener/TestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/listener/TestEngineListener.kt
@@ -105,3 +105,5 @@ interface TestEngineListener {
    fun specInstantiationError(kclass: KClass<out Spec>, t: Throwable) {}
 
 }
+
+val NoopTestEngineListener = object : TestEngineListener {}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/DescribeSpecUnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/DescribeSpecUnfinishedTestDefinitionTest.kt
@@ -1,0 +1,13 @@
+package com.sksamuel.kotest.engine.spec.unfinished
+
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.style.DescribeSpec
+
+@Ignored// this is used by the UnfinishedTestDefinitionTest, rather than being a stand alone test
+internal class DescribeSpecUnfinishedTestDefinitionTest : DescribeSpec({
+
+   describe("describe") {
+      it("unfinished it")
+   }
+
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/ExpectSpecUnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/ExpectSpecUnfinishedTestDefinitionTest.kt
@@ -1,0 +1,12 @@
+package com.sksamuel.kotest.engine.spec.unfinished
+
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.style.ExpectSpec
+
+@Ignored// this is used by the UnfinishedTestDefinitionTest, rather than being a stand alone test
+internal class ExpectSpecUnfinishedTestDefinitionTest : ExpectSpec({
+
+   context("context") {
+      expect("unfinished expect")
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/FeatureSpecUnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/FeatureSpecUnfinishedTestDefinitionTest.kt
@@ -1,0 +1,12 @@
+package com.sksamuel.kotest.engine.spec.unfinished
+
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.style.FeatureSpec
+
+@Ignored// this is used by the UnfinishedTestDefinitionTest, rather than being a stand alone test
+internal class FeatureSpecUnfinishedTestDefinitionTest : FeatureSpec({
+
+   feature("feature") {
+      scenario("unfinished scenario")
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/FunSpecUnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/FunSpecUnfinishedTestDefinitionTest.kt
@@ -1,0 +1,12 @@
+package com.sksamuel.kotest.engine.spec.unfinished
+
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.style.FunSpec
+
+@Ignored// this is used by the UnfinishedTestDefinitionTest, rather than being a stand alone test
+internal class FunSpecUnfinishedTestDefinitionTest : FunSpec({
+
+   context("context") {
+      test("unfinished test")
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/ShouldSpecUnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/ShouldSpecUnfinishedTestDefinitionTest.kt
@@ -1,0 +1,12 @@
+package com.sksamuel.kotest.engine.spec.unfinished
+
+import io.kotest.core.annotation.Ignored
+import io.kotest.core.spec.style.ShouldSpec
+
+@Ignored// this is used by the UnfinishedTestDefinitionTest, rather than being a stand alone test
+internal class ShouldSpecUnfinishedTestDefinitionTest : ShouldSpec({
+
+   context("context") {
+      should("unfinished should")
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/UnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/unfinished/UnfinishedTestDefinitionTest.kt
@@ -1,0 +1,58 @@
+package com.sksamuel.kotest.engine.spec.unfinished
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.scopes.TestDslState
+import io.kotest.engine.KotestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.inspectors.forAtLeastOne
+import io.kotest.matchers.string.shouldContain
+
+class UnfinishedTestDefinitionTest : FunSpec() {
+   init {
+
+      test("fun spec") {
+         val result = KotestEngineLauncher()
+            .withListener(NoopTestEngineListener)
+            .withSpec(FunSpecUnfinishedTestDefinitionTest::class)
+            .launch()
+         result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished test") }
+         TestDslState.reset()
+      }
+
+      test("describe spec") {
+         val result = KotestEngineLauncher()
+            .withListener(NoopTestEngineListener)
+            .withSpec(DescribeSpecUnfinishedTestDefinitionTest::class)
+            .launch()
+         result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished it") }
+         TestDslState.reset()
+      }
+
+      test("should spec") {
+         val result = KotestEngineLauncher()
+            .withListener(NoopTestEngineListener)
+            .withSpec(ShouldSpecUnfinishedTestDefinitionTest::class)
+            .launch()
+         result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished should") }
+         TestDslState.reset()
+      }
+
+      test("feature spec") {
+         val result = KotestEngineLauncher()
+            .withListener(NoopTestEngineListener)
+            .withSpec(FeatureSpecUnfinishedTestDefinitionTest::class)
+            .launch()
+         result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished scenario") }
+         TestDslState.reset()
+      }
+
+      test("expect spec") {
+         val result = KotestEngineLauncher()
+            .withListener(NoopTestEngineListener)
+            .withSpec(ExpectSpecUnfinishedTestDefinitionTest::class)
+            .launch()
+         result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished expect") }
+         TestDslState.reset()
+      }
+   }
+}

--- a/kotest-runner/kotest-runner-junit4/src/jvmMain/kotlin/io/kotest/runner/junit4/KotestTestRunner.kt
+++ b/kotest-runner/kotest-runner-junit4/src/jvmMain/kotlin/io/kotest/runner/junit4/KotestTestRunner.kt
@@ -15,11 +15,13 @@ class KotestTestRunner(
    private val klass: Class<out Spec>
 ) : Runner() {
 
-   override fun run(notifier: RunNotifier) = runBlocking {
-      val listener = JUnitTestEngineListener(notifier)
-      KotestEngineLauncher()
-         .withListener(listener)
-         .withSpec(klass.kotlin).launch()
+   override fun run(notifier: RunNotifier) {
+      runBlocking {
+         val listener = JUnitTestEngineListener(notifier)
+         KotestEngineLauncher()
+            .withListener(listener)
+            .withSpec(klass.kotlin).launch()
+      }
    }
 
    override fun getDescription(): Description = klass.let { klass ->


### PR DESCRIPTION
Closes #2250

The return type of the engine launcher has changed from void to EngineResult. I don't think this will have any effect on binary compatibility.