### PR TITLE
Feature/introduce continuation arbs builder

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -156,7 +156,6 @@ interface ArbitraryBuilderSyntax {
    suspend fun <T> Arb<T>.bind(): T
 }
 
-@Suppress("UNCHECKED_CAST")
 private class ArbContinuation<A> : Continuation<Arb<A>>, ArbitraryBuilderSyntax {
    override val context: CoroutineContext = EmptyCoroutineContext
    private lateinit var returnedArb: Arb<A>

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -81,7 +81,7 @@ fun <A> arbitrary(
  */
 fun <A> arbitrary(
    edgecaseFn: (RandomSource) -> A?,
-   sampleFn: ArbitraryBuilderSyntax.(RandomSource) -> A
+   sampleFn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A
 ): Arb<A> =
    object : Arb<A>() {
       override fun edgecase(rs: RandomSource): A? = edgecaseFn(rs)
@@ -97,7 +97,7 @@ fun <A> arbitrary(
 fun <A> arbitrary(
    edgecaseFn: (RandomSource) -> A?,
    shrinker: Shrinker<A>,
-   sampleFn: ArbitraryBuilderSyntax.(RandomSource) -> A
+   sampleFn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A
 ): Arb<A> =
    object : Arb<A>() {
       override fun edgecase(rs: RandomSource): A? = edgecaseFn(rs)
@@ -149,9 +149,9 @@ object arbitrary {
     * Creates a new [Arb] that performs no shrinking, uses the given edge cases and
     * generates values from the given function.
     */
-   suspend fun <A> suspendable(
+   suspend inline fun <A> suspendable(
       edgecases: List<A>,
-      fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
+      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
    ): Arb<A> = suspendArbitraryBuilder(null, null,
       if (edgecases.isEmpty()) null else { rs -> edgecases.random(rs.random) }
    ) { rs -> fn(rs) }
@@ -160,10 +160,10 @@ object arbitrary {
     * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], uses the given edge cases and
     * generates values from the given function.
     */
-   suspend fun <A> suspendable(
+   suspend inline fun <A> suspendable(
       edgecases: List<A>,
       shrinker: Shrinker<A>,
-      fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
+      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
    ): Arb<A> = suspendArbitraryBuilder(
       shrinker,
       null,
@@ -175,9 +175,9 @@ object arbitrary {
     * Creates a new [Arb] that generates edge cases from the given [edgecaseFn] function
     * and generates samples from the given [sampleFn] function.
     */
-   suspend fun <A> suspendable(
-      edgecaseFn: (RandomSource) -> A?,
-      sampleFn: SuspendArbitraryBuilderSyntax.(RandomSource) -> A
+   suspend inline fun <A> suspendable(
+      crossinline edgecaseFn: (RandomSource) -> A?,
+      crossinline sampleFn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
    ): Arb<A> {
       val delegate: Arb<A> = suspendArbitraryBuilder { rs -> sampleFn(rs) }
 
@@ -191,10 +191,10 @@ object arbitrary {
     * Creates a new [Arb] that generates edge cases from the given [edgecaseFn] function,
     * performs shrinking using the supplied [Shrinker], and generates samples from the given [sampleFn] function.
     */
-   suspend fun <A> suspendable(
-      edgecaseFn: (RandomSource) -> A?,
+   suspend inline fun <A> suspendable(
+      crossinline edgecaseFn: (RandomSource) -> A?,
       shrinker: Shrinker<A>,
-      sampleFn: SuspendArbitraryBuilderSyntax.(RandomSource) -> A
+      crossinline sampleFn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
    ): Arb<A> {
       val delegate: Arb<A> = suspendArbitraryBuilder(shrinker) { rs -> sampleFn(rs) }
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -1,6 +1,5 @@
 package io.kotest.property.arbitrary
 
-import io.kotest.mpp.atomics.AtomicReference
 import io.kotest.property.Arb
 import io.kotest.property.Classifier
 import io.kotest.property.RandomSource
@@ -190,10 +189,10 @@ private class RestrictedArbContinuation<A>(
 ) : Continuation<Arb<A>>, RestrictedArbitraryBuilderScope {
    override val context: CoroutineContext = EmptyCoroutineContext
    private lateinit var returnedArb: Arb<A>
-   private val hasExecuted: AtomicReference<Boolean> = AtomicReference(false)
+   private var hasExecuted: Boolean = false
 
    override fun resumeWith(result: Result<Arb<A>>) {
-      hasExecuted.value = true
+      hasExecuted = true
       result.map { resultArb -> returnedArb = resultArb }.getOrThrow()
    }
 
@@ -227,7 +226,7 @@ private class RestrictedArbContinuation<A>(
     * we need to recreate the [RestrictedArbContinuation] instance and call [singleShotArb] again.
     */
    fun singleShotArb(): Arb<A> {
-      require(!hasExecuted.value) { "continuation has already been executed, if you see this error please raise a bug report" }
+      require(!hasExecuted) { "continuation has already been executed, if you see this error please raise a bug report" }
       fn.startCoroutine(this, this)
       return returnedArb
    }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -106,102 +106,98 @@ fun <A> arbitrary(
       private val delegate: Arb<A> = arbitraryBuilder(shrinker) { rs -> sampleFn(rs) }
    }
 
-@Suppress("ClassName")
-object arbitrary {
-   /**
-    * Creates a new [Arb] that performs no shrinking, has no edge cases and
-    * generates values from the given function.
-    */
-   suspend inline fun <A> suspendable(
-      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> = suspendArbitraryBuilder { rs -> fn(rs) }
+/**
+ * Creates a new [Arb] that performs no shrinking, has no edge cases and
+ * generates values from the given function.
+ */
+suspend inline fun <A> generateArbitrary(
+   crossinline fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = suspendArbitraryBuilder { rs -> fn(rs) }
 
-   /**
-    * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], has no edge cases and
-    * generates values from the given function.
-    */
-   suspend inline fun <A> suspendable(
-      shrinker: Shrinker<A>,
-      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> = suspendArbitraryBuilder(shrinker, null) { rs -> fn(rs) }
+/**
+ * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], has no edge cases and
+ * generates values from the given function.
+ */
+suspend inline fun <A> generateArbitrary(
+   shrinker: Shrinker<A>,
+   crossinline fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = suspendArbitraryBuilder(shrinker, null) { rs -> fn(rs) }
 
-   /**
-    * Creates a new [Arb] that classifies the generated values using the supplied [Classifier], has no edge cases and
-    * generates values from the given function.
-    */
-   suspend inline fun <A> suspendable(
-      classifier: Classifier<A>,
-      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> = suspendArbitraryBuilder(null, classifier) { rs -> fn(rs) }
+/**
+ * Creates a new [Arb] that classifies the generated values using the supplied [Classifier], has no edge cases and
+ * generates values from the given function.
+ */
+suspend inline fun <A> generateArbitrary(
+   classifier: Classifier<A>,
+   crossinline fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = suspendArbitraryBuilder(null, classifier) { rs -> fn(rs) }
 
-   /**
-    * Creates a new [Arb] that performs shrinking using the supplied [Shrinker],
-    * classifies the generated values using the supplied [Classifier], has no edge cases and
-    * generates values from the given function.
-    */
-   suspend inline fun <A> suspendable(
-      shrinker: Shrinker<A>,
-      classifier: Classifier<A>,
-      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> = suspendArbitraryBuilder(shrinker, classifier) { rs -> fn(rs) }
+/**
+ * Creates a new [Arb] that performs shrinking using the supplied [Shrinker],
+ * classifies the generated values using the supplied [Classifier], has no edge cases and
+ * generates values from the given function.
+ */
+suspend inline fun <A> generateArbitrary(
+   shrinker: Shrinker<A>,
+   classifier: Classifier<A>,
+   crossinline fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = suspendArbitraryBuilder(shrinker, classifier) { rs -> fn(rs) }
 
-   /**
-    * Creates a new [Arb] that performs no shrinking, uses the given edge cases and
-    * generates values from the given function.
-    */
-   suspend inline fun <A> suspendable(
-      edgecases: List<A>,
-      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> = suspendArbitraryBuilder(null, null,
-      if (edgecases.isEmpty()) null else { rs -> edgecases.random(rs.random) }
-   ) { rs -> fn(rs) }
+/**
+ * Creates a new [Arb] that performs no shrinking, uses the given edge cases and
+ * generates values from the given function.
+ */
+suspend inline fun <A> generateArbitrary(
+   edgecases: List<A>,
+   crossinline fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = suspendArbitraryBuilder(null, null,
+   if (edgecases.isEmpty()) null else { rs -> edgecases.random(rs.random) }
+) { rs -> fn(rs) }
 
-   /**
-    * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], uses the given edge cases and
-    * generates values from the given function.
-    */
-   suspend inline fun <A> suspendable(
-      edgecases: List<A>,
-      shrinker: Shrinker<A>,
-      crossinline fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> = suspendArbitraryBuilder(
-      shrinker,
-      null,
-      if (edgecases.isEmpty()) null else { rs -> edgecases.random(rs.random) }
-   ) { rs -> fn(rs) }
+/**
+ * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], uses the given edge cases and
+ * generates values from the given function.
+ */
+suspend inline fun <A> generateArbitrary(
+   edgecases: List<A>,
+   shrinker: Shrinker<A>,
+   crossinline fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = suspendArbitraryBuilder(
+   shrinker,
+   null,
+   if (edgecases.isEmpty()) null else { rs -> edgecases.random(rs.random) }
+) { rs -> fn(rs) }
 
+/**
+ * Creates a new [Arb] that generates edge cases from the given [edgecaseFn] function
+ * and generates samples from the given [sampleFn] function.
+ */
+suspend inline fun <A> generateArbitrary(
+   crossinline edgecaseFn: (RandomSource) -> A?,
+   crossinline sampleFn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> {
+   val delegate: Arb<A> = suspendArbitraryBuilder { rs -> sampleFn(rs) }
 
-   /**
-    * Creates a new [Arb] that generates edge cases from the given [edgecaseFn] function
-    * and generates samples from the given [sampleFn] function.
-    */
-   suspend inline fun <A> suspendable(
-      crossinline edgecaseFn: (RandomSource) -> A?,
-      crossinline sampleFn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> {
-      val delegate: Arb<A> = suspendArbitraryBuilder { rs -> sampleFn(rs) }
-
-      return object : Arb<A>() {
-         override fun edgecase(rs: RandomSource): A? = edgecaseFn(rs)
-         override fun sample(rs: RandomSource): Sample<A> = delegate.sample(rs)
-      }
+   return object : Arb<A>() {
+      override fun edgecase(rs: RandomSource): A? = edgecaseFn(rs)
+      override fun sample(rs: RandomSource): Sample<A> = delegate.sample(rs)
    }
+}
 
-   /**
-    * Creates a new [Arb] that generates edge cases from the given [edgecaseFn] function,
-    * performs shrinking using the supplied [Shrinker], and generates samples from the given [sampleFn] function.
-    */
-   suspend inline fun <A> suspendable(
-      crossinline edgecaseFn: (RandomSource) -> A?,
-      shrinker: Shrinker<A>,
-      crossinline sampleFn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
-   ): Arb<A> {
-      val delegate: Arb<A> = suspendArbitraryBuilder(shrinker) { rs -> sampleFn(rs) }
+/**
+ * Creates a new [Arb] that generates edge cases from the given [edgecaseFn] function,
+ * performs shrinking using the supplied [Shrinker], and generates samples from the given [sampleFn] function.
+ */
+suspend inline fun <A> generateArbitrary(
+   crossinline edgecaseFn: (RandomSource) -> A?,
+   shrinker: Shrinker<A>,
+   crossinline sampleFn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> {
+   val delegate: Arb<A> = suspendArbitraryBuilder(shrinker) { rs -> sampleFn(rs) }
 
-      return object : Arb<A>() {
-         override fun edgecase(rs: RandomSource): A? = edgecaseFn(rs)
-         override fun sample(rs: RandomSource): Sample<A> = delegate.sample(rs)
-      }
+   return object : Arb<A>() {
+      override fun edgecase(rs: RandomSource): A? = edgecaseFn(rs)
+      override fun sample(rs: RandomSource): Sample<A> = delegate.sample(rs)
    }
 }
 
@@ -264,7 +260,7 @@ suspend fun <A> suspendArbitraryBuilder(
    shrinker: Shrinker<A>? = null,
    classifier: Classifier<A>? = null,
    edgecaseFn: EdgecaseFn<A>? = null,
-   fn: suspend SuspendArbitraryBuilderSyntax.(RandomSource) -> A
+   fn: suspend GenerateArbitraryBuilderSyntax.(RandomSource) -> A
 ): Arb<A> = suspendCoroutineUninterceptedOrReturn { cont ->
    val arb = object : Arb<A>() {
       override fun edgecase(rs: RandomSource): A? = singleShotArb().edgecase(rs)
@@ -354,7 +350,7 @@ interface BaseArbitraryBuilderSyntax {
 @RestrictsSuspension
 interface ArbitraryBuilderSyntax : BaseArbitraryBuilderSyntax
 
-interface SuspendArbitraryBuilderSyntax : BaseArbitraryBuilderSyntax
+interface GenerateArbitraryBuilderSyntax : BaseArbitraryBuilderSyntax
 
 sealed class SingleShotArbContinuation<F : BaseArbitraryBuilderSyntax, A>(
    override val context: CoroutineContext,
@@ -366,8 +362,8 @@ sealed class SingleShotArbContinuation<F : BaseArbitraryBuilderSyntax, A>(
 
    class Suspendedable<A>(
       override val context: CoroutineContext,
-      fn: suspend SuspendArbitraryBuilderSyntax.() -> Arb<A>
-   ) : SingleShotArbContinuation<SuspendArbitraryBuilderSyntax, A>(context, fn), SuspendArbitraryBuilderSyntax
+      fn: suspend GenerateArbitraryBuilderSyntax.() -> Arb<A>
+   ) : SingleShotArbContinuation<GenerateArbitraryBuilderSyntax, A>(context, fn), GenerateArbitraryBuilderSyntax
 
    private lateinit var returnedArb: Arb<A>
    private var hasExecuted: Boolean = false

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -107,10 +107,7 @@ fun <A> arbitraryBuilder(
             { value },
             classifier,
             shrinker,
-            { rs ->
-               // use edgecase function if provided, otherwise retain those from flatmap compositions
-               if (edgecaseFn != null) edgecaseFn.invoke(rs) else value
-            }
+            { rs -> edgecaseFn?.invoke(rs) ?: value }
          ).build()
       }
       wrapReturn.startCoroutine(continuation, continuation)

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -6,13 +6,47 @@ import io.kotest.property.RandomSource
 import io.kotest.property.Sample
 import io.kotest.property.Shrinker
 import io.kotest.property.sampleOf
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.RestrictsSuspension
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import kotlin.coroutines.resume
+import kotlin.coroutines.startCoroutine
 
 /**
  * Creates a new [Arb] that performs no shrinking, has no edge cases and
  * generates values from the given function.
  */
-fun <A> arbitrary(fn: (RandomSource) -> A): Arb<A> =
-   arbitrary(emptyList(), fn)
+fun <A> arbitrary(fn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A): Arb<A> =
+   arbitraryBuilder { rs -> fn(rs) }
+
+/**
+ * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], has no edge cases and
+ * generates values from the given function.
+ */
+fun <A> arbitrary(shrinker: Shrinker<A>, fn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A): Arb<A> =
+   arbitraryBuilder(shrinker) { rs -> fn(rs) }
+
+/**
+ * Creates a new [Arb] that classifies the generated values using the supplied [Classifier], has no edge cases and
+ * generates values from the given function.
+ */
+fun <A> arbitrary(classifier: Classifier<A>, fn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A): Arb<A> =
+   arbitraryBuilder(null, classifier) { rs -> fn(rs) }
+
+/**
+ * Creates a new [Arb] that performs shrinking using the supplied [Shrinker],
+ * classifies the generated values using the supplied [Classifier], has no edge cases and
+ * generates values from the given function.
+ */
+fun <A> arbitrary(
+   shrinker: Shrinker<A>,
+   classifier: Classifier<A>,
+   fn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> =
+   arbitraryBuilder(shrinker, classifier) { rs -> fn(rs) }
 
 /**
  * Creates a new [Arb] that performs no shrinking, uses the given edge cases and
@@ -56,12 +90,36 @@ fun <A> arbitrary(
       override fun sample(rs: RandomSource): Sample<A> = sampleOf(sampleFn(rs), shrinker)
    }
 
-/**
- * Creates a new [Arb] that performs shrinking using the supplied [Shrinker], has no edge cases and
- * generates values from the given function.
- */
-fun <A> arbitrary(shrinker: Shrinker<A>, fn: (RandomSource) -> A): Arb<A> =
-   arbitrary(emptyList(), shrinker, fn)
+fun <A> arbitraryBuilder(
+   shrinker: Shrinker<A>? = null,
+   classifier: Classifier<A>? = null,
+   edgecaseFn: EdgecaseFn<A>? = null,
+   builderFn: suspend ArbitraryBuilderSyntax.(RandomSource) -> A
+): Arb<A> = object : Arb<A>() {
+   override fun edgecase(rs: RandomSource): A? = computeArb().edgecase(rs)
+   override fun sample(rs: RandomSource): Sample<A> = computeArb().sample(rs)
+
+   private fun computeArb(): Arb<A> {
+      val continuation = ArbContinuation<A>()
+      val wrapReturn: suspend ArbitraryBuilderSyntax.() -> Arb<A> = {
+         val value: A = builderFn(randomSource.bind())
+         ArbitraryBuilder(
+            { value },
+            classifier,
+            shrinker,
+            { rs ->
+               // use edgecase function if provided, otherwise retain those from flatmap compositions
+               if (edgecaseFn != null) edgecaseFn.invoke(rs) else value
+            }
+         ).build()
+      }
+      wrapReturn.startCoroutine(continuation, continuation)
+      return continuation.returnedArb()
+   }
+
+   // passthrough arb to extract the propagated RandomSource
+   private val randomSource: Arb<RandomSource> = ArbitraryBuilder.create { it }.withEdgecaseFn { it }.build()
+}
 
 typealias SampleFn<A> = (RandomSource) -> A
 typealias EdgecaseFn<A> = (RandomSource) -> A?
@@ -90,5 +148,28 @@ class ArbitraryBuilder<A>(
          val sample = sampleFn(rs)
          return if (shrinker == null) Sample(sample) else sampleOf(sample, shrinker)
       }
+   }
+}
+
+@RestrictsSuspension
+interface ArbitraryBuilderSyntax {
+   suspend fun <T> Arb<T>.bind(): T
+}
+
+@Suppress("UNCHECKED_CAST")
+private class ArbContinuation<A> : Continuation<Arb<A>>, ArbitraryBuilderSyntax {
+   override val context: CoroutineContext = EmptyCoroutineContext
+   private lateinit var returnedArb: Arb<A>
+
+   fun returnedArb(): Arb<A> = returnedArb
+
+   override fun resumeWith(result: Result<Arb<A>>) = result.map { returnedArb = it }.getOrThrow()
+
+   override suspend fun <B> Arb<B>.bind(): B = suspendCoroutineUninterceptedOrReturn { c ->
+      returnedArb = this.flatMap { b: B ->
+         c.resume(b)
+         returnedArb
+      }
+      COROUTINE_SUSPENDED
    }
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/edgecases.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/edgecases.kt
@@ -33,7 +33,7 @@ fun <A> Arb<A>.edgecases(iterations: Int = 100, rs: RandomSource = RandomSource.
 /**
  * Returns a new [Arb] with the supplied edge cases replacing any existing edge cases.
  */
-fun <A> Arb<A>.withEdgecases(edgecases: List<A>): Arb<A> = arbitrary(edgecases) { this.next(it) }
+fun <A> Arb<A>.withEdgecases(edgecases: List<A>): Arb<A> = arbitrary(edgecases) { this@withEdgecases.next(it) }
 
 /**
  * Returns a new [Arb] with the supplied edge cases replacing any existing edge cases.

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
@@ -23,6 +23,7 @@ import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.numbers.IntClassifier
+import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.take
 import io.kotest.property.arbitrary.withEdgecases
@@ -121,6 +122,15 @@ class BuilderTest : FunSpec() {
             arb.edgecases() shouldContainExactlyInAnyOrder edges
          }
 
+         test("should assign edgecases and shrinker") {
+            val shrinker = IntShrinker(1..5)
+            val edges = setOf(1, 2)
+            val arb = arbitrary(edges.toList(), shrinker) { 5 }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder edges
+            arb.sample(RandomSource.seeded(1234L)).shrinks.children.value.map { it.value() } shouldBe shrinker.shrink(5)
+         }
+
          test("should use shrinker when provided") {
             val shrinker = IntShrinker(1..5)
             val arb = arbitrary(shrinker) { 5 }
@@ -161,6 +171,19 @@ class BuilderTest : FunSpec() {
 
             val shrinks = arb.sample(RandomSource.seeded(1234L)).shrinks
             shrinks.children.value.map { it.value() } shouldContainExactly shrinker.shrink(10)
+         }
+
+         test("should support .bind() syntax") {
+            val arb = Arb.constant(5)
+            val shrinker = IntShrinker(1..5)
+            val classifier = IntClassifier(1..5)
+            arbitrary { arb.bind() }.single() shouldBe 5
+            arbitrary(shrinker) { arb.bind() }.single() shouldBe 5
+            arbitrary(classifier) { arb.bind() }.single() shouldBe 5
+            arbitrary(shrinker, classifier) { arb.bind() }.single() shouldBe 5
+            arbitrary(listOf(5)) { arb.bind() }.single() shouldBe 5
+            arbitrary({ 5 }) { arb.bind() }.single() shouldBe 5
+            arbitrary({ 5 }, shrinker) { arb.bind() }.single() shouldBe 5
          }
       }
 
@@ -242,6 +265,15 @@ class BuilderTest : FunSpec() {
             arb.edgecases() shouldContainExactlyInAnyOrder edges
          }
 
+         test("should assign edgecases and shrinker") {
+            val shrinker = IntShrinker(1..5)
+            val edges = setOf(1, 2)
+            val arb = arbitrary.suspendable(edges.toList(), shrinker) { 5 }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder edges
+            arb.sample(RandomSource.seeded(1234L)).shrinks.children.value.map { it.value() } shouldBe shrinker.shrink(5)
+         }
+
          test("should use shrinker when provided") {
             val shrinker = IntShrinker(1..5)
             val arb = arbitrary.suspendable(shrinker) { 5 }
@@ -282,6 +314,19 @@ class BuilderTest : FunSpec() {
 
             val shrinks = arb.sample(RandomSource.seeded(1234L)).shrinks
             shrinks.children.value.map { it.value() } shouldContainExactly shrinker.shrink(10)
+         }
+
+         test("should support .bind() syntax") {
+            val arb = Arb.constant(5)
+            val shrinker = IntShrinker(1..5)
+            val classifier = IntClassifier(1..5)
+            arbitrary.suspendable { arb.bind() }.single() shouldBe 5
+            arbitrary.suspendable(shrinker) { arb.bind() }.single() shouldBe 5
+            arbitrary.suspendable(classifier) { arb.bind() }.single() shouldBe 5
+            arbitrary.suspendable(shrinker, classifier) { arb.bind() }.single() shouldBe 5
+            arbitrary.suspendable(listOf(5)) { arb.bind() }.single() shouldBe 5
+            arbitrary.suspendable({ 5 }) { arb.bind() }.single() shouldBe 5
+            arbitrary.suspendable({ 5 }, shrinker) { arb.bind() }.single() shouldBe 5
          }
       }
    }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
@@ -1,9 +1,11 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.ints.shouldBeBetween
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldHaveLengthBetween
 import io.kotest.property.Arb
@@ -11,7 +13,6 @@ import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.alphanumeric
 import io.kotest.property.arbitrary.arbitrary
-import io.kotest.property.arbitrary.arbitraryBuilder
 import io.kotest.property.arbitrary.edgecases
 import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
@@ -20,6 +21,8 @@ import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.take
 import io.kotest.property.arbitrary.withEdgecases
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.CoroutineContext
 import kotlin.random.nextInt
 
 class BuilderTest : FunSpec() {
@@ -44,7 +47,7 @@ class BuilderTest : FunSpec() {
          personArb.next().age.shouldBeBetween(21, 150)
       }
 
-      context("arbitrary builder using continuation") {
+      context("arbitrary builder using restricted continuation") {
          test("should be equivalent to chaining flatMaps") {
             val arbFlatMaps: Arb<String> =
                Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").flatMap { first ->
@@ -108,10 +111,92 @@ class BuilderTest : FunSpec() {
 
          test("should modify edgecases") {
             val edges = setOf("edge1", "edge2")
-            val arb = arbitraryBuilder(edgecaseFn = { edges.random(it.random) }) { "abcd" }
+            val arb = arbitrary(edges.toList()) { "abcd" }
 
             arb.edgecases() shouldContainExactlyInAnyOrder edges
          }
       }
+
+      context("suspend arbitrary builder with unrestricted continuation") {
+         suspend fun combineAsString(vararg values: Any?): String = values.joinToString(" ")
+
+         test("build arb on the parent coroutine context") {
+            val arb = withContext(Foo("hello")) {
+               arbitrary.suspendable {
+                  val hello = coroutineContext[Foo]?.value
+                  val world = arbitrary { "world" }.bind()
+                  val first = Arb.int(1..10).bind()
+                  val second = Arb.int(11..20).bind()
+                  combineAsString(hello, world, first, second)
+               }
+            }
+
+            arb.generate(RandomSource.seeded(1234L)).take(4).toList().map { it.value } shouldContainExactly listOf(
+               "hello world 2 20",
+               "hello world 6 12",
+               "hello world 7 19",
+               "hello world 9 13"
+            )
+         }
+
+         test("should bind edgecases") {
+            val arb: Arb<String> = arbitrary.suspendable {
+               val first = Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").bind()
+               val second = Arb.int(1..9).withEdgecases(5).bind()
+               val third = Arb.int(101..109).withEdgecases(100 + second, 109).bind()
+               combineAsString(first, second, third)
+            }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder setOf(
+               "edge1 5 105",
+               "edge2 5 105",
+               "edge1 5 109",
+               "edge2 5 109",
+            )
+         }
+
+         test("should preserve edgecases of dependent arbs, even when intermideary arb(s) have no edgecases") {
+
+            val arb: Arb<String> = arbitrary.suspendable {
+               val first = Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").bind()
+               val second = Arb.int(1..4).withEdgecases(emptyList()).bind()
+               val third = Arb.int(101..109).withEdgecases(100 + second).bind()
+               combineAsString(first, second, third)
+            }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder setOf(
+               "edge1 1 101",
+               "edge1 2 102",
+               "edge1 3 103",
+               "edge1 4 104",
+               "edge2 1 101",
+               "edge2 2 102",
+               "edge2 3 103",
+               "edge2 4 104"
+            )
+         }
+
+         test("should propagate exception") {
+            val throwingArb = arbitrary.suspendable {
+               val number = Arb.int(1..4).withEdgecases(emptyList()).bind()
+
+               // try to throw something inside the arb
+               number shouldBeGreaterThan 5
+            }
+
+            val assertionError = shouldThrow<AssertionError> { execute(RandomSource.seeded(1234L), throwingArb) }
+            assertionError.message shouldBe "4 should be > 5"
+         }
+      }
+   }
+
+   private data class Foo(val value: String) : CoroutineContext.Element {
+      companion object : CoroutineContext.Key<Foo>
+
+      override val key: CoroutineContext.Key<*> = Foo
+   }
+
+   private suspend fun execute(rs: RandomSource, arb: Arb<*>): Unit {
+      arb.generate(rs).take(1000).last()
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
@@ -85,6 +85,27 @@ class BuilderTest : FunSpec() {
             )
          }
 
+         test("should preserve edgecases of dependent arbs, even when intermideary arb(s) have no edgecases") {
+
+            val arb: Arb<String> = arbitrary {
+               val first = Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").bind()
+               val second = Arb.int(1..4).withEdgecases(emptyList()).bind()
+               val third = Arb.int(101..109).withEdgecases(100 + second).bind()
+               "$first $second $third"
+            }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder setOf(
+               "edge1 1 101",
+               "edge1 2 102",
+               "edge1 3 103",
+               "edge1 4 104",
+               "edge2 1 101",
+               "edge2 2 102",
+               "edge2 3 103",
+               "edge2 4 104"
+            )
+         }
+
          test("should modify edgecases") {
             val edges = setOf("edge1", "edge2")
             val arb = arbitraryBuilder(edgecaseFn = { edges.random(it.random) }) { "abcd" }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
@@ -1,15 +1,25 @@
 package com.sksamuel.kotest.property.arbitrary
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.ints.shouldBeBetween
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldHaveLengthBetween
 import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.alphanumeric
 import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.arbitraryBuilder
+import io.kotest.property.arbitrary.edgecases
+import io.kotest.property.arbitrary.flatMap
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.take
+import io.kotest.property.arbitrary.withEdgecases
 import kotlin.random.nextInt
 
 class BuilderTest : FunSpec() {
@@ -32,6 +42,55 @@ class BuilderTest : FunSpec() {
 
          personArb.next().name.shouldHaveLengthBetween(10, 12)
          personArb.next().age.shouldBeBetween(21, 150)
+      }
+
+      context("arbitrary builder using continuation") {
+         test("should be equivalent to chaining flatMaps") {
+            val arbFlatMaps: Arb<String> =
+               Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").flatMap { first ->
+                  Arb.int(1..9).withEdgecases(5).flatMap { second ->
+                     Arb.int(101..109).withEdgecases(100 + second).map { third ->
+                        "$first $second $third"
+                     }
+                  }
+               }
+
+            val arb: Arb<String> = arbitrary {
+               val first = Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").bind()
+               val second = Arb.int(1..9).withEdgecases(5).bind()
+               val third = Arb.int(101..109).withEdgecases(100 + second).bind()
+               "$first $second $third"
+            }
+
+            val flatMapsResult = arbFlatMaps.generate(RandomSource.seeded(12345L)).take(100).map { it.value }.toList()
+            val builderResult = arb.generate(RandomSource.seeded(12345L)).take(100).map { it.value }.toList()
+
+            // should be equivalent
+            builderResult shouldContainExactly flatMapsResult
+         }
+
+         test("should bind edgecases") {
+            val arb: Arb<String> = arbitrary {
+               val first = Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").bind()
+               val second = Arb.int(1..9).withEdgecases(5).bind()
+               val third = Arb.int(101..109).withEdgecases(100 + second, 109).bind()
+               "$first $second $third"
+            }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder setOf(
+               "edge1 5 105",
+               "edge2 5 105",
+               "edge1 5 109",
+               "edge2 5 109",
+            )
+         }
+
+         test("should modify edgecases") {
+            val edges = setOf("edge1", "edge2")
+            val arb = arbitraryBuilder(edgecaseFn = { edges.random(it.random) }) { "abcd" }
+
+            arb.edgecases() shouldContainExactlyInAnyOrder edges
+         }
       }
    }
 }


### PR DESCRIPTION
This is a proposed implementation for arbitrary builders using continuation passing style. This code is inspired by how monad fx on any `Kind<F, A>` was previously done in arrow.

This allows the following simplification as described in #2493:
```kotlin
data class Foo(val first: String, val multiplicationResult: Long)

val arbFirst: Arb<String> = ...
fun arbSecond(first: String): Arb<Int> = ...
val arbThird: Arb<Long> = ...

// with raw binds
val arbBind: Arb<String> = arbFirst.flatMap { first ->
   Arb.bind(arbSecond, arbThird) { second, third -> 
      Foo(first, second.toLong() * third)
   }
} 
// with continuation
// notice we also have access to the random source
val arb: Arb<String> = arbitrary { rs: RandomSource ->
   val first = arbFirst.bind()
   val multiplicationResult = arbSecond(first).bind().toLong() * arbThird.bind()
   Foo(first, multiplicationResult)
}
```

fixes #2493 
