### PR TITLE
#2741 Not work `js{}` and `js(BOTH){}` - only `js(IR) {}`

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -35,19 +35,19 @@ jobs:
             run: ./gradlew mingwX64Test --scan
 
          -  name: Run macOS tests
-            if: matrix.os == 'macOS-latest'
+            if: matrix.os == 'macOS-11'
             run: ./gradlew macosX64Test macosArm64TestKlibrary --scan
 
          -  name: Run watchOS tests
-            if: matrix.os == 'macOS-latest'
+            if: matrix.os == 'macOS-11'
             run: ./gradlew watchosArm32TestKlibrary watchosArm64TestKlibrary watchosSimulatorArm64TestKlibrary watchosX86Test watchosX64Test --scan
 
          -  name: Run tvOS tests
-            if: matrix.os == 'macOS-latest'
+            if: matrix.os == 'macOS-11'
             run: ./gradlew tvosArm64TestKlibrary tvosSimulatorArm64TestKlibrary tvosX64Test --scan
 
          -  name: Run iOS tests
-            if: matrix.os == 'macOS-latest'
+            if: matrix.os == 'macOS-11'
             run: ./gradlew iosArm32TestKlibrary iosArm64TestKlibrary iosSimulatorArm64TestKlibrary iosX64Test --scan
 
          -  name: Bundle the build report

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ node_modules/
 
 .docusaurus
 .DS_Store
+
+# NodeJS
+yarn.lock

--- a/documentation/docs/quick_start.mdx
+++ b/documentation/docs/quick_start.mdx
@@ -80,7 +80,7 @@ For example:
 
 ```kotlin
 plugins {
-  id("io.kotest.multiplatform") version "5.0.2"
+  id("io.kotest.multiplatform") version "5.0.3"
 }
 ```
 
@@ -89,7 +89,7 @@ Add the engine dependency to your `commonTest` dependencies block:
 ```kotlin
 kotlin {
   targets {
-    js(IR) { // LEGACY or BOTH are unsupported
+    js {
       browser() // to compile for the web
       nodejs() // to compile against node
     }
@@ -104,11 +104,6 @@ kotlin {
   }
 }
 ```
-
-:::caution
-Only the new IR compiler backend for Kotlin/JS is supported. If you are compiling JS with the legacy compiler backend then you will not be
-able to use Kotest for testing.
-:::
 
 Write your tests using [FunSpec](framework/styles.md#fun-spec), [ShouldSpec](framework/styles.md#should-spec) or [StringSpec](framework/styles.md#string-spec).
       Tests can be placed in either `commonTest` or `jsTest`

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,8 @@ systemProp.kotlin.native.disableCompilerDaemon=true
 kotlin.mpp.stability.nowarn=true
 kotlin.mpp.enableGranularSourceSetsMetadata=true
 
+kotlin.js.compiler=both
+
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.native.ignoreIncorrectDependencies=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotest-assertions/kotest-assertions-api/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-api/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(BOTH) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-assertions/kotest-assertions-core/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-core/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(BOTH) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-assertions/kotest-assertions-json/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-json/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
 
    targets {
       jvm()
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-assertions/kotest-assertions-shared/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-shared/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
 
       jvm()
 
-      js(BOTH) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-common/build.gradle.kts
+++ b/kotest-common/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(BOTH) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-extensions/kotest-extensions-http/build.gradle.kts
+++ b/kotest-extensions/kotest-extensions-http/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(BOTH) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-framework/kotest-framework-api/build.gradle.kts
+++ b/kotest-framework/kotest-framework-api/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
 
       jvm()
 
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-framework/kotest-framework-concurrency/build.gradle.kts
+++ b/kotest-framework/kotest-framework-concurrency/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-framework/kotest-framework-datatest/build.gradle.kts
+++ b/kotest-framework/kotest-framework-datatest/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
 
       jvm()
 
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
 
       jvm()
 
-      js(BOTH) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-property/kotest-property-lifecycle/build.gradle.kts
+++ b/kotest-property/kotest-property-lifecycle/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
    targets {
       jvm()
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/kotest-tests/kotest-tests-js/build.gradle.kts
+++ b/kotest-tests/kotest-tests-js/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 
 kotlin {
    targets {
-      js(IR) {
+      js {
          browser()
          nodejs()
       }

--- a/versions.properties
+++ b/versions.properties
@@ -45,7 +45,7 @@ version.junit.junit=4.13.2
 
 version.kotest-extensions=1.0.1
 
-version.kotlin=1.6.0
+version.kotlin=1.6.10
 
 version.kotlinx.coroutines=1.5.2
 ##             # available=1.6.0-RC


### PR DESCRIPTION
#2741 

* Updated Gradle version
* Updated Kotlin version
* Added support Legacy JS backend