### PR TITLE
Update continually.md to remove deprecated function

### DIFF
--- a/documentation/docs/assertions/continually.md
+++ b/documentation/docs/assertions/continually.md
@@ -16,7 +16,7 @@ Better to fail fast.
 class MyTests : ShouldSpec() {
   init {
     should("pass for 60 seconds") {
-      continually(60.seconds) {
+      continually(Duration.seconds(60)) {
         // code here that should succeed and continue to succeed for 60 seconds
       }
     }
@@ -30,7 +30,7 @@ The function passed to the `continually` block is executed every 10 milliseconds
 class MyTests: ShouldSpec() {
   init {
     should("pass for 60 seconds") {
-      continually(60.seconds, 5.seconds) {
+      continually(Duration.seconds(60), Duration.seconds(5)) {
         // code here that should succeed and continue to succeed for 60 seconds
       }
     }


### PR DESCRIPTION
`Int.seconds` is deprecated in favor of `Duration.seconds(Int)`.

```kotlin
@SinceKotlin("1.3")
@ExperimentalTime
@Deprecated("Use Duration.seconds() function instead.", ReplaceWith("Duration.seconds(this)", "kotlin.time.Duration"))
public val Int.seconds get() = toDuration(DurationUnit.SECONDS)
```