### PR TITLE
Add documentation for HTML Reporter

### DIFF
--- a/documentation/docs/extensions/html_reporter.md
+++ b/documentation/docs/extensions/html_reporter.md
@@ -1,0 +1,38 @@
+---
+id: html_reporter
+title: HTML Reporter
+sidebar_label: HTML Reporter
+slug: html_reporter.html
+---
+
+When using [JUnit XML](./junit_xml.md), we can generate XML results from tests that are able to produce output with nested
+tests. Unfortunately, Gradle generates its HTML reports with the results it has in-memory, which doesn't support nested
+tests, and it doesn't seem to be able to fetch results from a different XML.
+
+To solve this, Kotest has a listener that is able to generate HTML reports based on the XML reports that are generated
+by [JUnit XML](./junit_xml.md).
+
+In order to use it, we simply need to add it as a listener through [project config](../framework/project_config.md).
+
+```
+class ProjectConfig : AbstractProjectConfig() {
+
+   override val specExecutionOrder = SpecExecutionOrder.Annotated
+
+   override fun listeners(): List<Listener> {
+      return listOf(
+         JunitXmlReporter(
+            includeContainers = false,
+            useTestPathAsName = true
+         ),
+         HtmlReporter()
+      )
+   }
+}
+```
+
+Notice that we also add `JunitXmlReporter`. This will generate the necessary XML reports, used to generate the HTML reports.
+There's no additional configuration needed, it should simply start generating HTML reports.
+
+By default, it stores reports in `path/to/buildDir/reports/tests/test` but this can be modified by changing the parameter
+`outputDir`.

--- a/documentation/docs/extensions/index.md
+++ b/documentation/docs/extensions/index.md
@@ -22,6 +22,7 @@ maintained and hosted by third parties.
 | [Roboelectric](roboelectric.md) | Integrate roboelectric with the test lifecycle |
 | [Allure](allure.md) | Provides output for the allure framework |
 | [JUnit XML](junit_xml.md) | Provides output in the JUnit XML format for integration with reporting tools |
+| [HTML Reporter](html_reporter.md) | Generates HTML reports of test results based on [JUnit XML](junit_xml.md) |
 
 ### Third Party Extensions
 


### PR DESCRIPTION
As spoken in #2211, I'm opening this PR in order to add some documentation of the HTML Reporter so that it appears on the website. I've kept it simple and mostly used JUnit XML as an inspiration. 