### PR TITLE
Output coroutine debugging

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -49,7 +49,6 @@ class TestCaseExecutor(
       val interceptors = listOfNotNull(
          TestFinishedInterceptor(listener),
          InvocationCountCheckInterceptor,
-         CoroutineDebugProbeInterceptor,
          SupervisorScopeInterceptor,
          if (platform == Platform.JVM) coroutineDispatcherFactoryInterceptor(defaultCoroutineDispatcherFactory) else null,
          if (platform == Platform.JVM) coroutineErrorCollectorInterceptor() else null,
@@ -64,6 +63,7 @@ class TestCaseExecutor(
          TestInvocationInterceptor(configuration.registry, timeMark),
          InvocationTimeoutInterceptor,
          if (platform == Platform.JVM && testCase.config.testCoroutineDispatcher) TestCoroutineDispatcherInterceptor() else null,
+         CoroutineDebugProbeInterceptor,
       )
 
       val innerExecute: suspend (TestCase, TestScope) -> TestResult = { tc, scope ->

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/concurrency/withDebugProbe.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/concurrency/withDebugProbe.kt
@@ -10,7 +10,12 @@ internal actual inline fun <T> withDebugProbe(f: () -> T): T {
       DebugProbes.sanitizeStackTraces = true
       DebugProbes.install()
       try {
-         f()
+         val t = f()
+         DebugProbes.dumpCoroutines()
+         t
+      } catch (t: Throwable) {
+         DebugProbes.dumpCoroutines()
+         throw t
       } catch (t: Throwable) {
          DebugProbes.dumpCoroutines()
          throw t

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/concurrency/withDebugProbe.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/concurrency/withDebugProbe.kt
@@ -16,9 +16,6 @@ internal actual inline fun <T> withDebugProbe(f: () -> T): T {
       } catch (t: Throwable) {
          DebugProbes.dumpCoroutines()
          throw t
-      } catch (t: Throwable) {
-         DebugProbes.dumpCoroutines()
-         throw t
       } finally {
          DebugProbes.uninstall()
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/concurrency/withDebugProbe.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/concurrency/withDebugProbe.kt
@@ -5,12 +5,15 @@ import kotlinx.coroutines.debug.DebugProbes
 
 @ExperimentalCoroutinesApi
 internal actual inline fun <T> withDebugProbe(f: () -> T): T {
-   DebugProbes.enableCreationStackTraces = false
-   DebugProbes.sanitizeStackTraces = true
    return if (!DebugProbes.isInstalled) {
+      DebugProbes.enableCreationStackTraces = true
+      DebugProbes.sanitizeStackTraces = true
       DebugProbes.install()
       try {
          f()
+      } catch (t: Throwable) {
+         DebugProbes.dumpCoroutines()
+         throw t
       } finally {
          DebugProbes.uninstall()
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
@@ -24,7 +24,7 @@ class CoroutineDebugTest : FunSpec() {
                .launch()
                .errors.shouldBeEmpty()
          }
-         output shouldContain "Coroutine DeferredCoroutine"
+         output shouldContain "DeferredCoroutine"
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.kotest.engine.coroutines
+
+import io.kotest.core.config.ProjectConfiguration
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.extensions.system.captureStandardOut
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+
+class CoroutineDebugTest : FunSpec() {
+   init {
+      test("coroutine debug should dump coroutine stacks on error") {
+
+         val c = ProjectConfiguration()
+         c.coroutineDebugProbes = true
+
+         val output = captureStandardOut {
+            TestEngineLauncher(NoopTestEngineListener)
+               .withClasses(Wibble::class)
+               .withConfiguration(c)
+               .launch()
+               .errors.shouldBeEmpty()
+         }
+         output shouldContain "Coroutine DeferredCoroutine"
+      }
+   }
+}
+
+private class Wibble : FunSpec() {
+   init {
+      coroutineDebugProbes = true
+      test("a") {
+         val deferred = async { delay(1000) }
+         error("qwe")
+      }
+   }
+}

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/WordSpecEngineKitTest.kt
@@ -104,7 +104,7 @@ class WordSpecEngineKitTest : FunSpec({
    }
 })
 
-class WordSpecSample : WordSpec({
+private class WordSpecSample : WordSpec({
 
    "a container" should {
       "skip a test".config(enabled = false) {}


### PR DESCRIPTION
This dumps the coroutines on an exception automatically, in addition moves the debug lambda further down the test executor stack so it picks up all exceptions.

Closes #2680