### PR TITLE
Add Arb.ints zero inclusive variants

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/int.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/int.kt
@@ -20,6 +20,15 @@ fun positive() = object : Matcher<Int> {
   override fun test(value: Int) = MatcherResult(value > 0, "$value should be > 0", "$value should not be > 0")
 }
 
+fun Int.shouldBeNonNegative(): Int {
+   this shouldBe nonNegative()
+   return this
+}
+
+fun nonNegative() = object : Matcher<Int> {
+   override fun test(value: Int) = MatcherResult(value >= 0, "$value should be >= 0", "$value should not be >= 0")
+}
+
 fun Int.shouldBeNegative(): Int {
    this shouldBe negative()
    return this
@@ -27,6 +36,15 @@ fun Int.shouldBeNegative(): Int {
 
 fun negative() = object : Matcher<Int> {
   override fun test(value: Int) = MatcherResult(value < 0, "$value should be < 0", "$value should not be < 0")
+}
+
+fun Int.shouldBeNonPositive(): Int {
+   this shouldBe nonPositive()
+   return this
+}
+
+fun nonPositive() = object : Matcher<Int> {
+   override fun test(value: Int) = MatcherResult(value <= 0, "$value should be <= 0", "$value should not be <= 0")
 }
 
 fun Int.shouldBeEven(): Int {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/ints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/ints.kt
@@ -22,19 +22,30 @@ fun Arb.Companion.int(range: IntRange = Int.MIN_VALUE..Int.MAX_VALUE): Arb<Int> 
 }
 
 /**
- * Returns an [Arb] that produces positives [Int]s,  where the edge cases are 1 and [max].
+ * Returns an [Arb] that produces positives [Int]s, where the edge cases are 1 and [max].
  */
 fun Arb.Companion.positiveInts(max: Int = Int.MAX_VALUE) = int(1..max)
 
 /**
+ * Returns an [Arb] that produces positives [Int]s or 0, where the edge cases are 0, 1 and [max].
+ */
+fun Arb.Companion.nonNegativeInts(max: Int = Int.MAX_VALUE) = int(0..max)
+
+/**
  * Returns an [Arb] that produces natural [Int]s, excluding 0, where the edge cases are 1 and [max].
  */
+@Deprecated("use positiveInts", ReplaceWith("positiveInts"))
 fun Arb.Companion.nats(max: Int = Int.MAX_VALUE) = positiveInts(max)
 
 /**
  * Returns an [Arb] that produces negative [Int]s, where the edge cases are [min] and -1.
  */
 fun Arb.Companion.negativeInts(min: Int = Int.MIN_VALUE) = int(min until 0)
+
+/**
+ * Returns an [Arb] that produces negative [Int]s or 0, where the edge cases are [min], -1 and 0.
+ */
+fun Arb.Companion.nonPositiveInts(min: Int = Int.MIN_VALUE) = int(min..0)
 
 class IntShrinker(val range: IntRange) : Shrinker<Int> {
    override fun shrink(value: Int): List<Int> =

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/IntTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/IntTest.kt
@@ -4,9 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.blocking.forAll
 import io.kotest.data.row
 import io.kotest.inspectors.forAll
-import io.kotest.matchers.ints.shouldBeBetween
-import io.kotest.matchers.ints.shouldBeGreaterThan
-import io.kotest.matchers.ints.shouldBePositive
+import io.kotest.matchers.ints.*
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.PropTest
@@ -43,12 +41,24 @@ class IntTest : FunSpec({
       }
    }
 
-   test("Arb.nats should return positive ints only") {
-      val nats = Arb.nats().take(1000).toSet()
-      nats.forAll {
-         it.shouldBePositive()
-      }
-      nats.size.shouldBeGreaterThan(50)
+   test("Arb.positiveInts should return positive ints only") {
+      val numbers = Arb.positiveInts().take(1000).toSet()
+      numbers.forAll { it.shouldBePositive() }
+   }
+
+   test("Arb.nonNegativeInts should return non negative ints only") {
+      val numbers = Arb.nonNegativeInts().take(1000).toSet()
+      numbers.forAll { it.shouldBeNonNegative() }
+   }
+
+   test("Arb.negativeInts should return negative ints only") {
+      val numbers = Arb.negativeInts().take(1000).toSet()
+      numbers.forAll { it.shouldBeNegative() }
+   }
+
+   test("Arb.nonPositiveInts should return non positive ints only") {
+      val numbers = Arb.nonPositiveInts().take(1000).toSet()
+      numbers.forAll { it.shouldBeNonPositive() }
    }
 })
 


### PR DESCRIPTION
This PR:
- Adds `Arb.nonPositive` with matcher
- Adds `Arb.nonNegative` with matcher
- Deprecates `Arb.nats`