### PR TITLE
Fix issues in `shouldStartWith` and `shouldEndWith`

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -63,7 +63,7 @@ fun <T> endWith(slice: Collection<T>) = object : Matcher<List<T>> {
    override fun test(value: List<T>) =
       MatcherResult(
          value.subList(value.size - slice.size, value.size) == slice,
-         { "List should end with ${slice.printed().value} but was ${value.take(slice.size).printed().value}" },
+         { "List should end with ${slice.printed().value} but was ${value.takeLast(slice.size).printed().value}" },
          { "List should not end with ${slice.printed().value}" }
       )
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -27,13 +27,16 @@ infix fun <T> Array<T>.shouldNotStartWith(slice: Array<T>) = asList().shouldNotS
 infix fun <T> List<T>.shouldNotStartWith(element: T) = this shouldNot startWith(listOf(element))
 infix fun <T> List<T>.shouldNotStartWith(slice: Collection<T>) = this shouldNot startWith(slice)
 
-fun <T> startWith(slice: Collection<T>) = object : Matcher<List<T>> {
-   override fun test(value: List<T>) =
-      MatcherResult(
-         value.subList(0, slice.size) == slice,
-         { "List should start with ${slice.printed().value} but was ${value.take(slice.size).printed().value}" },
-         { "List should not start with ${slice.printed().value}" }
+fun <T> startWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
+   override fun test(value: List<T>): MatcherResult {
+      val valueSlice = value.take(expectedSlice.size)
+
+      return MatcherResult(
+         valueSlice == expectedSlice,
+         { "List should start with ${expectedSlice.printed().value} but was ${valueSlice.printed().value}" },
+         { "List should not start with ${expectedSlice.printed().value}" }
       )
+   }
 }
 
 infix fun <T> Iterable<T>.shouldEndWith(element: T) = toList().shouldEndWith(listOf(element))
@@ -59,11 +62,14 @@ infix fun <T> Array<T>.shouldNotEndWith(slice: Array<T>) = asList().shouldNotEnd
 infix fun <T> List<T>.shouldNotEndWith(element: T) = this shouldNot endWith(listOf(element))
 infix fun <T> List<T>.shouldNotEndWith(slice: Collection<T>) = this shouldNot endWith(slice)
 
-fun <T> endWith(slice: Collection<T>) = object : Matcher<List<T>> {
-   override fun test(value: List<T>) =
-      MatcherResult(
-         value.subList(value.size - slice.size, value.size) == slice,
-         { "List should end with ${slice.printed().value} but was ${value.takeLast(slice.size).printed().value}" },
-         { "List should not end with ${slice.printed().value}" }
+fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
+   override fun test(value: List<T>): MatcherResult {
+      val valueSlice = value.takeLast(expectedSlice.size)
+
+      return MatcherResult(
+         valueSlice == expectedSlice,
+         { "List should end with ${expectedSlice.printed().value} but was ${valueSlice.printed().value}" },
+         { "List should not end with ${expectedSlice.printed().value}" }
       )
+   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -46,13 +46,13 @@ class StartWithEndWithTest : WordSpec() {
          }
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
-               listOf(1L, 2L) should endWith(listOf(1L, 3L))
+               listOf(1L, 2L, 3L, 4L) should endWith(listOf(1L, 3L))
             }.shouldHaveMessage("""List should end with [
   1L,
   3L
 ] but was [
-  1L,
-  2L
+  3L,
+  4L
 ]""")
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -33,6 +33,20 @@ class StartWithEndWithTest : WordSpec() {
   2L
 ]""")
          }
+         "print errors unambiguously when the actual value is empty"  {
+            shouldThrow<AssertionError> {
+               emptyList<Long>() should startWith(listOf(1L, 3L))
+            }.shouldHaveMessage(
+               """
+                  |List should start with [
+                  |  1L,
+                  |  3L
+                  |] but was [
+                  |${"  "}
+                  |]
+               """.trimMargin()
+            )
+         }
       }
 
       "endWith" should {
@@ -54,6 +68,20 @@ class StartWithEndWithTest : WordSpec() {
   3L,
   4L
 ]""")
+         }
+         "print errors unambiguously when the actual value is empty"  {
+            shouldThrow<AssertionError> {
+               emptyList<Long>() should endWith(listOf(1L, 3L))
+            }.shouldHaveMessage(
+               """
+                  |List should end with [
+                  |  1L,
+                  |  3L
+                  |] but was [
+                  |${"  "}
+                  |]
+               """.trimMargin()
+            )
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -25,13 +25,17 @@ class StartWithEndWithTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf(1L, 2L) should startWith(listOf(1L, 3L))
-            }.shouldHaveMessage("""List should start with [
-  1L,
-  3L
-] but was [
-  1L,
-  2L
-]""")
+            }.shouldHaveMessage(
+               """
+                  |List should start with [
+                  |  1L,
+                  |  3L
+                  |] but was [
+                  |  1L,
+                  |  2L
+                  |]
+               """.trimMargin()
+            )
          }
          "print errors unambiguously when the actual value is empty"  {
             shouldThrow<AssertionError> {
@@ -61,13 +65,17 @@ class StartWithEndWithTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf(1L, 2L, 3L, 4L) should endWith(listOf(1L, 3L))
-            }.shouldHaveMessage("""List should end with [
-  1L,
-  3L
-] but was [
-  3L,
-  4L
-]""")
+            }.shouldHaveMessage(
+               """
+                  |List should end with [
+                  |  1L,
+                  |  3L
+                  |] but was [
+                  |  3L,
+                  |  4L
+                  |]
+               """.trimMargin()
+            )
          }
          "print errors unambiguously when the actual value is empty"  {
             shouldThrow<AssertionError> {


### PR DESCRIPTION
This PR addresses two issues:

* If a `shouldEndWith` assertion failed, it would report the first N elements of the list, rather than the last N elements
* If `shouldEndWith` or `shouldStartWith` was used with an actual value that was shorter than the expected slice, an `IndexOutOfBoundsException` would be thrown