### PR TITLE
PropTestConfig's iterations parameter not being respected #2428

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest10.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest10.kt
@@ -18,7 +18,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    config: PropTestConfig,
@@ -33,7 +33,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    iterations: Int,
@@ -48,7 +48,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    iterations: Int,
@@ -64,12 +64,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -88,7 +87,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -107,7 +105,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -118,7 +115,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -127,7 +124,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -138,7 +134,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -154,7 +150,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
+) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -169,7 +165,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, config) { a, b, c, d, E, F, G, H, I, J -> property(a, b, c, d, E, F, G, H, I, J) shouldBe true }
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    iterations: Int,
@@ -184,7 +180,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
+) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    iterations: Int,
@@ -200,28 +196,16 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  config) { a, b, c, d, E, F, G, H, I, J -> property(a, b, c, d, E, F, G, H, I, J) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I, J>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I, J>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -235,6 +219,17 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I, J -> property(a, b, c, d, e, F, G, H, I, J) shouldBe true }
 
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
+) = forAll(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
+) = forAll(config.copy(iterations = iterations), property)
+
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -247,7 +242,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
+) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -262,62 +257,50 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    genI: Gen<I>,
    genJ: Gen<J>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
-
-suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
-   iterations: Int,
-   genA: Gen<A>,
-   genB: Gen<B>,
-   genC: Gen<C>,
-   genD: Gen<D>,
-   genE: Gen<E>,
-   genF: Gen<F>,
-   genG: Gen<G>,
-   genH: Gen<H>,
-   genI: Gen<I>,
-   genJ: Gen<J>,
-   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  property)
-
-suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   genA: Gen<A>,
-   genB: Gen<B>,
-   genC: Gen<C>,
-   genD: Gen<D>,
-   genE: Gen<E>,
-   genF: Gen<F>,
-   genG: Gen<G>,
-   genH: Gen<H>,
-   genI: Gen<I>,
-   genJ: Gen<J>,
-   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ,  config) {
-   a, b, c, d, E, F, G, H, I, J ->
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, config) {
+      a, b, c, d, E, F, G, H, I, J ->
    property(a, b, c, d, E, F, G, H, I, J) shouldBe false
 }
 
+suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
+   iterations: Int,
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   genI: Gen<I>,
+   genJ: Gen<J>,
+   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
+) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
+
+suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   genI: Gen<I>,
+   genJ: Gen<J>,
+   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
+) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
+
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = forNone(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I, J>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I, J>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -330,3 +313,14 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    config
 ) { a, b, c, d, E, F, G, H, I, J -> property(a, b, c, d, E, F, G, H, I, J) shouldBe false }
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
+) = forNone(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest11.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest11.kt
@@ -19,7 +19,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    config: PropTestConfig,
@@ -35,7 +35,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    iterations: Int,
@@ -51,7 +51,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    iterations: Int,
@@ -68,12 +68,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -93,7 +92,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -113,7 +111,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -125,7 +122,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -134,7 +131,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -146,7 +142,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -163,7 +159,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
+) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -179,7 +175,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config) { a, b, c, d, E, F, G, H, I, J, K -> property(a, b, c, d, E, F, G, H, I, J, K) shouldBe true }
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    iterations: Int,
@@ -212,28 +208,16 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config) { a, b, c, d, E, F, G, H, I, J, K -> property(a, b, c, d, E, F, G, H, I, J, K) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I, J, K>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I, J, K>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -248,6 +232,17 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I, J, K -> property(a, b, c, d, e, F, G, H, I, J, K) shouldBe true }
 
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
+) = forAll(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
+) = forAll(config.copy(iterations = iterations), property)
+
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -261,7 +256,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
+) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -277,7 +272,10 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config) {
+      a, b, c, d, E, F, G, H, I, J, K ->
+   property(a, b, c, d, E, F, G, H, I, J, K) shouldBe false
+}
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    iterations: Int,
@@ -310,31 +308,16 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    genJ: Gen<J>,
    genK: Gen<K>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config) {
-   a, b, c, d, E, F, G, H, I, J, K ->
-   property(a, b, c, d, E, F, G, H, I, J, K) shouldBe false
-}
+) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = forNone(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I, J, K>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I, J, K>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -348,3 +331,14 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    config
 ) { a, b, c, d, E, F, G, H, I, J, K -> property(a, b, c, d, E, F, G, H, I, J, K) shouldBe false }
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
+) = forNone(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest12.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest12.kt
@@ -20,7 +20,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    config: PropTestConfig,
@@ -37,7 +37,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    iterations: Int,
@@ -54,7 +54,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    iterations: Int,
@@ -72,12 +72,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -98,7 +97,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -119,7 +117,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -132,7 +129,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -141,7 +138,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -154,7 +150,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -172,7 +168,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
+) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -189,7 +185,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config) { a, b, c, d, E, F, G, H, I, J, K, L -> property(a, b, c, d, E, F, G, H, I, J, K, L) shouldBe true }
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    iterations: Int,
@@ -224,28 +220,16 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config) { a, b, c, d, E, F, G, H, I, J, K, L -> property(a, b, c, d, E, F, G, H, I, J, K, L) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I, J, K, L>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I, J, K, L>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -261,6 +245,17 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I, J, K, L -> property(a, b, c, d, e, F, G, H, I, J, K, L) shouldBe true }
 
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
+) = forAll(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
+) = forAll(config.copy(iterations = iterations), property)
+
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -275,7 +270,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
+) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -292,7 +287,10 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL), config, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config) {
+      a, b, c, d, E, F, G, H, I, J, K, L ->
+   property(a, b, c, d, E, F, G, H, I, J, K, L) shouldBe false
+}
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    iterations: Int,
@@ -327,31 +325,16 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    genK: Gen<K>,
    genL: Gen<L>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config) {
-   a, b, c, d, E, F, G, H, I, J, K, L ->
-   property(a, b, c, d, E, F, G, H, I, J, K, L) shouldBe false
-}
+) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = forNone(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I, J, K, L>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I, J, K, L>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -366,3 +349,14 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    config
 ) { a, b, c, d, E, F, G, H, I, J, K, L -> property(a, b, c, d, E, F, G, H, I, J, K, L) shouldBe false }
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
+) = forNone(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
@@ -14,7 +14,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = proptest<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
+): PropertyContext = proptest<A, B, C, D, E, F>(genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F> checkAll(
    config: PropTestConfig,
@@ -25,7 +25,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, property)
 
 suspend fun <A, B, C, D, E, F> checkAll(
    iterations: Int,
@@ -36,7 +36,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F> checkAll(
    iterations: Int,
@@ -48,12 +48,11 @@ suspend fun <A, B, C, D, E, F> checkAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
@@ -68,7 +67,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ) = proptest<A, B, C, D, E, F>(
-   PropertyTesting.defaultIterationCount,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
@@ -83,14 +81,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ) = proptest<A, B, C, D, E, F>(
-   iterations,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
    Arb.default<D>(),
    Arb.default<E>(),
    Arb.default<F>(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -99,14 +96,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ) = proptest<A, B, C, D, E, F>(
-   iterations,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
    Arb.default<D>(),
    Arb.default<E>(),
    Arb.default<F>(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -118,7 +114,7 @@ suspend fun <A, B, C, D, E, F> forAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = forAll<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
+) = forAll<A, B, C, D, E, F>(PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
 suspend fun <A, B, C, D, E, F> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -129,7 +125,7 @@ suspend fun <A, B, C, D, E, F> forAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = forAll<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
+) = proptest<A, B, C, D, E, F>(genA, genB, genC, genD, genE, genF, config) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe true }
 
 suspend fun <A, B, C, D, E, F> forAll(
    iterations: Int,
@@ -152,16 +148,24 @@ suspend fun <A, B, C, D, E, F> forAll(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = proptest<A, B, C, D, E, F>(iterations, genA, genB, genC, genD, genE, genF, config) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe true }
+) = forAll<A, B, C, D, E, F>(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
-): PropertyContext = forAll<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll<A, B, C, D, E, F>(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
-): PropertyContext = forAll<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, config, property)
+): PropertyContext = proptest<A, B, C, D, E, F>(
+   Arb.default<A>(),
+   Arb.default<B>(),
+   Arb.default<C>(),
+   Arb.default<D>(),
+   Arb.default<E>(),
+   Arb.default<F>(),
+   config
+) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe true }
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    iterations: Int,
@@ -172,16 +176,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = proptest<A, B, C, D, E, F>(
-   iterations,
-   Arb.default<A>(),
-   Arb.default<B>(),
-   Arb.default<C>(),
-   Arb.default<D>(),
-   Arb.default<E>(),
-   Arb.default<F>(),
-   config
-) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe true }
+) = forAll<A, B, C, D, E, F>(config.copy(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F> forNone(
    genA: Gen<A>,
@@ -191,7 +186,7 @@ suspend fun <A, B, C, D, E, F> forNone(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = forNone<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
+) = forNone<A, B, C, D, E, F>(PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
 suspend fun <A, B, C, D, E, F> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -202,7 +197,10 @@ suspend fun <A, B, C, D, E, F> forNone(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = forNone<A, B, C, D, E, F>(computeDefaultIteration(genA, genB, genC, genD, genE, genF), config, genA, genB, genC, genD, genE, genF, property)
+) = proptest<A, B, C, D, E, F>(genA, genB, genC, genD, genE, genF, config) {
+      a, b, c, d, e, f ->
+   property(a, b, c, d, e, f) shouldBe false
+}
 
 suspend fun <A, B, C, D, E, F> forNone(
    iterations: Int,
@@ -225,19 +223,24 @@ suspend fun <A, B, C, D, E, F> forNone(
    genE: Gen<E>,
    genF: Gen<F>,
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = proptest<A, B, C, D, E, F>(iterations, genA, genB, genC, genD, genE, genF, config) {
-   a, b, c, d, e, f ->
-   property(a, b, c, d, e, f) shouldBe false
-}
+) = forNone<A, B, C, D, E, F>(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
-): PropertyContext = forNone<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone<A, B, C, D, E, F>(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
-): PropertyContext = forNone<A, B, C, D, E, F>(PropertyTesting.defaultIterationCount, config, property)
+): PropertyContext = proptest<A, B, C, D, E, F>(
+   Arb.default<A>(),
+   Arb.default<B>(),
+   Arb.default<C>(),
+   Arb.default<D>(),
+   Arb.default<E>(),
+   Arb.default<F>(),
+   config
+) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe false }
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    iterations: Int,
@@ -248,13 +251,4 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
-) = proptest<A, B, C, D, E, F>(
-   iterations,
-   Arb.default<A>(),
-   Arb.default<B>(),
-   Arb.default<C>(),
-   Arb.default<D>(),
-   Arb.default<E>(),
-   Arb.default<F>(),
-   config
-) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe false }
+) = forNone<A, B, C, D, E, F>(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest7.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest7.kt
@@ -15,7 +15,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), genA, genB, genC, genD, genE, genF, genG, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F, G> checkAll(
    config: PropTestConfig,
@@ -27,7 +27,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), config, genA, genB, genC, genD, genE, genF, genG, property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, genG, property)
 
 suspend fun <A, B, C, D, E, F, G> checkAll(
    iterations: Int,
@@ -39,7 +39,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F, G> checkAll(
    iterations: Int,
@@ -52,12 +52,11 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -73,7 +72,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -89,7 +87,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -97,7 +94,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -106,7 +103,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -114,7 +110,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -127,7 +123,7 @@ suspend fun <A, B, C, D, E, F,G> forAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
+) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
 
 suspend fun <A, B, C, D, E, F, G> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -139,7 +135,7 @@ suspend fun <A, B, C, D, E, F, G> forAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), config, genA, genB, genC, genD, genE, genF, genG, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, config) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe true }
 
 suspend fun <A, B, C, D, E, F, G> forAll(
    iterations: Int,
@@ -164,28 +160,16 @@ suspend fun <A, B, C, D, E, F, G> forAll(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, config) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = proptest<A, B, C, D, E, F, G>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -196,6 +180,17 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe true }
 
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
+) = forAll(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
+) = forAll(config.copy(iterations = iterations), property)
+
 suspend fun <A, B, C, D, E, F, G> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -205,7 +200,7 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
+) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
 
 suspend fun <A, B, C, D, E, F, G> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -217,7 +212,10 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG), config, genA, genB, genC, genD, genE, genF, genG, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, config) {
+      a, b, c, d, e, f, g ->
+   property(a, b, c, d, e, f, g) shouldBe false
+}
 
 suspend fun <A, B, C, D, E, F, G> forNone(
    iterations: Int,
@@ -242,19 +240,25 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    genF: Gen<F>,
    genG: Gen<G>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, config) {
-   a, b, c, d, e, f, g ->
-   property(a, b, c, d, e, f, g) shouldBe false
-}
+) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
+): PropertyContext = proptest<A, B, C, D, E, F, G>(
+   Arb.default(),
+   Arb.default(),
+   Arb.default(),
+   Arb.default(),
+   Arb.default(),
+   Arb.default(),
+   Arb.default(),
+   config
+) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe false }
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    iterations: Int,
@@ -265,14 +269,4 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
-) = proptest<A, B, C, D, E, F, G>(
-   iterations,
-   Arb.default(),
-   Arb.default(),
-   Arb.default(),
-   Arb.default(),
-   Arb.default(),
-   Arb.default(),
-   Arb.default(),
-   config
-) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe false }
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest8.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest8.kt
@@ -16,7 +16,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH), genA, genB, genC, genD, genE, genF, genG, genH, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    config: PropTestConfig,
@@ -29,7 +29,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH), config, genA, genB, genC, genD, genE, genF, genG, genH, property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, genG, genH, property)
 
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    iterations: Int,
@@ -42,7 +42,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    iterations: Int,
@@ -56,12 +56,11 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -78,7 +77,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -95,7 +93,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -104,7 +101,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -113,7 +110,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -122,7 +118,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -136,7 +132,7 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
+) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -149,7 +145,7 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH), config, genA, genB, genC, genD, genE, genF, genG, genH, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, config) { a, b, c, d, E, F, G, H -> property(a, b, c, d, E, F, G, H) shouldBe true }
 
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    iterations: Int,
@@ -176,28 +172,16 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, config) { a, b, c, d, E, F, G, H -> property(a, b, c, d, E, F, G, H) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -209,6 +193,17 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g, h -> property(a, b, c, d, e, f, g, h) shouldBe true }
 
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
+) = forAll(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
+) = forAll(config.copy(iterations = iterations), property)
+
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -219,7 +214,7 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
+) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -232,7 +227,10 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH), config, genA, genB, genC, genD, genE, genF, genG, genH, property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, config) {
+      a, b, c, d, E, F, G, h ->
+   property(a, b, c, d, E, F, G, h) shouldBe false
+}
 
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    iterations: Int,
@@ -259,31 +257,16 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    genG: Gen<G>,
    genH: Gen<H>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, config) {
-   a, b, c, d, E, F, G, h ->
-   property(a, b, c, d, E, F, G, h) shouldBe false
-}
+) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = forNone(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -294,3 +277,14 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    config
 ) { a, b, c, d, E, F, G, H -> property(a, b, c, d, E, F, G, H) shouldBe false }
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
+) = forNone(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest9.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest9.kt
@@ -17,7 +17,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI), genA, genB, genC, genD, genE, genF, genG, genH, genI,  PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI,  PropTestConfig(), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    config: PropTestConfig,
@@ -31,7 +31,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
-): PropertyContext = checkAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI), config, genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
+): PropertyContext = checkAll(config, genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    iterations: Int,
@@ -45,7 +45,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI,  PropTestConfig(), property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, PropTestConfig(iterations = iterations), property)
 
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    iterations: Int,
@@ -60,12 +60,11 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
-): PropertyContext = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI,  config, property)
+): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -83,7 +82,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ) = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -101,7 +99,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -111,7 +108,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -120,7 +117,6 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ) = proptest(
-   iterations,
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -130,7 +126,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    Arb.default(),
    Arb.default(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -145,7 +141,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
+) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    config: PropTestConfig = PropTestConfig(),
@@ -159,7 +155,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forAll(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI), config, genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, config) { a, b, c, d, E, F, G, H, I -> property(a, b, c, d, E, F, G, H, I) shouldBe true }
 
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    iterations: Int,
@@ -173,7 +169,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
+) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    iterations: Int,
@@ -188,28 +184,16 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI,  config) { a, b, c, d, E, F, G, H, I -> property(a, b, c, d, E, F, G, H, I) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -222,6 +206,17 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I -> property(a, b, c, d, e, F, G, H, I) shouldBe true }
 
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
+) = forAll(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
+) = forAll(config.copy(iterations = iterations), property)
+
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -233,7 +228,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI), PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
+) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    config: PropTestConfig = PropTestConfig(),
@@ -247,60 +242,48 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    genH: Gen<H>,
    genI: Gen<I>,
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forNone(computeDefaultIteration(genA, genB, genC, genD, genE, genF, genG, genH, genI), config, genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
-
-suspend fun <A, B, C, D, E, F, G, H, I> forNone(
-   iterations: Int,
-   genA: Gen<A>,
-   genB: Gen<B>,
-   genC: Gen<C>,
-   genD: Gen<D>,
-   genE: Gen<E>,
-   genF: Gen<F>,
-   genG: Gen<G>,
-   genH: Gen<H>,
-   genI: Gen<I>,
-   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI,  property)
-
-suspend fun <A, B, C, D, E, F, G, H, I> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   genA: Gen<A>,
-   genB: Gen<B>,
-   genC: Gen<C>,
-   genD: Gen<D>,
-   genE: Gen<E>,
-   genF: Gen<F>,
-   genG: Gen<G>,
-   genH: Gen<H>,
-   genI: Gen<I>,
-   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = proptest(iterations, genA, genB, genC, genD, genE, genF, genG, genH, genI,  config) {
-   a, b, c, d, E, F, G, H, I ->
+) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, config) {
+      a, b, c, d, E, F, G, H, I ->
    property(a, b, c, d, E, F, G, H, I) shouldBe false
 }
 
+suspend fun <A, B, C, D, E, F, G, H, I> forNone(
+   iterations: Int,
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   genI: Gen<I>,
+   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
+) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
+
+suspend fun <A, B, C, D, E, F, G, H, I> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   genA: Gen<A>,
+   genB: Gen<B>,
+   genC: Gen<C>,
+   genD: Gen<D>,
+   genE: Gen<E>,
+   genF: Gen<F>,
+   genG: Gen<G>,
+   genH: Gen<H>,
+   genI: Gen<I>,
+   property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
+) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
+
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
-   iterations: Int,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = forNone(iterations, PropTestConfig(), property)
-
-suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
-   iterations: Int,
-   config: PropTestConfig,
-   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
-) = proptest<A, B, C, D, E, F, G, H, I>(
-   iterations,
+): PropertyContext = proptest<A, B, C, D, E, F, G, H, I>(
    Arb.default(),
    Arb.default(),
    Arb.default(),
@@ -312,3 +295,14 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    Arb.default(),
    config
 ) { a, b, c, d, E, F, G, H, I -> property(a, b, c, d, E, F, G, H, I) shouldBe false }
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
+   iterations: Int,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
+) = forNone(iterations, PropTestConfig(), property)
+
+suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
+   iterations: Int,
+   config: PropTestConfig,
+   crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
@@ -9,6 +9,12 @@ import io.kotest.property.RandomSource
 import io.kotest.property.random
 import kotlin.math.max
 
+private fun actualIterations(iterations: Int, config: PropTestConfig) =
+   config.iterations ?: iterations
+
+private fun checkMinSize(minSize: Int, iterations: Int) =
+   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+
 suspend fun <A> proptest(
    iterations: Int,
    genA: Gen<A>,
@@ -16,7 +22,8 @@ suspend fun <A> proptest(
    property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext {
 
-   require(iterations >= genA.minIterations()) { "Require at least ${genA.minIterations()} iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(genA.minIterations(), actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -24,7 +31,7 @@ suspend fun <A> proptest(
    when (genA) {
       is Arb -> {
          genA.generate(random, config.edgeConfig)
-            .take(iterations)
+            .take(actualIterations)
             .forEach { a ->
                val shrinkfn = shrinkfn(a, property, config.shrinkingMode)
                config.listeners.forEach { it.beforeTest() }
@@ -59,7 +66,8 @@ suspend fun <A, B> proptest(
 
    // we must have enough iterations to cover the max(minsize).
    val minSize = max(genA.minIterations(), genB.minIterations())
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -77,7 +85,7 @@ suspend fun <A, B> proptest(
    } else {
       genA.generate(random, config.edgeConfig)
          .zip(genB.generate(random, config.edgeConfig))
-         .take(iterations)
+         .take(actualIterations)
          .forEach { (a, b) ->
             val shrinkfn = shrinkfn(a, b, property, config.shrinkingMode)
             config.listeners.forEach { it.beforeTest() }
@@ -103,7 +111,8 @@ suspend fun <A, B, C> proptest(
 
    // we must have enough iterations to cover the max(minsize).
    val minSize = max(max(genA.minIterations(), genB.minIterations()), genC.minIterations())
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -124,7 +133,7 @@ suspend fun <A, B, C> proptest(
       genA.generate(random, config.edgeConfig)
          .zip(genB.generate(random, config.edgeConfig))
          .zip(genC.generate(random, config.edgeConfig))
-         .take(iterations)
+         .take(actualIterations)
          .forEach { (ab, c) ->
             val (a, b) = ab
             val shrinkfn = shrinkfn(a, b, c, property, config.shrinkingMode)
@@ -154,7 +163,8 @@ suspend fun <A, B, C, D> proptest(
 
    val minSize =
       listOf(genA.minIterations(), genB.minIterations(), genC.minIterations(), genD.minIterations()).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -179,7 +189,7 @@ suspend fun <A, B, C, D> proptest(
          .zip(genB.generate(random, config.edgeConfig))
          .zip(genC.generate(random, config.edgeConfig))
          .zip(genD.generate(random, config.edgeConfig))
-         .take(iterations)
+         .take(actualIterations)
          .forEach { (abc, d) ->
             val (ab, c) = abc
             val (a, b) = ab
@@ -216,7 +226,8 @@ suspend fun <A, B, C, D, E> proptest(
       genD.minIterations(),
       genE.minIterations()
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -243,7 +254,7 @@ suspend fun <A, B, C, D, E> proptest(
          .zip(genC.generate(random, config.edgeConfig))
          .zip(genD.generate(random, config.edgeConfig))
          .zip(genE.generate(random, config.edgeConfig))
-         .take(iterations)
+         .take(actualIterations)
          .forEach { (abcd, e) ->
             val (abc, d) = abcd
             val (ab, c) = abc
@@ -283,7 +294,8 @@ suspend fun <A, B, C, D, E, F> proptest(
       genE.minIterations(),
       genF.minIterations()
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -294,7 +306,7 @@ suspend fun <A, B, C, D, E, F> proptest(
       .zip(genD.generate(random, config.edgeConfig))
       .zip(genE.generate(random, config.edgeConfig))
       .zip(genF.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcde, f) ->
          val (abcd, e) = abcde
          val (abc, d) = abcd
@@ -335,7 +347,8 @@ suspend fun <A, B, C, D, E, F, G> proptest(
       genF.minIterations(),
       genG.minIterations(),
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -347,7 +360,7 @@ suspend fun <A, B, C, D, E, F, G> proptest(
       .zip(genE.generate(random, config.edgeConfig))
       .zip(genF.generate(random, config.edgeConfig))
       .zip(genG.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcdef, g) ->
          val (abcde, f) = abcdef
          val (abcd, e) = abcde
@@ -397,7 +410,8 @@ suspend fun <A, B, C, D, E, F, G, H> proptest(
       genG.minIterations(),
       genH.minIterations(),
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -410,7 +424,7 @@ suspend fun <A, B, C, D, E, F, G, H> proptest(
       .zip(genF.generate(random, config.edgeConfig))
       .zip(genG.generate(random, config.edgeConfig))
       .zip(genH.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcdefg, h) ->
          val (abcdef, g) = abcdefg
          val (abcde, f) = abcdef
@@ -463,7 +477,8 @@ suspend fun <A, B, C, D, E, F, G, H, I> proptest(
       genH.minIterations(),
       genI.minIterations(),
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -477,7 +492,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> proptest(
       .zip(genG.generate(random, config.edgeConfig))
       .zip(genH.generate(random, config.edgeConfig))
       .zip(genI.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcdefgh, i) ->
          val (abcdefg, h) = abcdefgh
          val (abcdef, g) = abcdefg
@@ -533,7 +548,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> proptest(
       genI.minIterations(),
       genJ.minIterations(),
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -548,7 +564,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> proptest(
       .zip(genH.generate(random, config.edgeConfig))
       .zip(genI.generate(random, config.edgeConfig))
       .zip(genJ.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcdefghi, j) ->
          val (abcdefgh, i) = abcdefghi
          val (abcdefg, h) = abcdefgh
@@ -607,7 +623,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> proptest(
       genJ.minIterations(),
       genK.minIterations(),
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -623,7 +640,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> proptest(
       .zip(genI.generate(random, config.edgeConfig))
       .zip(genJ.generate(random, config.edgeConfig))
       .zip(genK.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcdefghij, k) ->
          val (abcdefghi, j) = abcdefghij
          val (abcdefgh, i) = abcdefghi
@@ -697,7 +714,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> proptest(
       genK.minIterations(),
       genL.minIterations(),
    ).maxOrNull() ?: 0
-   require(iterations >= minSize) { "Require at least $minSize iterations to cover requirements" }
+   val actualIterations = actualIterations(iterations, config)
+   checkMinSize(minSize, actualIterations)
 
    val context = PropertyContext()
    val random = config.seed?.random() ?: RandomSource.default()
@@ -714,7 +732,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> proptest(
       .zip(genJ.generate(random, config.edgeConfig))
       .zip(genK.generate(random, config.edgeConfig))
       .zip(genL.generate(random, config.edgeConfig))
-      .take(iterations)
+      .take(actualIterations)
       .forEach { (abcdefghijk, l) ->
          val (abcdefghij, k) = abcdefghijk
          val (abcdefghi, j) = abcdefghij

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
@@ -13,7 +13,7 @@ suspend fun <A> Gen<A>.checkAll(property: suspend PropertyContext.(A) -> Unit) =
 suspend fun <A> checkAll(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA), genA, PropTestConfig(), property)
+): PropertyContext = proptest(genA, PropTestConfig(), property)
 
 @JvmName("checkAllExt")
 suspend fun <A> Gen<A>.checkAll(iterations: Int, property: suspend PropertyContext.(A) -> Unit) =
@@ -23,7 +23,7 @@ suspend fun <A> checkAll(
    iterations: Int,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = proptest(iterations, genA, PropTestConfig(), property)
+): PropertyContext = proptest(genA, PropTestConfig(iterations = iterations), property)
 
 @JvmName("checkAllExt")
 suspend fun <A> Gen<A>.checkAll(config: PropTestConfig, property: suspend PropertyContext.(A) -> Unit) =
@@ -33,7 +33,7 @@ suspend fun <A> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = proptest(computeDefaultIteration(genA), genA, config, property)
+): PropertyContext = proptest(genA, config, property)
 
 @JvmName("checkAllExt")
 suspend fun <A> Gen<A>.checkAll(
@@ -47,12 +47,11 @@ suspend fun <A> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = proptest(iterations, genA, config, property)
+): PropertyContext = proptest(genA, config.copy(iterations = iterations), property)
 
 suspend inline fun <reified A> checkAll(
    noinline property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext = proptest(
-   PropertyTesting.defaultIterationCount,
    Arb.default<A>(),
    PropTestConfig(),
    property
@@ -62,25 +61,27 @@ suspend inline fun <reified A> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext = proptest(
-   iterations,
    Arb.default<A>(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
 suspend inline fun <reified A> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A) -> Unit
-): PropertyContext = checkAll(PropertyTesting.defaultIterationCount, config, property)
-
-suspend inline fun <reified A> checkAll(
-   iterations: Int,
-   config: PropTestConfig,
-   noinline property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext = proptest(
-   iterations,
    Arb.default<A>(),
    config,
+   property
+)
+
+suspend inline fun <reified A> checkAll(
+   iterations: Int,
+   config: PropTestConfig,
+   noinline property: suspend PropertyContext.(A) -> Unit
+): PropertyContext = proptest(
+   Arb.default<A>(),
+   config.copy(iterations = iterations),
    property
 )
 
@@ -91,7 +92,7 @@ suspend fun <A> Gen<A>.forAll(property: suspend PropertyContext.(A) -> Boolean) 
 suspend fun <A> forAll(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
-) = forAll(computeDefaultIteration(genA), PropTestConfig(), genA, property)
+) = forAll(PropTestConfig(), genA, property)
 
 @JvmName("forAllExt")
 suspend fun <A> Gen<A>.forAll(iterations: Int, property: suspend PropertyContext.(A) -> Boolean) =
@@ -111,41 +112,43 @@ suspend fun <A> forAll(
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
-) = forAll(computeDefaultIteration(genA), config, genA, property)
+) = proptest(genA, config) { a -> property(a) shouldBe true }
 
 @JvmName("forAllExt")
 suspend fun <A> Gen<A>.forAll(iterations: Int, config: PropTestConfig, property: suspend PropertyContext.(A) -> Boolean) =
-   forAll(iterations, config, this, property)
+   forAll(config.copy(iterations = iterations), this, property)
 
 suspend fun <A> forAll(
    iterations: Int,
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
-) = proptest(iterations, genA, config) { a -> property(a) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, property)
 
 suspend inline fun <reified A> forAll(
    crossinline property: PropertyContext.(A) -> Boolean
-) = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+) = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A) -> Boolean
-) = forAll(iterations, PropTestConfig(), property)
+) = forAll(PropTestConfig(iterations = iterations), property)
 
 suspend inline fun <reified A> forAll(
    config: PropTestConfig,
    crossinline property: PropertyContext.(A) -> Boolean
-) = forAll(PropertyTesting.defaultIterationCount, config, property)
+) = proptest<A>(
+   Arb.default<A>(),
+   config
+) { a -> property(a) shouldBe true }
 
 suspend inline fun <reified A> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A) -> Boolean
 ) = proptest<A>(
-   iterations,
    Arb.default<A>(),
-   config
+   config.copy(iterations = iterations)
 ) { a -> property(a) shouldBe true }
 
 @JvmName("forNoneExt")
@@ -155,7 +158,7 @@ suspend fun <A> Gen<A>.forNone(property: suspend PropertyContext.(A) -> Boolean)
 suspend fun <A> forNone(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
-) = forNone(computeDefaultIteration(genA), PropTestConfig(), genA, property)
+) = forNone(PropTestConfig(), genA, property)
 
 @JvmName("forNoneExt")
 suspend fun <A> Gen<A>.forNone(iterations: Int, property: suspend PropertyContext.(A) -> Boolean) =
@@ -175,7 +178,10 @@ suspend fun <A> forNone(
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
-) = forNone(computeDefaultIteration(genA), config, genA, property)
+) = proptest<A>(
+   genA,
+   config
+) { a -> property(a) shouldBe false }
 
 @JvmName("forNoneExt")
 suspend fun <A> Gen<A>.forNone(
@@ -190,11 +196,11 @@ suspend fun <A> forNone(
    config: PropTestConfig,
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
-) = proptest(iterations, genA, config) { a -> property(a) shouldBe false }
+) = forNone(config.copy(iterations = iterations), genA, property)
 
 suspend inline fun <reified A> forNone(
    crossinline property: PropertyContext.(A) -> Boolean
-) = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+) = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A> forNone(
    iterations: Int,
@@ -204,14 +210,13 @@ suspend inline fun <reified A> forNone(
 suspend inline fun <reified A> forNone(
    config: PropTestConfig,
    crossinline property: PropertyContext.(A) -> Boolean
-) = forNone(PropertyTesting.defaultIterationCount, config, property)
+) = proptest<A>(
+   Arb.default<A>(),
+   config
+) { a -> property(a) shouldBe false }
 
 suspend inline fun <reified A> forNone(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A) -> Boolean
-) = proptest<A>(
-   iterations,
-   Arb.default<A>(),
-   config
-) { a -> property(a) shouldBe false }
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
@@ -13,7 +13,6 @@ suspend fun <A, B, C, D> checkAll(
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Unit
 ): PropertyContext = proptest<A, B, C, D>(
-   computeDefaultIteration(genA, genB, genC, genD),
    genA,
    genB,
    genC,
@@ -30,7 +29,7 @@ suspend fun <A, B, C, D> checkAll(
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Unit
 ): PropertyContext =
-   checkAll<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), config, genA, genB, genC, genD, property)
+   proptest<A, B, C, D>(genA, genB, genC, genD, config, property)
 
 suspend fun <A, B, C, D> checkAll(
    iterations: Int,
@@ -39,7 +38,7 @@ suspend fun <A, B, C, D> checkAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Unit
-): PropertyContext = proptest<A, B, C, D>(iterations, genA, genB, genC, genD, PropTestConfig(), property)
+): PropertyContext = checkAll(PropTestConfig(iterations = iterations), genA, genB, genC, genD, property)
 
 suspend fun <A, B, C, D> checkAll(
    iterations: Int,
@@ -49,12 +48,11 @@ suspend fun <A, B, C, D> checkAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Unit
-): PropertyContext = proptest<A, B, C, D>(iterations, genA, genB, genC, genD, config, property)
+): PropertyContext = checkAll(config.copy(iterations = iterations), genA, genB, genC, genD, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
 ) = proptest<A, B, C, D>(
-   PropertyTesting.defaultIterationCount,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
@@ -67,7 +65,6 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
 ) = proptest<A, B, C, D>(
-   PropertyTesting.defaultIterationCount,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
@@ -80,12 +77,11 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
 ) = proptest<A, B, C, D>(
-   iterations,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
    Arb.default<D>(),
-   PropTestConfig(),
+   PropTestConfig(iterations = iterations),
    property
 )
 
@@ -94,12 +90,11 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
 ) = proptest<A, B, C, D>(
-   iterations,
    Arb.default<A>(),
    Arb.default<B>(),
    Arb.default<C>(),
    Arb.default<D>(),
-   config,
+   config.copy(iterations = iterations),
    property
 )
 
@@ -110,7 +105,6 @@ suspend fun <A, B, C, D> forAll(
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = forAll<A, B, C, D>(
-   computeDefaultIteration(genA, genB, genC, genD),
    PropTestConfig(),
    genA,
    genB,
@@ -126,7 +120,7 @@ suspend fun <A, B, C, D> forAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
-) = forAll<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), config, genA, genB, genC, genD, property)
+) = proptest<A, B, C, D>(genA, genB, genC, genD, config) { a, b, c, d -> property(a, b, c, d) shouldBe true }
 
 suspend fun <A, B, C, D> forAll(
    iterations: Int,
@@ -145,17 +139,22 @@ suspend fun <A, B, C, D> forAll(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
-) =
-   proptest<A, B, C, D>(iterations, genA, genB, genC, genD, config) { a, b, c, d -> property(a, b, c, d) shouldBe true }
+) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forAll(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
-): PropertyContext = forAll(PropertyTesting.defaultIterationCount, config, property)
+): PropertyContext = proptest(
+   Arb.default<A>(),
+   Arb.default<B>(),
+   Arb.default<C>(),
+   Arb.default<D>(),
+   config
+) { a, b, c, d -> property(a, b, c, d) shouldBe true }
 
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    iterations: Int,
@@ -166,14 +165,7 @@ suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
-) = proptest(
-   iterations,
-   Arb.default<A>(),
-   Arb.default<B>(),
-   Arb.default<C>(),
-   Arb.default<D>(),
-   config
-) { a, b, c, d -> property(a, b, c, d) shouldBe true }
+) = forAll(config.copy(iterations = iterations), property)
 
 suspend fun <A, B, C, D> forNone(
    genA: Gen<A>,
@@ -182,7 +174,6 @@ suspend fun <A, B, C, D> forNone(
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = forNone<A, B, C, D>(
-   computeDefaultIteration(genA, genB, genC, genD),
    PropTestConfig(),
    genA,
    genB,
@@ -198,7 +189,7 @@ suspend fun <A, B, C, D> forNone(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
-) = forNone<A, B, C, D>(computeDefaultIteration(genA, genB, genC, genD), config, genA, genB, genC, genD, property)
+) = proptest<A, B, C, D>(genA, genB, genC, genD, config) { a, b, c, d -> property(a, b, c, d) shouldBe false }
 
 suspend fun <A, B, C, D> forNone(
    iterations: Int,
@@ -217,17 +208,22 @@ suspend fun <A, B, C, D> forNone(
    genC: Gen<C>,
    genD: Gen<D>,
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
-) =
-   proptest<A, B, C, D>(iterations, genA, genB, genC, genD, config) { a, b, c, d -> property(a, b, c, d) shouldBe false }
+) = forNone<A, B, C, D>(config.copy(iterations = iterations), genA, genB, genC, genD, property)
 
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, PropTestConfig(), property)
+): PropertyContext = forNone(PropTestConfig(), property)
 
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
-): PropertyContext = forNone(PropertyTesting.defaultIterationCount, config, property)
+): PropertyContext = proptest(
+   Arb.default<A>(),
+   Arb.default<B>(),
+   Arb.default<C>(),
+   Arb.default<D>(),
+   config
+) { a, b, c, d -> property(a, b, c, d) shouldBe false }
 
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    iterations: Int,
@@ -238,11 +234,4 @@ suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
-) = proptest(
-   iterations,
-   Arb.default<A>(),
-   Arb.default<B>(),
-   Arb.default<C>(),
-   Arb.default<D>(),
-   config
-) { a, b, c, d -> property(a, b, c, d) shouldBe false }
+) = forNone(config.copy(iterations = iterations), property)

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigTest.kt
@@ -5,254 +5,291 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.PropTestConfig
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.orNull
+import io.kotest.property.checkAll
 import io.kotest.property.internal.proptest
 
 class PropTestConfigTest : FunSpec() {
    init {
+      val defaultIterations = 1000
+
       test("PropTestConfig iterations should be used by proptest1 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations)
-         ) {
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            ) {
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest2 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations)
-         ) { _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            ) { _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest3 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest4 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest5 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest6 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest7 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest8 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest9 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest10 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest11 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               1000,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations)
+            )
+            { _, _, _, _, _, _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
 
       test("PropTestConfig iterations should be used by proptest12 if present") {
-         val expectedIterations = 10
+         checkAll(Arb.int(1..1000).orNull()) { iterations ->
+            val expectedIterations = iterations ?: defaultIterations
 
-         var iterationCount = 0
-         proptest(
-            1000,
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            Arb.int(),
-            PropTestConfig(iterations = expectedIterations))
-         { _, _, _, _, _, _, _, _, _, _, _, _ ->
-            iterationCount++
+            var iterationCount = 0
+            proptest(
+               defaultIterations,
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               Arb.int(),
+               PropTestConfig(iterations = iterations))
+            { _, _, _, _, _, _, _, _, _, _, _, _ ->
+               iterationCount++
+            }
+
+            iterationCount shouldBe expectedIterations
          }
-
-         iterationCount shouldBe expectedIterations
       }
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.PropTestConfig
+import io.kotest.property.PropertyTesting
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.orNull
 import io.kotest.property.checkAll
@@ -11,15 +12,12 @@ import io.kotest.property.internal.proptest
 
 class PropTestConfigTest : FunSpec() {
    init {
-      val defaultIterations = 1000
-
       test("PropTestConfig iterations should be used by proptest1 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                PropTestConfig(iterations = iterations)
             ) {
@@ -32,11 +30,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest2 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                PropTestConfig(iterations = iterations)
@@ -50,11 +47,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest3 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -70,11 +66,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest4 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -91,11 +86,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest5 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -113,11 +107,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest6 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -136,11 +129,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest7 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -160,11 +152,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest8 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -185,11 +176,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest9 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -211,11 +201,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest10 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -238,11 +227,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest11 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               1000,
                Arb.int(),
                Arb.int(),
                Arb.int(),
@@ -266,11 +254,10 @@ class PropTestConfigTest : FunSpec() {
 
       test("PropTestConfig iterations should be used by proptest12 if present") {
          checkAll(Arb.int(1..1000).orNull()) { iterations ->
-            val expectedIterations = iterations ?: defaultIterations
+            val expectedIterations = iterations ?: PropertyTesting.defaultIterationCount
 
             var iterationCount = 0
             proptest(
-               defaultIterations,
                Arb.int(),
                Arb.int(),
                Arb.int(),

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigTest.kt
@@ -1,0 +1,258 @@
+package com.sksamuel.kotest.property
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.PropTestConfig
+import io.kotest.property.arbitrary.int
+import io.kotest.property.internal.proptest
+
+class PropTestConfigTest : FunSpec() {
+   init {
+      test("PropTestConfig iterations should be used by proptest1 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations)
+         ) {
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest2 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations)
+         ) { _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest3 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest4 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest5 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest6 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest7 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest8 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest9 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest10 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest11 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+
+      test("PropTestConfig iterations should be used by proptest12 if present") {
+         val expectedIterations = 10
+
+         var iterationCount = 0
+         proptest(
+            1000,
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            Arb.int(),
+            PropTestConfig(iterations = expectedIterations))
+         { _, _, _, _, _, _, _, _, _, _, _, _ ->
+            iterationCount++
+         }
+
+         iterationCount shouldBe expectedIterations
+      }
+   }
+}


### PR DESCRIPTION
PR to fix #2428 (which I raised myself)

* Corrected behavior regarding the PropTestConfig iterations parameter
    * removed the iteration parameter from the internal `proptest` functions
    * the iteration parameter of `checkAll`, `forAll`, and `forNone` are now just an accessory to alter the configuration value
    * centralized the default iteration resolution behavior to the internal protest functions
* Added tests covering each arity of `proptest`