### PR TITLE
Return the resulting value of the function block from shouldCompleteWithin

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 
-fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A) {
+fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A): A {
 
   val ref = AtomicReference<A>(null)
   val latch = CountDownLatch(1)
@@ -21,7 +21,7 @@ fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A) {
     throw failure("Test should have completed within $timeout/$unit")
   }
 
-  ref.get()
+  return ref.get()
 }
 
 fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: () -> A) {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/concurrent/ConcurrentTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/concurrent/ConcurrentTest.kt
@@ -30,6 +30,14 @@ class ConcurrentTest : FunSpec({
       message shouldBe "Test should have completed within 1000/MILLISECONDS"
    }
 
+   test("should return the resulting value of the function block") {
+      val result = shouldCompleteWithin(1000, TimeUnit.MILLISECONDS) {
+         "some value"
+      }
+
+      result shouldBe "some value"
+   }
+
    test("should not throw any if given lambda did not complete in given time") {
       shouldNotThrowAny {
          shouldTimeout(1, TimeUnit.SECONDS) {


### PR DESCRIPTION
Non-suspend version of shouldCompleteWithin returns the result of computation so that it can be further asserted like this:
```
val result = shouldCompleteWithin(1000, TimeUnit.MILLISECONDS) {
  computeSomeValue()
}

result shouldBe "some value"
```

Closed: #2307