### PR TITLE
Add shouldThrowMessage matcher

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -18,6 +18,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `shouldThrow<T> { block }` | General purpose construct that asserts that the block throws a `T` Throwable or a subtype of `T`|
 | `shouldThrowExactly<T> { block }` | General purpose construct that asserts that the block throws exactly `T` |
 | `shouldThrowAny { block }` | General purpose construct that asserts that the block throws a Throwable of any type |
+| `shouldThrowMessage(message) { block }` | Verifies that a block of code throws any Throwable with given message |
 
 | Types ||
 | ------- | ---- |


### PR DESCRIPTION
I propose to add this here just because `shouldThrow`, `shouldThrowAny` and the rest were here and I didn't find this one. Besides this proposal, I believe it could be clearer to move all throwable assertions to another subtitle, but that's up to you. 😄

BTW, thanks for this great framework! I've been using it in a course of software design and the DSL you created is very natural for my students.