### PR TITLE
Made MapEq use failure(expected, actual, msg)

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt
@@ -1,12 +1,16 @@
 package io.kotest.assertions.eq
 
+import io.kotest.assertions.Actual
+import io.kotest.assertions.Expected
 import io.kotest.assertions.failure
+import io.kotest.assertions.show.Printed
 import io.kotest.assertions.show.show
 
 internal object MapEq : Eq<Map<*, *>?> {
    override fun equals(actual: Map<*, *>?, expected: Map<*, *>?, strictNumberEq: Boolean): Throwable? {
       return when {
          actual == null && expected == null -> null
+
          actual != null && expected != null -> {
             val haveUnequalKeys = eq(actual.keys, expected.keys, strictNumberEq)
             if(haveUnequalKeys != null) generateError(actual, expected)
@@ -14,10 +18,11 @@ internal object MapEq : Eq<Map<*, *>?> {
                val hasDifferentValue = actual.keys.any { key ->
                   eq(actual[key], expected[key], strictNumberEq) != null
                }
-               if(hasDifferentValue) generateError(actual, expected)
+               if (hasDifferentValue) generateError(actual, expected)
                else null
             }
          }
+
          else -> generateError(actual, expected)
       }
    }
@@ -25,6 +30,8 @@ internal object MapEq : Eq<Map<*, *>?> {
 
 private fun generateError(actual: Map<*, *>?, expected: Map<*, *>?): Throwable {
    return failure(
+      Expected(expected.print()),
+      Actual(actual.print()),
       buildFailureMessage(
          actual,
          expected
@@ -33,26 +40,28 @@ private fun generateError(actual: Map<*, *>?, expected: Map<*, *>?): Throwable {
 }
 
 private fun buildFailureMessage(actual: Map<*, *>?, expected: Map<*, *>?): String {
-   val keysDifferentAt = when {
+   return when {
       actual != null && expected != null -> {
          val keysHavingDifferentValues = actual.keys.filterNot { expected[it] == actual[it] }
-         "Values differed at keys ${keysHavingDifferentValues.joinToString(limit = 10)}"
+         "Values differed at keys ${keysHavingDifferentValues.joinToString(limit = 10)}\n"
       }
+
       else -> ""
    }
-   return "Expected\n${expected?.toFormattedString()}\nto be equal to\n${actual?.toFormattedString()}\n$keysDifferentAt"
 }
 
 
-private fun Map<*, *>.toFormattedString(): String {
-   if (isEmpty()) return "{}"
+private fun Map<*, *>?.print(): Printed {
+   if (this == null) return null.show()
+   if (isEmpty()) return Printed("{}")
    val indentation = "  "
    val newLine = "\n"
-   return toList()
+   return Printed(toList()
       .joinToString(
          separator = ",$newLine",
          prefix = "{$newLine",
          postfix = "$newLine}",
          limit = 10
       ) { "$indentation${it.first.show().value} = ${it.second.show().value}" }
+   )
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/MapEqTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/MapEqTest.kt
@@ -6,6 +6,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.opentest4j.AssertionFailedError
 
 class MapEqTest : FunSpec({
    test("should give null for simple equal maps") {
@@ -15,23 +17,20 @@ class MapEqTest : FunSpec({
    }
 
    test("should give error for simple not equal maps") {
-      val map1 = mapOf("a" to "b")
-      val map2 = mapOf("a" to "c")
+      val map1 = mapOf("a" to "actual")
+      val map2 = mapOf("a" to "expected")
 
       val throwable = MapEq.equals(map1, map2)
 
       assertSoftly {
-         throwable.shouldNotBeNull()
+         throwable.shouldBeInstanceOf<AssertionFailedError>()
          throwable.message shouldBe """
-            Expected
-            {
-              "a" = "c"
-            }
-            to be equal to
-            {
-              "a" = "b"
-            }
             Values differed at keys a
+            expected:<{
+              "a" = "expected"
+            }> but was:<{
+              "a" = "actual"
+            }>
          """.trimIndent()
       }
    }
@@ -88,15 +87,12 @@ class MapEqTest : FunSpec({
       assertSoftly {
          throwable.shouldNotBeNull()
          throwable.message shouldBe """
-            Expected
-            {
-              "1" = [("2", [("3", "bar")])]
-            }
-            to be equal to
-            {
-              "1" = [("2", [("3", [("4", ["foo"])])])]
-            }
             Values differed at keys 1
+            expected:<{
+              "1" = [("2", [("3", "bar")])]
+            }> but was:<{
+              "1" = [("2", [("3", [("4", ["foo"])])])]
+            }>
          """.trimIndent()
       }
    }
@@ -132,15 +128,12 @@ class MapEqTest : FunSpec({
       assertSoftly {
          throwable.shouldNotBeNull()
          throwable.message shouldBe """
-            Expected
-            {
-              [("a", "c")] = [("a", [1, 2, 3])]
-            }
-            to be equal to
-            {
-              [("a", "b")] = [("a", [1, 2, 3])]
-            }
             Values differed at keys {a=b}
+            expected:<{
+              [("a", "c")] = [("a", [1, 2, 3])]
+            }> but was:<{
+              [("a", "b")] = [("a", [1, 2, 3])]
+            }>
          """.trimIndent()
       }
    }


### PR DESCRIPTION
Assertion failures when comparing maps using `shouldBe` should now show diff using IntelliJ

Prior to this PR:
![image](https://user-images.githubusercontent.com/316857/120556374-b3c2e000-c3fc-11eb-98f7-1458bc648fde.png)

With changes:
![image](https://user-images.githubusercontent.com/316857/120556490-d94fe980-c3fc-11eb-849a-0fb6a834f93d.png)

Diff window:
![image](https://user-images.githubusercontent.com/316857/120556590-fd132f80-c3fc-11eb-960e-78111b51bada.png)
