### PR TITLE
Revert "Update continually.md to remove deprecated function"

### DIFF
--- a/documentation/docs/assertions/continually.md
+++ b/documentation/docs/assertions/continually.md
@@ -16,7 +16,7 @@ Better to fail fast.
 class MyTests : ShouldSpec() {
   init {
     should("pass for 60 seconds") {
-      continually(Duration.seconds(60)) {
+      continually(60.seconds) {
         // code here that should succeed and continue to succeed for 60 seconds
       }
     }
@@ -30,7 +30,7 @@ The function passed to the `continually` block is executed every 10 milliseconds
 class MyTests: ShouldSpec() {
   init {
     should("pass for 60 seconds") {
-      continually(Duration.seconds(60), Duration.seconds(5)) {
+      continually(60.seconds, 5.seconds) {
         // code here that should succeed and continue to succeed for 60 seconds
       }
     }


### PR DESCRIPTION
Reverts kotest/kotest#2586

Since the API has been undeprecated..