### PR TITLE
Fix withClue and assertSoftly interference with concurrent coroutines

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -73,9 +73,9 @@ object NoopErrorCollector : ErrorCollector {
 
 open class BasicErrorCollector : ErrorCollector {
 
-   private val failures = mutableListOf<Throwable>()
-   private var mode = ErrorCollectionMode.Hard
-   private val clues = mutableListOf<Clue>()
+   protected val failures = mutableListOf<Throwable>()
+   protected var mode = ErrorCollectionMode.Hard
+   protected val clues = mutableListOf<Clue>()
 
    override fun getCollectionMode(): ErrorCollectionMode = mode
 

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -2,24 +2,59 @@
 
 package io.kotest.assertions
 
-import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.CopyableThreadContextElement
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlin.coroutines.CoroutineContext
 
-actual val errorCollector: ErrorCollector get() = ThreadLocalErrorCollector.instance.get()
+actual val errorCollector: ErrorCollector get() = threadLocalErrorCollector.get()
 
 /**
- * A [kotlin.coroutines.CoroutineContext.Element] which keeps the error collector synchronized with thread-switching coroutines.
+ * A [CoroutineContext.Element] which keeps the error collector synchronized with thread-switching coroutines.
  *
  * When using [withClue] or [assertSoftly] on the JVM without the Kotest framework, this context element
  * should be added to each top-level coroutine context, e.g. via
- * - runBlocking(errorCollectorContextElement) { ... }
- * - runBlockingTest(Dispatchers.IO + errorCollectorContextElement) { ... }
+ * - `runBlocking(errorCollectorContextElement) { ... }`
+ * - `runTest(Dispatchers.IO + errorCollectorContextElement) { ... }`
  */
-val errorCollectorContextElement get() = ThreadLocalErrorCollector.instance.asContextElement()
+val errorCollectorContextElement: CoroutineContext.Element
+   get() = ErrorCollectorContextElement(threadLocalErrorCollector.get())
 
-class ThreadLocalErrorCollector : BasicErrorCollector() {
-   companion object {
-      val instance = object : ThreadLocal<ErrorCollector>() {
-         override fun initialValue() = ThreadLocalErrorCollector()
-      }
+
+private val threadLocalErrorCollector = object : ThreadLocal<CoroutineLocalErrorCollector>() {
+   override fun initialValue() = CoroutineLocalErrorCollector()
+}
+
+
+private class CoroutineLocalErrorCollector : BasicErrorCollector() {
+   fun copy(): CoroutineLocalErrorCollector {
+      val result = CoroutineLocalErrorCollector()
+      result.failures.addAll(failures)
+      result.mode = mode
+      result.clues.addAll(clues)
+      return result
    }
+}
+
+
+@OptIn(ExperimentalCoroutinesApi::class)
+private class ErrorCollectorContextElement(private val coroutineLocalErrorCollector: CoroutineLocalErrorCollector) :
+   CopyableThreadContextElement<CoroutineLocalErrorCollector> {
+
+   override val key: CoroutineContext.Key<ErrorCollectorContextElement> = Key
+
+   override fun updateThreadContext(context: CoroutineContext): CoroutineLocalErrorCollector {
+      val oldState = threadLocalErrorCollector.get()
+      threadLocalErrorCollector.set(coroutineLocalErrorCollector)
+      return oldState
+   }
+
+   override fun restoreThreadContext(context: CoroutineContext, oldState: CoroutineLocalErrorCollector) {
+      threadLocalErrorCollector.set(oldState)
+   }
+
+   override fun copyForChildCoroutine(): CopyableThreadContextElement<CoroutineLocalErrorCollector> {
+      return ErrorCollectorContextElement(threadLocalErrorCollector.get().copy())
+   }
+
+   companion object Key : CoroutineContext.Key<ErrorCollectorContextElement>
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/CluesTests.kt
@@ -1,10 +1,11 @@
 package io.kotest.assertions
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -24,11 +25,20 @@ class CluesTests : FunSpec({
    }
 
    test("concurrent withClue invocations should be isolated from each other") {
-      withContext(Dispatchers.Default) {
+      @OptIn(ExperimentalCoroutinesApi::class)
+      withContext(Dispatchers.IO.limitedParallelism(8)) {
          val repetitionCount = 100
          val parentCoroutineCount = 2
          val childCoroutineCount = 10
          val stepCount = 2
+
+         // These parameters specify a certain quota of repetitions to succeed in dispatching coroutines to
+         // a specified minimum number of threads. This safeguards against subtle differences in dispatcher
+         // implementations (how many threads to allocate, how many threads to actually use for coroutines).
+         val minimumThreadCount = 2
+         val minimumThreadRepetitionQuota = repetitionCount / 2
+
+         var minimumThreadRepetitionCount = 0
 
          for (repetitionNumber in 1..repetitionCount) {
             val threadIds = mutableSetOf<Long>()
@@ -57,8 +67,11 @@ class CluesTests : FunSpec({
                }
             }
 
-            threadIds shouldHaveAtLeastSize 2
+            if (threadIds.size >= minimumThreadCount)
+               minimumThreadRepetitionCount++
          }
+
+         minimumThreadRepetitionCount shouldBeGreaterThanOrEqual minimumThreadRepetitionQuota
       }
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
@@ -1,6 +1,5 @@
 package io.kotest.engine.test.interceptors
 
-import io.kotest.assertions.ThreadLocalErrorCollector
 import io.kotest.assertions.errorCollectorContextElement
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -24,7 +23,7 @@ internal object CoroutineErrorCollectorInterceptor : TestExecutionInterceptor {
       scope: TestScope,
       test: suspend (TestCase, TestScope) -> TestResult
    ): TestResult {
-      logger.log { Pair(testCase.name.testName, "Adding ${ThreadLocalErrorCollector.instance} to coroutine context") }
+      logger.log { Pair(testCase.name.testName, "Adding $errorCollectorContextElement to coroutine context") }
       return withContext(errorCollectorContextElement) {
          test(testCase, scope)
       }


### PR DESCRIPTION
Fixes #2790 by providing a coroutine-local error collector. Test case included.