### PR TITLE
Fix withClue and assertSoftly for coroutines switching threads (#2447)

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -91,7 +91,7 @@ open class BasicErrorCollector : ErrorCollector {
       clues.removeAt(0)
    }
 
-   override fun clueContext(): List<Clue> = clues.toList()
+   override fun clueContext(): List<Clue> = clues.reversed()
 
    override fun pushError(t: Throwable) {
       failures.add(t)

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -2,49 +2,24 @@
 
 package io.kotest.assertions
 
-import java.util.Stack
+import kotlinx.coroutines.asContextElement
 
-actual val errorCollector: ErrorCollector = ThreadLocalErrorCollector
+actual val errorCollector: ErrorCollector get() = ThreadLocalErrorCollector.instance.get()
 
-object ThreadLocalErrorCollector : ErrorCollector {
+/**
+ * A [CoroutineContext.Element] which keeps the error collector synchronized with thread-switching coroutines.
+ *
+ * When using [withClue] or [assertSoftly] on the JVM without the Kotest framework, this context element
+ * should be added to each top-level coroutine context, e.g. via
+ * - runBlocking(errorCollectorContextElement) { ... }
+ * - runBlockingTest(Dispatchers.IO + errorCollectorContextElement) { ... }
+ */
+val errorCollectorContextElement get() = ThreadLocalErrorCollector.instance.asContextElement()
 
-   private val clueContext = object : ThreadLocal<Stack<Clue>>() {
-      override fun initialValue(): Stack<Clue> = Stack()
+class ThreadLocalErrorCollector : BasicErrorCollector() {
+   companion object {
+      val instance = object : ThreadLocal<ErrorCollector>() {
+         override fun initialValue() = ThreadLocalErrorCollector()
+      }
    }
-
-   private val failures = object : ThreadLocal<MutableList<Throwable>>() {
-      override fun initialValue(): MutableList<Throwable> = mutableListOf()
-   }
-
-   private val collectionMode = object : ThreadLocal<ErrorCollectionMode>() {
-      override fun initialValue() = ErrorCollectionMode.Hard
-   }
-
-   override fun setCollectionMode(mode: ErrorCollectionMode) = collectionMode.set(mode)
-
-   override fun getCollectionMode(): ErrorCollectionMode = collectionMode.get()
-
-   override fun pushClue(clue: Clue) {
-      clueContext.get().push(clue)
-   }
-
-   override fun popClue() {
-      clueContext.get().pop()
-   }
-
-   override fun clueContext(): List<Clue> = clueContext.get()
-
-   override fun errors(): List<Throwable> = failures.get().toList()
-
-   /**
-    * Adds the given error to the current context.
-    */
-   override fun pushError(t: Throwable) {
-      failures.get().add(t)
-   }
-
-   /**
-    * Clears all errors from the current context.
-    */
-   override fun clear() = failures.get().clear()
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
@@ -1,0 +1,28 @@
+package io.kotest.assertions
+
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+class AssertSoftlyTests : FunSpec({
+   test("assertSoftly should collect errors across multiple coroutine threads") {
+      withContext(Dispatchers.Unconfined) {
+         shouldThrowExactly<MultiAssertionError> {
+            assertSoftly {
+               Thread.currentThread().run {
+                  println("assertSoftly block begins on $name, id $id")
+                  "assertSoftly block begins on $name, id $id" shouldBe "collected failure"
+               }
+               delay(10)
+               Thread.currentThread().run {
+                  println("assertSoftly block ends on $name, id $id")
+                  "assertSoftly block ends on $name, id $id" shouldBe "collected failure"
+               }
+            }
+         }
+      }
+   }
+})

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
@@ -2,6 +2,7 @@ package io.kotest.assertions
 
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -10,19 +11,21 @@ import kotlinx.coroutines.withContext
 class AssertSoftlyTests : FunSpec({
    test("assertSoftly should collect errors across multiple coroutine threads") {
       withContext(Dispatchers.Unconfined) {
+         val threadIds = mutableSetOf<Long>()
          shouldThrowExactly<MultiAssertionError> {
             assertSoftly {
                Thread.currentThread().run {
-                  println("assertSoftly block begins on $name, id $id")
+                  threadIds.add(Thread.currentThread().id)
                   "assertSoftly block begins on $name, id $id" shouldBe "collected failure"
                }
                delay(10)
                Thread.currentThread().run {
-                  println("assertSoftly block ends on $name, id $id")
+                  threadIds.add(Thread.currentThread().id)
                   "assertSoftly block ends on $name, id $id" shouldBe "collected failure"
                }
             }
          }
+         threadIds shouldHaveSize 2
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldHaveSize
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -8,11 +9,13 @@ import kotlinx.coroutines.withContext
 class CluesTests : FunSpec({
    test("withClue should not fail on coroutine thread switch") {
       withContext(Dispatchers.Unconfined) {
+         val threadIds = mutableSetOf<Long>()
          withClue("should not fail") {
-            Thread.currentThread().run { println("withClue block begins on $name, id $id") }
+            threadIds.add(Thread.currentThread().id)
             delay(10)
-            Thread.currentThread().run { println("withClue block ends on $name, id $id") }
+            threadIds.add(Thread.currentThread().id)
          }
+         threadIds shouldHaveSize 2
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
@@ -1,0 +1,19 @@
+package io.kotest.assertions
+
+import io.kotest.core.spec.style.FunSpec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+class CluesTests : FunSpec({
+   test("withClue should not fail on coroutine thread switch") {
+      withContext(Dispatchers.Unconfined) {
+         withClue("should not fail") {
+            Thread.currentThread().run { println("withClue block begins on $name, id $id") }
+            delay(10)
+            Thread.currentThread().run { println("withClue block ends on $name, id $id") }
+         }
+      }
+   }
+})

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
@@ -3,7 +3,6 @@ package io.kotest.assertions
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 
 class CluesTests : FunSpec({

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -24,6 +24,7 @@ import io.kotest.engine.test.interceptors.TestCaseExtensionInterceptor
 import io.kotest.engine.test.interceptors.TimeoutInterceptor
 import io.kotest.engine.test.interceptors.blockedThreadTimeoutInterceptor
 import io.kotest.engine.test.interceptors.coroutineDispatcherFactoryInterceptor
+import io.kotest.engine.test.interceptors.coroutineErrorCollectorInterceptor
 import io.kotest.mpp.log
 import io.kotest.mpp.timeInMillis
 
@@ -48,6 +49,7 @@ class TestCaseExecutor(
          CoroutineDebugProbeInterceptor,
          SupervisorScopeInterceptor,
          if (platform == Platform.JVM) coroutineDispatcherFactoryInterceptor(defaultCoroutineDispatcherFactory) else null,
+         if (platform == Platform.JVM) coroutineErrorCollectorInterceptor() else null,
          TestCaseExtensionInterceptor,
          EnabledCheckInterceptor,
          LifecycleInterceptor(listener, start),

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
@@ -17,3 +17,10 @@ internal expect fun coroutineDispatcherFactoryInterceptor(
  */
 @JVMOnly
 internal expect fun blockedThreadTimeoutInterceptor(): TestExecutionInterceptor
+
+/**
+ * Returns a [TestExecutionInterceptor] for keeping the error collector synchronized
+ * with thread-switching coroutines.
+ */
+@JVMOnly
+internal expect fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor

--- a/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
+++ b/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
@@ -9,3 +9,6 @@ internal actual fun coroutineDispatcherFactoryInterceptor(
 
 internal actual fun blockedThreadTimeoutInterceptor(): TestExecutionInterceptor =
    error("Unsupported on $platform")
+
+internal actual fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor =
+   error("Unsupported on $platform")

--- a/kotest-framework/kotest-framework-engine/src/jsMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
@@ -9,3 +9,6 @@ internal actual fun coroutineDispatcherFactoryInterceptor(
 
 internal actual fun blockedThreadTimeoutInterceptor(): TestExecutionInterceptor =
    error("Unsupported on $platform")
+
+internal actual fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor =
+   error("Unsupported on $platform")

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
@@ -1,0 +1,25 @@
+package io.kotest.engine.test.interceptors
+
+import io.kotest.assertions.errorCollectorContextElement
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestContext
+import io.kotest.core.test.TestResult
+import kotlinx.coroutines.withContext
+
+internal actual fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor =
+   CoroutineErrorCollectorInterceptor
+
+/**
+ * A [TestExecutionInterceptor] for keeping the error collector synchronized with thread-switching coroutines.
+ * Note: This is a JVM only option.
+ */
+internal object CoroutineErrorCollectorInterceptor : TestExecutionInterceptor {
+
+   override suspend fun intercept(
+      test: suspend (TestCase, TestContext) -> TestResult
+   ): suspend (TestCase, TestContext) -> TestResult = { testCase, context ->
+      withContext(errorCollectorContextElement) {
+         test(testCase, context)
+      }
+   }
+}


### PR DESCRIPTION
This should fix #2447 by keeping the error collector synchronized with thread-switching coroutines.

The required context element is automatically installed by the Kotest framework. When using the assertions without the framework, it is currently the user's responsibility to install the required context element, e.g. via
```
runBlocking(errorCollectorContextElement) { ... }
```

As has been discussed in https://github.com/kotest/kotest/issues/2447#issuecomment-917174018, `withClue` could be redesigned to avoid the error collector altogether. In this fix, I did not touch the implementation in order not to mess up message formatting.

Another improvement would be to find a way to automatically install the required `errorCollectorContextElement` for those not using the Kotest framework. Some approaches have been contemplated in https://github.com/kotest/kotest/issues/2447#issuecomment-917691838. Another option might be to ask the Kotlin team to provide an API for installing default context elements.

I'd suggest to go with this rather light-weight approach for the initial 5.0 release and follow up later for further improvements.