### PR TITLE
Fix issue #2369 with Arb.localDate

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
@@ -48,9 +48,11 @@ fun Arb.Companion.localDate(
    maxDate: LocalDate = LocalDate.of(2030, 12, 31)
 ): Arb<LocalDate> {
 
-   val yearRange = (minDate.year..maxDate.year)
-   val feb28Date = LocalDate.of(yearRange.random(), 2, 28)
+   val feb28DateThisYear = LocalDate.of(LocalDate.now().year, 2, 28)
+   val minDateYear = if (minDate.isBefore(feb28DateThisYear)) minDate.year else minDate.year + 1
+   val yearRange = (minDateYear..maxDate.year)
 
+   val feb28Date = LocalDate.of(yearRange.random(), 2, 28)
    val feb29Year = yearRange.firstOrNull { Year.of(it).isLeap }
    val feb29Date = feb29Year?.let { LocalDate.of(it, 2, 29) }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.property.arbitrary
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.date.shouldBeAfter
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
@@ -39,6 +40,12 @@ class DateTest : WordSpec({
          years shouldBe setOf(1998, 1999)
          months shouldBe (1..12).toSet()
          days shouldBe (1..31).toSet()
+      }
+
+      "generate LocalDates after the minYear" {
+         checkAll(100_000, Arb.localDate(LocalDate.of(2021, 7, 17))) {
+            it shouldBeAfter LocalDate.of(2021, 7, 16)
+         }
       }
 
       "Contain Feb 29th if leap year" {


### PR DESCRIPTION
Arb.localDate doesn’t take into account the date/month portion of the
specified minDatex. So when you specify minDate that is after the
default edge case date, it will (intermittently) fail. Here’s an example
Arb.localDate(minDate = LocalDate.now().plusDays(10)) will generate a
2021-02-28 date.