### PR TITLE
Take deprecation of `listeners` into account in documentation of junit_xml extension

### DIFF
--- a/documentation/docs/extensions/junit_xml.md
+++ b/documentation/docs/extensions/junit_xml.md
@@ -26,7 +26,7 @@ To configure in your project, you need to add the `JunitXmlReporter` using [proj
 
 ```kotlin
 class MyConfig : AbstractProjectConfig() {
-  override fun listeners(): List<Listener> = listOf(
+  override fun extensions(): List<Extension> = listOf(
     JunitXmlReporter(
       includeContainers = false,
       useTestPathAsName = true


### PR DESCRIPTION
I stumbled over the fact that the example in the documentation describes a deprecated way of adding the junit xml extension to the `ProjectConfig`.