### PR TITLE
#2412 Makes Sequence.containExactly work for single pass sequences

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -2,6 +2,8 @@
 
 package io.kotest.matchers.sequences
 
+import io.kotest.assertions.eq.eq
+import io.kotest.assertions.show.show
 import io.kotest.matchers.*
 
 private fun <T> Sequence<T>.toString(limit: Int = 10) = this.joinToString(", ", limit = limit)
@@ -79,17 +81,25 @@ fun <T> containExactly(vararg expected: T): Matcher<Sequence<T>?> = containExact
 
 /** Assert that a sequence contains exactly the given values and nothing else, in order. */
 fun <T, C : Sequence<T>> containExactly(expected: C): Matcher<C?> = neverNullMatcher { value ->
-   var passed: Boolean = value.count() == expected.count()
+   val actualIterator = value.withIndex().iterator()
+   val expectedIterator = expected.withIndex().iterator()
+
+   var passed = true
    var failMessage = "Sequence should contain exactly $expected but was $value"
-   if (passed) {
-      val diff = value.zip(expected) { a, b -> Triple(a, b, a == b) }.withIndex().find { !it.value.third }
-      if (diff != null) {
+   while (passed && actualIterator.hasNext() && expectedIterator.hasNext()) {
+      val actualElement = actualIterator.next()
+      val expectedElement = expectedIterator.next()
+      if (eq(actualElement.value, expectedElement.value) != null) {
+         failMessage += " (expected ${expectedElement.value.show().value} at ${expectedElement.index} but found ${actualElement.value.show().value})"
          passed = false
-         failMessage += " (expected ${diff.value.second} at ${diff.index} but found ${diff.value.first})"
       }
-   } else {
-      failMessage += " (expected ${expected.count()} elements but found ${value.count()})"
    }
+
+   if (actualIterator.hasNext() || expectedIterator.hasNext()) {
+      failMessage += "Actual and Expected sequence have unequal number of elements"
+      passed = false
+   }
+
    MatcherResult(
       passed,
       failMessage,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -85,7 +85,7 @@ fun <T, C : Sequence<T>> containExactly(expected: C): Matcher<C?> = neverNullMat
    val expectedIterator = expected.withIndex().iterator()
 
    var passed = true
-   var failMessage = "Sequence should contain exactly $expected but was $value"
+   var failMessage = "Sequence should contain exactly $expected but was $value."
    while (passed && actualIterator.hasNext() && expectedIterator.hasNext()) {
       val actualElement = actualIterator.next()
       val expectedElement = expectedIterator.next()
@@ -95,8 +95,13 @@ fun <T, C : Sequence<T>> containExactly(expected: C): Matcher<C?> = neverNullMat
       }
    }
 
-   if (actualIterator.hasNext() || expectedIterator.hasNext()) {
-      failMessage += "Actual and Expected sequence have unequal number of elements"
+   if (passed && actualIterator.hasNext()) {
+      failMessage += "\nActual sequence has more element than Expected sequence"
+      passed = false
+   }
+
+   if (passed && expectedIterator.hasNext()) {
+      failMessage += "\nExpected sequence has more element than Actual sequence"
       passed = false
    }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -634,6 +634,25 @@ class SequenceMatchersTest : WordSpec() {
          succeed("for same elements but different order (variadic)") {
             repeating.shouldNotContainExactly(1, 1, 2, 2, 3, 3)
          }
+
+         succeed("for single traversable equal sequence") {
+            var count1 = 0
+            var count2 = 0
+            val seq1 = generateSequence { if(count1 < 5) count1++ else null }
+            val seq2 = generateSequence { if(count2 < 5) count2++ else null }
+
+            seq1.shouldContainExactly(seq2)
+         }
+
+         fail("for single traversable unequal sequence") {
+            var count1 = 0
+            var count2 = 0
+            val seq1 = generateSequence { if(count1 < 5) count1++ else null }
+            val seq2 = generateSequence { if(count2 < 6) count2++ else null }
+
+            seq1.shouldContainExactly(seq2)
+         }
+
       }
 
       "contain in any order" should {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -40,6 +40,8 @@ import io.kotest.matchers.sequences.shouldNotContainNull
 import io.kotest.matchers.sequences.shouldNotContainOnlyNulls
 import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
+import io.kotest.matchers.shouldBe
+import java.lang.AssertionError
 
 class SequenceMatchersTest : WordSpec() {
 


### PR DESCRIPTION
closes: #2412 