### PR TITLE
Refactor `shouldHaveSameStructure`

### DIFF
--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -45,7 +45,8 @@ _**Kotlin 1.5 is now the minimum supported version**_
 * Added arb for hexidecimal codepoints #2409
 * Added `shouldEqualSpecifiedJson` to match a JSON structure on a subset of (specified) keys. (#2298)
 * `shouldEqualJson` now supports high-precision numbers (#2458)
-* Added `shouldHaveSameStructure` to file matchers
+* Added `shouldHaveSameStructureAs` to file matchers
+* Added `shouldHaveSameStructureAndContentAs` to file matchers
 
 #### Deprecations
 


### PR DESCRIPTION
- Rename to `shouldHaveSameStructureAs`
  - It doesn't check files content, only if the tree is the same
- Added `shouldHaveSameStructureAndContentAs`
  - It checks if the tree and the content of the files is the same

For both new assertions, add filters and comparison functions