### PR TITLE
Improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 *.iml
 .idea
 
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# virtual machine crash logs, see https://www.java.com/en/download/help/error_hotspot.html
 hs_err_pid*
 out/
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 ==========
 
 [![Build Status](https://github.com/kotest/kotest/workflows/build/badge.svg)](https://github.com/kotest/kotest/actions)
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest)
 ![intellij-badge](https://img.shields.io/jetbrains/plugin/v/14080-kotest?label=intellij%20plugin)
 ![GitHub](https://img.shields.io/github/license/kotest/kotest)
 [![kotest @ kotlinlang.slack.com](https://img.shields.io/static/v1?label=kotlinlang&message=kotest&color=blue&logo=slack)](https://kotlinlang.slack.com/archives/CT0G9SD7Z)
-[![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/kotest/kotest.svg)](http://isitmaintained.com/project/kotest/kotest "Average time to resolve an issue")
+[![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/kotest/kotest.svg)](https://isitmaintained.com/project/kotest/kotest "Average time to resolve an issue")
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-framework-api.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 __Kotest is a flexible and comprehensive testing tool for [Kotlin](https://kotlinlang.org/) with multiplatform support.__
@@ -16,8 +16,8 @@ Looking to upgrade? - see the [changelog](https://kotest.io/docs/changelog.html)
 
 Community
 ---------
-* [Kotest channel](https://kotlinlang.slack.com/messages/kotest) in the Kotlin Slack (get an invite [here](http://slack.kotlinlang.org/))
-* [Stack Overflow](http://stackoverflow.com/questions/tagged/kotest) (don't forget to use the tag "kotest".)
+* [Kotest channel](https://kotlinlang.slack.com/messages/kotest) in the Kotlin Slack (get an invite [here](https://slack.kotlinlang.org/))
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/kotest) (don't forget to use the tag "kotest".)
 * [Contribute](https://github.com/kotest/kotest/wiki/contribute)
 * [Blogs and articles](https://kotest.io/docs/blogs/).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ==========
 
 [![Build Status](https://github.com/kotest/kotest/workflows/build/badge.svg)](https://github.com/kotest/kotest/actions)
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](https://search.maven.org/search?q=g:io.kotest%20OR%20g:io.kotest.extensions)
 ![intellij-badge](https://img.shields.io/jetbrains/plugin/v/14080-kotest?label=intellij%20plugin)
 ![GitHub](https://img.shields.io/github/license/kotest/kotest)
 [![kotest @ kotlinlang.slack.com](https://img.shields.io/static/v1?label=kotlinlang&message=kotest&color=blue&logo=slack)](https://kotlinlang.slack.com/archives/CT0G9SD7Z)

--- a/blog/release_4.2.md
+++ b/blog/release_4.2.md
@@ -28,7 +28,7 @@ The core assertions library is now published for ios, watchos and tvos. This bri
 
 ### Kotlinx Date/Time Matchers
 
-A new [assertions module](https://search.maven.org/search?q=kotest-assertions-kotlinx-time) has been created `kotest-assertions-kotlinx-time`
+A new [assertions module](https://search.maven.org/artifact/io.kotest/kotest-assertions-kotlinx-time) has been created `kotest-assertions-kotlinx-time`
 which contains matchers for the new [Kotlinx Datetime library](https://github.com/Kotlin/kotlinx-datetime).
 Since the datetime library has an _incubating_ status, this assertions module may require breaking changes in the future if the date/time API mandates it.
 

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1,7 +1,7 @@
 Kotest
 ==========
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-core.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest) [![GitHub license](https://img.shields.io/github/license/kotest/kotest.svg)]()
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-core.svg?label=latest%20release"/>](https://search.maven.org/search?q=g:io.kotest) [![GitHub license](https://img.shields.io/github/license/kotest/kotest.svg)]()
 
 This version of the document is for the 4.x releases.
 For version 3.3 see [here](reference_3.3.md)

--- a/doc/reference.md
+++ b/doc/reference.md
@@ -1,7 +1,7 @@
 Kotest
 ==========
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-core.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest) [![GitHub license](https://img.shields.io/github/license/kotest/kotest.svg)]()
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-core.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest) [![GitHub license](https://img.shields.io/github/license/kotest/kotest.svg)]()
 
 This version of the document is for the 4.x releases.
 For version 3.3 see [here](reference_3.3.md)

--- a/doc/reference_3.1.md
+++ b/doc/reference_3.1.md
@@ -772,7 +772,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [`SystemUtils.IS_OS_LINUX`](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_LINUX) from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/doc/reference_3.1.md
+++ b/doc/reference_3.1.md
@@ -1,7 +1,7 @@
 KotlinTest
 ==========
 
-[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
+[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
 
 This version of the document is aimed at version 3.1
 
@@ -772,7 +772,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/doc/reference_3.1.md
+++ b/doc/reference_3.1.md
@@ -1,7 +1,7 @@
 KotlinTest
 ==========
 
-[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
+[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](https://search.maven.org/search?q=g:io.kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
 
 This version of the document is aimed at version 3.1
 

--- a/doc/reference_3.2.md
+++ b/doc/reference_3.2.md
@@ -777,7 +777,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [`SystemUtils.IS_OS_LINUX`](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_LINUX) from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/doc/reference_3.2.md
+++ b/doc/reference_3.2.md
@@ -1,7 +1,7 @@
 KotlinTest
 ==========
 
-[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
+[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
 
 This version of the document is for version 3.2+.
 For docs for earlier versions see [here](reference_3.1.md)
@@ -777,7 +777,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/doc/reference_3.2.md
+++ b/doc/reference_3.2.md
@@ -1,7 +1,7 @@
 KotlinTest
 ==========
 
-[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
+[<img src="https://img.shields.io/maven-central/v/io.kotlintest/kotlintest-core.svg?label=latest%20release"/>](https://search.maven.org/search?q=g:io.kotlintest) [![GitHub license](https://img.shields.io/github/license/kotlintest/kotlintest.svg)]()
 
 This version of the document is for version 3.2+.
 For docs for earlier versions see [here](reference_3.1.md)

--- a/doc/reference_3.3.md
+++ b/doc/reference_3.3.md
@@ -803,7 +803,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/doc/reference_3.3.md
+++ b/doc/reference_3.3.md
@@ -803,7 +803,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS).IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [`SystemUtils.IS_OS_LINUX`](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_LINUX) from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/doc/styles.md
+++ b/doc/styles.md
@@ -296,7 +296,7 @@ class MyTests : FreeSpec({
 
 ### Feature Spec
 
-`FeatureSpec` allows you to use `feature` and `scenario`, which will be familiar to those who have used [cucumber](http://docs.cucumber.io/gherkin/reference/).
+`FeatureSpec` allows you to use `feature` and `scenario`, which will be familiar to those who have used [cucumber](https://cucumber.io/docs/gherkin/reference/).
 Although not intended to be exactly the same as cucumber, the keywords mimic the style.
 
 ```kotlin

--- a/doc/styles.md
+++ b/doc/styles.md
@@ -30,10 +30,10 @@ and then the test itself as a lambda. If in doubt, this is the style to use.
 
 ```kotlin
 class MyTests : FunSpec({
-	test("String length should return the length of the string") {
-		"sammy".length shouldBe 5
-		"".length shouldBe 0
-	}
+    test("String length should return the length of the string") {
+        "sammy".length shouldBe 5
+        "".length shouldBe 0
+    }
 })
 ```
 
@@ -47,9 +47,9 @@ class MyTests : DescribeSpec({
         }
     }
     xcontext("this block is disabled") {
-      test("disabled by inheritance from the parent") {
-        // test here
-      }
+        test("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -62,9 +62,9 @@ class MyTests : DescribeSpec({
 
 ```kotlin
 class MyTests : StringSpec({
-	"strings.length should return size of string" {
-		"hello".length shouldBe 5
-	}
+    "strings.length should return size of string" {
+        "hello".length shouldBe 5
+    }
 })
 ```
 
@@ -72,9 +72,9 @@ Adding config to the test.
 
 ```kotlin
 class MyTests : StringSpec({
-	"strings.length should return size of string".config(enabled = false, invocations = 3) {
-		"hello".length shouldBe 5
-	}
+    "strings.length should return size of string".config(enabled = false, invocations = 3) {
+        "hello".length shouldBe 5
+    }
 })
 ```
 
@@ -86,10 +86,10 @@ Note that this is the only Spec that does not support nesting.
 
 ```kotlin
 class MyTests : ShouldSpec({
-	should("return the length of the string") {
-		"sammy".length shouldBe 5
-		"".length shouldBe 0
-	}
+    should("return the length of the string") {
+        "sammy".length shouldBe 5
+        "".length shouldBe 0
+    }
 })
 ```
 
@@ -98,12 +98,12 @@ Tests can be nested in one or more context blocks as well:
 
 ```kotlin
 class MyTests : ShouldSpec({
-	context("String.length") {
-		should("return the length of the string") {
-			"sammy".length shouldBe 5
-			"".length shouldBe 0
-		}
-	}
+    context("String.length") {
+        should("return the length of the string") {
+            "sammy".length shouldBe 5
+            "".length shouldBe 0
+        }
+    }
 })
 ```
 
@@ -117,9 +117,9 @@ class MyTests : ShouldSpec({
         }
     }
     xcontext("this block is disabled") {
-      should("disabled by inheritance from the parent") {
-        // test here
-      }
+        should("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -145,9 +145,9 @@ class MyTests : DescribeSpec({
         }
 
         describe("for the opposite team") {
-          it("Should negate one score") {
-            // test here
-          }
+            it("Should negate one score") {
+                // test here
+            }
         }
     }
 })
@@ -163,9 +163,9 @@ class MyTests : DescribeSpec({
         }
     }
     xdescribe("this block is disabled") {
-      it("disabled by inheritance from the parent") {
-        // test here
-      }
+        it("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -241,12 +241,12 @@ class MyTests : DescribeSpec({
 
 ```kotlin
 class MyTests : WordSpec({
-	"String.length" should {
-		"return the length of the string" {
-			"sammy".length shouldBe 5
-			"".length shouldBe 0
-		}
-	}
+    "String.length" should {
+        "return the length of the string" {
+            "sammy".length shouldBe 5
+            "".length shouldBe 0
+        }
+    }
 })
 ```
 
@@ -255,18 +255,18 @@ in Kotlin, we must use backticks or the uppercase variant.
 
 ```kotlin
 class MyTests : WordSpec({
-	"Hello" When {
-		"asked for length" should {
-			"return 5" {
-				"Hello".length shouldBe 5
-			}
-		}
-		"appended to Bob" should {
-			"return Hello Bob" {
-				"Hello " + "Bob" shouldBe "Hello Bob"
-			}
-		}
-	}
+    "Hello" When {
+        "asked for length" should {
+            "return 5" {
+                "Hello".length shouldBe 5
+            }
+        }
+        "appended to Bob" should {
+            "return Hello Bob" {
+                "Hello " + "Bob" shouldBe "Hello Bob"
+            }
+        }
+    }
 })
 ```
 
@@ -301,14 +301,14 @@ Although not intended to be exactly the same as cucumber, the keywords mimic the
 
 ```kotlin
 class MyTests : FeatureSpec({
-	feature("the can of coke") {
-		scenario("should be fizzy when I shake it") {
-			// test here
-		}
-		scenario("and should be tasty") {
-			// test here
-		}
-	}
+    feature("the can of coke") {
+        scenario("should be fizzy when I shake it") {
+            // test here
+        }
+        scenario("and should be tasty") {
+            // test here
+        }
+    }
 })
 ```
 
@@ -322,9 +322,9 @@ class MyTests : FeatureSpec({
         }
     }
     xfeature("this block is disabled") {
-      scenario("disabled by inheritance from the parent") {
-        // test here
-      }
+        scenario("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -366,9 +366,9 @@ class MyTests : DescribeSpec({
         }
     }
     xcontext("this block is disabled") {
-      expect("disabled by inheritance from the parent") {
-        // test here
-      }
+        expect("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```

--- a/documentation/docs/assertions/index.md
+++ b/documentation/docs/assertions/index.md
@@ -15,7 +15,7 @@ the comprehensive assertion / matchers support. These can be used with the [Kote
 or with another test framework like JUnit or Spock.
 
 
-[![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-core-jvm.svg?label=release)](https://search.maven.org/search?q=kotest)
+[![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-core-jvm.svg?label=release)](https://search.maven.org/search?q=g:io.kotest)
 [![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-assertions-core-jvm.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 The core functionality of the assertion modules are functions that test state. Kotest calls these types of state

--- a/documentation/docs/blog/release_4.2.md
+++ b/documentation/docs/blog/release_4.2.md
@@ -28,7 +28,7 @@ The core assertions library is now published for ios, watchos and tvos. This bri
 
 ### Kotlinx Date/Time Matchers
 
-A new [assertions module](https://search.maven.org/search?q=kotest-assertions-kotlinx-time) has been created `kotest-assertions-kotlinx-time`
+A new [assertions module](https://search.maven.org/artifact/io.kotest/kotest-assertions-kotlinx-time) has been created `kotest-assertions-kotlinx-time`
 which contains matchers for the new [Kotlinx Datetime library](https://github.com/Kotlin/kotlinx-datetime).
 Since the datetime library has an _incubating_ status, this assertions module may require breaking changes in the future if the date/time API mandates it.
 

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -947,7 +947,7 @@ uri should haveFragment("results")
 
 * **Arrow matcher module**
 
-A new module has been added which includes matchers for [Arrow](http://arrow-kt.io) - the popular and awesome
+A new module has been added which includes matchers for [Arrow](https://arrow-kt.io/) - the popular and awesome
  functional programming library for Kotlin. To include this module add `kotlintest-assertions-arrow` to your build.
 
 The included matchers are:

--- a/documentation/docs/extensions/allure.md
+++ b/documentation/docs/extensions/allure.md
@@ -20,7 +20,7 @@ To start, add the below dependency to your Gradle build file.
 io.kotest.extensions:kotest-extensions-allure:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-allure.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-allure)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-allure.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-allure)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-allure.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-allure/)
 
 

--- a/documentation/docs/extensions/allure.md
+++ b/documentation/docs/extensions/allure.md
@@ -20,7 +20,7 @@ To start, add the below dependency to your Gradle build file.
 io.kotest.extensions:kotest-extensions-allure:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-allure.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-allure)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-allure.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-allure)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-allure.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-allure/)
 
 

--- a/documentation/docs/extensions/kafka.md
+++ b/documentation/docs/extensions/kafka.md
@@ -11,7 +11,7 @@ where using the kafka docker images are an issue.
 To use this extension add the `io.kotest.extensions:kotest-extensions-embedded-kafka` module to your test compile path.
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-embedded-kafka.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-embedded-kafka)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-embedded-kafka.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-embedded-kafka)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-embedded-kafka.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-embedded-kafka/)
 
 

--- a/documentation/docs/extensions/kafka.md
+++ b/documentation/docs/extensions/kafka.md
@@ -11,7 +11,7 @@ where using the kafka docker images are an issue.
 To use this extension add the `io.kotest.extensions:kotest-extensions-embedded-kafka` module to your test compile path.
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-embedded-kafka.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-embedded-kafka)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-embedded-kafka.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-embedded-kafka)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-embedded-kafka.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-embedded-kafka/)
 
 

--- a/documentation/docs/extensions/koin.md
+++ b/documentation/docs/extensions/koin.md
@@ -14,7 +14,7 @@ The [Koin DI Framework](https://insert-koin.io/) can be used with Kotest through
 To add the listener to your project, add the dependency to your project:
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-koin.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-koin)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-koin.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-koin)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-koin.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-koin/)
 
 

--- a/documentation/docs/extensions/koin.md
+++ b/documentation/docs/extensions/koin.md
@@ -14,7 +14,7 @@ The [Koin DI Framework](https://insert-koin.io/) can be used with Kotest through
 To add the listener to your project, add the dependency to your project:
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-koin.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-koin)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-koin.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-koin)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-koin.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-koin/)
 
 

--- a/documentation/docs/extensions/ktor.md
+++ b/documentation/docs/extensions/ktor.md
@@ -16,7 +16,7 @@ To add Ktor matchers, add the following dependency to your project
 io.kotest.extensions:kotest-assertions-ktor:${version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-ktor.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-assertions-ktor)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-ktor.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-assertions-ktor)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-assertions-ktor.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-assertions-ktor/)
 
 

--- a/documentation/docs/extensions/ktor.md
+++ b/documentation/docs/extensions/ktor.md
@@ -16,7 +16,7 @@ To add Ktor matchers, add the following dependency to your project
 io.kotest.extensions:kotest-assertions-ktor:${version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-ktor.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-assertions-ktor)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-ktor.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-assertions-ktor)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-assertions-ktor.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-assertions-ktor/)
 
 

--- a/documentation/docs/extensions/mockserver.md
+++ b/documentation/docs/extensions/mockserver.md
@@ -13,7 +13,7 @@ Requires the `io.kotest.extensions:kotest-extensions-mockserver` module to be ad
 :::
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-mockserver.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-mockserver)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-mockserver)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-mockserver.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-mockserver/)
 
 

--- a/documentation/docs/extensions/mockserver.md
+++ b/documentation/docs/extensions/mockserver.md
@@ -13,7 +13,7 @@ Requires the `io.kotest.extensions:kotest-extensions-mockserver` module to be ad
 :::
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-mockserver)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-mockserver)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-mockserver.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-mockserver/)
 
 

--- a/documentation/docs/extensions/roboelectric.md
+++ b/documentation/docs/extensions/roboelectric.md
@@ -13,7 +13,7 @@ slug: robolectric.html
 
 To add this module to project you need specify following in your `build.gradle`:
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-robolectric)](https://search.maven.org/search?q=g:io.kotest.extensions%20a:kotest-extensions-robolectric)
+[![Latest Release](https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-robolectric)](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-robolectric)
 
 ```kotlin
 testImplementation("io.kotest.extensions:kotest-extensions-robolectric:${version}")

--- a/documentation/docs/extensions/spring.md
+++ b/documentation/docs/extensions/spring.md
@@ -8,7 +8,7 @@ slug: spring.html
 Kotest offers a Spring extension that allows you to test code that wires dependencies using Spring.
 To use this extension add the `io.kotest.extensions:kotest-extensions-spring` module to your test compile path.
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-spring.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-spring)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-spring.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-spring)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-spring.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-spring/)
 
 

--- a/documentation/docs/extensions/spring.md
+++ b/documentation/docs/extensions/spring.md
@@ -8,7 +8,7 @@ slug: spring.html
 Kotest offers a Spring extension that allows you to test code that wires dependencies using Spring.
 To use this extension add the `io.kotest.extensions:kotest-extensions-spring` module to your test compile path.
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-spring.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-spring)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-spring.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-spring)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-spring.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-spring/)
 
 

--- a/documentation/docs/extensions/test_containers.md
+++ b/documentation/docs/extensions/test_containers.md
@@ -18,7 +18,7 @@ To use add the below dependency to your Gradle build file.
 io.kotest.extensions:kotest-extensions-testcontainers:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-testcontainers.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-testcontainers)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-testcontainers)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-testcontainers.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-testcontainers/)
 
 Note: The group id is different (io.kotest.extensions) from the main kotest dependencies (io.kotest).

--- a/documentation/docs/extensions/test_containers.md
+++ b/documentation/docs/extensions/test_containers.md
@@ -18,7 +18,7 @@ To use add the below dependency to your Gradle build file.
 io.kotest.extensions:kotest-extensions-testcontainers:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-testcontainers)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-testcontainers)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-testcontainers.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-testcontainers/)
 
 Note: The group id is different (io.kotest.extensions) from the main kotest dependencies (io.kotest).

--- a/documentation/docs/extensions/wiremock.md
+++ b/documentation/docs/extensions/wiremock.md
@@ -13,7 +13,7 @@ URL, header and body content patterns etc.
 Kotest provides a module ```kotest-extensions-wiremock``` for integration with wiremock.
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-wiremock)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-wiremock)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-wiremock.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-wiremock/)
 
 

--- a/documentation/docs/extensions/wiremock.md
+++ b/documentation/docs/extensions/wiremock.md
@@ -13,7 +13,7 @@ URL, header and body content patterns etc.
 Kotest provides a module ```kotest-extensions-wiremock``` for integration with wiremock.
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-wiremock.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-wiremock)
+[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest-extensions-wiremock)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest.extensions/kotest-extensions-wiremock.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/extensions/kotest-extensions-wiremock/)
 
 

--- a/documentation/docs/framework/conditional_evaluation.md
+++ b/documentation/docs/framework/conditional_evaluation.md
@@ -20,7 +20,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](http://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS) .IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS) .IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/documentation/docs/framework/conditional_evaluation.md
+++ b/documentation/docs/framework/conditional_evaluation.md
@@ -20,7 +20,7 @@ If you're looking for something like JUnit's `@Ignore`, this is for you.
 
 You can use the same mechanism to run tests only under certain conditions.
  For example you could run certain tests only on Linux systems using
- [SystemUtils](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_WINDOWS) .IS_OS_LINUX from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
+ [`SystemUtils.IS_OS_LINUX`](https://commons.apache.org/proper/commons-lang/javadocs/api-release/org/apache/commons/lang3/SystemUtils.html#IS_OS_LINUX) from [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/).
 
 ```kotlin
 "should do something".config(enabled = IS_OS_LINUX) {

--- a/documentation/docs/framework/index.md
+++ b/documentation/docs/framework/index.md
@@ -6,7 +6,7 @@ slug: framework.html
 
 ![intro_gif](../images/intro_gif.gif)
 
-[![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-framework-engine.svg?label=release)](https://search.maven.org/search?q=kotest)
+[![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-framework-engine.svg?label=release)](https://search.maven.org/search?q=g:io.kotest%20OR%20g:io.kotest.extensions)
 [![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-framework-engine.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 Test with Style

--- a/documentation/docs/framework/styles.md
+++ b/documentation/docs/framework/styles.md
@@ -43,10 +43,10 @@ and then the test itself as a lambda. If in doubt, this is the style to use.
 
 ```kotlin
 class MyTests : FunSpec({
-	test("String length should return the length of the string") {
-		"sammy".length shouldBe 5
-		"".length shouldBe 0
-	}
+    test("String length should return the length of the string") {
+        "sammy".length shouldBe 5
+        "".length shouldBe 0
+    }
 })
 ```
 
@@ -61,9 +61,9 @@ class MyTests : DescribeSpec({
         }
     }
     xcontext("this block is disabled") {
-      test("disabled by inheritance from the parent") {
-        // test here
-      }
+        test("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -76,9 +76,9 @@ class MyTests : DescribeSpec({
 
 ```kotlin
 class MyTests : StringSpec({
-	"strings.length should return size of string" {
-		"hello".length shouldBe 5
-	}
+    "strings.length should return size of string" {
+        "hello".length shouldBe 5
+    }
 })
 ```
 
@@ -86,9 +86,9 @@ Adding config to the test.
 
 ```kotlin
 class MyTests : StringSpec({
-	"strings.length should return size of string".config(enabled = false, invocations = 3) {
-		"hello".length shouldBe 5
-	}
+    "strings.length should return size of string".config(enabled = false, invocations = 3) {
+        "hello".length shouldBe 5
+    }
 })
 ```
 
@@ -100,10 +100,10 @@ class MyTests : StringSpec({
 
 ```kotlin
 class MyTests : ShouldSpec({
-	should("return the length of the string") {
-		"sammy".length shouldBe 5
-		"".length shouldBe 0
-	}
+    should("return the length of the string") {
+        "sammy".length shouldBe 5
+        "".length shouldBe 0
+    }
 })
 ```
 
@@ -112,12 +112,12 @@ Tests can be nested in one or more context blocks as well:
 
 ```kotlin
 class MyTests : ShouldSpec({
-	context("String.length") {
-		should("return the length of the string") {
-			"sammy".length shouldBe 5
-			"".length shouldBe 0
-		}
-	}
+    context("String.length") {
+        should("return the length of the string") {
+            "sammy".length shouldBe 5
+            "".length shouldBe 0
+        }
+    }
 })
 ```
 
@@ -134,9 +134,9 @@ class MyTests : ShouldSpec({
         }
     }
     xcontext("this block is disabled") {
-      should("disabled by inheritance from the parent") {
-        // test here
-      }
+        should("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -165,9 +165,9 @@ class MyTests : DescribeSpec({
         }
 
         describe("for the opposite team") {
-          it("Should negate one score") {
-            // test here
-          }
+            it("Should negate one score") {
+                // test here
+            }
         }
     }
 })
@@ -183,9 +183,9 @@ class MyTests : DescribeSpec({
         }
     }
     xdescribe("this block is disabled") {
-      it("disabled by inheritance from the parent") {
-        // test here
-      }
+        it("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -274,12 +274,12 @@ class MyTests : DescribeSpec({
 
 ```kotlin
 class MyTests : WordSpec({
-	"String.length" should {
-		"return the length of the string" {
-			"sammy".length shouldBe 5
-			"".length shouldBe 0
-		}
-	}
+    "String.length" should {
+        "return the length of the string" {
+            "sammy".length shouldBe 5
+            "".length shouldBe 0
+        }
+    }
 })
 ```
 
@@ -288,18 +288,18 @@ in Kotlin, we must use backticks or the uppercase variant.
 
 ```kotlin
 class MyTests : WordSpec({
-	"Hello" When {
-		"asked for length" should {
-			"return 5" {
-				"Hello".length shouldBe 5
-			}
-		}
-		"appended to Bob" should {
-			"return Hello Bob" {
-				"Hello " + "Bob" shouldBe "Hello Bob"
-			}
-		}
-	}
+    "Hello" When {
+        "asked for length" should {
+            "return 5" {
+                "Hello".length shouldBe 5
+            }
+        }
+        "appended to Bob" should {
+            "return Hello Bob" {
+                "Hello " + "Bob" shouldBe "Hello Bob"
+            }
+        }
+    }
 })
 ```
 
@@ -345,14 +345,14 @@ Although not intended to be exactly the same as cucumber, the keywords mimic the
 
 ```kotlin
 class MyTests : FeatureSpec({
-	feature("the can of coke") {
-		scenario("should be fizzy when I shake it") {
-			// test here
-		}
-		scenario("and should be tasty") {
-			// test here
-		}
-	}
+    feature("the can of coke") {
+        scenario("should be fizzy when I shake it") {
+            // test here
+        }
+        scenario("and should be tasty") {
+            // test here
+        }
+    }
 })
 ```
 
@@ -368,9 +368,9 @@ class MyTests : FeatureSpec({
         }
     }
     xfeature("this block is disabled") {
-      scenario("disabled by inheritance from the parent") {
-        // test here
-      }
+        scenario("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```
@@ -415,9 +415,9 @@ class MyTests : DescribeSpec({
         }
     }
     xcontext("this block is disabled") {
-      expect("disabled by inheritance from the parent") {
-        // test here
-      }
+        expect("disabled by inheritance from the parent") {
+            // test here
+        }
     }
 })
 ```

--- a/documentation/docs/framework/styles.md
+++ b/documentation/docs/framework/styles.md
@@ -340,7 +340,7 @@ The innermost test must not use the `-` (minus) keyword after the test name.
 
 ## Feature Spec
 
-`FeatureSpec` allows you to use `feature` and `scenario`, which will be familiar to those who have used [cucumber](http://docs.cucumber.io/gherkin/reference/).
+`FeatureSpec` allows you to use `feature` and `scenario`, which will be familiar to those who have used [cucumber](https://cucumber.io/docs/gherkin/reference/).
 Although not intended to be exactly the same as cucumber, the keywords mimic the style.
 
 ```kotlin

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -13,7 +13,7 @@ For latest updates see [Changelog](changelog.md).<br/>
 See our [quick start](quick_start.mdx) guide to get up and running.
 
 [![GitHub stars](https://img.shields.io/github/stars/kotest/kotest.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/kotest/kotest/stargazers/)
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](https://search.maven.org/search?q=g:io.kotest)
 ![GitHub](https://img.shields.io/github/license/kotest/kotest)
 [![kotest @ kotlinlang.slack.com](https://img.shields.io/static/v1?label=kotlinlang&message=kotest&color=blue&logo=slack)](https://kotlinlang.slack.com/archives/CT0G9SD7Z)
 

--- a/documentation/docs/index.md
+++ b/documentation/docs/index.md
@@ -13,14 +13,14 @@ For latest updates see [Changelog](changelog.md).<br/>
 See our [quick start](quick_start.mdx) guide to get up and running.
 
 [![GitHub stars](https://img.shields.io/github/stars/kotest/kotest.svg?style=social&label=Star&maxAge=2592000)](https://GitHub.com/kotest/kotest/stargazers/)
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-framework-api-jvm.svg?label=latest%20release"/>](https://search.maven.org/#search|ga|1|kotest)
 ![GitHub](https://img.shields.io/github/license/kotest/kotest)
 [![kotest @ kotlinlang.slack.com](https://img.shields.io/static/v1?label=kotlinlang&message=kotest&color=blue&logo=slack)](https://kotlinlang.slack.com/archives/CT0G9SD7Z)
 
 Community
 ---------
-* [Stack Overflow](http://stackoverflow.com/questions/tagged/kotest) (don't forget to use the tag "kotest".)
-* [Kotest channel](https://kotlinlang.slack.com/messages/kotest) in the Kotlin Slack (get an invite [here](http://slack.kotlinlang.org/))
+* [Stack Overflow](https://stackoverflow.com/questions/tagged/kotest) (don't forget to use the tag "kotest".)
+* [Kotest channel](https://kotlinlang.slack.com/messages/kotest) in the Kotlin Slack (get an invite [here](https://slack.kotlinlang.org/))
 * [Contribute](https://github.com/kotest/kotest/wiki/contribute)
 
 Test with Style

--- a/documentation/docs/proptest/index.mdx
+++ b/documentation/docs/proptest/index.mdx
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 Kotest is split into several subprojects which can be used independently. One of these subprojects is the property test framework.
 You do **not** need to be using Kotest as your test framework (although you should!) to benefit from the property test support.
 
-[![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-property.svg?label=release)](https://search.maven.org/search?q=kotest)
+[![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-property.svg?label=release)](https://search.maven.org/search?q=g:io.kotest)
 [![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-framework-engine.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -152,7 +152,7 @@ function Home() {
 
                      &nbsp;
 
-                     <a href="http://stackoverflow.com/questions/tagged/kotest">
+                     <a href="https://stackoverflow.com/questions/tagged/kotest">
                         <img
                            src="https://img.shields.io/badge/stackoverflow-kotest-blue?style=for-the-badge"
                            alt="stack overflow"/>

--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -128,7 +128,7 @@ function Home() {
 
                      &nbsp;
 
-                     <a href="https://search.maven.org/search?q=kotest">
+                     <a href="https://search.maven.org/search?q=g:io.kotest%20OR%20g:io.kotest.extensions">
                         <img
                            src="https://img.shields.io/maven-central/v/io.kotest/kotest-property.svg?label=release&style=for-the-badge"
                            alt="version badge"/>

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/codepoints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/codepoints.kt
@@ -4,13 +4,13 @@ import io.kotest.property.Arb
 
 /**
  * The minimum value of a Unicode code point, constant {@code U+000000}.
- * http://www.unicode.org/glossary/#code_point
+ * https://www.unicode.org/glossary/#code_point
  */
 internal const val MIN_CODE_POINT = 0x000000
 
 /**
  * The maximum value of a Unicode code point, constant {@code U+10FFFF}.
- * http://www.unicode.org/glossary/#code_point
+ * https://www.unicode.org/glossary/#code_point
  */
 internal const val MAX_CODE_POINT = 0X10FFFF
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
@@ -30,7 +30,7 @@ fun <A> Arb.Companion.choose(a: Pair<Int, A>, b: Pair<Int, A>, vararg cs: Pair<I
 
    // The algorithm for pick is a migration of
    // the algorithm from Haskell QuickCheck
-   // http://hackage.haskell.org/package/QuickCheck
+   // https://hackage.haskell.org/package/QuickCheck
    // See function frequency in the package Test.QuickCheck
    tailrec fun pick(n: Int, l: Sequence<Pair<Int, A>>): A {
       val (w, e) = l.first()
@@ -75,7 +75,7 @@ fun <A> Arb.Companion.choose(a: Pair<Int, Arb<A>>, b: Pair<Int, Arb<A>>, vararg 
 
    // The algorithm for pick is a migration of
    // the algorithm from Haskell QuickCheck
-   // http://hackage.haskell.org/package/QuickCheck
+   // https://hackage.haskell.org/package/QuickCheck
    // See function frequency in the package Test.QuickCheck
    tailrec fun pick(n: Int, l: List<Pair<Int, Arb<A>>>): Arb<A> {
       val (w, e) = l.first()

--- a/signing-pom-details.gradle.kts
+++ b/signing-pom-details.gradle.kts
@@ -49,12 +49,12 @@ publishing {
          pom {
             name.set("Kotest")
             description.set("Kotlin Test Framework")
-            url.set("http://www.github.com/kotest/kotest")
+            url.set("https://github.com/kotest/kotest")
 
             scm {
-               connection.set("scm:git:http://www.github.com/kotest/kotest/")
-               developerConnection.set("scm:git:http://github.com/sksamuel/")
-               url.set("http://www.github.com/kotest/kotest/")
+               connection.set("scm:git:https://github.com/kotest/kotest/")
+               developerConnection.set("scm:git:https://github.com/sksamuel/")
+               url.set("https://github.com/kotest/kotest/")
             }
 
             licenses {


### PR DESCRIPTION
(See also commit messages)
- Updates links from HTTP to HTTPS (except for sites which do not properly support HTTPS)
- Improves links to Apache Commons Lang `SystemUtils` Javadoc
- Consistently use spaces for indentation in the `styles.md` files
- Improve links to search.maven.org