### PR TITLE
Add NaN matchers to Float

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/NaN.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/NaN.kt
@@ -1,0 +1,65 @@
+package io.kotest.matchers.floats
+
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * Asserts that this [Float] is [Float.NaN]
+ *
+ * Verifies that this [Float] is the Not-a-Number constant [Float.NaN]
+ *
+ * Opposite of [shouldNotBeNaN]
+ *
+ * ```
+ * Float.NaN.shouldBeNaN()   // Assertion passes
+ * 1f.shouldBeNaN()          // Assertion fails
+ * ```
+ * @see [beNaN]
+ */
+fun Float.shouldBeNaN(): Float {
+   this should beNaN()
+   return this
+}
+
+/**
+ * Assert that this [Float] is not [Float.NaN]
+ *
+ * Verifies that this [Float] is NOT the Not-a-Number constant [Float.NaN]
+ *
+ * Opposite of [shouldBeNaN]
+ *
+ * ```
+ * 1f.shouldNotBeNaN()         // Assertion passes
+ * Float.NaN.shouldNotBeNaN()  // Assertion fails
+ * ```
+ * @see [beNaN]
+ */
+fun Float.shouldNotBeNaN(): Float {
+   this shouldNot beNaN()
+   return this
+}
+
+/**
+ * Matcher that matches [Float.NaN]
+ *
+ * Verifies that a specific [Float] is the Not-a-Number constant [Float.NaN]
+ *
+ * ```
+ *  0.5f should beNaN()          // Assertion fails
+ *  Float.NaN should beNaN()     // Assertion passes
+ * ```
+ *
+ * @see [Float.shouldBeNaN]
+ * @see [Float.shouldNotBeNaN]
+ */
+fun beNaN() = object : Matcher<Float> {
+  override fun test(value: Float) = MatcherResult(
+    value.isNaN(),
+    "$value should be NaN",
+    "$value should not be NaN"
+  )
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/doubles/arbs.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/doubles/arbs.kt
@@ -3,7 +3,12 @@ package com.sksamuel.kotest.matchers.doubles
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.filterNot
+import io.kotest.property.arbitrary.float
 
 val nonNumericDoubles = listOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY)
 val numericDoubles = Arb.double().filterNot { it in nonNumericDoubles }
 val nonMinNorMaxValueDoubles = numericDoubles.filterNot { it in listOf(Double.MAX_VALUE, Double.MIN_VALUE) }
+
+
+val nonNumericFloats = listOf(Float.NaN, Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY)
+val numericFloats = Arb.float().filterNot { it in nonNumericFloats }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatMatchersTest.kt
@@ -1,14 +1,16 @@
 package com.sksamuel.kotest.matchers.floats
 
+import com.sksamuel.kotest.matchers.doubles.numericFloats
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.script.context
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.doubles.shouldBeWithinPercentageOf
+import io.kotest.matchers.floats.beNaN
 import io.kotest.matchers.floats.shouldBeExactly
 import io.kotest.matchers.floats.shouldBeGreaterThan
 import io.kotest.matchers.floats.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.floats.shouldBeLessThan
 import io.kotest.matchers.floats.shouldBeLessThanOrEqual
+import io.kotest.matchers.floats.shouldBeNaN
 import io.kotest.matchers.floats.shouldBeWithinPercentageOf
 import io.kotest.matchers.floats.shouldBeZero
 import io.kotest.matchers.floats.shouldNotBeExactly
@@ -16,11 +18,16 @@ import io.kotest.matchers.floats.shouldNotBeGreaterThan
 import io.kotest.matchers.floats.shouldNotBeGreaterThanOrEqual
 import io.kotest.matchers.floats.shouldNotBeLessThan
 import io.kotest.matchers.floats.shouldNotBeLessThanOrEqual
+import io.kotest.matchers.floats.shouldNotBeNaN
 import io.kotest.matchers.floats.shouldNotBeZero
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.float
+import io.kotest.property.checkAll
 
 class FloatMatchersTest : StringSpec() {
   init {
@@ -122,7 +129,7 @@ class FloatMatchersTest : StringSpec() {
 
         test("Refuse negative percentage") {
            shouldThrow<IllegalArgumentException> {
-              1.0.shouldBeWithinPercentageOf(1.0, -0.1)
+              1f.shouldBeWithinPercentageOf(1f, -0.1)
            }
         }
 
@@ -133,5 +140,54 @@ class FloatMatchersTest : StringSpec() {
            }
         }
      }
+
+
+     context("NaN matcher") {
+        test("Every numeric float should not be NaN") {
+              checkAll(100, numericFloats) {
+                 it.shouldNotMatchNaN()
+              }
+        }
+
+        test("The non-numeric floats") {
+           Float.NaN.shouldMatchNaN()
+           Float.POSITIVE_INFINITY.shouldNotMatchNaN()
+           Float.NEGATIVE_INFINITY.shouldNotMatchNaN()
+        }
+     }
+
   }
+
+   private fun shouldThrowAssertionError(message: String, vararg expression: () -> Any?) {
+      expression.forEach {
+         val exception = shouldThrow<AssertionError>(it)
+         exception.message shouldBe message
+      }
+   }
+
+   private fun Float.shouldMatchNaN() {
+      this should beNaN()
+      this.shouldBeNaN()
+
+      this.shouldThrowExceptionOnNotBeNaN()
+   }
+
+   private fun Float.shouldThrowExceptionOnNotBeNaN() {
+      shouldThrowAssertionError("$this should not be NaN",
+         { this.shouldNotBeNaN() },
+         { this shouldNot beNaN() })
+   }
+
+   private fun Float.shouldNotMatchNaN() {
+      this shouldNot beNaN()
+      this.shouldNotBeNaN()
+
+      this.shouldThrowExceptionOnBeNaN()
+   }
+
+   private fun Float.shouldThrowExceptionOnBeNaN() {
+      shouldThrowAssertionError("$this should be NaN",
+         { this.shouldBeNaN() },
+         { this should beNaN() })
+   }
 }


### PR DESCRIPTION
Currently, there are some assertion matchers that exist for Double but not Float. #2404 added some, and this PR adds some more: namely, the matchers relating to NaN.