### PR TITLE
Include the whole list when a `shouldContain` assertion fails.

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
@@ -37,7 +37,7 @@ fun <T, C : Collection<T>> contain(t: T, verifier: Equality<T> = Equality.defaul
       value.any { verifier.verify(it, t).areEqual() },
       {
          "Collection should contain element ${t.print().value} based on ${verifier.name()}; " +
-            "listing some elements ${value.take(5)}"
+            "but the collection is $value"
       },
       { "Collection should not contain element ${t.print().value} based on ${verifier.name()}" }
    )

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -306,7 +306,7 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                col should contain(4)
-            }.shouldHaveMessage("Collection should contain element 4 based on object equality; listing some elements [1, 2, 3]")
+            }.shouldHaveMessage("Collection should contain element 4 based on object equality; but the collection is [1, 2, 3]")
          }
       }
 
@@ -322,7 +322,7 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                col should contain(3, verifier)
-            }.shouldHaveMessage("Collection should contain element 3 based on object equality; listing some elements [1, 2, 3.0]")
+            }.shouldHaveMessage("Collection should contain element 3 based on object equality; but the collection is [1, 2, 3.0]")
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
@@ -49,8 +49,8 @@ class ShouldContainTest : WordSpec({
 
       "print errors unambiguously"  {
          shouldThrow<AssertionError> {
-            listOf<Any>(1, 2).shouldContain(listOf<Any>(1L, 2L))
-         }.shouldHaveMessage("Collection should contain element [1L, 2L] based on object equality; listing some elements [1, 2]")
+            listOf<Any>(1, 2, 3, 4, 5, 6, 7).shouldContain(listOf<Any>(1L, 2L))
+         }.shouldHaveMessage("Collection should contain element [1L, 2L] based on object equality; but the collection is [1, 2, 3, 4, 5, 6, 7]")
       }
    }
 })


### PR DESCRIPTION
Currently, `shouldContain` only prints the first five elements in the list, making understanding why the assertion failed difficult. 

This change instead includes the entire list in the error message when the assertion fails.