### PR TITLE
fix `DataClassPrintTest` - line endings in expected Strings on Windows

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/DataClassPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/DataClassPrintTest.kt
@@ -17,7 +17,7 @@ Ship(
   name          =  "HMS Queen Elizabeth"
   pennant       =  "R08"
 )
-""".trim()
+""".trim().replace("\n", System.lineSeparator())
       }
 
       test("data class print should format nested data class") {
@@ -36,7 +36,7 @@ Shipyard(
     pennant       =  "R08"
   )
 )
-""".trim()
+""".trim().replace("\n", System.lineSeparator())
       }
 
       test("print should default to basic data class output") {

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/DataClassPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/DataClassPrintTest.kt
@@ -1,10 +1,7 @@
 package io.kotest.assertions.print
 
-import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.throwable.shouldHaveMessage
 
 class DataClassPrintTest : FunSpec() {
    init {

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/DataClassPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/DataClassPrintTest.kt
@@ -10,21 +10,21 @@ class DataClassPrintTest : FunSpec() {
    init {
 
       test("data class print should format data class") {
-         val ship = Ship("HMS Queen Elizabeth", "R08", 65000, "Queen Elizbeth", true)
+         val ship = Ship("HMS Queen Elizabeth", "R08", 65000, "Queen Elizabeth", true)
          DataClassPrintJvm().print(ship, 0).value shouldBe
             """
 Ship(
-  class         =  "Queen Elizbeth"
+  class         =  "Queen Elizabeth"
   displacement  =  65000L
   leadShip      =  true
   name          =  "HMS Queen Elizabeth"
-  pennnant      =  "R08"
+  pennant       =  "R08"
 )
 """.trim()
       }
 
       test("data class print should format nested data class") {
-         val ship = Ship("HMS Queen Elizabeth", "R08", 65000, "Queen Elizbeth", true)
+         val ship = Ship("HMS Queen Elizabeth", "R08", 65000, "Queen Elizabeth", true)
          val shipyard = Shipyard("Rosyth Dockyard", "Fife, Scotland", ship)
          DataClassPrintJvm().print(shipyard, 0).value shouldBe
             """
@@ -32,19 +32,19 @@ Shipyard(
   location  =  "Fife, Scotland"
   name      =  "Rosyth Dockyard"
   starship  =  Ship(
-    class         =  "Queen Elizbeth"
+    class         =  "Queen Elizabeth"
     displacement  =  65000L
     leadShip      =  true
     name          =  "HMS Queen Elizabeth"
-    pennnant      =  "R08"
+    pennant       =  "R08"
   )
 )
 """.trim()
       }
 
       test("print should default to basic data class output") {
-         Ship("HMS Queen Elizabeth", "R08", 65000, "Queen Elizbeth", true).print().value shouldBe
-            """Ship(name=HMS Queen Elizabeth, pennnant=R08, displacement=65000, class=Queen Elizbeth, leadShip=true)"""
+         Ship("HMS Queen Elizabeth", "R08", 65000, "Queen Elizabeth", true).print().value shouldBe
+            """Ship(name=HMS Queen Elizabeth, pennant=R08, displacement=65000, class=Queen Elizabeth, leadShip=true)"""
       }
 
       test("should be resilient to direct cyclic references") {
@@ -70,7 +70,7 @@ data class Shipyard(
 
 data class Ship(
    val name: String,
-   val pennnant: String,
+   val pennant: String,
    val displacement: Long,
    val `class`: String,
    val leadShip: Boolean


### PR DESCRIPTION
While testing #2731 I had some errors in `DataClassPrintTest`, because the expected output uses Kotlin raw String literals, and they have `\n` for line endings. But `DataClassPrint` uses `System.lineSeparator()`. So on my Windows machine the expected strings have `\n`, but the generated Strings have `\r\n`


```
(contents match, but line-breaks differ; output has been escaped to show line-breaks)
expected:<Ship(\n  class         =  "Queen Elizbeth"\n  displacement  =  65000L\n  leadShip      =  true\n  name          =  "HMS Queen Elizabeth"\n  pennnant      =  "R08"\n)> but was:<Ship(\r\n  class         =  "Queen Elizbeth"\r\n  displacement  =  65000L\r\n  leadShip      =  true\r\n  name          =  "HMS Queen Elizabeth"\r\n  pennnant      =  "R08"\r\n)>
<Click to see difference>

io.kotest.assertions.AssertionFailedError: (contents match, but line-breaks differ; output has been escaped to show line-breaks)
expected:<Ship(\n  class         =  "Queen Elizbeth"\n  displacement  =  65000L\n  leadShip      =  true\n  name          =  "HMS Queen Elizabeth"\n  pennnant      =  "R08"\n)> but was:<Ship(\r\n  class         =  "Queen Elizbeth"\r\n  displacement  =  65000L\r\n  leadShip      =  true\r\n  name          =  "HMS Queen Elizabeth"\r\n  pennnant      =  "R08"\r\n)>
```

![image](https://user-images.githubusercontent.com/897017/146692017-f8215cc4-2305-49de-bc65-2d86d432c633.png)

Here's a quick fix to replace `\n` with `System.lineSeparator()`.

I also removed the unused imports, and fixed some spelling mistakes :)