### PR TITLE
MapMatchers: Add containExactly() that takes a vararg of pairs

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -82,6 +82,9 @@ fun <K, V> containAll(expected: Map<K, V>): Matcher<Map<K, V>> =
 fun <K, V> containExactly(expected: Map<K, V>): Matcher<Map<K, V>> =
   MapContainsMatcher(expected)
 
+fun <K, V> containExactly(vararg expected: Pair<K, V>): Matcher<Map<K, V>> =
+  MapContainsMatcher(expected.toMap())
+
 fun <K, V> haveSize(size: Int): Matcher<Map<K,V>> = object : Matcher<Map<K, V>> {
    override fun test(value: Map<K, V>) =
       MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -269,6 +269,7 @@ class MapMatchersTest : WordSpec() {
                val linkedList = LinkedList<Int>()
                linkedList.push(1)
                mapOf("a" to arrayList) shouldNot containExactly<String, List<Int>>(mapOf("a" to linkedList))
+               mapOf("a" to arrayList) shouldNot containExactly<String, List<Int>>("a" to linkedList)
             }
             e.message shouldBe """
           |


### PR DESCRIPTION
Similar to the collection matches, introduce a convenience overload of
containExactly() that takes a vararg of pairs.