### PR TITLE
Added Lifecycle methods for property test #2161

### DIFF
--- a/documentation/docs/why.md
+++ b/documentation/docs/why.md
@@ -1,0 +1,23 @@
+---
+title: Why Kotest
+sidebar_label: Why Kotest
+slug: why-kotest.html
+---
+
+## vs Junit
+
+* Powerful coroutine integration: Every test is a coroutine, therefore, you can invoke suspension methods without requiring `runBlocking` or other boilerplate
+  * One line configuration to enable coroutine debugging for a test or for all tests
+  * Callbacks allow modifying the coroutine context for child coroutines
+  * Customize the coroutine dispatcher used
+  * Launch multiple tests in parallel that do not block each other if they suspend
+
+* Multiplatform support
+  * Native and Javascript support
+  * Same test structure across all targets
+
+* Flexible test layout styles
+  * Simple DSL avoids needing to wrap test names in backticks
+  * Layout tests like Javascript frameworks - `describe`/`it`
+  * Or like Scalatest with `"my test" should "do foo"`
+  * Or in a BDD style with `given` / `when` / `then`.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -17,7 +17,6 @@ import io.kotest.core.spec.BeforeContainer
 import io.kotest.core.spec.BeforeEach
 import io.kotest.core.spec.BeforeSpec
 import io.kotest.core.spec.BeforeTest
-import io.kotest.core.spec.PrepareSpec
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.TestCaseExtensionFn
 import io.kotest.core.test.AssertionMode
@@ -294,11 +293,4 @@ abstract class TestConfiguration {
     * Returns any [TestCaseExtension] instances registered directly on this class.
     */
    fun registeredExtensions() = _extensions
-
-   @Deprecated(
-      "Cannot use inline version of prepare spec since this must run before the spec is created. Create a TestListener instance and register that globally.",
-      level = DeprecationLevel.ERROR
-   )
-   fun prepareSpec(f: PrepareSpec) {
-   }
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerContext.kt
@@ -3,12 +3,10 @@ package io.kotest.core.spec.style.scopes
 import io.kotest.core.spec.KotestDsl
 import io.kotest.core.spec.resolvedDefaultConfig
 import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestType
 import io.kotest.core.test.createNestedTest
 import io.kotest.core.test.createTestName
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A context that allows tests to be registered using the syntax:
@@ -30,10 +28,8 @@ import kotlin.coroutines.CoroutineContext
 @KotestDsl
 class BehaviorSpecGivenContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerContext.kt
@@ -24,10 +24,8 @@ import io.kotest.core.test.createTestName
 @KotestDsl
 class BehaviorSpecWhenContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerContext.kt
@@ -7,6 +7,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Extends a [TestContext] with methods used by test containers.
@@ -141,4 +142,9 @@ interface ContainerContext : TestContext {
          }
       })
    }
+}
+
+abstract class AbstractContainerContext(testContext: TestContext) : ContainerContext {
+   override val testCase: TestCase = testContext.testCase
+   override val coroutineContext: CoroutineContext = testContext.coroutineContext
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerContext.kt
@@ -27,10 +27,8 @@ import io.kotest.core.test.createTestName
  */
 class DescribeSpecContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerContext.kt
@@ -3,12 +3,10 @@ package io.kotest.core.spec.style.scopes
 import io.kotest.core.spec.KotestDsl
 import io.kotest.core.spec.resolvedDefaultConfig
 import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestType
 import io.kotest.core.test.createNestedTest
 import io.kotest.core.test.createTestName
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A context that allows tests to be registered using the syntax:

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerContext.kt
@@ -27,10 +27,8 @@ import kotlin.coroutines.CoroutineContext
 @KotestDsl
 class ExpectSpecContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerContext.kt
@@ -3,12 +3,10 @@ package io.kotest.core.spec.style.scopes
 import io.kotest.core.spec.KotestDsl
 import io.kotest.core.spec.resolvedDefaultConfig
 import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestType
 import io.kotest.core.test.createNestedTest
 import io.kotest.core.test.createTestName
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A scope that allows tests to be registered using the syntax:

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerContext.kt
@@ -27,10 +27,8 @@ import kotlin.coroutines.CoroutineContext
 @KotestDsl
 class FeatureSpecContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerContext.kt
@@ -33,10 +33,8 @@ typealias FreeScope = FreeSpecContainerContext
 
 class FreeSpecContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerContext.kt
@@ -20,10 +20,8 @@ import io.kotest.core.test.createTestName
 @KotestDsl
 class FunSpecContainerContext(
    private val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerContext.kt
@@ -4,12 +4,10 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.KotestDsl
 import io.kotest.core.spec.resolvedDefaultConfig
 import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestType
 import io.kotest.core.test.createNestedTest
 import io.kotest.core.test.createTestName
-import kotlin.coroutines.CoroutineContext
 
 /**
  * A scope that allows tests to be registered using the syntax:

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerContext.kt
@@ -22,10 +22,8 @@ import kotlin.coroutines.CoroutineContext
 @KotestDsl
 class ShouldSpecContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerContext.kt
@@ -6,13 +6,11 @@ import io.kotest.core.spec.KotestDsl
 import io.kotest.core.spec.resolvedDefaultConfig
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestType
 import io.kotest.core.test.createNestedTest
 import io.kotest.core.test.createTestName
-import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 
 /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerContext.kt
@@ -28,10 +28,8 @@ import kotlin.time.Duration
 @KotestDsl
 class WordSpecShouldContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerContext.kt
@@ -3,21 +3,17 @@ package io.kotest.core.spec.style.scopes
 import io.kotest.core.spec.KotestDsl
 import io.kotest.core.spec.resolvedDefaultConfig
 import io.kotest.core.test.NestedTest
-import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestContext
 import io.kotest.core.test.TestType
 import io.kotest.core.test.createNestedTest
 import io.kotest.core.test.createTestName
-import kotlin.coroutines.CoroutineContext
 
 @Suppress("FunctionName")
 @KotestDsl
 class WordSpecWhenContainerContext(
    val testContext: TestContext,
-) : ContainerContext {
+) : AbstractContainerContext(testContext) {
 
-   override val testCase: TestCase = testContext.testCase
-   override val coroutineContext: CoroutineContext = testContext.coroutineContext
    override suspend fun registerTestCase(nested: NestedTest) = testContext.registerTestCase(nested)
 
    override suspend fun addTest(name: String, type: TestType, test: suspend TestContext.() -> Unit) {

--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -63,11 +63,17 @@ kotlin {
          }
       }
 
+      val commonTest by getting {
+         dependencies {
+            implementation(project(Projects.Engine))
+            implementation(project(Projects.AssertionsCore))
+         }
+      }
+
       val jvmTest by getting {
          dependsOn(jvmMain)
          dependencies {
             implementation(project(Projects.JunitRunner))
-            implementation(project(Projects.AssertionsCore))
          }
       }
 

--- a/kotest-property/kotest-property-lifecycle/build.gradle.kts
+++ b/kotest-property/kotest-property-lifecycle/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
             }
          }
       }
-      js(BOTH) {
+      js(IR) {
          browser()
          nodejs()
       }

--- a/kotest-property/kotest-property-lifecycle/build.gradle.kts
+++ b/kotest-property/kotest-property-lifecycle/build.gradle.kts
@@ -1,0 +1,76 @@
+plugins {
+   id("java")
+   kotlin("multiplatform")
+   id("java-library")
+   id("com.adarshr.test-logger")
+}
+
+repositories {
+   mavenCentral()
+}
+
+kotlin {
+
+   targets {
+      jvm {
+         compilations.all {
+            kotlinOptions {
+               jvmTarget = "1.8"
+            }
+         }
+      }
+      js(BOTH) {
+         browser()
+         nodejs()
+      }
+   }
+
+   sourceSets {
+
+      val commonMain by getting {
+         dependencies {
+            compileOnly(kotlin("stdlib"))
+            api(project(Projects.Property))
+            api(project(Projects.Api))
+            implementation(Libs.Coroutines.coreCommon)
+            implementation(project(Projects.Common))
+         }
+      }
+
+      val commonTest by getting {
+         dependencies {
+            implementation(project(Projects.Engine))
+            implementation(project(Projects.AssertionsCore))
+         }
+      }
+
+      val jvmTest by getting {
+         dependencies {
+            implementation(project(Projects.JunitRunner))
+         }
+      }
+
+      all {
+         languageSettings.useExperimentalAnnotation("kotlin.time.ExperimentalTime")
+         languageSettings.useExperimentalAnnotation("kotlin.experimental.ExperimentalTypeInference")
+      }
+   }
+}
+
+tasks.named<Test>("jvmTest") {
+   useJUnitPlatform()
+   filter {
+      isFailOnNoMatchingTests = false
+   }
+   testLogging {
+      showExceptions = true
+      showStandardStreams = true
+      events = setOf(
+         org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED,
+         org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
+      )
+      exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+   }
+}
+
+apply(from = "../../publish-mpp.gradle.kts")

--- a/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
@@ -1,11 +1,27 @@
 package io.kotest.property.lifecycle
 
+import io.kotest.core.extensions.SpecExtension
 import io.kotest.core.spec.Spec
+import io.kotest.property.AfterPropertyContextElement
+import io.kotest.property.BeforePropertyContextElement
 import kotlinx.coroutines.withContext
+import kotlin.reflect.KClass
+
+abstract class BeforeAndAfterPropertyTestExtension : SpecExtension {
+
+   abstract suspend fun beforeProperty()
+   abstract suspend fun afterProperty()
+
+   override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
+      withContext(BeforePropertyContextElement(::beforeProperty) + AfterPropertyContextElement(::afterProperty)) {
+         process()
+      }
+   }
+}
 
 fun Spec.beforeProperty(f: suspend () -> Unit) {
    aroundTest { (testCase, execute) ->
-      withContext(io.kotest.property.BeforePropertyContextElement(f)) {
+      withContext(BeforePropertyContextElement(f)) {
          execute(testCase)
       }
    }
@@ -13,7 +29,7 @@ fun Spec.beforeProperty(f: suspend () -> Unit) {
 
 fun Spec.afterProperty(f: suspend () -> Unit) {
    aroundTest { (testCase, execute) ->
-      withContext(io.kotest.property.AfterPropertyContextElement(f)) {
+      withContext(AfterPropertyContextElement(f)) {
          execute(testCase)
       }
    }

--- a/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
@@ -1,0 +1,20 @@
+package io.kotest.property.lifecycle
+
+import io.kotest.core.spec.Spec
+import kotlinx.coroutines.withContext
+
+fun Spec.beforeProperty(f: suspend () -> Unit) {
+   aroundTest { (testCase, execute) ->
+      withContext(io.kotest.property.BeforePropertyContextElement(f)) {
+         execute(testCase)
+      }
+   }
+}
+
+fun Spec.afterProperty(f: suspend () -> Unit) {
+   aroundTest { (testCase, execute) ->
+      withContext(io.kotest.property.AfterPropertyContextElement(f)) {
+         execute(testCase)
+      }
+   }
+}

--- a/kotest-property/kotest-property-lifecycle/src/commonTest/kotlin/lifecycle/LifecyleTest.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonTest/kotlin/lifecycle/LifecyleTest.kt
@@ -1,0 +1,32 @@
+package lifecycle
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import io.kotest.property.lifecycle.afterProperty
+import io.kotest.property.lifecycle.beforeProperty
+
+class LifecyleTest : FunSpec() {
+   init {
+
+      var counter = 0
+
+      beforeProperty {
+         counter++
+      }
+
+      afterProperty {
+         counter++
+      }
+
+      test("property test") {
+         checkAll<String, String>(iterations = 31) { a, b -> a + b shouldBe "$a$b" }
+      }
+
+      afterSpec {
+         counter shouldBe 62
+      }
+   }
+
+
+}

--- a/kotest-property/kotest-property-lifecycle/src/commonTest/kotlin/lifecycle/LifecyleTest.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonTest/kotlin/lifecycle/LifecyleTest.kt
@@ -9,22 +9,34 @@ import io.kotest.property.lifecycle.beforeProperty
 class LifecyleTest : FunSpec() {
    init {
 
-      var counter = 0
+      var beforeCounter = 0
+      var afterCounter = 0
 
       beforeProperty {
-         counter++
+         beforeCounter++
       }
 
       afterProperty {
-         counter++
+         afterCounter++
+      }
+
+      beforeProperty {
+         // test that we can support multiple
+         beforeCounter++
+      }
+
+      afterProperty {
+         // test that we can support multiple
+         afterCounter++
       }
 
       test("property test") {
          checkAll<String, String>(iterations = 31) { a, b -> a + b shouldBe "$a$b" }
       }
 
-      afterSpec {
-         counter shouldBe 62
+      afterProject {
+         beforeCounter shouldBe 62
+         afterCounter shouldBe 62
       }
    }
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
@@ -25,7 +25,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = checkAll<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
+): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
 
 suspend fun <A, B, C, D, E, F> checkAll(
    iterations: Int,
@@ -36,7 +36,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = proptest<A, B, C, D, E, F>(iterations, genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
+): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F> checkAll(
    iterations: Int,
@@ -48,11 +48,11 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = proptest<A, B, C, D, E, F>(iterations, genA, genB, genC, genD, genE, genF, config, property)
+): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, config, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-) = proptest<A, B, C, D, E, F>(
+) = proptest(
    PropertyTesting.defaultIterationCount,
    Arb.default<A>(),
    Arb.default<B>(),

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/lifecycle.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/lifecycle.kt
@@ -1,0 +1,17 @@
+package io.kotest.property
+
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+
+typealias BeforeProperty = suspend () -> Unit
+typealias AfterProperty = suspend () -> Unit
+
+data class BeforePropertyContextElement(val before: BeforeProperty) :
+   AbstractCoroutineContextElement(BeforePropertyContextElement) {
+   companion object Key : CoroutineContext.Key<BeforePropertyContextElement>
+}
+
+data class AfterPropertyContextElement(val after: AfterProperty) :
+   AbstractCoroutineContextElement(AfterPropertyContextElement) {
+   companion object Key : CoroutineContext.Key<AfterPropertyContextElement>
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -57,6 +57,9 @@ include("kotest-property")
 // property test generators for kotlinx.datetime
 include("kotest-property:kotest-property-datetime")
 
+// contains  extensions for property testing that build on the kotest test framework
+include("kotest-property:kotest-property-lifecycle")
+
 // support for executing tests via junit platform through gradle
 // this will also bring in the required libs for the intellij plugin
 include("kotest-runner:kotest-runner-junit5")


### PR DESCRIPTION
I'm interested in feedback on this approach (ignore the AbstractContainerContext stuff that's just noise).

The before/after listeners are added to the coroutineContext, so it means we can add them from anywhere. The downside is that they have to be called from a suspend function in order to get access to the coroutineContext, which means you can't just call `beforeProperty` in the spec. Instead, `beforeProperty` is an extension function which calls `beforeSpec` to get access to a suspend continuation. So this means a dependency on Spec, which means I had to create a new module to avoid bringing Kotest into the property test library.

Other options are, we make people do
```
beforeSpec {
   beforeProperty {
   }
 }
 ```

Or we say Kotest prop test 5.0 needs Kotest framework 5.0.

Closes #2161