### PR TITLE
Update docs building gh action to use node 14.x

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
          -  uses: actions/checkout@v2
          -  uses: actions/setup-node@v2
             with:
-               node-version: '12.x'
+               node-version: '14.x'
          -  name: Release to GitHub Pages
             env:
                USE_SSH: true


### PR DESCRIPTION
Looks like the current docusaurus requires node 14.x or above. Resulting in failure of doc generation.

 https://github.com/kotest/kotest/runs/4204467568?check_suite_focus=true