### PR TITLE
improved geo location generator

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/geo.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/geo.kt
@@ -1,9 +1,34 @@
 package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
+import kotlin.math.PI
+import kotlin.math.acos
 
-fun Arb.Companion.latlong(): Arb<Pair<Double, Double>> = arbitrary {
-   val lat = it.random.nextDouble(-180.0, 180.0)
-   val long = it.random.nextDouble(-180.0, 180.0)
-   Pair(lat, long)
+
+@Deprecated("", replaceWith = ReplaceWith("geoLocation()"))
+fun Arb.Companion.latlong(): Arb<Pair<Double, Double>> =
+   Arb.geoLocation().map { loc -> Pair(loc.latitudeDeg, loc.longitudeDeg) }
+
+data class GeoLocation(val latitude: Double, val longitude: Double) {
+   @Deprecated("", replaceWith = ReplaceWith("latitude"))
+   val first = latitude
+   @Deprecated("", replaceWith = ReplaceWith("longitude"))
+   val second = longitude
+
+   val latitudeRad: Double = latitude
+   val longitudeRad: Double = longitude
+   val latitudeDeg: Double = 180.0 * latitude / PI
+   val longitudeDeg: Double = 180.0 * longitude / PI
+}
+
+fun Arb.Companion.geoLocation(): Arb<GeoLocation> = arbitrary(
+   listOf(
+      GeoLocation(-PI / 2, 0.0), // south pole
+      GeoLocation(PI / 2, 0.0) // north pole
+   )
+) {
+   val random = it.random
+   val lat = acos(random.nextDouble(-1.0, 1.0)) - PI / 2
+   val lon = random.nextDouble(-PI, PI)
+   GeoLocation(latitude = lat, longitude = lon)
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/geo.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/geo.kt
@@ -5,14 +5,14 @@ import kotlin.math.PI
 import kotlin.math.acos
 
 
-@Deprecated("", replaceWith = ReplaceWith("geoLocation()"))
+@Deprecated("Use geoLocation()", replaceWith = ReplaceWith("geoLocation()"))
 fun Arb.Companion.latlong(): Arb<Pair<Double, Double>> =
    Arb.geoLocation().map { loc -> Pair(loc.latitudeDeg, loc.longitudeDeg) }
 
 data class GeoLocation(val latitude: Double, val longitude: Double) {
-   @Deprecated("", replaceWith = ReplaceWith("latitude"))
+   @Deprecated("Use latitude", replaceWith = ReplaceWith("latitude"))
    val first = latitude
-   @Deprecated("", replaceWith = ReplaceWith("longitude"))
+   @Deprecated("Use longitude", replaceWith = ReplaceWith("longitude"))
    val second = longitude
 
    val latitudeRad: Double = latitude


### PR DESCRIPTION
This morning I noticed that the `Arb.latlon` generator does not produce proper geo coordinates:
- latitude should be in range -90°...+90° and
- it should not be uniformly distributed in its range for the points on the sphere to be uniformly distributed

While updating I also added a dedicated class for geo locations with descriptive property names and degree and radian values.
Plus backward compatibility code with deprecation annotations with `ReplaceWith` hints.