### PR TITLE
Remove Linux ARM64 target.

### DIFF
--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -63,15 +63,6 @@ jobs:
                ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
                ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
 
-         -  name: publish linux Arm64 release
-            run: ./gradlew publishLinuxArm64PublicationToDeployRepository
-            env:
-               RELEASE_VERSION: ${{ github.event.inputs.version }}
-               OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-               OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-               ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-               ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-
    publish_macos:
       runs-on: macos-latest
       needs: publish_linux

--- a/.github/workflows/release_linux.yml
+++ b/.github/workflows/release_linux.yml
@@ -63,14 +63,5 @@ jobs:
                ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
                ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
 
-         -  name: publish linux Arm64 release
-            run: ./gradlew publishLinuxArm64PublicationToDeployRepository
-            env:
-               RELEASE_VERSION: ${{ github.event.inputs.version }}
-               OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-               OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-               ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
-               ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-
 env:
    GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/kotest-assertions/kotest-assertions-api/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-api/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 

--- a/kotest-assertions/kotest-assertions-core/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-core/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 

--- a/kotest-assertions/kotest-assertions-shared/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-shared/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 
@@ -94,10 +93,6 @@ kotlin {
       }
 
       val linuxX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val linuxArm64Main by getting {
          dependsOn(desktopMain)
       }
 

--- a/kotest-common/build.gradle.kts
+++ b/kotest-common/build.gradle.kts
@@ -25,7 +25,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 
@@ -80,10 +79,6 @@ kotlin {
       }
 
       val linuxX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val linuxArm64Main by getting {
          dependsOn(desktopMain)
       }
 

--- a/kotest-framework/kotest-framework-api/build.gradle.kts
+++ b/kotest-framework/kotest-framework-api/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 
@@ -87,10 +86,6 @@ kotlin {
       }
 
       val linuxX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val linuxArm64Main by getting {
          dependsOn(desktopMain)
       }
 

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -38,7 +38,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 
@@ -132,10 +131,6 @@ kotlin {
       }
 
       val linuxX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val linuxArm64Main by getting {
          dependsOn(desktopMain)
       }
 

--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
       }
 
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 
@@ -100,10 +99,6 @@ kotlin {
       }
 
       val linuxX64Main by getting {
-         dependsOn(desktopMain)
-      }
-
-      val linuxArm64Main by getting {
          dependsOn(desktopMain)
       }
 

--- a/kotest-tests/kotest-tests-native/build.gradle.kts
+++ b/kotest-tests/kotest-tests-native/build.gradle.kts
@@ -9,7 +9,6 @@ repositories {
 kotlin {
    targets {
       linuxX64()
-      linuxArm64()
 
       mingwX64()
 
@@ -58,10 +57,6 @@ kotlin {
       }
 
       val linuxX64Test by getting {
-         dependsOn(nativeTest)
-      }
-
-      val linuxArm64Test by getting {
          dependsOn(nativeTest)
       }
 


### PR DESCRIPTION
kotlinx.coroutines doesn't yet support Linux ARM64, which means kotest can't be built for Linux ARM64 - see https://github.com/kotest/kotest/pull/2449#issuecomment-912917560.