### PR TITLE
Allow extensions to be registered via a spec annotation #2551

### DIFF
--- a/kotest-common/src/jvmMain/kotlin/io/kotest/mpp/reflection.kt
+++ b/kotest-common/src/jvmMain/kotlin/io/kotest/mpp/reflection.kt
@@ -62,6 +62,13 @@ object JvmReflection : Reflection {
    override fun <T : Any> newInstanceNoArgConstructor(klass: KClass<T>): T {
       return klass.java.newInstance()
    }
+
+   override fun <T : Any> newInstanceNoArgConstructorOrObjectInstance(klass: KClass<T>): T {
+      return when (val obj = klass.objectInstance) {
+         null -> newInstanceNoArgConstructor(klass)
+         else -> obj
+      }
+   }
 }
 
 actual val reflection: Reflection = JvmReflection

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Configuration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Configuration.kt
@@ -333,7 +333,7 @@ class Configuration {
    /**
     * Returns all globally registered [Listener]s.
     */
-   @SoftDeprecated("Listeners have been subsumed into extensions")
+   @Deprecated("Listeners have been subsumed into extensions", level = DeprecationLevel.ERROR)
    fun listeners() = extensions()
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/ApplyExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/ApplyExtension.kt
@@ -1,0 +1,8 @@
+package io.kotest.core.extensions
+
+import kotlin.reflect.KClass
+
+@Repeatable
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class ApplyExtension(vararg val factory: KClass<out ExtensionFactory>)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/ExtensionFactory.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/ExtensionFactory.kt
@@ -1,0 +1,7 @@
+package io.kotest.core.extensions
+
+import kotlin.reflect.KClass
+
+interface ExtensionFactory {
+   fun extension(spec: KClass<*>): Extension?
+}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecFinalizeExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecFinalizeExtension.kt
@@ -18,5 +18,5 @@ interface SpecFinalizeExtension : Extension {
    /**
     * Accepts a [Spec] for processing before that spec is completed.
     */
-   fun finalize(spec: Spec)
+   fun finalizeSpec(spec: Spec)
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecIgnoredListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecIgnoredListener.kt
@@ -6,5 +6,5 @@ import kotlin.reflect.KClass
  * This listener is invoked if a spec was disabled and never executed.
  */
 interface SpecIgnoredListener {
-   suspend fun ignored(kClass: KClass<*>, reason: String?)
+   suspend fun ignoredSpec(kclass: KClass<*>, reason: String?)
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecInitializeExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecInitializeExtension.kt
@@ -6,6 +6,6 @@ import io.kotest.core.spec.Spec
  * An [Extension] point that enables hooking into the spec factory lifecycle.
  */
 interface SpecInitializeExtension : Extension {
-   suspend fun initialize(spec: Spec): Spec
+   suspend fun initializeSpec(spec: Spec): Spec
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/events/testcase.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/events/testcase.kt
@@ -1,7 +1,12 @@
 package io.kotest.engine.events
 
 import io.kotest.core.config.configuration
-import io.kotest.core.listeners.TestListener
+import io.kotest.core.listeners.AfterContainerListener
+import io.kotest.core.listeners.AfterEachListener
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.BeforeContainerListener
+import io.kotest.core.listeners.BeforeEachListener
+import io.kotest.core.listeners.BeforeTestListener
 import io.kotest.core.spec.resolvedTestListeners
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -15,16 +20,16 @@ import io.kotest.fp.Try
  */
 internal suspend fun TestCase.invokeAllBeforeTestCallbacks(): Try<TestCase> =
    Try {
-      spec.resolvedTestListeners() + configuration.extensions().filterIsInstance<TestListener>()
+      spec.resolvedTestListeners() + configuration.extensions()
    }.fold({
       Try.Failure(it)
    }, { listeners ->
       listeners.map {
          Try {
-            if (type == TestType.Container) it.beforeContainer(this)
-            if (type == TestType.Test) it.beforeEach(this)
-            it.beforeAny(this)
-            it.beforeTest(this)
+            if (type == TestType.Container && it is BeforeContainerListener) it.beforeContainer(this)
+            if (type == TestType.Test && it is BeforeEachListener) it.beforeEach(this)
+            if (it is BeforeTestListener) it.beforeAny(this)
+            if (it is BeforeTestListener) it.beforeTest(this)
             this
          }
       }.find { it.isFailure() } ?: Try { this }
@@ -36,7 +41,7 @@ internal suspend fun TestCase.invokeAllBeforeTestCallbacks(): Try<TestCase> =
  */
 internal suspend fun TestCase.invokeAllAfterTestCallbacks(result: TestResult): Try<TestCase> =
    Try {
-      this.config.listeners + spec.resolvedTestListeners() + configuration.extensions().filterIsInstance<TestListener>()
+      this.config.listeners + spec.resolvedTestListeners() + configuration.extensions()
    }.fold({
       Try.Failure(it)
    }, { listeners ->
@@ -45,10 +50,10 @@ internal suspend fun TestCase.invokeAllAfterTestCallbacks(result: TestResult): T
          var currentException: Error? = null
          listeners.forEach {
             try {
-               it.afterTest(this, currentResult)
-               it.afterAny(this, currentResult)
-               if (type == TestType.Test) it.afterEach(this, currentResult)
-               if (type == TestType.Container) it.afterContainer(this, currentResult)
+               if (it is AfterTestListener) it.afterTest(this, currentResult)
+               if (it is AfterTestListener) it.afterAny(this, currentResult)
+               if (type == TestType.Test && it is AfterEachListener) it.afterEach(this, currentResult)
+               if (type == TestType.Container && it is AfterContainerListener) it.afterContainer(this, currentResult)
             } catch (e: Error) {
                if (!listOf(TestStatus.Failure, TestStatus.Error).contains(currentResult.status)) {
                   currentResult = TestResult(

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SpecWrapperExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SpecWrapperExtension.kt
@@ -1,0 +1,144 @@
+package io.kotest.engine.extensions
+
+import io.kotest.core.extensions.Extension
+import io.kotest.core.extensions.InactiveSpecListener
+import io.kotest.core.extensions.SpecCreationErrorListener
+import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.extensions.SpecFinalizeExtension
+import io.kotest.core.extensions.SpecIgnoredListener
+import io.kotest.core.extensions.SpecInitializeExtension
+import io.kotest.core.extensions.SpecInterceptExtension
+import io.kotest.core.listeners.AfterContainerListener
+import io.kotest.core.listeners.AfterEachListener
+import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.BeforeContainerListener
+import io.kotest.core.listeners.BeforeEachListener
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.listeners.BeforeTestListener
+import io.kotest.core.listeners.FinalizeSpecListener
+import io.kotest.core.listeners.PrepareSpecListener
+import io.kotest.core.listeners.SpecInstantiationListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import kotlin.reflect.KClass
+
+/**
+ * Wraps another extension, delegating spec extensions only for the specified spec.
+ */
+internal class SpecWrapperExtension(
+   private val delegate: Extension,
+   private val target: KClass<*>
+) : SpecInstantiationListener,
+   SpecCreationErrorListener,
+   SpecExtension,
+   SpecInterceptExtension,
+   SpecFinalizeExtension,
+   SpecIgnoredListener,
+   SpecInitializeExtension,
+   InactiveSpecListener,
+   AfterSpecListener,
+   BeforeSpecListener,
+   PrepareSpecListener,
+   FinalizeSpecListener,
+   BeforeTestListener,
+   AfterTestListener,
+   BeforeEachListener,
+   AfterEachListener,
+   BeforeContainerListener,
+   AfterContainerListener {
+
+   override suspend fun beforeContainer(testCase: TestCase) {
+      if (delegate is BeforeContainerListener && testCase.spec::class == target) delegate.beforeContainer(testCase)
+   }
+
+   override suspend fun afterContainer(testCase: TestCase, result: TestResult) {
+      if (delegate is AfterContainerListener && testCase.spec::class == target) delegate.afterContainer(
+         testCase,
+         result
+      )
+   }
+
+   override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+      if (delegate is AfterEachListener && testCase.spec::class == target) delegate.afterEach(testCase, result)
+   }
+
+   override suspend fun afterAny(testCase: TestCase, result: TestResult) {
+      if (delegate is AfterTestListener && testCase.spec::class == target) delegate.afterAny(testCase, result)
+   }
+
+   override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+      if (delegate is AfterTestListener && testCase.spec::class == target) delegate.afterTest(testCase, result)
+   }
+
+   override suspend fun beforeEach(testCase: TestCase) {
+      if (delegate is BeforeEachListener && testCase.spec::class == target) delegate.beforeEach(testCase)
+   }
+
+   override suspend fun beforeAny(testCase: TestCase) {
+      if (delegate is BeforeTestListener && testCase.spec::class == target) delegate.beforeAny(testCase)
+   }
+
+   override suspend fun beforeTest(testCase: TestCase) {
+      if (delegate is BeforeTestListener && testCase.spec::class == target) delegate.beforeTest(testCase)
+   }
+
+   override suspend fun onSpecCreationError(kclass: KClass<*>, t: Throwable) {
+      if (delegate is SpecCreationErrorListener && kclass == target) delegate.onSpecCreationError(kclass, t)
+   }
+
+   override fun finalizeSpec(spec: Spec) {
+      if (delegate is SpecFinalizeExtension && spec::class == target) delegate.finalizeSpec(spec)
+   }
+
+   override suspend fun ignoredSpec(kclass: KClass<*>, reason: String?) {
+      if (delegate is SpecIgnoredListener && kclass == target) delegate.ignoredSpec(kclass, reason)
+   }
+
+   override suspend fun initializeSpec(spec: Spec): Spec {
+      return if (delegate is SpecInitializeExtension && spec::class == target) delegate.initializeSpec(spec) else spec
+   }
+
+   override suspend fun interceptSpec(spec: Spec, process: suspend (Spec) -> Unit) {
+      if (delegate is SpecInterceptExtension && spec::class == target)
+         delegate.interceptSpec(spec, process)
+      else process(spec)
+   }
+
+   override suspend fun afterSpec(spec: Spec) {
+      if (delegate is AfterSpecListener && spec::class == target) delegate.afterSpec(spec)
+   }
+
+   override suspend fun beforeSpec(spec: Spec) {
+      if (delegate is BeforeSpecListener && spec::class == target) delegate.beforeSpec(spec)
+   }
+
+   override suspend fun finalizeSpec(kclass: KClass<out Spec>, results: Map<TestCase, TestResult>) {
+      if (delegate is FinalizeSpecListener && kclass == target) delegate.finalizeSpec(kclass, results)
+   }
+
+   override suspend fun inactive(spec: Spec, results: Map<TestCase, TestResult>) {
+      if (delegate is InactiveSpecListener && spec::class == target) delegate.inactive(spec, results)
+   }
+
+   override fun specInstantiated(spec: Spec) {
+      if (delegate is SpecInstantiationListener && spec::class == target) delegate.specInstantiated(spec)
+   }
+
+   override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+      if (delegate is SpecExtension && spec::class == target) delegate.intercept(spec, execute) else execute(spec)
+   }
+
+   override suspend fun prepareSpec(kclass: KClass<out Spec>) {
+      if (delegate is PrepareSpecListener && kclass == target) delegate.prepareSpec(kclass)
+   }
+
+   override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
+      if (delegate is SpecExtension && spec == target) delegate.intercept(spec, process) else process()
+   }
+
+   override fun specInstantiationError(kclass: KClass<out Spec>, t: Throwable) {
+      if (delegate is SpecInstantiationListener && kclass == target) delegate.specInstantiationError(kclass, t)
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExecutor.kt
@@ -12,6 +12,7 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.TestEngineListener
+import io.kotest.engine.spec.interceptor.ApplyExtensionsInterceptor
 import io.kotest.engine.spec.interceptor.IgnoreNestedSpecStylesInterceptor
 import io.kotest.engine.spec.interceptor.IgnoredSpecInterceptor
 import io.kotest.engine.spec.interceptor.RunIfActiveInterceptor
@@ -58,6 +59,7 @@ class SpecExecutor(
          SpecEnterInterceptor(listener),
          SpecLaunchExtensionInterceptor(conf.extensions().filterIsInstance<SpecLaunchExtension>()),
          IgnoredSpecInterceptor(listener, conf),
+         ApplyExtensionsInterceptor(conf),
       )
 
       val innerExecute: suspend (SpecRef) -> Map<TestCase, TestResult> = {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExtensions.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExtensions.kt
@@ -61,7 +61,7 @@ internal class SpecExtensions(private val configuration: Configuration) {
    suspend fun specInstantiated(spec: Spec) = runCatching {
       log { "SpecExtensions: specInstantiated spec:$spec" }
       configuration.extensions().filterIsInstance<SpecInstantiationListener>().forEach { it.specInstantiated(spec) }
-      configuration.extensions().filterIsInstance<SpecInitializeExtension>().forEach { it.initialize(spec) }
+      configuration.extensions().filterIsInstance<SpecInitializeExtension>().forEach { it.initializeSpec(spec) }
    }
 
    suspend fun specInstantiationError(kclass: KClass<out Spec>, t: Throwable) = kotlin.runCatching {
@@ -90,7 +90,7 @@ internal class SpecExtensions(private val configuration: Configuration) {
    suspend fun ignored(kclass: KClass<out Spec>) {
       val exts = configuration.extensions().filterIsInstance<SpecIgnoredListener>()
       log { "SpecExtensions: ignored(${exts.size}) $kclass" }
-      exts.forEach { it.ignored(kclass, null) }
+      exts.forEach { it.ignoredSpec(kclass, null) }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ApplyExtensionsInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ApplyExtensionsInterceptor.kt
@@ -1,0 +1,38 @@
+package io.kotest.engine.spec.interceptor
+
+import io.kotest.core.config.Configuration
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.engine.extensions.SpecWrapperExtension
+import io.kotest.mpp.annotation
+import io.kotest.mpp.newInstanceNoArgConstructorOrObjectInstance
+
+/**
+ * If the spec is annotated with the [ApplyExtension] annotation, registers any extensions
+ * returned by that annotation.
+ *
+ * Note: annotations are only available on the JVM.
+ */
+internal class ApplyExtensionsInterceptor(private val conf: Configuration) : SpecRefInterceptor {
+
+   override suspend fun intercept(
+      fn: suspend (SpecRef) -> Map<TestCase, TestResult>
+   ): suspend (SpecRef) -> Map<TestCase, TestResult> = { ref ->
+
+      val extensions = mutableListOf<Extension>()
+
+      ref.kclass.annotation<ApplyExtension>()?.factory?.forEach { factoryClass ->
+         val factory = factoryClass.newInstanceNoArgConstructorOrObjectInstance()
+         val extension = factory.extension(ref.kclass)
+         if (extension != null) extensions.add(SpecWrapperExtension(extension, ref.kclass))
+      }
+
+      extensions.forEach { conf.register(it) }
+      fn(ref).apply {
+         extensions.forEach { conf.deregister(it) }
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/SpecFinalizerExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/SpecFinalizerExtensionTest.kt
@@ -47,7 +47,7 @@ class SpecFinalizerExtensionTest : FunSpec() {
 
 object MySpecFinalizeExtension : SpecFinalizeExtension {
    val finalized = AtomicBoolean(false)
-   override fun finalize(spec: Spec) {
+   override fun finalizeSpec(spec: Spec) {
       finalized.set(true)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AnnotationExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AnnotationExtensionTest.kt
@@ -1,0 +1,144 @@
+package com.sksamuel.kotest.engine.extensions.spec
+
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.extensions.Extension
+import io.kotest.core.extensions.ExtensionFactory
+import io.kotest.core.extensions.SpecInitializeExtension
+import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.listeners.BeforeTestListener
+import io.kotest.core.listeners.PrepareSpecListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.matchers.shouldBe
+import kotlin.reflect.KClass
+
+class AnnotationExtensionTest : FunSpec() {
+   init {
+
+      beforeTest {
+         instantiations = 0
+         beforeSpec = 0
+         afterSpec = 0
+         afterTest = 0
+         prepareSpec = 0
+         beforeTest = 0
+         initializeSpec = 0
+      }
+
+      test("a spec annotated with ApplyExtension should have that extension applied") {
+         TestEngineLauncher(NoopTestEngineListener)
+            .withClasses(MyAnnotatedSpec1::class)
+            .launch()
+         instantiations.shouldBe(1)
+         beforeSpec.shouldBe(1)
+         afterSpec.shouldBe(1)
+         afterTest.shouldBe(1)
+         beforeTest.shouldBe(1)
+         // prepareSpec.shouldBe(1)
+         initializeSpec.shouldBe(1)
+      }
+
+      test("a spec annotated with multiple ApplyExtension's should have all extensions applied") {
+         TestEngineLauncher(NoopTestEngineListener)
+            .withClasses(MyAnnotatedSpec2::class)
+            .launch()
+         instantiations.shouldBe(2)
+         beforeSpec.shouldBe(2)
+         afterSpec.shouldBe(2)
+         afterTest.shouldBe(2)
+         beforeTest.shouldBe(2)
+         // prepareSpec.shouldBe(2)
+         initializeSpec.shouldBe(2)
+      }
+
+      test("ApplyExtension should only apply to the spec they are annotating") {
+         TestEngineLauncher(NoopTestEngineListener)
+            .withClasses(MyAnnotatedSpec1::class, NotAnnotatedSpec::class)
+            .launch()
+         instantiations.shouldBe(1)
+         beforeSpec.shouldBe(1)
+         afterSpec.shouldBe(1)
+         afterTest.shouldBe(1)
+         beforeTest.shouldBe(1)
+         // prepareSpec.shouldBe(1)
+         initializeSpec.shouldBe(1)
+      }
+   }
+}
+
+@ApplyExtension(MyExtensionFactory::class)
+private class MyAnnotatedSpec1 : FunSpec() {
+   init {
+      test("a") {}
+   }
+}
+
+@ApplyExtension(MyExtensionFactory::class, MyExtensionFactory::class)
+private class MyAnnotatedSpec2 : FunSpec() {
+   init {
+      test("a") {}
+   }
+}
+
+private class NotAnnotatedSpec : FunSpec() {
+   init {
+      test("a") {}
+   }
+}
+
+object MyExtensionFactory : ExtensionFactory {
+   override fun extension(spec: KClass<*>): Extension {
+      return MyExtension()
+   }
+}
+
+private var instantiations = 0
+private var beforeSpec = 0
+private var afterSpec = 0
+private var beforeTest = 0
+private var afterTest = 0
+private var initializeSpec = 0
+private var prepareSpec = 0
+
+class MyExtension : BeforeSpecListener,
+   AfterSpecListener,
+   BeforeTestListener,
+   AfterTestListener,
+   SpecInitializeExtension,
+   PrepareSpecListener {
+
+   init {
+      instantiations++
+   }
+
+   override suspend fun beforeSpec(spec: Spec) {
+      beforeSpec++
+   }
+
+   override suspend fun afterSpec(spec: Spec) {
+      afterSpec++
+   }
+
+   override suspend fun initializeSpec(spec: Spec): Spec {
+      initializeSpec++
+      return spec
+   }
+
+   override suspend fun beforeTest(testCase: TestCase) {
+      beforeTest++
+   }
+
+   override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+      afterTest++
+   }
+
+   override suspend fun prepareSpec(kclass: KClass<out Spec>) {
+      prepareSpec++
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecInitializeExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecInitializeExtensionTest.kt
@@ -48,7 +48,7 @@ class SpecInitializeExtensionTest : FunSpec() {
 
 object MySpecInitializeExtension : SpecInitializeExtension {
    val invoked = AtomicBoolean(false)
-   override suspend fun initialize(spec: Spec): Spec {
+   override suspend fun initializeSpec(spec: Spec): Spec {
       invoked.set(true)
       return spec
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecInstantiationExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecInstantiationExtensionTest.kt
@@ -18,7 +18,7 @@ class SpecInstantiationExtensionTest : FunSpec() {
       test("SpecInstantiationExtension should trigger for successful instantiation") {
          var count = 0
          val ext = object : SpecInitializeExtension {
-            override suspend fun initialize(spec: Spec): Spec {
+            override suspend fun initializeSpec(spec: Spec): Spec {
                count++
                return spec
             }


### PR DESCRIPTION
Closes #2551

Example syntax:

```kotlin
@ApplyExtension(MyExtension::class)
class MyAnnotatedSpec : FunSpec() {
   init {
      test("a") {}
   }
}
```