### PR TITLE
#2293 Fixes ShouldContainExactly for collection containing byte arrays

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.collections
 
+import io.kotest.assertions.eq.eq
 import io.kotest.assertions.show.Printed
 import io.kotest.assertions.show.show
 import io.kotest.matchers.*
@@ -20,7 +21,7 @@ fun <T> containExactly(vararg expected: T): Matcher<Collection<T>?> = containExa
 /** Assert that a collection contains exactly the given values and nothing else, in order. */
 fun <T, C : Collection<T>> containExactly(expected: C): Matcher<C?> = neverNullMatcher { actual ->
 
-   val passed = actual.size == expected.size && actual.zip(expected).all { (a, b) -> a == b }
+   val passed = eq(actual, expected, strictNumberEq = true) == null
 
    val failureMessage = {
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -73,6 +73,11 @@ class ShouldContainExactlyTest : WordSpec() {
             }
          }
 
+         "test contains exactly for byte arrays" {
+            listOf("hello".toByteArray()) shouldContainExactly listOf("hello".toByteArray())
+            listOf("helloworld".toByteArray()) shouldNotContainExactly listOf("hello".toByteArray())
+         }
+
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf<Any>(1L, 2L).shouldContainExactly(listOf<Any>(1, 2))

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/DefaultEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/DefaultEq.kt
@@ -12,7 +12,7 @@ import io.kotest.assertions.show.show
  * and in the case of inequality, delegates to [failure].
  */
 internal object DefaultEq : Eq<Any> {
-   override fun equals(actual: Any, expected: Any): Throwable? {
+   override fun equals(actual: Any, expected: Any, strictNumberEq: Boolean): Throwable? {
       return if (test(actual, expected)) null else {
          failure(Expected(expected.show()), Actual(actual.show()))
       }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/Eq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/Eq.kt
@@ -10,13 +10,13 @@ import io.kotest.assertions.show.show
  * This equality typeclass is at the heart of the shouldBe matcher.
  */
 interface Eq<T> {
-   fun equals(actual: T, expected: T): Throwable?
+   fun equals(actual: T, expected: T, strictNumberEq: Boolean = false): Throwable?
 }
 
 /**
  * Locates the applicable [Eq] for the inputs, and invokes it, returning the error if any.
  */
-fun <T : Any?> eq(actual: T, expected: T): Throwable? {
+fun <T : Any?> eq(actual: T, expected: T, strictNumberEq: Boolean = false): Throwable? {
    // if we have null and non null, usually that's a failure, but people can override equals to allow it
    return when {
       actual === expected -> null
@@ -24,16 +24,16 @@ fun <T : Any?> eq(actual: T, expected: T): Throwable? {
       actual == null && expected != null && actual != expected -> actualIsNull(expected)
       actual != null && expected == null && actual != expected -> expectedIsNull(actual)
       actual != null && expected != null -> when {
-         actual is Map<*, *> && expected is Map<*, *> -> MapEq.equals(actual, expected)
+         actual is Map<*, *> && expected is Map<*, *> -> MapEq.equals(actual, expected, strictNumberEq)
          actual is Regex && expected is Regex -> RegexEq.equals(actual, expected)
          actual is String && expected is String -> StringEq.equals(actual, expected)
-         actual is Number && expected is Number -> NumberEq.equals(actual, expected)
+         actual is Number && expected is Number -> NumberEq.equals(actual, expected, strictNumberEq)
          IterableEq.isValidIterable(actual) && IterableEq.isValidIterable(expected) -> {
-            IterableEq.equals(IterableEq.asIterable(actual), IterableEq.asIterable(expected))
+            IterableEq.equals(IterableEq.asIterable(actual), IterableEq.asIterable(expected), strictNumberEq)
          }
-         shouldShowDataClassDiff(actual, expected) -> DataClassEq.equals(actual as Any, expected as Any)
+         shouldShowDataClassDiff(actual, expected) -> DataClassEq.equals(actual as Any, expected as Any, strictNumberEq)
          actual is Throwable && expected is Throwable -> ThrowableEq.equals(actual, expected)
-         else -> DefaultEq.equals(actual as Any, expected as Any)
+         else -> DefaultEq.equals(actual as Any, expected as Any,strictNumberEq)
       }
       else -> null
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt
@@ -4,15 +4,15 @@ import io.kotest.assertions.failure
 import io.kotest.assertions.show.show
 
 internal object MapEq : Eq<Map<*, *>?> {
-   override fun equals(actual: Map<*, *>?, expected: Map<*, *>?): Throwable? {
+   override fun equals(actual: Map<*, *>?, expected: Map<*, *>?, strictNumberEq: Boolean): Throwable? {
       return when {
          actual == null && expected == null -> null
          actual != null && expected != null -> {
-            val haveUnequalKeys = eq(actual.keys, expected.keys)
+            val haveUnequalKeys = eq(actual.keys, expected.keys, strictNumberEq)
             if(haveUnequalKeys != null) generateError(actual, expected)
             else {
                val hasDifferentValue = actual.keys.any { key ->
-                  eq(actual[key], expected[key]) != null
+                  eq(actual[key], expected[key], strictNumberEq) != null
                }
                if(hasDifferentValue) generateError(actual, expected)
                else null

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt
@@ -7,11 +7,14 @@ import io.kotest.assertions.show.show
 
 object NumberEq : Eq<Number> {
 
-   override fun equals(actual: Number, expected: Number): Throwable? {
-      return if (compare(actual, expected)) null else failure(Expected(expected.show()), Actual(actual.show()))
+   override fun equals(actual: Number, expected: Number, strictNumberEq: Boolean): Throwable? {
+      return if (compare(actual, expected, strictNumberEq)) null else failure(Expected(expected.show()), Actual(actual.show()))
    }
 
-   private fun compare(a: Number, b: Number): Boolean {
+   private fun compare(a: Number, b: Number, strictNumberEq: Boolean): Boolean {
+      if (strictNumberEq) {
+         return a == b
+      }
       return when (a) {
          is Int -> when (b) {
             is Long -> a.toLong() == b

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/RegexEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/RegexEq.kt
@@ -10,7 +10,7 @@ import io.kotest.assertions.show.show
  * An implementation of [Eq] for comparing [Regex]s.
  */
 internal object RegexEq : Eq<Regex> {
-   override fun equals(actual: Regex, expected: Regex): Throwable? {
+   override fun equals(actual: Regex, expected: Regex, strictNumberEq: Boolean): Throwable? {
       return patternsAreNotEqual(actual, expected) ?: optionsAreNotEqual(actual, expected)
    }
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/StringEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/StringEq.kt
@@ -18,7 +18,7 @@ import io.kotest.assertions.show.show
  */
 object StringEq : Eq<String> {
 
-   override fun equals(actual: String, expected: String): Throwable? {
+   override fun equals(actual: String, expected: String, strictNumberEq: Boolean): Throwable? {
       return when {
          actual == expected -> null
          equalIgnoringWhitespace(actual, expected) -> {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/ThrowableEq.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/eq/ThrowableEq.kt
@@ -6,7 +6,7 @@ import io.kotest.assertions.failure
 import io.kotest.assertions.show.show
 
 object ThrowableEq : Eq<Throwable> {
-   override fun equals(actual: Throwable, expected: Throwable): Throwable? {
+   override fun equals(actual: Throwable, expected: Throwable, strictNumberEq: Boolean): Throwable? {
       return if (actual.message == expected.message && expected::class == actual::class)
          null
       else


### PR DESCRIPTION
For ShouldContainExactly to work `ByteArray` , `ShortArray` etc we have to use the `eq` instead of using default `equals` .
One downside of using `eq` is that it has `NumberEq` which try to do type change for comparing number of different type, for example if we are comparing a `Int` with a `Long` it will convert the `Long` to `Int` and then check equality using  default `equals`. This number conversion is not desired for `ShouldContainExactly`. 
https://github.com/kotest/kotest/blob/0ba14983d485b1b1caef0e5a2cd7402ba47e34d2/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt#L76-L95

So i order to make it work without changing the current behaviour of `shouldBe` (internally uses `eq`) and `ShouldContainExactly` I added a flag `strictNumberEq` to control conversion of number type in `NumberEq` . The default value for this is kept `false`.

One downside of this is that all implementation of need `Eq` need to keep forwarding `strictNumberEq` whenever they internally call `eq`.