### PR TITLE
Remove Arb#long workaround for incorrect randomly generated values

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/longs.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/longs.kt
@@ -35,11 +35,8 @@ fun Arb.Companion.long(min: Long = Long.MIN_VALUE, max: Long = Long.MAX_VALUE) =
  */
 fun Arb.Companion.long(range: LongRange = Long.MIN_VALUE..Long.MAX_VALUE): Arb<Long> {
    val edgeCases = longArrayOf(range.first, -1, 0, 1, range.last).filter { it in range }.distinct()
-   return ArbitraryBuilder.create {
-      var value = it.random.nextLong(range)
-      while (value !in range) value = it.random.nextLong(range) // temporary workaround for KT-47304
-      value
-   }.withEdgecases(edgeCases)
+   return ArbitraryBuilder.create { it.random.nextLong(range) }
+      .withEdgecases(edgeCases)
       .withShrinker(LongShrinker(range))
       .withClassifier(LongClassifier(range))
       .build()


### PR DESCRIPTION
This workaround is redundant because it was fixed in Kotlin 1.6.0.

See [KT-47304](https://youtrack.jetbrains.com/issue/KT-47304).