### PR TITLE
Remove accidentally nested Try

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngine.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/KotestEngine.kt
@@ -80,7 +80,7 @@ class KotestEngine(private val config: KotestEngineConfig) {
             }
          )
 
-      Try { submitAll(plan) }
+      submitAll(plan)
          .fold(
             { error ->
                log(error) { "KotestEngine: Error during submit all" }


### PR DESCRIPTION
`submitAll` returns a `Try`. When it was called the returned `Try` was nested
inside another `Try`.

The result is that a failure inside `submitAll` ended up as a
`Success<Failure<Unit>>`, and so the error handling never kicked in and the
failure was swallowed.