### PR TITLE
Property Module: Allow global seed configuration. Synchronize defaults.

### DIFF
--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/sysprop.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/sysprop.kt
@@ -1,6 +1,10 @@
 package io.kotest.mpp
 
 fun sysprop(key: String, default: String): String = sysprop(key) ?: default
+fun <T> sysprop(key: String, default: T, converter: (String) -> T): T = sysprop(key)?.let { converter(it) } ?: default
+fun sysprop(key: String, default: Int): Int = sysprop(key, default) { it.toInt() }
+fun sysprop(key: String, default: Double): Double = sysprop(key, default) { it.toDouble() }
+fun sysprop(key: String, default: Boolean): Boolean = sysprop(key, default) { it == "true" }
 
 expect fun sysprop(name: String): String?
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/Gen.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/Gen.kt
@@ -167,7 +167,7 @@ fun <A> A.asSample(): Sample<A> = Sample(this)
 fun <A> sampleOf(a: A, shrinker: Shrinker<A>) = Sample(a, shrinker.rtree(a))
 
 data class EdgeConfig(
-   val edgecasesGenerationProbability: Double = PropertyTesting.edgecasesGenerationProbability
+   val edgecasesGenerationProbability: Double = PropertyTesting.defaultEdgecasesGenerationProbability
 ) {
    companion object;
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/classifications/output.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/classifications/output.kt
@@ -8,6 +8,5 @@ import io.kotest.property.PropertyTesting
 fun PropertyContext.outputClassifications(inputs: Int, config: PropTestConfig, seed: Long) {
    val result =
       PropertyResult(List(inputs) { it.toString() }, seed, attempts(), successes(), failures(), autoclassifications())
-   val enabled = config.outputLabels ?: PropertyTesting.outputClassifiations
-   if (enabled) config.labelsReporter.output(result)
+   if (config.outputClassifications) config.labelsReporter.output(result)
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -12,12 +12,27 @@ import kotlin.native.concurrent.ThreadLocal
 @ThreadLocal
 object PropertyTesting {
    var maxFilterAttempts: Int = 10
-   var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
-   var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
+
+   // PropTestConfig
+   var defaultSeed: Long? = null
+   var defaultMinSuccess: Int = Int.MAX_VALUE
+   var defaultMaxFailure: Int = 0
+   var defaultShrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000)
    var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", "1000").toInt()
-   var edgecasesGenerationProbability: Double = sysprop("kotest.proptest.arb.edgecases-generation-probability", "0.02").toDouble()
+   var defaultListeners: List<PropTestListener> = listOf()
+   var defaultEdgecasesGenerationProbability: Double = sysprop("kotest.proptest.arb.edgecases-generation-probability", "0.02").toDouble()
+   @Deprecated("Use defaultEdgecasesGenerationProbability instead. This property will be removed")
+   var edgecasesGenerationProbability: Double
+      get() = defaultEdgecasesGenerationProbability
+      set(value) { defaultEdgecasesGenerationProbability = value }
+   var defaultOutputClassifications: Boolean = sysprop("kotest.proptest.arb.output.classifications", "false") == "true"
+
+   var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
+   @Deprecated("This property is no longer used and will be removed")
+   var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
+   @Deprecated("This property is no longer used and will be removed")
    var edgecasesBindDeterminism: Double = sysprop("kotest.proptest.arb.edgecases-bind-determinism", "0.9").toDouble()
-   var outputClassifiations: Boolean = sysprop("kotest.proptest.arb.output.classificaions", "false") == "true"
+
 }
 
 /**
@@ -47,16 +62,16 @@ fun calculateMinimumIterations(vararg gens: Gen<*>): Int {
 }
 
 fun EdgeConfig.Companion.default(): EdgeConfig = EdgeConfig(
-   edgecasesGenerationProbability = PropertyTesting.edgecasesGenerationProbability
+   edgecasesGenerationProbability = PropertyTesting.defaultEdgecasesGenerationProbability
 )
 
 data class PropTest(
-   val seed: Long? = null,
-   val minSuccess: Int = Int.MAX_VALUE,
-   val maxFailure: Int = 0,
-   val shrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000),
+   val seed: Long? = PropertyTesting.defaultSeed,
+   val minSuccess: Int = PropertyTesting.defaultMinSuccess,
+   val maxFailure: Int = PropertyTesting.defaultMaxFailure,
+   val shrinkingMode: ShrinkingMode = PropertyTesting.defaultShrinkingMode,
    val iterations: Int? = null,
-   val listeners: List<PropTestListener> = listOf(),
+   val listeners: List<PropTestListener> = PropertyTesting.defaultListeners,
    val edgeConfig: EdgeConfig = EdgeConfig.default()
 )
 
@@ -71,15 +86,22 @@ fun PropTest.toPropTestConfig() =
       edgeConfig = edgeConfig
    )
 
+/**
+ * Property Test Configuration to be used by the underlying property test runner
+ *
+ * @property iterations The number of iterations to run. If null either the global [PropertyTesting]'s default value
+ *                      will be used, or the minimum iterations required for the supplied generations. Whichever is
+ *                      greater.
+ */
 data class PropTestConfig(
-   val seed: Long? = null,
-   val minSuccess: Int = Int.MAX_VALUE,
-   val maxFailure: Int = 0,
-   val shrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000),
+   val seed: Long? = PropertyTesting.defaultSeed,
+   val minSuccess: Int = PropertyTesting.defaultMinSuccess,
+   val maxFailure: Int = PropertyTesting.defaultMaxFailure,
+   val shrinkingMode: ShrinkingMode = PropertyTesting.defaultShrinkingMode,
    val iterations: Int? = null,
-   val listeners: List<PropTestListener> = listOf(),
+   val listeners: List<PropTestListener> = PropertyTesting.defaultListeners,
    val edgeConfig: EdgeConfig = EdgeConfig.default(),
-   val outputLabels: Boolean? = null,
+   val outputClassifications: Boolean = PropertyTesting.defaultOutputClassifications,
    val labelsReporter: LabelsReporter = StandardLabelsReporter
 )
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -12,6 +12,11 @@ import kotlin.native.concurrent.ThreadLocal
 @ThreadLocal
 object PropertyTesting {
    var maxFilterAttempts: Int = 10
+   var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
+   @Deprecated("This property is no longer used and will be removed")
+   var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
+   @Deprecated("This property is no longer used and will be removed")
+   var edgecasesBindDeterminism: Double = sysprop("kotest.proptest.arb.edgecases-bind-determinism", "0.9").toDouble()
 
    // PropTestConfig
    var defaultSeed: Long? = null
@@ -26,13 +31,6 @@ object PropertyTesting {
       get() = defaultEdgecasesGenerationProbability
       set(value) { defaultEdgecasesGenerationProbability = value }
    var defaultOutputClassifications: Boolean = sysprop("kotest.proptest.arb.output.classifications", "false") == "true"
-
-   var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
-   @Deprecated("This property is no longer used and will be removed")
-   var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
-   @Deprecated("This property is no longer used and will be removed")
-   var edgecasesBindDeterminism: Double = sysprop("kotest.proptest.arb.edgecases-bind-determinism", "0.9").toDouble()
-
 }
 
 /**

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -28,7 +28,7 @@ object PropertyTesting {
    var edgecasesGenerationProbability: Double
       get() = defaultEdgecasesGenerationProbability
       set(value) { defaultEdgecasesGenerationProbability = value }
-   var defaultOutputClassifications: Boolean = sysprop("kotest.proptest.arb.output.classifications", "false") == "true"
+   var defaultOutputClassifications: Boolean = sysprop("kotest.proptest.arb.output.classifications", false)
 }
 
 /**

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -12,20 +12,18 @@ import kotlin.native.concurrent.ThreadLocal
 @ThreadLocal
 object PropertyTesting {
    var maxFilterAttempts: Int = 10
-   var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", "true") == "true"
-   @Deprecated("This property is no longer used and will be removed")
-   var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", "false") == "true"
-   @Deprecated("This property is no longer used and will be removed")
-   var edgecasesBindDeterminism: Double = sysprop("kotest.proptest.arb.edgecases-bind-determinism", "0.9").toDouble()
+   var shouldPrintShrinkSteps: Boolean = sysprop("kotest.proptest.output.shrink-steps", true)
+   var shouldPrintGeneratedValues: Boolean = sysprop("kotest.proptest.output.generated-values", false)
+   var edgecasesBindDeterminism: Double = sysprop("kotest.proptest.arb.edgecases-bind-determinism", 0.9)
 
    // PropTestConfig
-   var defaultSeed: Long? = null
-   var defaultMinSuccess: Int = Int.MAX_VALUE
-   var defaultMaxFailure: Int = 0
+   var defaultSeed: Long? = sysprop("kotest.proptest.default.seed", null, { it.toLong() })
+   var defaultMinSuccess: Int = sysprop("kotest.proptest.default.min-success", Int.MAX_VALUE)
+   var defaultMaxFailure: Int = sysprop("kotest.proptest.default.max-failure", 0)
    var defaultShrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000)
-   var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", "1000").toInt()
+   var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", 1000)
    var defaultListeners: List<PropTestListener> = listOf()
-   var defaultEdgecasesGenerationProbability: Double = sysprop("kotest.proptest.arb.edgecases-generation-probability", "0.02").toDouble()
+   var defaultEdgecasesGenerationProbability: Double = sysprop("kotest.proptest.arb.edgecases-generation-probability", 0.02)
    @Deprecated("Use defaultEdgecasesGenerationProbability instead. This property will be removed")
    var edgecasesGenerationProbability: Double
       get() = defaultEdgecasesGenerationProbability

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ClassifierArityTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ClassifierArityTest.kt
@@ -11,7 +11,7 @@ class ClassifierArityTest : FunSpec() {
 
       test("classifiers for prop test arity 2") {
          val out = captureStandardOut {
-            checkAll<String, Int>(PropTestConfig(outputLabels = true, seed = 678673131234)) { _, _ -> }
+            checkAll<String, Int>(PropTestConfig(outputClassifications = true, seed = 678673131234)) { _, _ -> }
          }
          repeat(2) { k ->
             out.shouldContain("Label statistics for arg $k (1000 inputs):")
@@ -22,7 +22,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _ -> }
@@ -36,7 +36,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _ -> }
@@ -50,7 +50,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _ -> }
@@ -64,7 +64,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _ -> }
@@ -78,7 +78,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _, _ -> }
@@ -92,7 +92,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _, _, _ -> }
@@ -106,7 +106,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _, _, _, _ -> }
@@ -120,7 +120,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _, _, _, _, _ -> }
@@ -134,7 +134,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _, _, _, _, _, _ -> }
@@ -148,7 +148,7 @@ class ClassifierArityTest : FunSpec() {
          val out = captureStandardOut {
             checkAll<Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int>(
                PropTestConfig(
-                  outputLabels = true,
+                  outputClassifications = true,
                   seed = 678673131234
                )
             ) { _, _, _, _, _, _, _, _, _, _, _, _ -> }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DefaultClassifierTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DefaultClassifierTest.kt
@@ -13,7 +13,7 @@ class DefaultClassifierTest : FunSpec() {
 
       test("String classifier should be provided by default string arb") {
          val out = captureStandardOut {
-            checkAll<String>(PropTestConfig(outputLabels = true, seed = 123123123)) {}
+            checkAll<String>(PropTestConfig(outputClassifications = true, seed = 123123123)) {}
          }
          println(out)
          out.shouldContain("Label statistics for arg 0 (1000 inputs):")
@@ -26,7 +26,7 @@ class DefaultClassifierTest : FunSpec() {
 
       test("int classifier should be provided by default int arb") {
          val out = captureStandardOut {
-            checkAll<Int>(PropTestConfig(outputLabels = true, seed = 9848976132)) {}
+            checkAll<Int>(PropTestConfig(outputClassifications = true, seed = 9848976132)) {}
          }
          Arb.long()
          println(out)
@@ -42,7 +42,7 @@ class DefaultClassifierTest : FunSpec() {
 
       test("long classifier should be provided by default long arb") {
          val out = captureStandardOut {
-            checkAll<Long>(PropTestConfig(outputLabels = true, seed = 1234864124)) {}
+            checkAll<Long>(PropTestConfig(outputClassifications = true, seed = 1234864124)) {}
          }
          println(out)
          out.shouldContain("Label statistics for arg 0 (1000 inputs):")


### PR DESCRIPTION
Implementation for enhancement request #2438 (which I raised myself, and is open to critique)

* Synchronized naming across PropertyTesting parameters which ultimately affect the `PropTestConfig` data class
* Synchronized default values for `PropTest`, `PropTestConfig`, and the global `PropertyTesting` object
* Added defaults configuration for the other `PropTestConfig` values
* Correct spelling for `outputClassifiations`. This is a recent addition so I'm not sure if it amounts to a breaking change yet? **Correct me if I'm wrong please**
* Deprecated configuration values not following the pattern
* Started the documentation process for these values

_Note: I have not added `sysprop` declarations for the new configurations as I am not sure what the exact pattern should be for their namespaces_ 