### PR TITLE
Fixes withEnvironment empty system environment variables on Linux 

### DIFF
--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt
@@ -66,7 +66,7 @@ inline fun <T> withEnvironment(environment: Map<String, String?>, mode: Override
    val originalEnvironment = if (isWindows) {
       System.getenv().toSortedMap(String.CASE_INSENSITIVE_ORDER)
    } else {
-      System.getenv()
+      System.getenv().toMap()
    }
 
    setEnvironmentMap(mode.override(originalEnvironment, environment))

--- a/kotest-extensions/src/jvmTest/kotlin/com/sksamuel/kt/extensions/system/SystemEnvironmentExtensionTest.kt
+++ b/kotest-extensions/src/jvmTest/kotlin/com/sksamuel/kt/extensions/system/SystemEnvironmentExtensionTest.kt
@@ -22,20 +22,20 @@ class SystemEnvironmentExtensionTest : FreeSpec() {
    private val value = "SystemEnvironmentExtensionTestBar"
 
    init {
+         "Should return original environment to its place after execution" - {
+            val before = System.getenv().toMap()
+
+            executeOnAllEnvironmentOverloads {
+               System.getenv() shouldNotBe before
+            }
+            System.getenv() shouldBe before
+
+         }
+
       "Should set environment to specific map" - {
          executeOnAllEnvironmentOverloads {
             System.getenv(key) shouldBe value
          }
-      }
-
-      "Should return original environment to its place after execution" - {
-         val before = System.getenv().toMap()
-
-         executeOnAllEnvironmentOverloads {
-            System.getenv() shouldNotBe before
-         }
-         System.getenv() shouldBe before
-
       }
 
       "Should return the computed value" - {


### PR DESCRIPTION
fixes #2614 

This PR:
- Reorders the test of `withEnvironment` to provoke the failure
- Uses `toMap()` to create an immutable copy of the original system environment