### PR TITLE
Add `shouldHaveSameStructure ` to file matchers

### DIFF
--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -45,6 +45,7 @@ _**Kotlin 1.5 is now the minimum supported version**_
 * Added arb for hexidecimal codepoints #2409
 * Added `shouldEqualSpecifiedJson` to match a JSON structure on a subset of (specified) keys. (#2298)
 * `shouldEqualJson` now supports high-precision numbers (#2458)
+* Added `shouldHaveSameStructure` to file matchers
 
 #### Deprecations
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -2,6 +2,7 @@ package io.kotest.matchers.file
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.collections.shouldBeSameSizeAs
 import io.kotest.matchers.paths.beSymbolicLink
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -145,7 +146,6 @@ fun beLarger(other: File): Matcher<File> = object : Matcher<File> {
    }
 }
 
-
 fun File.shouldBeCanonical() = this should beCanonicalPath()
 fun File.shouldNotBeCanonical() = this shouldNot beCanonicalPath()
 fun beCanonicalPath(): Matcher<File> = object : Matcher<File> {
@@ -176,7 +176,6 @@ fun beRelative(): Matcher<File> = object : Matcher<File> {
          { "File $value should be relative" },
          { "File $value should not be relative" })
 }
-
 
 infix fun File.shouldHaveFileSize(size: Long) = this should haveFileSize(size)
 infix fun File.shouldNotHaveFileSize(size: Long) = this shouldNot haveFileSize(size)
@@ -251,4 +250,19 @@ fun startWithPath(prefix: String) = object : Matcher<File> {
       {
          "File $value should not start with $prefix"
       })
+}
+
+infix fun File.shouldHaveSameStructure(file: File) {
+   val expectFiles = this.walkTopDown().toList()
+   val actualFiles = file.walkTopDown().toList()
+
+   expectFiles shouldBeSameSizeAs actualFiles
+
+   expectFiles.zip(actualFiles) { expect, actual ->
+      when {
+         expect.isDirectory -> actual.shouldBeADirectory()
+         expect.isFile -> expect.shouldHaveSameContentAs(actual)
+         else -> error("There is an unexpected error analyzing file trees")
+      }
+   }
 }


### PR DESCRIPTION
Compare if two file trees have the same structure:

- Both trees have the same size
- All directories have the same path
- All files have the same content