### PR TITLE
More powerful extension registration mechanism

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,11 +28,7 @@ tasks {
    }
 }
 
-// apply plugin: "io.kotest"
-
 allprojects {
-
-//   apply(plugin = "io.kotest")
 
    repositories {
       mavenCentral()

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -290,7 +290,7 @@ abstract class TestConfiguration {
    fun registeredAutoCloseables(): List<Lazy<AutoCloseable>> = _autoCloseables.toList()
 
    /**
-    * Returns any [TestCaseExtension] instances registered directly on this class.
+    * Returns any [Extension] instances registered directly on this class.
     */
    fun registeredExtensions() = _extensions
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Configuration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Configuration.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 /**
  * The global configuration singleton.
  *
- * This is a global singleton for historic reasons and is slowly being replaced with a non global variable.
+ * This is a global singleton for historic reasons and is slowly being replaced with a non-global variable.
  *
  * Expect this val to disappear in Kotest 6.0
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/AfterSpecExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/AfterSpecExtension.kt
@@ -1,0 +1,16 @@
+package io.kotest.core.extensions
+
+import io.kotest.core.spec.Spec
+
+/**
+ * An extension point that is invoked after all tests have completed in a spec instance.
+ *
+ * This extension is useful for executing cleanup logic that should only be invoked
+ * if the spec was active.
+ *
+ * This extension is invoked once per active spec instance. If a spec is instantiated and used
+ * multiple times, then this extension will also be invoked multiple times.
+ */
+interface AfterSpecExtension : Extension {
+   fun afterSpec(spec: Spec)
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/BeforeSpecExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/BeforeSpecExtension.kt
@@ -1,0 +1,16 @@
+package io.kotest.core.extensions
+
+import io.kotest.core.spec.Spec
+
+/**
+ * An extension point that is invoked before any tests in an active spec.
+ *
+ * This extension is useful for executing setup logic that should only be invoked
+ * if the spec is active.
+ *
+ * This extension is invoked once per active spec instance. If a spec is instantiated and used
+ * multiple times, then this extension will also be invoked multiple times.
+ */
+interface BeforeSpecExtension : Extension {
+   fun beforeSpec(spec: Spec): Unit = Unit
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/MountableExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/MountableExtension.kt
@@ -1,0 +1,37 @@
+package io.kotest.core.extensions
+
+import io.kotest.core.spec.Spec
+
+/**
+ * An installable extension that returns a materialized value to the user and allows for
+ * a configuration block.
+ *
+ * This allows extensions to provide control objects which differ from the extension itself.
+ *
+ * For example:
+ *
+ * class MyTest : FunSpec() {
+ *  init {
+ *   val kafka = install(EmbeddedKafka) {
+ *     port = 9092
+ *   }
+ *  }
+ * }
+ *
+ * Here `kafka` is a materialized value that contains details of the host/port of the
+ * started kafka instance.
+ *
+ */
+interface MountableExtension<CONFIG, MATERIALIZED> : Extension {
+   // cannot be suspending as it is invoked from mount that is itself invoked in constructors
+   fun mount(configure: CONFIG.() -> Unit): MATERIALIZED
+}
+
+// cannot be suspending as it is used in constructors
+fun <CONFIG, MATERIALIZED> Spec.install(
+   mountable: MountableExtension<CONFIG, MATERIALIZED>,
+   configure: CONFIG.() -> Unit = {}
+): MATERIALIZED {
+   extensions(mountable)
+   return mountable.mount(configure)
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/PostInstantiationExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/PostInstantiationExtension.kt
@@ -3,14 +3,19 @@ package io.kotest.core.extensions
 import io.kotest.core.spec.Spec
 
 /**
- * An extension point that is used to post-process a spec class after it has been instantiated.
+ * An extension point that is used to post-process a spec class after it has been instantiated
+ * by Kotest using reflection at runtime.
  *
- * This extension is useful for dependency injection or for invoking initialization logic.
+ * This extension allows the spec to be replaced with another instance of the same type, which can
+ * be useful for proxying or dependency injection.
+ *
+ * Note: This extension invoked only when classes are created by Kotest and is therefore
+ * restricted to JVM platforms. This restriction may be dropped in future releases.
  */
 interface PostInstantiationExtension : Extension {
 
    /**
-    * Accepts a [Spec] for post processing.
+    * Accepts a [Spec] for post-processing.
     *
     * This function must return a spec to be used. Typically, the same instance is returned,
     * but the implementation is free to return another instance if desired.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecFinalizeExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecFinalizeExtension.kt
@@ -1,0 +1,22 @@
+package io.kotest.core.extensions
+
+import io.kotest.core.spec.Spec
+
+/**
+ * An extension point that is used to post-process a spec class once all (if any) tests have
+ * complete and the spec instance will no longer be used.
+ *
+ * Note: This extension is invoked regardless of whether the spec had any tests, or if the spec
+ * was disabled. This extension is intended to be used for cleanup logic which must run anytime
+ * a spec is instantiated, regardless of whether the spec was then ultimately executed.
+ *
+ * This extension is invoked once per spec instance. If a spec is instantiated multiple times,
+ * then this extension will also be invoked multiple times.
+ */
+interface SpecFinalizeExtension : Extension {
+
+   /**
+    * Accepts a [Spec] for processing before that spec is completed.
+    */
+   fun finalize(spec: Spec)
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecInitializeExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecInitializeExtension.kt
@@ -1,0 +1,24 @@
+package io.kotest.core.extensions
+
+import io.kotest.core.spec.Spec
+
+/**
+ * An extension point that is invoked after a spec class has been created.
+ *
+ * Note: This extension is always invoked on a spec instance, regardless of whether that spec is
+ * then ultimately skipped (no tests or all tests disabled). This extension is intended
+ * for logic that must be invoked even when the spec is ultimately not used.
+ *
+ * Compare to [BeforeSpecExtension] which is only invoked if the spec is active and contains
+ * at least one test.
+ *
+ * This extension is invoked once per spec instance. If a spec is instantiated multiple times,
+ * then this extension will also be invoked multiple times.
+ */
+interface SpecInitializeExtension : Extension {
+
+   /**
+    * Accepts a [Spec] for processing before any tests are executed or enabled/disabled checks are performed.
+    */
+   fun initialize(spec: Spec)
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecInterceptExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecInterceptExtension.kt
@@ -4,10 +4,13 @@ import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import kotlin.reflect.KClass
 
+@Deprecated("Renamed to SpecInterceptExtension")
+typealias SpecExtension = SpecInterceptExtension
+
 /**
  * Extension point that allows intercepting execution of specs.
  */
-interface SpecExtension : Extension {
+interface SpecInterceptExtension : Extension {
 
    /**
     * Intercepts a [Spec] before it has been instantiated.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/DslDrivenSpec.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/DslDrivenSpec.kt
@@ -3,7 +3,7 @@ package io.kotest.core.spec
 import io.kotest.core.Tuple2
 import io.kotest.core.config.configuration
 import io.kotest.core.test.Identifiers
-import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecInterceptExtension
 import io.kotest.core.factory.TestFactory
 import io.kotest.core.factory.addPrefix
 import io.kotest.core.factory.createTestCases
@@ -80,7 +80,7 @@ abstract class DslDrivenSpec : Spec() {
 
    @Deprecated("this makes no sense")
    fun aroundSpec(aroundSpecFn: AroundSpecFn) {
-      extension(object : SpecExtension {
+      extension(object : SpecInterceptExtension {
          override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
             aroundSpecFn(Tuple2(spec, process))
          }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/events/Extensions.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/events/Extensions.kt
@@ -1,0 +1,43 @@
+package io.kotest.engine.events
+
+import io.kotest.core.config.Configuration
+import io.kotest.core.extensions.AfterSpecExtension
+import io.kotest.core.extensions.BeforeSpecExtension
+import io.kotest.core.extensions.Extension
+import io.kotest.core.extensions.SpecFinalizeExtension
+import io.kotest.core.extensions.SpecInitializeExtension
+import io.kotest.core.spec.Spec
+import io.kotest.fp.Try
+
+/**
+ * Used to send invoke extension points on specs.
+ */
+class Extensions(private val configuration: Configuration) {
+
+   /**
+    * Returns all [Extension]s applicable to the [Spec]. This includes extensions via the
+    * function override, those registered explicitly in the spec, and project wide extensions
+    * from configuration.
+    */
+   private fun resolvedExtensions(spec: Spec): List<Extension> {
+      return spec.extensions() + // overriding in the spec
+         spec.registeredExtensions() + // registered on the spec
+         configuration.extensions() // globals
+   }
+
+   fun specInitialize(spec: Spec): Try<Unit> = Try {
+      resolvedExtensions(spec).filterIsInstance<SpecInitializeExtension>().forEach { it.initialize(spec) }
+   }
+
+   fun specFinalize(spec: Spec): Try<Unit> = Try {
+      resolvedExtensions(spec).filterIsInstance<SpecFinalizeExtension>().forEach { it.finalize(spec) }
+   }
+
+   fun beforeSpec(spec: Spec): Try<Unit> = Try {
+      resolvedExtensions(spec).filterIsInstance<BeforeSpecExtension>().forEach { it.beforeSpec(spec) }
+   }
+
+   fun afterSpec(spec: Spec): Try<Unit> = Try {
+      resolvedExtensions(spec).filterIsInstance<AfterSpecExtension>().forEach { it.afterSpec(spec) }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/events/spec.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/events/spec.kt
@@ -2,6 +2,7 @@ package io.kotest.engine.events
 
 import io.kotest.core.config.configuration
 import io.kotest.core.config.testListeners
+import io.kotest.core.extensions.SpecFinalizeExtension
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.resolvedTestListeners
 import io.kotest.fp.Try
@@ -34,5 +35,10 @@ internal suspend fun Spec.invokeAfterSpec(): Try<Spec> = Try {
 
    val listeners = resolvedTestListeners() + configuration.testListeners()
    listeners.forEach { it.afterSpec(this) }
+
+   configuration.extensions().filterIsInstance<SpecFinalizeExtension>().forEach {
+      it.finalize(this)
+   }
+
    this
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/lookup.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/lookup.kt
@@ -2,10 +2,10 @@ package io.kotest.engine.extensions
 
 import io.kotest.core.config.configuration
 import io.kotest.core.extensions.Extension
-import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecInterceptExtension
 import io.kotest.core.spec.Spec
 
-fun Spec.resolvedSpecExtensions(): List<SpecExtension> = resolvedExtensions().filterIsInstance<SpecExtension>()
+fun Spec.resolvedSpecInterceptors(): List<SpecInterceptExtension> = resolvedExtensions().filterIsInstance<SpecInterceptExtension>()
 
 /**
  * Returns all [Extension]s applicable to this [Spec]. This includes extensions via the

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/AfterSpecExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/AfterSpecExtensionTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.config.configuration
+import io.kotest.core.extensions.AfterSpecExtension
+import io.kotest.core.spec.Isolate
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.KotestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Isolate
+class AfterSpecExtensionTest : FunSpec() {
+   init {
+
+      test("AfterSpecExtension's should be triggered for a spec with tests") {
+
+         configuration.registerExtension(MyAfterSpecExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyPopulatedSpec2::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MyAfterSpecExtension)
+
+         MyAfterSpecExtension.invoked.get() shouldBe true
+      }
+
+      test("AfterSpecExtension's should NOT be triggered for a spec without tests") {
+
+         MyAfterSpecExtension.invoked.set(false)
+         configuration.registerExtension(MyAfterSpecExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyEmptySpec2::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MyAfterSpecExtension)
+
+         MyAfterSpecExtension.invoked.get() shouldBe false
+      }
+   }
+}
+
+object MyAfterSpecExtension : AfterSpecExtension {
+   val invoked = AtomicBoolean(false)
+   override fun afterSpec(spec: Spec) {
+      invoked.set(true)
+   }
+}
+
+private class MyEmptySpec2 : FunSpec()
+
+private class MyPopulatedSpec2 : FunSpec() {
+   init {
+      test("foo") {}
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/BeforeSpecExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/BeforeSpecExtensionTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.config.configuration
+import io.kotest.core.extensions.AfterSpecExtension
+import io.kotest.core.spec.Isolate
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.KotestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Isolate
+class BeforeSpecExtensionTest : FunSpec() {
+   init {
+
+      test("BeforeSpecExtension's should be triggered for a spec with tests") {
+
+         configuration.registerExtension(MyBeforeSpecExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyPopulatedSpec3::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MyAfterSpecExtension)
+
+         MyBeforeSpecExtension.invoked.get() shouldBe true
+      }
+
+      test("BeforeSpecExtension's should NOT be triggered for a spec without tests") {
+
+         MyBeforeSpecExtension.invoked.set(false)
+         configuration.registerExtension(MyBeforeSpecExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyEmptySpec3::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MyBeforeSpecExtension)
+
+         MyBeforeSpecExtension.invoked.get() shouldBe false
+      }
+   }
+}
+
+object MyBeforeSpecExtension : AfterSpecExtension {
+   val invoked = AtomicBoolean(false)
+   override fun afterSpec(spec: Spec) {
+      invoked.set(true)
+   }
+}
+
+private class MyEmptySpec3 : FunSpec()
+
+private class MyPopulatedSpec3 : FunSpec() {
+   init {
+      test("foo") {}
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/MountableExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/MountableExtensionTest.kt
@@ -1,0 +1,44 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.extensions.BeforeSpecExtension
+import io.kotest.core.extensions.MountableExtension
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicBoolean
+
+class MountableExtensionTest : FunSpec() {
+
+   private val mountable = MyMountable()
+   private val control = install(mountable) {
+      a = "bar"
+   }
+
+   init {
+      test("mountable extensions should invoke configuration block") {
+         control.a shouldBe "bar"
+      }
+
+      test("mountable extensions should be installed as regular extensions") {
+         mountable.before.get() shouldBe true
+      }
+   }
+}
+
+data class Config(var a: String)
+
+class MyMountable : MountableExtension<Config, Config>, BeforeSpecExtension {
+
+   val before = AtomicBoolean(false)
+
+   override fun beforeSpec(spec: Spec) {
+      before.set(true)
+   }
+
+   override fun mount(configure: (Config) -> Unit): Config {
+      val config = Config("foo")
+      configure(config)
+      return config
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/SpecFinalizerExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/SpecFinalizerExtensionTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.config.configuration
+import io.kotest.core.extensions.SpecFinalizeExtension
+import io.kotest.core.spec.Isolate
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.KotestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Isolate
+class SpecFinalizerExtensionTest : FunSpec() {
+   init {
+
+      test("SpecFinalizerExtension's should be triggered for a spec with tests") {
+
+         configuration.registerExtension(MySpecFinalizeExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyPopulatedSpec::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MySpecFinalizeExtension)
+
+         MySpecFinalizeExtension.finalized.get() shouldBe true
+      }
+
+      test("SpecFinalizerExtension's should be triggered for a spec without tests") {
+
+         MySpecFinalizeExtension.finalized.set(false)
+         configuration.registerExtension(MySpecFinalizeExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyEmptySpec::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MySpecFinalizeExtension)
+
+         MySpecFinalizeExtension.finalized.get() shouldBe true
+      }
+   }
+}
+
+object MySpecFinalizeExtension : SpecFinalizeExtension {
+   val finalized = AtomicBoolean(false)
+   override fun finalize(spec: Spec) {
+      finalized.set(true)
+   }
+}
+
+private class MyEmptySpec : FunSpec()
+
+private class MyPopulatedSpec : FunSpec() {
+   init {
+      test("foo") {}
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/SpecInitializerExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/SpecInitializerExtensionTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.config.configuration
+import io.kotest.core.extensions.SpecInitializeExtension
+import io.kotest.core.spec.Isolate
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.KotestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicBoolean
+
+@Isolate
+class MySpecInitializerExtensionTest : FunSpec() {
+   init {
+
+      test("SpecFinalizerExtension's should be triggered for a spec with tests") {
+
+         configuration.registerExtension(MySpecInitializeExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyPopulatedSpec4::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MySpecInitializeExtension)
+
+         MySpecInitializeExtension.invoked.get() shouldBe true
+      }
+
+      test("SpecFinalizerExtension's should be triggered for a spec without tests") {
+
+         MySpecFinalizeExtension.finalized.set(false)
+         configuration.registerExtension(MySpecInitializeExtension)
+
+         KotestEngineLauncher()
+            .withSpec(MyEmptySpec4::class)
+            .withListener(NoopTestEngineListener)
+            .launch()
+
+         configuration.deregisterExtension(MySpecInitializeExtension)
+
+         MySpecInitializeExtension.invoked.get() shouldBe true
+      }
+   }
+}
+
+object MySpecInitializeExtension : SpecInitializeExtension {
+   val invoked = AtomicBoolean(false)
+   override fun initialize(spec: Spec) {
+      invoked.set(true)
+   }
+}
+
+private class MyEmptySpec4 : FunSpec()
+
+private class MyPopulatedSpec4 : FunSpec() {
+   init {
+      test("foo") {}
+   }
+}

--- a/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
@@ -1,6 +1,6 @@
 package io.kotest.property.lifecycle
 
-import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecInterceptExtension
 import io.kotest.core.spec.Spec
 import io.kotest.property.AfterPropertyContextElement
 import io.kotest.property.BeforePropertyContextElement
@@ -8,7 +8,7 @@ import kotlinx.coroutines.withContext
 import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
 
-interface BeforeAndAfterPropertyTestExtension : SpecExtension {
+interface BeforeAndAfterPropertyTestInterceptExtension : SpecInterceptExtension {
 
    suspend fun beforeProperty()
    suspend fun afterProperty()
@@ -29,14 +29,14 @@ interface BeforeAndAfterPropertyTestExtension : SpecExtension {
 }
 
 fun Spec.beforeProperty(f: suspend () -> Unit) {
-   extension(object : BeforeAndAfterPropertyTestExtension {
+   extension(object : BeforeAndAfterPropertyTestInterceptExtension {
       override suspend fun beforeProperty() { f() }
       override suspend fun afterProperty() { }
    })
 }
 
 fun Spec.afterProperty(f: suspend () -> Unit) {
-   extension(object : BeforeAndAfterPropertyTestExtension {
+   extension(object : BeforeAndAfterPropertyTestInterceptExtension {
       override suspend fun beforeProperty() { }
       override suspend fun afterProperty() { f() }
    })

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/LateinitSpecInterceptorStringSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/LateinitSpecInterceptorStringSpecTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.extensions
 
-import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecInterceptExtension
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -11,7 +11,7 @@ class LateinitSpecInterceptorStringSpecTest : StringSpec() {
 
    private lateinit var string: String
 
-   inner class Interceptor : SpecExtension {
+   inner class Interceptor : SpecInterceptExtension {
       override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
          this@LateinitSpecInterceptorStringSpecTest.string = "Hello"
          process()

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/LateinitSpecInterceptorWordSpecTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/LateinitSpecInterceptorWordSpecTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.extensions
 
-import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecInterceptExtension
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
@@ -10,7 +10,7 @@ class LateinitSpecInterceptorWordSpecTest : WordSpec() {
 
    private lateinit var string: String
 
-   inner class Interceptor : SpecExtension {
+   inner class Interceptor : SpecInterceptExtension {
       override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
          this@LateinitSpecInterceptorWordSpecTest.string = "Hello"
          process()

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/SpecExtensionTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/SpecExtensionTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.extensions
 
-import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecInterceptExtension
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.spec.toDescription
@@ -12,7 +12,7 @@ object SpecExtensionNumbers {
    var before = 0
    var after = 0
 
-   val ext = object : SpecExtension {
+   val ext = object : SpecInterceptExtension {
       override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
          if (spec.toDescription().name.qualifiedName == SpecExtensionTest::class.java.name) {
             before++


### PR DESCRIPTION
Closes #2417

Unrelated to the intention of the PR but nevertheless included here, SpecExtension has been renamed to SpecInterceptExtension (since there are many spec extensions) and new After/Before spec extensions added.