### PR TITLE
Fix throw handling return type

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/fail.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/fail.kt
@@ -20,6 +20,6 @@ import io.kotest.assertions.throwables.shouldThrow
  * @see shouldThrow
  * @see shouldThrowExactly
  */
-inline fun shouldFail(block: () -> Any?): AssertionError = shouldThrow(block)
+inline fun shouldFail(block: () -> Unit): AssertionError = shouldThrow(block)
 
 fun fail(msg: String): Nothing = throw failure(msg)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
@@ -86,7 +86,7 @@ inline fun <reified T : Throwable> shouldNotThrowUnit(block: () -> Unit) = shoul
  *
  * @see [shouldThrowUnit]
  */
-inline fun <reified T : Throwable> shouldThrow(block: () -> Any?): T {
+inline fun <reified T : Throwable> shouldThrow(block: () -> Unit): T {
    assertionCounter.inc()
    val expectedExceptionClass = T::class
    val thrownThrowable = try {
@@ -133,7 +133,7 @@ inline fun <reified T : Throwable> shouldThrow(block: () -> Any?): T {
  *
  * @see [shouldNotThrowUnit]
  */
-inline fun <reified T : Throwable> shouldNotThrow(block: () -> Any?) {
+inline fun <reified T : Throwable> shouldNotThrow(block: () -> Unit) {
    assertionCounter.inc()
    val thrown = try {
       block()


### PR DESCRIPTION
It seems more appropriate to set it to Unit, as it doesn't use the lambda's return.

I have a simple case where this was a problem.

```kotlin
shouldThrow<IllegalStateException> {
    val a = error("")
}

// and

var a: Int
shouldThrow<IllegalStateException> {
    a = error("")
}
```

But I didn't know if it was appropriate to actually add this to test code.
If you comment on this, I will take it.