### PR TITLE
Feature/2656 inspectors for maps #2656

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/CollectionInspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/CollectionInspectorsTest.kt
@@ -1,0 +1,500 @@
+package com.sksamuel.kotest.inspectors
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.inspectors.forAny
+import io.kotest.inspectors.forAtLeastOne
+import io.kotest.inspectors.forAtMostOne
+import io.kotest.inspectors.forExactly
+import io.kotest.inspectors.forNone
+import io.kotest.inspectors.forOne
+import io.kotest.inspectors.forSome
+import io.kotest.matchers.comparables.beGreaterThan
+import io.kotest.matchers.comparables.beLessThan
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+@Suppress("ConstantConditionIf")
+class CollectionInspectorsTest : WordSpec() {
+
+   private val list = listOf(1, 2, 3, 4, 5)
+   private val array = arrayOf(1, 2, 3, 4, 5)
+
+   data class DummyEntry(
+      val id: Int,
+      val name: String,
+   )
+
+   init {
+
+      "forAll" should {
+         "pass if all elements of an array pass" {
+            array.forAll {
+               it.shouldBeGreaterThan(0)
+            }
+         }
+         "pass if all elements of a collection pass" {
+            list.forAll {
+               it.shouldBeGreaterThan(0)
+            }
+         }
+         "return itself" {
+            array.forAll {
+               it.shouldBeGreaterThan(0)
+            }.forAll {
+               it.shouldBeGreaterThan(0)
+            }
+
+            list.forAll {
+               it.shouldBeGreaterThan(0)
+            }.forAll {
+               it.shouldBeGreaterThan(0)
+            }
+         }
+         "fail when an exception is thrown inside an array" {
+            shouldThrowAny {
+               array.forAll {
+                  if (true) throw NullPointerException()
+               }
+            }.message shouldBe "0 elements passed but expected 5\n" +
+               "\n" +
+               "The following elements passed:\n" +
+               "--none--\n" +
+               "\n" +
+               "The following elements failed:\n" +
+               "1 => java.lang.NullPointerException\n" +
+               "2 => java.lang.NullPointerException\n" +
+               "3 => java.lang.NullPointerException\n" +
+               "4 => java.lang.NullPointerException\n" +
+               "5 => java.lang.NullPointerException"
+         }
+         "fail when an exception is thrown inside a list" {
+            shouldThrowAny {
+               list.forAll {
+                  if (true) throw NullPointerException()
+               }
+            }.message shouldBe "0 elements passed but expected 5\n" +
+               "\n" +
+               "The following elements passed:\n" +
+               "--none--\n" +
+               "\n" +
+               "The following elements failed:\n" +
+               "1 => java.lang.NullPointerException\n" +
+               "2 => java.lang.NullPointerException\n" +
+               "3 => java.lang.NullPointerException\n" +
+               "4 => java.lang.NullPointerException\n" +
+               "5 => java.lang.NullPointerException"
+         }
+
+         "forNone" should {
+            "pass if no elements pass fn test for a list" {
+               list.forNone {
+                  it shouldBe 10
+               }
+            }
+            "pass if no elements pass fn test for an array" {
+               array.forNone {
+                  it shouldBe 10
+               }
+            }
+            "pass if an element throws an exception" {
+               val items = listOf(1, 2, 3)
+               items.forNone {
+                  if (true) throw NullPointerException()
+               }
+            }
+         }
+         "return itself" {
+            list.forNone {
+               it shouldBe 10
+            }.forNone {
+               it shouldBe 10
+            }
+            array.forNone {
+               it shouldBe 10
+            }.forNone {
+               it shouldBe 10
+            }
+         }
+         "fail if one elements passes fn test" {
+            shouldThrow<AssertionError> {
+               list.forNone {
+                  it shouldBe 4
+               }
+            }.message shouldBe """1 elements passed but expected 0
+
+The following elements passed:
+4
+
+The following elements failed:
+1 => expected:<4> but was:<1>
+2 => expected:<4> but was:<2>
+3 => expected:<4> but was:<3>
+5 => expected:<4> but was:<5>"""
+         }
+         "fail if all elements pass fn test" {
+            shouldThrow<AssertionError> {
+               list.forNone {
+                  it should beGreaterThan(0)
+               }
+            }.message shouldBe """5 elements passed but expected 0
+
+The following elements passed:
+1
+2
+3
+4
+5
+
+The following elements failed:
+--none--"""
+         }
+         "work inside assertSoftly block" {
+            val dummyEntries = listOf(
+               DummyEntry(id = 1, name = "first"),
+               DummyEntry(id = 2, name = "second"),
+            )
+
+            assertSoftly(dummyEntries) {
+               forNone {
+                  it.id shouldBe 3
+                  it.name shouldBe "third"
+               }
+            }
+         }
+
+         "forSome" should {
+            "pass if one elements pass test"  {
+               list.forSome {
+                  it shouldBe 3
+               }
+            }
+            "pass if size-1 elements pass test"  {
+               list.forSome {
+                  it should beGreaterThan(1)
+               }
+            }
+            "return itself" {
+               list.forSome {
+                  it shouldBe 3
+               }.forSome {
+                  it shouldBe 3
+               }
+
+               array.forSome {
+                  it shouldBe 3
+               }.forSome {
+                  it shouldBe 3
+               }
+            }
+            "fail if no elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forSome {
+                     it should beLessThan(0)
+                  }
+               }.message shouldBe """No elements passed but expected at least one
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1 => 1 should be < 0
+2 => 2 should be < 0
+3 => 3 should be < 0
+4 => 4 should be < 0
+5 => 5 should be < 0"""
+            }
+            "fail if all elements pass test"  {
+               shouldThrow<AssertionError> {
+                  list.forSome {
+                     it should beGreaterThan(0)
+                  }
+               }.message shouldBe """All elements passed but expected < 5
+
+The following elements passed:
+1
+2
+3
+4
+5
+
+The following elements failed:
+--none--"""
+            }
+            "work inside assertSoftly block" {
+               val dummyEntries = listOf(
+                  DummyEntry(id = 1, name = "first"),
+                  DummyEntry(id = 1, name = "first"),
+                  DummyEntry(id = 2, name = "second"),
+               )
+
+               assertSoftly(dummyEntries) {
+                  forSome {
+                     it.id shouldBe 1
+                     it.name shouldBe "first"
+                  }
+               }
+            }
+         }
+
+         "forOne" should {
+            "pass if one elements pass test"  {
+               list.forOne {
+                  it shouldBe 3
+               }
+            }
+            "return itself" {
+               list.forOne {
+                  it shouldBe 3
+               }.forOne {
+                  it shouldBe 3
+               }
+
+               array.forOne {
+                  it shouldBe 3
+               }.forOne {
+                  it shouldBe 3
+               }
+            }
+            "fail if > 1 elements pass test"  {
+               shouldThrow<AssertionError> {
+                  list.forOne {
+                     it should beGreaterThan(2)
+                  }
+               }.message shouldBe """3 elements passed but expected 1
+
+The following elements passed:
+3
+4
+5
+
+The following elements failed:
+1 => 1 should be > 2
+2 => 2 should be > 2"""
+            }
+            "fail if no elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forOne {
+                     it shouldBe 22
+                  }
+               }.message shouldBe """0 elements passed but expected 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1 => expected:<22> but was:<1>
+2 => expected:<22> but was:<2>
+3 => expected:<22> but was:<3>
+4 => expected:<22> but was:<4>
+5 => expected:<22> but was:<5>"""
+            }
+            "work inside assertSoftly block" {
+               val dummyEntries = listOf(
+                  DummyEntry(id = 1, name = "first"),
+                  DummyEntry(id = 2, name = "second"),
+               )
+
+               assertSoftly(dummyEntries) {
+                  forOne {
+                     it.id shouldBe 1
+                     it.name shouldBe "first"
+                  }
+               }
+            }
+         }
+
+         "forAny" should {
+            "pass if one elements pass test"  {
+               list.forAny {
+                  it shouldBe 3
+               }
+            }
+            "pass if at least elements pass test"  {
+               list.forAny {
+                  it should beGreaterThan(2)
+               }
+            }
+            "return itself" {
+               list.forAny {
+                  it shouldBe 3
+               }.forAny {
+                  it shouldBe 3
+               }
+
+               array.forAny {
+                  it shouldBe 3
+               }.forAny {
+                  it shouldBe 3
+               }
+            }
+            "fail if no elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forAny {
+                     it shouldBe 6
+                  }
+               }.message shouldBe """0 elements passed but expected at least 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1 => expected:<6> but was:<1>
+2 => expected:<6> but was:<2>
+3 => expected:<6> but was:<3>
+4 => expected:<6> but was:<4>
+5 => expected:<6> but was:<5>"""
+            }
+            "work inside assertSoftly block" {
+               val dummyEntries = listOf(
+                  DummyEntry(id = 1, name = "first"),
+                  DummyEntry(id = 2, name = "second"),
+               )
+
+               assertSoftly(dummyEntries) {
+                  forAny {
+                     it.id shouldBe 1
+                     it.name shouldBe "first"
+                  }
+               }
+            }
+         }
+
+         "forExactly" should {
+            "pass if exactly k elements pass"  {
+               list.forExactly(2) {
+                  it should beLessThan(3)
+               }
+            }
+            "fail if more elements pass test"  {
+               shouldThrow<AssertionError> {
+                  list.forExactly(2) {
+                     it should beGreaterThan(2)
+                  }
+               }.message shouldBe """3 elements passed but expected 2
+
+The following elements passed:
+3
+4
+5
+
+The following elements failed:
+1 => 1 should be > 2
+2 => 2 should be > 2"""
+            }
+            "fail if less elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forExactly(2) {
+                     it should beLessThan(2)
+                  }
+               }.message shouldBe """1 elements passed but expected 2
+
+The following elements passed:
+1
+
+The following elements failed:
+2 => 2 should be < 2
+3 => 3 should be < 2
+4 => 4 should be < 2
+5 => 5 should be < 2"""
+            }
+            "fail if no elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forExactly(2) {
+                     it shouldBe 33
+                  }
+               }.message shouldBe """0 elements passed but expected 2
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1 => expected:<33> but was:<1>
+2 => expected:<33> but was:<2>
+3 => expected:<33> but was:<3>
+4 => expected:<33> but was:<4>
+5 => expected:<33> but was:<5>"""
+            }
+         }
+
+         "forAtMostOne" should {
+            "pass if one elements pass test"  {
+               list.forAtMostOne {
+                  it shouldBe 3
+               }
+            }
+            "fail if 2 elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forAtMostOne {
+                     it should beGreaterThan(3)
+                  }
+               }.message shouldBe """2 elements passed but expected at most 1
+
+The following elements passed:
+4
+5
+
+The following elements failed:
+1 => expected:<22> but was:<1>
+2 => expected:<22> but was:<2>
+3 => expected:<22> but was:<3>"""
+            }
+            "work inside assertSoftly block" {
+               val dummyEntries = listOf(
+                  DummyEntry(id = 1, name = "first"),
+                  DummyEntry(id = 2, name = "second"),
+               )
+
+               assertSoftly(dummyEntries) {
+                  forAtMostOne {
+                     it.id shouldBe 1
+                     it.name shouldBe "first"
+                  }
+               }
+            }
+         }
+
+         "forAtLeastOne" should {
+            "pass if one elements pass test"  {
+               list.forAtLeastOne {
+                  it shouldBe 3
+               }
+            }
+            "fail if no elements pass test"  {
+               shouldThrow<AssertionError> {
+                  array.forAtLeastOne {
+                     it shouldBe 22
+                  }
+               }.message shouldBe """0 elements passed but expected at least 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1 => expected:<22> but was:<1>
+2 => expected:<22> but was:<2>
+3 => expected:<22> but was:<3>
+4 => expected:<22> but was:<4>
+5 => expected:<22> but was:<5>"""
+            }
+            "work inside assertSoftly block" {
+               val dummyEntries = listOf(
+                  DummyEntry(id = 1, name = "first"),
+                  DummyEntry(id = 2, name = "second"),
+               )
+
+               assertSoftly(dummyEntries) {
+                  forAtLeastOne {
+                     it.id shouldBe 1
+                     it.name shouldBe "first"
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/InspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/InspectorsTest.kt
@@ -5,24 +5,39 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
+import io.kotest.inspectors.forAllKeys
+import io.kotest.inspectors.forAllValues
 import io.kotest.inspectors.forAny
+import io.kotest.inspectors.forAnyKey
+import io.kotest.inspectors.forAnyValue
 import io.kotest.inspectors.forAtLeastOne
 import io.kotest.inspectors.forAtMostOne
 import io.kotest.inspectors.forExactly
+import io.kotest.inspectors.forKeysExactly
 import io.kotest.inspectors.forNone
+import io.kotest.inspectors.forNoneKey
+import io.kotest.inspectors.forNoneValue
 import io.kotest.inspectors.forOne
+import io.kotest.inspectors.forOneKey
+import io.kotest.inspectors.forOneValue
 import io.kotest.inspectors.forSome
+import io.kotest.inspectors.forSomeKeys
+import io.kotest.inspectors.forSomeValues
+import io.kotest.inspectors.forValuesExactly
 import io.kotest.matchers.comparables.beGreaterThan
 import io.kotest.matchers.comparables.beLessThan
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 
 @Suppress("ConstantConditionIf")
 class InspectorsTest : WordSpec() {
 
    private val list = listOf(1, 2, 3, 4, 5)
    private val array = arrayOf(1, 2, 3, 4, 5)
+   private val map = mapOf(1 to "1", 2 to "2", 3 to "3", 4 to "4", 5 to "5")
 
    data class DummyEntry(
       val id: Int,
@@ -30,6 +45,36 @@ class InspectorsTest : WordSpec() {
    )
 
    init {
+
+      "forAllKeys" should {
+         "pass if all keys of a map pass" {
+            map.forAllKeys {
+               it.shouldBeGreaterThan(0)
+            }
+         }
+         "return itself" {
+            map.forAllKeys {
+               it.shouldBeGreaterThan(0)
+            }.forAllKeys {
+               it.shouldBeGreaterThan(0)
+            }
+         }
+      }
+
+      "forAllValues" should {
+         "pass if all values of a map pass" {
+            map.forAllValues {
+               it.toInt().shouldBeGreaterThan(0)
+            }
+         }
+         "return itself" {
+            map.forAllValues {
+               it.toInt().shouldBeGreaterThan(0)
+            }.forAllKeys {
+               it.toInt().shouldBeGreaterThan(0)
+            }
+         }
+      }
 
       "forAll" should {
          "pass if all elements of an array pass" {
@@ -40,6 +85,11 @@ class InspectorsTest : WordSpec() {
          "pass if all elements of a collection pass" {
             list.forAll {
                it.shouldBeGreaterThan(0)
+            }
+         }
+         "pass if all entries of a map pass" {
+            map.forAll {
+               it.key.shouldBe(it.value.toInt())
             }
          }
          "return itself" {
@@ -53,6 +103,12 @@ class InspectorsTest : WordSpec() {
                it.shouldBeGreaterThan(0)
             }.forAll {
                it.shouldBeGreaterThan(0)
+            }
+
+            map.forAll {
+               it.key.shouldBe(it.value.toInt())
+            }.forAll {
+               it.key.shouldBe(it.value.toInt())
             }
          }
          "fail when an exception is thrown inside an array" {
@@ -89,6 +145,53 @@ class InspectorsTest : WordSpec() {
                "4 => java.lang.NullPointerException\n" +
                "5 => java.lang.NullPointerException"
          }
+         "fail when an exception is thrown inside a map" {
+            shouldThrowAny {
+               map.forAll {
+                  if (true) throw NullPointerException()
+               }
+            }.message shouldBe "0 elements passed but expected 5\n" +
+               "\n" +
+               "The following elements passed:\n" +
+               "--none--\n" +
+               "\n" +
+               "The following elements failed:\n" +
+               "1=1 => java.lang.NullPointerException\n" +
+               "2=2 => java.lang.NullPointerException\n" +
+               "3=3 => java.lang.NullPointerException\n" +
+               "4=4 => java.lang.NullPointerException\n" +
+               "5=5 => java.lang.NullPointerException"
+         }
+      }
+
+      "forNoneKeys" should {
+         "pass if no keys pass fn test for a map"  {
+            map.forNoneKey {
+               it.shouldBeGreaterThan(10)
+            }
+         }
+         "return itself" {
+            map.forNoneKey {
+               it.shouldBeGreaterThan(10)
+            }.forNoneKey {
+               it.shouldBeGreaterThan(10)
+            }
+         }
+      }
+
+      "forNoneValues" should {
+         "pass if no values pass fn test for a map"  {
+            map.forNoneValue {
+               it.toInt().shouldBeGreaterThan(10)
+            }
+         }
+         "return itself" {
+            map.forNoneValue {
+               it.toInt().shouldBeGreaterThan(10)
+            }.forNoneValue {
+               it.toInt().shouldBeGreaterThan(10)
+            }
+         }
       }
 
       "forNone" should {
@@ -108,6 +211,16 @@ class InspectorsTest : WordSpec() {
                if (true) throw NullPointerException()
             }
          }
+         "pass if no entries of a map pass" {
+            map.forNone {
+               it shouldBe mapOf(10 to "10").entries.first()
+            }
+         }
+         "pass if an entry throws an exception" {
+            map.forNone {
+               if (true) throw NullPointerException()
+            }
+         }
          "return itself" {
             list.forNone {
                it shouldBe 10
@@ -118,6 +231,9 @@ class InspectorsTest : WordSpec() {
                it shouldBe 10
             }.forNone {
                it shouldBe 10
+            }
+            map.forNone {
+               it shouldBe mapOf(10 to "10").entries.first()
             }
          }
          "fail if one elements passes fn test" {
@@ -166,6 +282,77 @@ The following elements failed:
                }
             }
          }
+         "fail if one entry passes fn test" {
+            shouldThrow<AssertionError> {
+               map.forNone {
+                  it shouldBe mapOf(4 to "4").entries.first()
+               }
+            }.message shouldBe """1 elements passed but expected 0
+
+The following elements passed:
+4=4
+
+The following elements failed:
+1=1 => expected:<4=4> but was:<1=1>
+2=2 => expected:<4=4> but was:<2=2>
+3=3 => expected:<4=4> but was:<3=3>
+5=5 => expected:<4=4> but was:<5=5>"""
+         }
+         "fail if all entries pass fn test" {
+            shouldThrow<AssertionError> {
+               map.forNone {
+                  it.key shouldBe it.value.toInt()
+               }
+            }.message shouldBe """5 elements passed but expected 0
+
+The following elements passed:
+1=1
+2=2
+3=3
+4=4
+5=5
+
+The following elements failed:
+--none--"""
+         }
+         "work inside assertSoftly block (for map)" {
+            assertSoftly(map) {
+               forNone {
+                  it.key shouldBe 10
+                  it.value shouldBe "10"
+               }
+            }
+         }
+      }
+
+      "forSomeKeys" should {
+         "pass if one key pass fn test for a map"  {
+            map.forSomeKeys {
+               it shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forSomeKeys {
+               it shouldBe 1
+            }.forSomeKeys {
+               it shouldBe 1
+            }
+         }
+      }
+
+      "forSomeValues" should {
+         "pass if one value pass fn test for a map"  {
+            map.forSomeValues {
+               it.toInt() shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forSomeValues {
+               it.toInt() shouldBe 1
+            }.forSomeValues {
+               it.toInt() shouldBe 1
+            }
+         }
       }
 
       "forSome" should {
@@ -179,6 +366,11 @@ The following elements failed:
                it should beGreaterThan(1)
             }
          }
+         "pass if one entry pass test"  {
+            map.forSome {
+               it shouldBe mapOf(1 to "1").entries.first()
+            }
+         }
          "return itself" {
             list.forSome {
                it shouldBe 3
@@ -190,6 +382,12 @@ The following elements failed:
                it shouldBe 3
             }.forSome {
                it shouldBe 3
+            }
+
+            map.forSome {
+               it shouldBe mapOf(1 to "1").entries.first()
+            }.forSome {
+               it shouldBe mapOf(1 to "1").entries.first()
             }
          }
          "fail if no elements pass test"  {
@@ -240,12 +438,89 @@ The following elements failed:
                }
             }
          }
+         "fail if no entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forSome {
+                  it shouldBe mapOf(0 to "0").entries.first()
+               }
+            }.message shouldBe """No elements passed but expected at least one
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1=1 => expected:<0=0> but was:<1=1>
+2=2 => expected:<0=0> but was:<2=2>
+3=3 => expected:<0=0> but was:<3=3>
+4=4 => expected:<0=0> but was:<4=4>
+5=5 => expected:<0=0> but was:<5=5>"""
+         }
+         "fail if all entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forSome {
+                  it.key shouldBe it.value.toInt()
+               }
+            }.message shouldBe """All elements passed but expected < 5
+
+The following elements passed:
+1=1
+2=2
+3=3
+4=4
+5=5
+
+The following elements failed:
+--none--"""
+         }
+         "work inside assertSoftly block (for map)" {
+            assertSoftly(map) {
+               forSome {
+                  it.key shouldBe 1
+                  it.value shouldBe "1"
+               }
+            }
+         }
+      }
+
+      "forOneKey" should {
+         "pass if one key pass fn test for a map"  {
+            map.forOneKey {
+               it shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forOneKey {
+               it shouldBe 1
+            }.forOneKey {
+               it shouldBe 1
+            }
+         }
+      }
+
+      "forOneValue" should {
+         "pass if one value pass fn test for a map"  {
+            map.forOneValue {
+               it.toInt() shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forOneValue {
+               it.toInt() shouldBe 1
+            }.forOneValue {
+               it.toInt() shouldBe 1
+            }
+         }
       }
 
       "forOne" should {
          "pass if one elements pass test"  {
             list.forOne {
                it shouldBe 3
+            }
+         }
+         "pass if one entry pass test"  {
+            map.forOne {
+               it shouldBe mapOf(1 to "1").entries.first()
             }
          }
          "return itself" {
@@ -259,6 +534,12 @@ The following elements failed:
                it shouldBe 3
             }.forOne {
                it shouldBe 3
+            }
+
+            map.forOne {
+               it shouldBe mapOf(1 to "1").entries.first()
+            }.forOne {
+               it shouldBe mapOf(1 to "1").entries.first()
             }
          }
          "fail if > 1 elements pass test"  {
@@ -307,6 +588,77 @@ The following elements failed:
                }
             }
          }
+         "fail if > 1 entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forOne {
+                  mapOf(3 to "3", 4 to "4", 5 to "5").shouldContain(it.toPair())
+               }
+            }.message shouldBe """3 elements passed but expected 1
+
+The following elements passed:
+3=3
+4=4
+5=5
+
+The following elements failed:
+1=1 => Map should contain mapping 1=1 but was {3=3, 4=4, 5=5}
+2=2 => Map should contain mapping 2=2 but was {3=3, 4=4, 5=5}"""
+         }
+         "fail if no entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forOne {
+                  it shouldBe mapOf(22 to "22").entries.first()
+               }
+            }.message shouldBe """0 elements passed but expected 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1=1 => expected:<22=22> but was:<1=1>
+2=2 => expected:<22=22> but was:<2=2>
+3=3 => expected:<22=22> but was:<3=3>
+4=4 => expected:<22=22> but was:<4=4>
+5=5 => expected:<22=22> but was:<5=5>"""
+         }
+         "work inside assertSoftly block (for map)" {
+            assertSoftly(map) {
+               forOne {
+                  it.key shouldBe 1
+                  it.value shouldBe "1"
+               }
+            }
+         }
+      }
+
+      "forAnyKey" should {
+         "pass if one key pass fn test for a map"  {
+            map.forAnyKey {
+               it shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forAnyKey {
+               it shouldBe 1
+            }.forAnyKey {
+               it shouldBe 1
+            }
+         }
+      }
+
+      "forAnyValue" should {
+         "pass if one value pass fn test for a map"  {
+            map.forAnyValue {
+               it.toInt() shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forAnyValue {
+               it.toInt() shouldBe 1
+            }.forAnyValue {
+               it.toInt() shouldBe 1
+            }
+         }
       }
 
       "forAny" should {
@@ -320,6 +672,11 @@ The following elements failed:
                it should beGreaterThan(2)
             }
          }
+         "pass if any entries pass test"  {
+            map.forAny {
+               mapOf(1 to "1", 2 to "2").shouldContain(it.toPair())
+            }
+         }
          "return itself" {
             list.forAny {
                it shouldBe 3
@@ -331,6 +688,12 @@ The following elements failed:
                it shouldBe 3
             }.forAny {
                it shouldBe 3
+            }
+
+            map.forAny {
+               mapOf(1 to "1", 2 to "2").shouldContain(it.toPair())
+            }.forAny {
+               mapOf(1 to "1", 2 to "2").shouldContain(it.toPair())
             }
          }
          "fail if no elements pass test"  {
@@ -363,12 +726,72 @@ The following elements failed:
                }
             }
          }
+         "fail if no entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forAny {
+                  it shouldBe mapOf(6 to "6").entries.first()
+               }
+            }.message shouldBe """0 elements passed but expected at least 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1=1 => expected:<6=6> but was:<1=1>
+2=2 => expected:<6=6> but was:<2=2>
+3=3 => expected:<6=6> but was:<3=3>
+4=4 => expected:<6=6> but was:<4=4>
+5=5 => expected:<6=6> but was:<5=5>"""
+         }
+         "work inside assertSoftly block (for map)" {
+            assertSoftly(map) {
+               forAny {
+                  it.key shouldBe 1
+                  it.value shouldBe "1"
+               }
+            }
+         }
       }
+      "forKeysExactly" should {
+         "pass if one key pass fn test for a map"  {
+            map.forKeysExactly(1) {
+               it shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forKeysExactly(1) {
+               it shouldBe 1
+            }.forKeysExactly(1) {
+               it shouldBe 1
+            }
+         }
+      }
+
+      "forValuesExactly" should {
+         "pass if one value pass fn test for a map"  {
+            map.forValuesExactly(1) {
+               it.toInt() shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forValuesExactly(1) {
+               it.toInt() shouldBe 1
+            }.forValuesExactly(1) {
+               it.toInt() shouldBe 1
+            }
+         }
+      }
+
 
       "forExactly" should {
          "pass if exactly k elements pass"  {
             list.forExactly(2) {
                it should beLessThan(3)
+            }
+         }
+         "pass if exactly k entries pass"  {
+            map.forExactly(4) {
+               it shouldNotBe mapOf(1 to "1").entries.first()
             }
          }
          "fail if more elements pass test"  {
@@ -420,6 +843,55 @@ The following elements failed:
 4 => expected:<33> but was:<4>
 5 => expected:<33> but was:<5>"""
          }
+         "fail if more entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forExactly(3) {
+                  it shouldNotBe mapOf(1 to "1").entries.first()
+               }
+            }.message shouldBe """4 elements passed but expected 3
+
+The following elements passed:
+2=2
+3=3
+4=4
+5=5
+
+The following elements failed:
+1=1 => 1=1 should not equal 1=1"""
+         }
+         "fail if less entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forExactly(5) {
+                  it shouldNotBe mapOf(1 to "1").entries.first()
+               }
+            }.message shouldBe """4 elements passed but expected 5
+
+The following elements passed:
+2=2
+3=3
+4=4
+5=5
+
+The following elements failed:
+1=1 => 1=1 should not equal 1=1"""
+         }
+         "fail if no entries pass test"  {
+            shouldThrow<AssertionError> {
+               map.forExactly(1) {
+                  it shouldBe mapOf(10 to "10").entries.first()
+               }
+            }.message shouldBe """0 elements passed but expected 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1=1 => expected:<10=10> but was:<1=1>
+2=2 => expected:<10=10> but was:<2=2>
+3=3 => expected:<10=10> but was:<3=3>
+4=4 => expected:<10=10> but was:<4=4>
+5=5 => expected:<10=10> but was:<5=5>"""
+         }
       }
 
       "forAtMostOnce" should {
@@ -436,6 +908,14 @@ The following elements failed:
                }
             }
          }
+         "work inside assertSoftly block (for map)" {
+            assertSoftly(map) {
+               forAtMostOne {
+                  it.key shouldBe 1
+                  it.value shouldBe "1"
+               }
+            }
+         }
       }
 
       "forAtLeastOne" should {
@@ -449,6 +929,14 @@ The following elements failed:
                forAtLeastOne {
                   it.id shouldBe 1
                   it.name shouldBe "first"
+               }
+            }
+         }
+         "work inside assertSoftly block (for map)" {
+            assertSoftly(map) {
+               forAtLeastOne {
+                  it.key shouldBe 1
+                  it.value shouldBe "1"
                }
             }
          }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
@@ -63,7 +63,7 @@ class MapInspectorsTest : WordSpec() {
          "return itself" {
             map.forAllValues {
                it.toInt().shouldBeGreaterThan(0)
-            }.forAllKeys {
+            }.forAllValues {
                it.toInt().shouldBeGreaterThan(0)
             }
          }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
@@ -24,25 +24,14 @@ import io.kotest.inspectors.forSome
 import io.kotest.inspectors.forSomeKeys
 import io.kotest.inspectors.forSomeValues
 import io.kotest.inspectors.forValuesExactly
-import io.kotest.matchers.comparables.beGreaterThan
-import io.kotest.matchers.comparables.beLessThan
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.maps.shouldContain
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
 @Suppress("ConstantConditionIf")
-class InspectorsTest : WordSpec() {
-
-   private val list = listOf(1, 2, 3, 4, 5)
-   private val array = arrayOf(1, 2, 3, 4, 5)
+class MapInspectorsTest : WordSpec() {
    private val map = mapOf(1 to "1", 2 to "2", 3 to "3", 4 to "4", 5 to "5")
-
-   data class DummyEntry(
-      val id: Int,
-      val name: String,
-   )
 
    init {
 
@@ -77,73 +66,17 @@ class InspectorsTest : WordSpec() {
       }
 
       "forAll" should {
-         "pass if all elements of an array pass" {
-            array.forAll {
-               it.shouldBeGreaterThan(0)
-            }
-         }
-         "pass if all elements of a collection pass" {
-            list.forAll {
-               it.shouldBeGreaterThan(0)
-            }
-         }
          "pass if all entries of a map pass" {
             map.forAll {
                it.key.shouldBe(it.value.toInt())
             }
          }
          "return itself" {
-            array.forAll {
-               it.shouldBeGreaterThan(0)
-            }.forAll {
-               it.shouldBeGreaterThan(0)
-            }
-
-            list.forAll {
-               it.shouldBeGreaterThan(0)
-            }.forAll {
-               it.shouldBeGreaterThan(0)
-            }
-
             map.forAll {
                it.key.shouldBe(it.value.toInt())
             }.forAll {
                it.key.shouldBe(it.value.toInt())
             }
-         }
-         "fail when an exception is thrown inside an array" {
-            shouldThrowAny {
-               array.forAll {
-                  if (true) throw NullPointerException()
-               }
-            }.message shouldBe "0 elements passed but expected 5\n" +
-               "\n" +
-               "The following elements passed:\n" +
-               "--none--\n" +
-               "\n" +
-               "The following elements failed:\n" +
-               "1 => java.lang.NullPointerException\n" +
-               "2 => java.lang.NullPointerException\n" +
-               "3 => java.lang.NullPointerException\n" +
-               "4 => java.lang.NullPointerException\n" +
-               "5 => java.lang.NullPointerException"
-         }
-         "fail when an exception is thrown inside a list" {
-            shouldThrowAny {
-               list.forAll {
-                  if (true) throw NullPointerException()
-               }
-            }.message shouldBe "0 elements passed but expected 5\n" +
-               "\n" +
-               "The following elements passed:\n" +
-               "--none--\n" +
-               "\n" +
-               "The following elements failed:\n" +
-               "1 => java.lang.NullPointerException\n" +
-               "2 => java.lang.NullPointerException\n" +
-               "3 => java.lang.NullPointerException\n" +
-               "4 => java.lang.NullPointerException\n" +
-               "5 => java.lang.NullPointerException"
          }
          "fail when an exception is thrown inside a map" {
             shouldThrowAny {
@@ -195,22 +128,6 @@ class InspectorsTest : WordSpec() {
       }
 
       "forNone" should {
-         "pass if no elements pass fn test for a list" {
-            list.forNone {
-               it shouldBe 10
-            }
-         }
-         "pass if no elements pass fn test for an array" {
-            array.forNone {
-               it shouldBe 10
-            }
-         }
-         "pass if an element throws an exception" {
-            val items = listOf(1, 2, 3)
-            items.forNone {
-               if (true) throw NullPointerException()
-            }
-         }
          "pass if no entries of a map pass" {
             map.forNone {
                it shouldBe mapOf(10 to "10").entries.first()
@@ -222,64 +139,10 @@ class InspectorsTest : WordSpec() {
             }
          }
          "return itself" {
-            list.forNone {
-               it shouldBe 10
-            }.forNone {
-               it shouldBe 10
-            }
-            array.forNone {
-               it shouldBe 10
-            }.forNone {
-               it shouldBe 10
-            }
             map.forNone {
                it shouldBe mapOf(10 to "10").entries.first()
-            }
-         }
-         "fail if one elements passes fn test" {
-            shouldThrow<AssertionError> {
-               list.forNone {
-                  it shouldBe 4
-               }
-            }.message shouldBe """1 elements passed but expected 0
-
-The following elements passed:
-4
-
-The following elements failed:
-1 => expected:<4> but was:<1>
-2 => expected:<4> but was:<2>
-3 => expected:<4> but was:<3>
-5 => expected:<4> but was:<5>"""
-         }
-         "fail if all elements pass fn test" {
-            shouldThrow<AssertionError> {
-               list.forNone {
-                  it should beGreaterThan(0)
-               }
-            }.message shouldBe """5 elements passed but expected 0
-
-The following elements passed:
-1
-2
-3
-4
-5
-
-The following elements failed:
---none--"""
-         }
-         "work inside assertSoftly block" {
-            val dummyEntries = listOf(
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 2, name = "second"),
-            )
-
-            assertSoftly(dummyEntries) {
-               forNone {
-                  it.id shouldBe 3
-                  it.name shouldBe "third"
-               }
+            }.forNone {
+               it shouldBe mapOf(10 to "10").entries.first()
             }
          }
          "fail if one entry passes fn test" {
@@ -356,86 +219,16 @@ The following elements failed:
       }
 
       "forSome" should {
-         "pass if one elements pass test"  {
-            list.forSome {
-               it shouldBe 3
-            }
-         }
-         "pass if size-1 elements pass test"  {
-            list.forSome {
-               it should beGreaterThan(1)
-            }
-         }
          "pass if one entry pass test"  {
             map.forSome {
                it shouldBe mapOf(1 to "1").entries.first()
             }
          }
          "return itself" {
-            list.forSome {
-               it shouldBe 3
-            }.forSome {
-               it shouldBe 3
-            }
-
-            array.forSome {
-               it shouldBe 3
-            }.forSome {
-               it shouldBe 3
-            }
-
             map.forSome {
                it shouldBe mapOf(1 to "1").entries.first()
             }.forSome {
                it shouldBe mapOf(1 to "1").entries.first()
-            }
-         }
-         "fail if no elements pass test"  {
-            shouldThrow<AssertionError> {
-               array.forSome {
-                  it should beLessThan(0)
-               }
-            }.message shouldBe """No elements passed but expected at least one
-
-The following elements passed:
---none--
-
-The following elements failed:
-1 => 1 should be < 0
-2 => 2 should be < 0
-3 => 3 should be < 0
-4 => 4 should be < 0
-5 => 5 should be < 0"""
-         }
-         "fail if all elements pass test"  {
-            shouldThrow<AssertionError> {
-               list.forSome {
-                  it should beGreaterThan(0)
-               }
-            }.message shouldBe """All elements passed but expected < 5
-
-The following elements passed:
-1
-2
-3
-4
-5
-
-The following elements failed:
---none--"""
-         }
-         "work inside assertSoftly block" {
-            val dummyEntries = listOf(
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 2, name = "second"),
-            )
-
-            assertSoftly(dummyEntries) {
-               forSome {
-                  it.id shouldBe 1
-                  it.name shouldBe "first"
-               }
             }
          }
          "fail if no entries pass test"  {
@@ -513,79 +306,16 @@ The following elements failed:
       }
 
       "forOne" should {
-         "pass if one elements pass test"  {
-            list.forOne {
-               it shouldBe 3
-            }
-         }
          "pass if one entry pass test"  {
             map.forOne {
                it shouldBe mapOf(1 to "1").entries.first()
             }
          }
          "return itself" {
-            list.forOne {
-               it shouldBe 3
-            }.forOne {
-               it shouldBe 3
-            }
-
-            array.forOne {
-               it shouldBe 3
-            }.forOne {
-               it shouldBe 3
-            }
-
             map.forOne {
                it shouldBe mapOf(1 to "1").entries.first()
             }.forOne {
                it shouldBe mapOf(1 to "1").entries.first()
-            }
-         }
-         "fail if > 1 elements pass test"  {
-            shouldThrow<AssertionError> {
-               list.forOne {
-                  it should beGreaterThan(2)
-               }
-            }.message shouldBe """3 elements passed but expected 1
-
-The following elements passed:
-3
-4
-5
-
-The following elements failed:
-1 => 1 should be > 2
-2 => 2 should be > 2"""
-         }
-         "fail if no elements pass test"  {
-            shouldThrow<AssertionError> {
-               array.forOne {
-                  it shouldBe 22
-               }
-            }.message shouldBe """0 elements passed but expected 1
-
-The following elements passed:
---none--
-
-The following elements failed:
-1 => expected:<22> but was:<1>
-2 => expected:<22> but was:<2>
-3 => expected:<22> but was:<3>
-4 => expected:<22> but was:<4>
-5 => expected:<22> but was:<5>"""
-         }
-         "work inside assertSoftly block" {
-            val dummyEntries = listOf(
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 2, name = "second"),
-            )
-
-            assertSoftly(dummyEntries) {
-               forOne {
-                  it.id shouldBe 1
-                  it.name shouldBe "first"
-               }
             }
          }
          "fail if > 1 entries pass test"  {
@@ -662,68 +392,16 @@ The following elements failed:
       }
 
       "forAny" should {
-         "pass if one elements pass test"  {
-            list.forAny {
-               it shouldBe 3
-            }
-         }
-         "pass if at least elements pass test"  {
-            list.forAny {
-               it should beGreaterThan(2)
-            }
-         }
          "pass if any entries pass test"  {
             map.forAny {
                mapOf(1 to "1", 2 to "2").shouldContain(it.toPair())
             }
          }
          "return itself" {
-            list.forAny {
-               it shouldBe 3
-            }.forAny {
-               it shouldBe 3
-            }
-
-            array.forAny {
-               it shouldBe 3
-            }.forAny {
-               it shouldBe 3
-            }
-
             map.forAny {
                mapOf(1 to "1", 2 to "2").shouldContain(it.toPair())
             }.forAny {
                mapOf(1 to "1", 2 to "2").shouldContain(it.toPair())
-            }
-         }
-         "fail if no elements pass test"  {
-            shouldThrow<AssertionError> {
-               array.forAny {
-                  it shouldBe 6
-               }
-            }.message shouldBe """0 elements passed but expected at least 1
-
-The following elements passed:
---none--
-
-The following elements failed:
-1 => expected:<6> but was:<1>
-2 => expected:<6> but was:<2>
-3 => expected:<6> but was:<3>
-4 => expected:<6> but was:<4>
-5 => expected:<6> but was:<5>"""
-         }
-         "work inside assertSoftly block" {
-            val dummyEntries = listOf(
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 2, name = "second"),
-            )
-
-            assertSoftly(dummyEntries) {
-               forAny {
-                  it.id shouldBe 1
-                  it.name shouldBe "first"
-               }
             }
          }
          "fail if no entries pass test"  {
@@ -784,64 +462,10 @@ The following elements failed:
 
 
       "forExactly" should {
-         "pass if exactly k elements pass"  {
-            list.forExactly(2) {
-               it should beLessThan(3)
-            }
-         }
          "pass if exactly k entries pass"  {
             map.forExactly(4) {
                it shouldNotBe mapOf(1 to "1").entries.first()
             }
-         }
-         "fail if more elements pass test"  {
-            shouldThrow<AssertionError> {
-               list.forExactly(2) {
-                  it should beGreaterThan(2)
-               }
-            }.message shouldBe """3 elements passed but expected 2
-
-The following elements passed:
-3
-4
-5
-
-The following elements failed:
-1 => 1 should be > 2
-2 => 2 should be > 2"""
-         }
-         "fail if less elements pass test"  {
-            shouldThrow<AssertionError> {
-               array.forExactly(2) {
-                  it should beLessThan(2)
-               }
-            }.message shouldBe """1 elements passed but expected 2
-
-The following elements passed:
-1
-
-The following elements failed:
-2 => 2 should be < 2
-3 => 3 should be < 2
-4 => 4 should be < 2
-5 => 5 should be < 2"""
-         }
-         "fail if no elements pass test"  {
-            shouldThrow<AssertionError> {
-               array.forExactly(2) {
-                  it shouldBe 33
-               }
-            }.message shouldBe """0 elements passed but expected 2
-
-The following elements passed:
---none--
-
-The following elements failed:
-1 => expected:<33> but was:<1>
-2 => expected:<33> but was:<2>
-3 => expected:<33> but was:<3>
-4 => expected:<33> but was:<4>
-5 => expected:<33> but was:<5>"""
          }
          "fail if more entries pass test"  {
             shouldThrow<AssertionError> {
@@ -894,19 +518,27 @@ The following elements failed:
          }
       }
 
-      "forAtMostOnce" should {
-         "work inside assertSoftly block" {
-            val dummyEntries = listOf(
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 2, name = "second"),
-            )
-
-            assertSoftly(dummyEntries) {
-               forAtMostOne {
-                  it.id shouldBe 1
-                  it.name shouldBe "first"
-               }
+      "forAtMostOne" should {
+         "pass if one elements pass test"  {
+            map.forAtMostOne {
+               it shouldBe mapOf(3 to "3")
             }
+         }
+         "fail if 2 elements pass test"  {
+            shouldThrow<AssertionError> {
+               map.forAtMostOne {
+                  mapOf(4 to "4", 5 to "5").shouldContain(it.toPair())
+               }
+            }.message shouldBe """2 elements passed but expected at most 1
+
+The following elements passed:
+4=4
+5=5
+
+The following elements failed:
+1=1 => Map should contain mapping 1=1 but was {4=4, 5=5}
+2=2 => Map should contain mapping 2=2 but was {4=4, 5=5}
+3=3 => Map should contain mapping 3=3 but was {4=4, 5=5}"""
          }
          "work inside assertSoftly block (for map)" {
             assertSoftly(map) {
@@ -919,18 +551,27 @@ The following elements failed:
       }
 
       "forAtLeastOne" should {
-         "work inside assertSoftly block" {
-            val dummyEntries = listOf(
-               DummyEntry(id = 1, name = "first"),
-               DummyEntry(id = 2, name = "second"),
-            )
-
-            assertSoftly(dummyEntries) {
-               forAtLeastOne {
-                  it.id shouldBe 1
-                  it.name shouldBe "first"
-               }
+         "pass if one elements pass test"  {
+            map.forAtLeastOne {
+               it shouldBe mapOf(3 to "3").entries.first()
             }
+         }
+         "fail if no elements pass test"  {
+            shouldThrow<AssertionError> {
+               map.forAtLeastOne {
+                  it shouldBe mapOf(22 to "22").entries.first()
+               }
+            }.message shouldBe """0 elements passed but expected at least 1
+
+The following elements passed:
+--none--
+
+The following elements failed:
+1=1 => expected:<22=22> but was:<1=1>
+2=2 => expected:<22=22> but was:<2=2>
+3=3 => expected:<22=22> but was:<3=3>
+4=4 => expected:<22=22> but was:<4=4>
+5=5 => expected:<22=22> but was:<5=5>"""
          }
          "work inside assertSoftly block (for map)" {
             assertSoftly(map) {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
@@ -11,7 +11,11 @@ import io.kotest.inspectors.forAny
 import io.kotest.inspectors.forAnyKey
 import io.kotest.inspectors.forAnyValue
 import io.kotest.inspectors.forAtLeastOne
+import io.kotest.inspectors.forAtLeastOneKey
+import io.kotest.inspectors.forAtLeastOneValue
 import io.kotest.inspectors.forAtMostOne
+import io.kotest.inspectors.forAtMostOneKey
+import io.kotest.inspectors.forAtMostOneValue
 import io.kotest.inspectors.forExactly
 import io.kotest.inspectors.forKeysExactly
 import io.kotest.inspectors.forNone
@@ -518,6 +522,36 @@ The following elements failed:
          }
       }
 
+      "forAtMostOneKey" should {
+         "pass if one key pass fn test for a map"  {
+            map.forAtMostOneKey {
+               it shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forAtMostOneKey {
+               it shouldBe 1
+            }.forAtMostOneKey {
+               it shouldBe 1
+            }
+         }
+      }
+
+      "forAtMostOneValue" should {
+         "pass if one value pass fn test for a map"  {
+            map.forAtMostOneValue {
+               it.toInt() shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forAtMostOneValue {
+               it.toInt() shouldBe 1
+            }.forAtMostOneValue {
+               it.toInt() shouldBe 1
+            }
+         }
+      }
+
       "forAtMostOne" should {
          "pass if one elements pass test"  {
             map.forAtMostOne {
@@ -549,6 +583,37 @@ The following elements failed:
             }
          }
       }
+
+      "forAtLeastOneKey" should {
+         "pass if one key pass fn test for a map"  {
+            map.forAtLeastOneKey {
+               it shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forAtLeastOneKey {
+               it shouldBe 1
+            }.forAtLeastOneKey {
+               it shouldBe 1
+            }
+         }
+      }
+
+      "forAtLeastOneValue" should {
+         "pass if one value pass fn test for a map"  {
+            map.forAtLeastOneValue {
+               it.toInt() shouldBe 1
+            }
+         }
+         "return itself" {
+            map.forAtLeastOneValue {
+               it.toInt() shouldBe 1
+            }.forAtLeastOneValue {
+               it.toInt() shouldBe 1
+            }
+         }
+      }
+
 
       "forAtLeastOne" should {
          "pass if one elements pass test"  {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/Inspectors.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/Inspectors.kt
@@ -1,5 +1,16 @@
 package io.kotest.inspectors
 
+inline fun <K, V, C : Map<K, V>> C.forAllValues(fn: (V) -> Unit): C = apply { values.forAll(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAllKeys(fn: (K) -> Unit): C = apply { keys.forAll(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAll(fn: (Map.Entry<K, V>) -> Unit): C = apply {
+   val results = runTests(this, fn)
+   val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
+   if (passed.size < this.size) {
+      val msg = "${passed.size} elements passed but expected ${this.size}"
+      buildAssertionError(msg, results)
+   }
+}
+
 inline fun <T> Sequence<T>.forAll(fn: (T) -> Unit): Sequence<T> = apply { toList().forAll(fn) }
 inline fun <T> Array<T>.forAll(fn: (T) -> Unit): Array<T> = apply { asList().forAll(fn) }
 inline fun <T, C : Collection<T>> C.forAll(fn: (T) -> Unit): C = apply {
@@ -15,6 +26,17 @@ inline fun <T> Sequence<T>.forOne(fn: (T) -> Unit): Sequence<T> = apply { toList
 inline fun <T> Array<T>.forOne(fn: (T) -> Unit): Array<T> = apply { asList().forOne(fn) }
 inline fun <T, C : Collection<T>> C.forOne(fn: (T) -> Unit): C = forExactly(1, fn)
 
+inline fun <K, V, C : Map<K, V>> C.forValuesExactly(k: Int, fn: (V) -> Unit): C = apply { values.forExactly(k, fn) }
+inline fun <K, V, C : Map<K, V>> C.forKeysExactly(k: Int, fn: (K) -> Unit): C = apply { keys.forExactly(k, fn) }
+inline fun <K, V, C : Map<K, V>> C.forExactly(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
+   val results = runTests(this, fn)
+   val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
+   if (passed.size != k) {
+      val msg = "${passed.size} elements passed but expected $k"
+      buildAssertionError(msg, results)
+   }
+}
+
 inline fun <T> Sequence<T>.forExactly(k: Int, fn: (T) -> Unit): Sequence<T> = apply { toList().forExactly(k, fn) }
 inline fun <T> Array<T>.forExactly(k: Int, fn: (T) -> Unit): Array<T> = apply { toList().forExactly(k, fn) }
 inline fun <T, C : Collection<T>> C.forExactly(k: Int, fn: (T) -> Unit): C = apply {
@@ -23,6 +45,18 @@ inline fun <T, C : Collection<T>> C.forExactly(k: Int, fn: (T) -> Unit): C = app
    if (passed.size != k) {
       val msg = "${passed.size} elements passed but expected $k"
       buildAssertionError(msg, results)
+   }
+}
+
+inline fun <K, V, C : Map<K, V>> C.forSomeValues(fn: (V) -> Unit): C = apply { values.forSome(fn) }
+inline fun <K, V, C : Map<K, V>> C.forSomeKeys(fn: (K) -> Unit): C = apply { keys.forSome(fn) }
+inline fun <K, V, C : Map<K, V>> C.forSome(fn: (Map.Entry<K, V>) -> Unit): C = apply {
+   val results = runTests(this, fn)
+   val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
+   if (passed.isEmpty()) {
+      buildAssertionError("No elements passed but expected at least one", results)
+   } else if (passed.size == size) {
+      buildAssertionError("All elements passed but expected < $size", results)
    }
 }
 
@@ -38,13 +72,30 @@ inline fun <T, C : Collection<T>> C.forSome(fn: (T) -> Unit): C = apply {
    }
 }
 
+inline fun <K, V, C : Map<K, V>> C.forAnyValues(fn: (V) -> Unit): C = apply { values.forAny(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAnyKeys(fn: (K) -> Unit): C = apply { keys.forAny(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAny(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtLeastOne(fn) }
 inline fun <T> Sequence<T>.forAny(fn: (T) -> Unit): Sequence<T> = apply { toList().forAny(fn) }
 inline fun <T> Array<T>.forAny(fn: (T) -> Unit): Array<T> = apply { toList().forAny(fn) }
 inline fun <T, C : Collection<T>> C.forAny(fn: (T) -> Unit): C = apply { forAtLeastOne(fn) }
 
+inline fun <K, V, C : Map<K, V>> C.forAtLeastOneValue(fn: (V) -> Unit): C = apply { values.forAtLeastOne(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAtLeastOneKey(fn: (K) -> Unit): C = apply { keys.forAtLeastOne(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAtLeastOne(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtLeast(1, fn) }
 inline fun <T> Sequence<T>.forAtLeastOne(fn: (T) -> Unit): Sequence<T> = apply { toList().forAtLeastOne(fn) }
 inline fun <T> Array<T>.forAtLeastOne(fn: (T) -> Unit): Array<T> = apply { toList().forAtLeastOne(fn) }
 inline fun <T, C : Collection<T>> C.forAtLeastOne(f: (T) -> Unit) = forAtLeast(1, f)
+
+inline fun <K, V, C : Map<K, V>> C.forValuesAtLeast(k: Int, fn: (V) -> Unit): C = apply { values.forAtLeast(k, fn) }
+inline fun <K, V, C : Map<K, V>> C.forKeysAtLeast(k: Int, fn: (K) -> Unit): C = apply { keys.forAtLeast(k, fn) }
+inline fun <K, V, C : Map<K, V>> C.forAtLeast(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
+   val results = runTests(this, fn)
+   val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
+   if (passed.size < k) {
+      val msg = "${passed.size} elements passed but expected at least $k"
+      buildAssertionError(msg, results)
+   }
+}
 
 inline fun <T> Sequence<T>.forAtLeast(k: Int, fn: (T) -> Unit): Sequence<T> = apply { toList().forAtLeast(k, fn) }
 inline fun <T> Array<T>.forAtLeast(k: Int, fn: (T) -> Unit): Array<T> = apply { toList().forAtLeast(k, fn) }
@@ -57,9 +108,21 @@ inline fun <T, C : Collection<T>> C.forAtLeast(k: Int, fn: (T) -> Unit): C = app
    }
 }
 
+inline fun <K, V, C : Map<K, V>> C.forAtMostOneValue(fn: (V) -> Unit): C = apply { values.forAtMostOne(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAtMostOneKey(fn: (K) -> Unit): C = apply { keys.forAtMostOne(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAtMostOne(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtMost(1, fn) }
 inline fun <T> Sequence<T>.forAtMostOne(fn: (T) -> Unit): Sequence<T> = apply { toList().forAtMostOne(fn) }
 inline fun <T> Array<T>.forAtMostOne(fn: (T) -> Unit): Array<T> = apply { toList().forAtMostOne(fn) }
 inline fun <T, C : Collection<T>> C.forAtMostOne(fn: (T) -> Unit) = forAtMost(1, fn)
+
+inline fun <K, V, C : Map<K, V>> C.forAtMost(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
+   val results = runTests(this, fn)
+   val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
+   if (passed.size > k) {
+      val msg = "${passed.size} elements passed but expected at most $k"
+      buildAssertionError(msg, results)
+   }
+}
 
 inline fun <T> Sequence<T>.forAtMost(k: Int, fn: (T) -> Unit): Sequence<T> = apply { toList().forAtMost(k, fn) }
 inline fun <T> Array<T>.forAtMost(k: Int, fn: (T) -> Unit): Array<T> = apply { toList().forAtMost(k, fn) }
@@ -68,6 +131,15 @@ inline fun <T, C : Collection<T>> C.forAtMost(k: Int, fn: (T) -> Unit): C = appl
    val passed = results.filterIsInstance<ElementPass<T>>()
    if (passed.size > k) {
       val msg = "${passed.size} elements passed but expected at most $k"
+      buildAssertionError(msg, results)
+   }
+}
+
+inline fun <K, V, C : Map<K, V>> C.forNone(fn: (Map.Entry<K, V>) -> Unit): C = apply {
+   val results = runTests(this, fn)
+   val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
+   if (passed.isNotEmpty()) {
+      val msg = "${passed.size} elements passed but expected ${0}"
       buildAssertionError(msg, results)
    }
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/Inspectors.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/Inspectors.kt
@@ -22,6 +22,10 @@ inline fun <T, C : Collection<T>> C.forAll(fn: (T) -> Unit): C = apply {
    }
 }
 
+inline fun <K, V, C : Map<K, V>> C.forOneValue(fn: (V) -> Unit): C = apply { values.forExactly(1, fn) }
+inline fun <K, V, C : Map<K, V>> C.forOneKey(fn: (K) -> Unit): C = apply { keys.forExactly(1, fn) }
+inline fun <K, V, C : Map<K, V>> C.forOne(fn: (Map.Entry<K, V>) -> Unit): C = apply { forExactly(1, fn) }
+
 inline fun <T> Sequence<T>.forOne(fn: (T) -> Unit): Sequence<T> = apply { toList().forOne(fn) }
 inline fun <T> Array<T>.forOne(fn: (T) -> Unit): Array<T> = apply { asList().forOne(fn) }
 inline fun <T, C : Collection<T>> C.forOne(fn: (T) -> Unit): C = forExactly(1, fn)
@@ -72,8 +76,8 @@ inline fun <T, C : Collection<T>> C.forSome(fn: (T) -> Unit): C = apply {
    }
 }
 
-inline fun <K, V, C : Map<K, V>> C.forAnyValues(fn: (V) -> Unit): C = apply { values.forAny(fn) }
-inline fun <K, V, C : Map<K, V>> C.forAnyKeys(fn: (K) -> Unit): C = apply { keys.forAny(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAnyValue(fn: (V) -> Unit): C = apply { values.forAny(fn) }
+inline fun <K, V, C : Map<K, V>> C.forAnyKey(fn: (K) -> Unit): C = apply { keys.forAny(fn) }
 inline fun <K, V, C : Map<K, V>> C.forAny(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtLeastOne(fn) }
 inline fun <T> Sequence<T>.forAny(fn: (T) -> Unit): Sequence<T> = apply { toList().forAny(fn) }
 inline fun <T> Array<T>.forAny(fn: (T) -> Unit): Array<T> = apply { toList().forAny(fn) }
@@ -115,6 +119,8 @@ inline fun <T> Sequence<T>.forAtMostOne(fn: (T) -> Unit): Sequence<T> = apply { 
 inline fun <T> Array<T>.forAtMostOne(fn: (T) -> Unit): Array<T> = apply { toList().forAtMostOne(fn) }
 inline fun <T, C : Collection<T>> C.forAtMostOne(fn: (T) -> Unit) = forAtMost(1, fn)
 
+inline fun <K, V, C : Map<K, V>> C.forValuesAtMost(k: Int, fn: (V) -> Unit): C = apply { values.forAtMost(k, fn) }
+inline fun <K, V, C : Map<K, V>> C.forKeysAtMost(k: Int, fn: (K) -> Unit): C = apply { keys.forAtMost(k, fn) }
 inline fun <K, V, C : Map<K, V>> C.forAtMost(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -135,6 +141,8 @@ inline fun <T, C : Collection<T>> C.forAtMost(k: Int, fn: (T) -> Unit): C = appl
    }
 }
 
+inline fun <K, V, C : Map<K, V>> C.forNoneValue(fn: (V) -> Unit): C = apply { values.forNone(fn) }
+inline fun <K, V, C : Map<K, V>> C.forNoneKey(fn: (K) -> Unit): C = apply { keys.forNone(fn) }
 inline fun <K, V, C : Map<K, V>> C.forNone(fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/runTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/runTests.kt
@@ -5,15 +5,28 @@ import io.kotest.assertions.errorCollector
 
 inline fun <T> runTests(col: Collection<T>, f: (T) -> Unit): List<ElementResult<T>> {
    return col.map {
-      val originalAssertionMode = errorCollector.getCollectionMode()
-      try {
-         errorCollector.setCollectionMode(ErrorCollectionMode.Hard)
-         f(it)
-         ElementPass(it)
-      } catch (e: Throwable) {
-         ElementFail(it, e)
-      } finally {
-         errorCollector.setCollectionMode(originalAssertionMode)
-      }
+      runTest(it, f)
+   }
+}
+
+inline fun <K, V, T : Map.Entry<K, V>> runTests(
+   map: Map<K, V>,
+   f: (Map.Entry<K, V>) -> Unit
+): List<ElementResult<Map.Entry<K, V>>> {
+   return map.entries.map {
+      runTest(it, f)
+   }
+}
+
+inline fun <T> runTest(t: T, f: (T) -> Unit): ElementResult<T> {
+   val originalAssertionMode = errorCollector.getCollectionMode()
+   return try {
+      errorCollector.setCollectionMode(ErrorCollectionMode.Hard)
+      f(t)
+      ElementPass(t)
+   } catch (e: Throwable) {
+      ElementFail(t, e)
+   } finally {
+      errorCollector.setCollectionMode(originalAssertionMode)
    }
 }


### PR DESCRIPTION
Implements kotest/kotest#2656

I've implemented inspectors for maps. I took a look at the way you wrote it for collections. 

I noticed that there are missing tests in `InspectorsTest` (e.g. for `forAtLeastOne` and `forAtMostOne`), so I'm going to write them soon, but this test class is getting too big (~1k lines of code :scream:) and that's why I'd like to separate inspectors' tests into more files. I'm thinking of creating separate test class for each of: `Collection` and `Map`. What do you think?