### PR TITLE
Convert inspectors to matchers/asserts

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -13,7 +13,6 @@ fun <T> Iterable<T>?.shouldContainExactly(vararg expected: T) = this?.toList() s
 fun <T> Array<T>?.shouldContainExactly(vararg expected: T) = this?.asList() should containExactly(*expected)
 
 infix fun <T, C : Collection<T>> C?.shouldContainExactly(expected: C) = this should containExactly(expected)
-fun <T> Collection<T>?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)
 
 fun <T> containExactly(vararg expected: T): Matcher<Collection<T>?> = containExactly(expected.asList())
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inspectors/asserts.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inspectors/asserts.kt
@@ -1,0 +1,36 @@
+package io.kotest.matchers.collections.inspectors
+
+import io.kotest.matchers.should
+
+//internal typealias MatcherBlock<T> = (T) -> Unit
+fun interface MatcherBlock<T> {
+   operator fun invoke(element: T): Unit
+}
+
+fun <T> Array<T>.shouldContain(times: Int, block: MatcherBlock<T>) = asList() should containExactly(times, block)
+fun <T> Iterable<T>?.shouldContain(times: Int, block: MatcherBlock<T>) = this should containExactly(times, block)
+
+
+infix fun <T> Array<T>.shouldAll(block: MatcherBlock<T>) = asList() should all(block)
+infix fun <T> Array<T>.shouldNotContain(block: MatcherBlock<T>) = asList() should containExactly(0, block)
+infix fun <T> Array<T>.shouldContainSome(block: MatcherBlock<T>) = asList() should containSome(block)
+infix fun <T> Array<T>.shouldContainOne(block: MatcherBlock<T>) = asList() should containExactly(1, block)
+
+infix fun <T> Iterable<T>?.shouldAll(block: MatcherBlock<T>) = this should all(block)
+infix fun <T> Iterable<T>?.shouldNotContain(block: MatcherBlock<T>) = this should containExactly(0, block)
+infix fun <T> Iterable<T>?.shouldContainSome(block: MatcherBlock<T>) = this should containSome(block)
+infix fun <T> Iterable<T>?.shouldContainOne(block: MatcherBlock<T>) = this should containExactly(1, block)
+
+
+fun <T> Array<T>.shouldContainAtLeast(times: Int, block: MatcherBlock<T>) = asList() should containAtLeast(times, block)
+infix fun <T> Array<T>.shouldContainAtLeastOne(block: MatcherBlock<T>) = asList() should containAtLeast(1, block)
+
+fun <T> Iterable<T>?.shouldContainAtLeast(times: Int, block: MatcherBlock<T>) = this should containAtLeast(times, block)
+infix fun <T> Iterable<T>?.shouldContainAtLeastOne(block: MatcherBlock<T>) = this should containAtLeast(1, block)
+
+
+fun <T> Array<T>.shouldContainAtMost(times: Int, block: MatcherBlock<T>) = asList() should containAtMost(times, block)
+infix fun <T> Array<T>.shouldContainAtMostOne(block: MatcherBlock<T>) = asList() should containAtMost(1, block)
+
+fun <T> Iterable<T>?.shouldContainAtMost(times: Int, block: MatcherBlock<T>) = this should containAtMost(times, block)
+infix fun <T> Iterable<T>?.shouldContainAtMostOne(block: MatcherBlock<T>) = this should containAtMost(1, block)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inspectors/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inspectors/matchers.kt
@@ -1,0 +1,68 @@
+package io.kotest.matchers.collections.inspectors
+
+import io.kotest.inspectors.ElementResult
+import io.kotest.inspectors.buildAssertionError
+import io.kotest.inspectors.runTests
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+
+
+fun <T> all(block: MatcherBlock<T>) = buildCollectionMatcher(
+   { items -> with(items.count()) { this..this } },
+   block,
+   { violations -> "Expected all ${violations.count()} elements to pass, but found ${violations.countFails()} failures" },
+   { violations -> "Expected no element to pass, but ${violations.countMatches()} did" },
+)
+
+
+fun <T> containExactly(times: Int = 1, block: MatcherBlock<T>) = buildCollectionMatcher(
+   { times..times },
+   block,
+   { violations -> "${violations.countMatches()} elements passed but expected $times" },
+   { violations -> "${violations.countMatches()} elements passed, expected to differ from $times" },
+)
+
+fun <T> containSome(block: MatcherBlock<T>) = buildCollectionMatcher(
+   { items -> 1 until items.count() },
+   block,
+   { violations -> "Expected some, but not all, elements to match, but ${if (violations.countMatches() == 0) "none" else "all"} did" },
+   { violations -> "Expected all or none of the elements in the collection to match, but ${violations.countMatches()} did" },
+)
+
+/** Tests that at least [times] elements of the collection matches the block */
+fun <T> containAtMost(times: Int = 1, block: MatcherBlock<T>) = buildCollectionMatcher(
+   { 0..times },
+   block,
+   { violations -> "${violations.countMatches()} elements passed but expected at most $times" },
+   { violations -> "${violations.countMatches()} elements passed but expected > $times" },
+)
+
+/** Tests that at least [times] elements of the collection matches the block */
+fun <T> containAtLeast(times: Int = 1, block: MatcherBlock<T>) = buildCollectionMatcher(
+   { times..Int.MAX_VALUE },
+   block,
+   { violations -> "${violations.countMatches()} elements passed but expected at least $times" },
+   { violations -> "${violations.countMatches()} elements passed but expected < $times" },
+)
+
+internal fun <T> buildCollectionMatcher(
+   validRange: (Iterable<T>) -> IntRange,
+   block: MatcherBlock<T>,
+   failureMessageFn: (violations: List<ElementResult<T>>) -> String,
+   negatedFailureMessageFn: (violations: List<ElementResult<T>>) -> String
+) = object : Matcher<Iterable<T>?> {
+   override fun test(ts: Iterable<T>?): MatcherResult {
+      checkNotNull(ts) // TODO
+      val elementResults = runTests(ts.toList()) { element -> block(element) }
+      val matchCount = elementResults.count { it.error() == null }
+
+      return MatcherResult(
+         matchCount in validRange(ts),
+         { buildAssertionError(failureMessageFn(elementResults), elementResults) },
+         { buildAssertionError(negatedFailureMessageFn(elementResults), elementResults) },
+      )
+   }
+}
+
+private fun <T> List<ElementResult<T>>.countMatches() = this.count { it.error() == null }
+private fun <T> List<ElementResult<T>>.countFails() = this.count { it.error() != null }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/InspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/InspectorsTest.kt
@@ -4,7 +4,13 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.inspectors.*
+import io.kotest.matchers.collections.inspectors.shouldAll
+import io.kotest.matchers.collections.inspectors.shouldNotContain
+import io.kotest.matchers.collections.inspectors.shouldContain
+import io.kotest.matchers.collections.inspectors.shouldContainAtLeastOne
+import io.kotest.matchers.collections.inspectors.shouldContainAtMostOne
+import io.kotest.matchers.collections.inspectors.shouldContainOne
+import io.kotest.matchers.collections.inspectors.shouldContainSome
 import io.kotest.matchers.comparables.beGreaterThan
 import io.kotest.matchers.comparables.beLessThan
 import io.kotest.matchers.ints.shouldBeGreaterThan
@@ -26,18 +32,18 @@ class InspectorsTest : WordSpec() {
 
       "forAll" should {
          "pass if all elements of an array pass" {
-            array.forAll {
+            array.shouldAll {
                it.shouldBeGreaterThan(0)
             }
          }
          "pass if all elements of a collection pass" {
-            list.forAll {
+            list.shouldAll {
                it.shouldBeGreaterThan(0)
             }
          }
          "fail when an exception is thrown inside an array" {
             shouldThrowAny {
-               array.forAll {
+               array.shouldAll {
                   if (true) throw NullPointerException()
                }
             }.message shouldBe "0 elements passed but expected 5\n" +
@@ -54,7 +60,7 @@ class InspectorsTest : WordSpec() {
          }
          "fail when an exception is thrown inside a list" {
             shouldThrowAny {
-               list.forAll {
+               list.shouldAll {
                   if (true) throw NullPointerException()
                }
             }.message shouldBe "0 elements passed but expected 5\n" +
@@ -73,24 +79,24 @@ class InspectorsTest : WordSpec() {
 
       "forNone" should {
          "pass if no elements pass fn test for a list" {
-            list.forNone {
+            list.shouldNotContain {
                it shouldBe 10
             }
          }
          "pass if no elements pass fn test for an array" {
-            array.forNone {
+            array.shouldNotContain {
                it shouldBe 10
             }
          }
          "pass if an element throws an exception" {
             val items = listOf(1, 2, 3)
-            items.forNone {
+            items.shouldNotContain {
                if (true) throw NullPointerException()
             }
          }
          "fail if one elements passes fn test" {
             shouldThrow<AssertionError> {
-               list.forNone {
+               list.shouldNotContain {
                   it shouldBe 4
                }
             }.message shouldBe """1 elements passed but expected 0
@@ -106,7 +112,7 @@ The following elements failed:
          }
          "fail if all elements pass fn test" {
             shouldThrow<AssertionError> {
-               list.forNone {
+               list.shouldNotContain {
                   it should beGreaterThan(0)
                }
             }.message shouldBe """5 elements passed but expected 0
@@ -128,7 +134,7 @@ The following elements failed:
             )
 
             assertSoftly(dummyEntries) {
-               forNone {
+               shouldNotContain {
                   it.id shouldBe 3
                   it.name shouldBe "third"
                }
@@ -138,18 +144,18 @@ The following elements failed:
 
       "forSome" should {
          "pass if one elements pass test"  {
-            list.forSome {
+            list.shouldContainSome {
                it shouldBe 3
             }
          }
          "pass if size-1 elements pass test"  {
-            list.forSome {
+            list.shouldContainSome {
                it should beGreaterThan(1)
             }
          }
          "fail if no elements pass test"  {
             shouldThrow<AssertionError> {
-               array.forSome {
+               array.shouldContainSome {
                   it should beLessThan(0)
                }
             }.message shouldBe """No elements passed but expected at least one
@@ -166,7 +172,7 @@ The following elements failed:
          }
          "fail if all elements pass test"  {
             shouldThrow<AssertionError> {
-               list.forSome {
+               list.shouldContainSome {
                   it should beGreaterThan(0)
                }
             }.message shouldBe """All elements passed but expected < 5
@@ -189,7 +195,7 @@ The following elements failed:
             )
 
             assertSoftly(dummyEntries) {
-               forSome {
+               shouldContainSome {
                   it.id shouldBe 1
                   it.name shouldBe "first"
                }
@@ -199,13 +205,13 @@ The following elements failed:
 
       "forOne" should {
          "pass if one elements pass test"  {
-            list.forOne {
+            list.shouldContainOne {
                it shouldBe 3
             }
          }
          "fail if > 1 elements pass test"  {
             shouldThrow<AssertionError> {
-               list.forOne {
+               list.shouldContainOne {
                   it should beGreaterThan(2)
                }
             }.message shouldBe """3 elements passed but expected 1
@@ -221,7 +227,7 @@ The following elements failed:
          }
          "fail if no elements pass test"  {
             shouldThrow<AssertionError> {
-               array.forOne {
+               array.shouldContainOne {
                   it shouldBe 22
                }
             }.message shouldBe """0 elements passed but expected 1
@@ -243,7 +249,7 @@ The following elements failed:
             )
 
             assertSoftly(dummyEntries) {
-               forOne {
+               shouldContainOne {
                   it.id shouldBe 1
                   it.name shouldBe "first"
                }
@@ -253,18 +259,18 @@ The following elements failed:
 
       "forAny" should {
          "pass if one elements pass test"  {
-            list.forAny {
+            list.shouldContainAtLeastOne {
                it shouldBe 3
             }
          }
          "pass if at least elements pass test"  {
-            list.forAny {
+            list.shouldContainAtLeastOne {
                it should beGreaterThan(2)
             }
          }
          "fail if no elements pass test"  {
             shouldThrow<AssertionError> {
-               array.forAny {
+               array.shouldContainAtLeastOne {
                   it shouldBe 6
                }
             }.message shouldBe """0 elements passed but expected at least 1
@@ -286,7 +292,7 @@ The following elements failed:
             )
 
             assertSoftly(dummyEntries) {
-               forAny {
+               shouldContainAtLeastOne {
                   it.id shouldBe 1
                   it.name shouldBe "first"
                }
@@ -296,13 +302,13 @@ The following elements failed:
 
       "forExactly" should {
          "pass if exactly k elements pass"  {
-            list.forExactly(2) {
+            list.shouldContain(2) {
                it should beLessThan(3)
             }
          }
          "fail if more elements pass test"  {
             shouldThrow<AssertionError> {
-               list.forExactly(2) {
+               list.shouldContain(2) {
                   it should beGreaterThan(2)
                }
             }.message shouldBe """3 elements passed but expected 2
@@ -318,7 +324,7 @@ The following elements failed:
          }
          "fail if less elements pass test"  {
             shouldThrow<AssertionError> {
-               array.forExactly(2) {
+               array.shouldContain(2) {
                   it should beLessThan(2)
                }
             }.message shouldBe """1 elements passed but expected 2
@@ -334,7 +340,7 @@ The following elements failed:
          }
          "fail if no elements pass test"  {
             shouldThrow<AssertionError> {
-               array.forExactly(2) {
+               array.shouldContain(2) {
                   it shouldBe 33
                }
             }.message shouldBe """0 elements passed but expected 2
@@ -359,7 +365,7 @@ The following elements failed:
             )
 
             assertSoftly(dummyEntries) {
-               forAtMostOne {
+               shouldContainAtMostOne {
                   it.id shouldBe 1
                   it.name shouldBe "first"
                }
@@ -375,7 +381,7 @@ The following elements failed:
             )
 
             assertSoftly(dummyEntries) {
-               forAtLeastOne {
+               shouldContainAtLeastOne {
                   it.id shouldBe 1
                   it.name shouldBe "first"
                }


### PR DESCRIPTION
Inspectors could possibly be considered _just another assertion_ and be named using the regular `should...` syntax rather than `for..`.

Related issues: #2145 


### My main arguments for the change:

#### Improved discoverability
When starting an assertion it feels like common practice to being with `subject should` and look for possible assertions. Inspectors will never show up when looking at the API this way

#### Erases the inspector concept
Inspectors become just another assertion. Less concepts to learn and a beginner will hopefully have an easy time picking up what these assertions do.


### Cons of changing:

#### Changes an established concept
Old users will have to change habits and possibly migrate old code at some point. Aliases for the old inspector names could still be provided until Kotest 6.0 perhaps


### Suggested new names:
`forAll` -> `shouldAll`  -  asserts every element passes 
`forNone` -> `shouldContainNone` -  asserts no element passes (alternative name: `shouldNotContain`?)
`forOne` -> `shouldContainOne` -  asserts only a single element passed
`forAtMostOne` -> `shouldContainAtMostOne` -  asserts that either 0 or 1 elements pass
`forAtLeastOne` -> `shouldContainAtLeastOne` - asserts that 1 or more elements passed
`forAtLeast(k)` -> `shouldContainAtLeast(k)` -  asserts that k or more elements passed
`forAtMost(k)` -> `shouldContainAtMost(k)` -  asserts that k or fewer elements passed
`forAny` which is an alias for `forAtLeastOne`  ->  `shouldContainAtLeastOne`
`forSome` -> `shouldContainSome` - asserts that between 1 and n-1 elements passed. Ie, if NONE pass or ALL pass then we consider that a failure.
`forExactly(k)` -> `shouldContain(k)` - asserts that exactly _k_ elements pass

Examples:
```kotlin
val subjects = listOf(person(), person())
subjects.shouldAll {
  it.age shouldBeInRange 18..65
  it.name shouldBeIn listOf("hans", "greta")
}
```

I also tried making matchers out of the inspectors, to unify them with all other assertions.

Opening this PR to gather feedback on what people would feel about a change. 