### PR TITLE
Fix endless recursion in 2-arity checkAll

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
@@ -17,7 +17,7 @@ suspend fun <A, B> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Unit
-): PropertyContext = checkAll(config, genA, genB, property)
+): PropertyContext = proptest(genA, genB, config, property)
 
 suspend fun <A, B> checkAll(
    iterations: Int,

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/CheckAllArity2.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/CheckAllArity2.kt
@@ -60,5 +60,21 @@ class CheckAllArity2 : FunSpec() {
          context.successes() shouldBe 55
          context.failures() shouldBe 0
       }
+
+      test("checkAll/customConfig/specifiedArbs") {
+
+         val context = checkAll(
+            config = PropTestConfig(seed = 333, iterations = 35),
+            Arb.int(),
+            Arb.int()
+         ) { a, b ->
+            a + b shouldBe b + a
+         }
+
+         context.attempts() shouldBe 35
+         context.successes() shouldBe 35
+         context.failures() shouldBe 0
+      }
+
    }
 }


### PR DESCRIPTION
2-arity checkAll with PropTestConfig overload used to call itself,
leading to StackOverflow exception.