### PR TITLE
Add missing redirect placeholders for actively linked docs

### DIFF
--- a/doc/clues.md
+++ b/doc/clues.md
@@ -1,0 +1,4 @@
+Clues
+==============
+
+[This page has moved](https://kotest.io/docs/assertions/clues.html)

--- a/doc/test_case_config.md
+++ b/doc/test_case_config.md
@@ -1,0 +1,4 @@
+Test Case Config
+================
+
+[This page has moved](https://kotest.io/docs/framework/testcaseconfig.html)

--- a/doc/test_ordering.md
+++ b/doc/test_ordering.md
@@ -1,0 +1,4 @@
+Test Ordering
+================
+
+[This page has moved](https://kotest.io/docs/framework/test-ordering.html)

--- a/doc/testfactories.md
+++ b/doc/testfactories.md
@@ -1,0 +1,4 @@
+Test Factories
+===================
+
+[This page has moved](https://kotest.io/docs/framework/test-factories.html)


### PR DESCRIPTION
## Changes in this PR

Some documentation pages in the [doc](https://github.com/kotest/kotest/tree/master/doc) folder were removed with a793ae57. However, some of these docs are still actively linked from [doc/reference.md](https://github.com/kotest/kotest/tree/master/doc/reference.md) (e.g. [Test Factories](https://github.com/kotest/kotest/blob/master/doc/reference.md#test-factories)), resulting in a 404 when opened. To prevent these errors, this commit adds redirect placeholder pages similar to those that were added with adcf4df9.