### PR TITLE
Arb.pair should return Arb<Pair<K, V>>

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
@@ -73,17 +73,9 @@ class MapShrinker<K, V> : Shrinker<Map<K, V>> {
  * Returns an [Arb] that produces Pairs of K,V using the supplied arbs for K and V.
  * Edgecases will be derived from [k] and [v].
  */
-fun <K, V> Arb.Companion.pair(k: Arb<K>, v: Arb<V>) = arbitrary(
-   edgecaseFn = { rs ->
-      when (rs.random.nextInt(4)) {
-         0, 1 -> k.edgecase(rs) to v.edgecase(rs)
-         2 -> k.edgecase(rs) to v.next(rs)
-         3 -> k.next(rs) to v.edgecase(rs)
-         else -> k.edgecase(rs) to v.edgecase(rs)
-      }
-   }
-) { rs ->
-   val ks = k.sample(rs)
-   val vs = v.sample(rs)
-   Pair(ks.value, vs.value)
+fun <K, V> Arb.Companion.pair(k: Arb<K>, v: Arb<V>): Arb<Pair<K, V>> {
+   val arbPairWithoutKeyEdges:Arb<Pair<K, V>> = Arb.bind(k.removeEdgecases(), v, ::Pair)
+   val arbPairWithoutValueEdges:Arb<Pair<K, V>> = Arb.bind(k, v.removeEdgecases(), ::Pair)
+   val arbPair: Arb<Pair<K, V>> = Arb.bind(k, v, ::Pair)
+   return Arb.choice(arbPair, arbPairWithoutKeyEdges, arbPairWithoutValueEdges)
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
@@ -1,0 +1,46 @@
+package com.sksamuel.kotest.property.arbitrary
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.alphanumeric
+import io.kotest.property.arbitrary.edgecases
+import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.pair
+import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.take
+import io.kotest.property.arbitrary.withEdgecases
+
+class MapsTest : FunSpec({
+   context("Arb.pair") {
+      test("should generate a pair of values from given arb key / value") {
+         val arbKey = Arb.int(1..10)
+         val arbValue = Arb.string(1..10, Codepoint.alphanumeric())
+         val arbPair: Arb<Pair<Int, String>> = Arb.pair(arbKey, arbValue)
+
+         arbPair.take(5, RandomSource.seeded(1234L)).toList() shouldContainExactly listOf(
+            Pair(6, "tI"),
+            Pair(6, "i7"),
+            Pair(9, "wmWkyqH"),
+            Pair(7, "J"),
+            Pair(7, "V")
+         )
+      }
+
+      test("should generate edgecases from key and value arbs") {
+         val arbKey = Arb.int(1..10).withEdgecases(5)
+         val arbValue = Arb.string(1..10, Codepoint.alphanumeric()).withEdgecases("edge")
+         val arbPair: Arb<Pair<Int, String>> = Arb.pair(arbKey, arbValue)
+
+         arbPair.edgecases(rs = RandomSource.seeded(1234L)).take(5).toList() shouldContainExactly listOf(
+            Pair(5, "edge"),
+            Pair(5, "awmWkyqH8"),
+            Pair(5, "V"),
+            Pair(7, "edge"),
+            Pair(5, "LOFBhzunuV")
+         )
+      }
+   }
+})

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -95,11 +95,11 @@ class ReflectiveBindTest : StringSpec(
             .toList()
 
          edgeCases shouldContainExactly listOf(
-            Wobble(a = "a", b = false, c = 1, d = Pair(2.780487668580398E307, Float.POSITIVE_INFINITY)),
-            Wobble(a = "", b = true, c = 0, d = Pair(-Double.MIN_VALUE, Float.NaN)),
-            Wobble(a = "a", b = true, c = 0, d = Pair(Double.POSITIVE_INFINITY, Float.MIN_VALUE)),
-            Wobble(a = "", b = false, c = Int.MIN_VALUE, d = Pair(-1.6820648195553769E308, Float.MIN_VALUE)),
-            Wobble(a = "a", b = false, c = 1, d = Pair(Double.MAX_VALUE, -1.3826198E38f))
+            Wobble(a = "a", b = false, c = 1, d = Pair(-0.0, Float.POSITIVE_INFINITY)),
+            Wobble(a = "", b = true, c = 0, d = Pair(3.5669621934936836E307, -3.4028235E38F)),
+            Wobble(a = "a", b = true, c = Int.MIN_VALUE, d = Pair(1.3317496548681731E308, -1.0F)),
+            Wobble(a = "", b = false, c = 1, d = Pair(-1.402243144992822E308, 1.0F)),
+            Wobble(a = "", b = false, c = 0, d = Pair(Double.POSITIVE_INFINITY, 3.4028235E38F))
          )
       }
 


### PR DESCRIPTION
This was a regression. The return type of `Arb.pair` changed from `Arb<Pair<K, V>>` to `Arb<Pair<K?, V?>>`