### PR TITLE
Feature/deprecate is stable

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/datatest/datatest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/datatest/datatest.kt
@@ -42,7 +42,7 @@ suspend fun <T : Any> ContainerContext.forAll(ts: List<T>, test: suspend (T) -> 
    forAll(ts.map { Pair(Identifiers.stableIdentifier(it), it) }, test)
 }
 
-@JvmName("forAllWithNames")
+@JvmName("withData")
 @Deprecated("Replaced with withData. Will be removed in 6.0")
 suspend fun <T : Any> ContainerContext.forAll(data: List<Pair<String, T>>, test: suspend (T) -> Unit) {
    data.forEach { (name, t) ->
@@ -84,7 +84,7 @@ fun <T : Any> RootContext.forAll(ts: List<T>, test: suspend (T) -> Unit) {
    this.forAll(ts.map { Pair(Identifiers.stableIdentifier(it), it) }, test)
 }
 
-@JvmName("forAllWithNames")
+@JvmName("withData")
 @Deprecated("Replaced with withData. Will be removed in 6.0")
 fun <T : Any> RootContext.forAll(data: List<Pair<String, T>>, test: suspend (T) -> Unit) {
    data.forEach { (name, t) ->

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestContext.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestContext.kt
@@ -27,9 +27,4 @@ interface TestContext : CoroutineScope {
     * Will throw if the current test is not a container test.
     */
    suspend fun registerTestCase(nested: NestedTest)
-
-   /**
-    * Invoked when the test has completed and this scope is finished.
-    */
-   fun close() {}
 }

--- a/kotest-framework/kotest-framework-datatest/src/commonMain/kotlin/io/kotest/datatest/Identifier.kt
+++ b/kotest-framework/kotest-framework-datatest/src/commonMain/kotlin/io/kotest/datatest/Identifier.kt
@@ -1,12 +1,8 @@
 package io.kotest.datatest
 
-import io.kotest.core.test.Identifiers
-import io.kotest.mpp.hasAnnotation
-
 fun getStableIdentifier(t: Any): String {
-   return when {
-      t::class.hasAnnotation<IsStableType>() -> t.toString()
-      t is WithDataTestName -> t.dataTestName()
-      else -> Identifiers.stableIdentifier(t)
+   return when (t) {
+      is WithDataTestName -> t.dataTestName()
+      else -> t.toString()
    }
 }

--- a/kotest-framework/kotest-framework-datatest/src/commonMain/kotlin/io/kotest/datatest/IsStableType.kt
+++ b/kotest-framework/kotest-framework-datatest/src/commonMain/kotlin/io/kotest/datatest/IsStableType.kt
@@ -7,5 +7,6 @@ package io.kotest.datatest
  *  Note: If you want to provide a custom implementation of test name generation other than what
  *  toString gives, you will need to extend [WithDataTestName] interface.
  * */
+@Deprecated("This annotation no longer has any effect. Will be removed in 6.0")
 @Target(AnnotationTarget.CLASS)
 annotation class IsStableType

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -9,6 +9,7 @@ import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestStatus
 import io.kotest.engine.concurrency.NoopCoroutineDispatcherFactory
 import io.kotest.engine.test.interceptors.AssertionModeInterceptor
+import io.kotest.engine.test.interceptors.IncompleteContainerCheckInterceptor
 import io.kotest.engine.test.interceptors.CoroutineDebugProbeInterceptor
 import io.kotest.engine.test.interceptors.CoroutineScopeInterceptor
 import io.kotest.engine.test.interceptors.EnabledCheckInterceptor
@@ -44,6 +45,7 @@ class TestCaseExecutor(
 
       val interceptors = listOfNotNull(
          InvocationCountCheckInterceptor,
+         IncompleteContainerCheckInterceptor,
          CoroutineDebugProbeInterceptor,
          SupervisorScopeInterceptor,
          if (platform == Platform.JVM) coroutineDispatcherFactoryInterceptor(defaultCoroutineDispatcherFactory) else null,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/IncompleteContainerCheckInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/IncompleteContainerCheckInterceptor.kt
@@ -1,0 +1,46 @@
+package io.kotest.engine.test.interceptors
+
+import io.kotest.core.test.NestedTest
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestContext
+import io.kotest.core.test.TestResult
+import io.kotest.core.test.TestType
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Tests that a container test contains at least one test.
+ */
+object IncompleteContainerCheckInterceptor : TestExecutionInterceptor {
+
+   override suspend fun intercept(
+      test: suspend (TestCase, TestContext) -> TestResult
+   ): suspend (TestCase, TestContext) -> TestResult = { testCase, context ->
+
+      when (testCase.type) {
+         TestType.Container -> {
+            val ctc = CollectingTestContext(context)
+            test(testCase, ctc).apply {
+               if (ctc.count == 0)
+                  throw IncompleteContainerTestException(testCase)
+            }
+         }
+         TestType.Test -> test(testCase, context)
+      }
+   }
+}
+
+class CollectingTestContext(private val delegate: TestContext) : TestContext {
+
+   var count = 0
+
+   override val testCase: TestCase = delegate.testCase
+   override val coroutineContext: CoroutineContext = delegate.coroutineContext
+
+   override suspend fun registerTestCase(nested: NestedTest) {
+      delegate.registerTestCase(nested)
+      count++
+   }
+}
+
+class IncompleteContainerTestException(testCase: TestCase) :
+   RuntimeException("Test ${testCase.displayName} did not contain any nested tests. This is invalid for a container test")

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/IncompleteContainerCheckInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/IncompleteContainerCheckInterceptorTest.kt
@@ -1,0 +1,62 @@
+package com.sksamuel.kotest.engine.test.interceptors
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.toDescription
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestCaseConfig
+import io.kotest.core.test.TestResult
+import io.kotest.core.test.TestType
+import io.kotest.core.test.createNestedTest
+import io.kotest.core.test.createTestName
+import io.kotest.engine.test.NoopTestContext
+import io.kotest.engine.test.interceptors.IncompleteContainerCheckInterceptor
+import io.kotest.engine.test.interceptors.IncompleteContainerTestException
+
+class IncompleteContainerCheckInterceptorTest : FunSpec() {
+   init {
+      test("TestType.Type should pass") {
+         val testCase = TestCase.test(
+            IncompleteContainerCheckInterceptorTest::class.toDescription().appendTest("wibble"),
+            this@IncompleteContainerCheckInterceptorTest,
+            parent = null,
+            test = {}
+         )
+         IncompleteContainerCheckInterceptor.intercept { _, _ -> TestResult.success(0) }
+            .invoke(testCase, NoopTestContext(testCase, coroutineContext))
+      }
+      test("incomplete container should throw") {
+         shouldThrow<IncompleteContainerTestException> {
+            val testCase = TestCase.container(
+               IncompleteContainerCheckInterceptorTest::class.toDescription().appendTest("wibble"),
+               this@IncompleteContainerCheckInterceptorTest,
+               parent = null,
+               test = {}
+            )
+            IncompleteContainerCheckInterceptor.intercept { _, _ -> TestResult.success(0) }
+               .invoke(testCase, NoopTestContext(testCase, coroutineContext))
+         }
+      }
+      test("complete container should pass") {
+         val testCase = TestCase.container(
+            IncompleteContainerCheckInterceptorTest::class.toDescription().appendTest("wibble"),
+            this@IncompleteContainerCheckInterceptorTest,
+            parent = null,
+            test = {}
+         )
+         IncompleteContainerCheckInterceptor.intercept { testCase, context ->
+            context.registerTestCase(
+               createNestedTest(
+                  createTestName("foo"),
+                  false,
+                  TestCaseConfig(),
+                  TestType.Test,
+                  null,
+                  null
+               ) {}
+            )
+            TestResult.success(0)
+         }.invoke(testCase, NoopTestContext(testCase, coroutineContext))
+      }
+   }
+}


### PR DESCRIPTION
We originally added isStable so that unstable classes would not break data testing.
Since we now support repeated test names by default, and since isStable does not work on JS or native, we should remove this and just use the toString.

Closes #2482