### PR TITLE
Add BigDecimal edge case for equals vs compareTo discrepancy

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
@@ -4,8 +4,10 @@ import io.kotest.property.Arb
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-private val bigDecimalEdgecases = listOf(
+internal val bigDecimalEdgecases = listOf(
    BigDecimal(0.0),
+   // BigDecimal compareTo and equals are not consistent
+   BigDecimal("0.00"),
    BigDecimal(1.0),
    BigDecimal(-1.0),
    BigDecimal("1e-300"),

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
@@ -3,10 +3,12 @@ package com.sksamuel.kotest.property.arbitrary
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.concurrent.shouldCompleteWithin
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.arbitrary.bigDecimalEdgecases
 import io.kotest.property.arbitrary.take
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -34,5 +36,10 @@ class BigDecimalTest : FunSpec({
          Arb.bigDecimal(BigDecimal.valueOf(-100_000.00), BigDecimal.valueOf(100_000.00)).take(100).forEach { _ ->
          }
       }
+   }
+
+   test("bigDecimalEdgecases should contain zeros with differing precision") {
+      bigDecimalEdgecases.shouldContain(BigDecimal("0.00"))
+      bigDecimalEdgecases.shouldContain(BigDecimal("0"))
    }
 })


### PR DESCRIPTION
BigDecimal is not consistent for equals and compareTo when the
scale differs. This adds an edge case using the String constructor for
BigDecimal to force a different scale.