### PR TITLE
Remove inconsistent exceptionClass default values

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
@@ -46,14 +46,14 @@ class EventuallyTest : WordSpec() {
          }
          "pass tests that completed within the time allowed" {
             val end = System.currentTimeMillis() + 150
-            eventually(1.seconds) {
+            eventually(1.seconds, RuntimeException::class) {
                if (System.currentTimeMillis() < end)
                   throw RuntimeException("foo")
             }
          }
          "fail tests that do not complete within the time allowed" {
             shouldThrow<AssertionError> {
-                eventually(150.milliseconds) {
+                eventually(150.milliseconds, RuntimeException::class) {
                     throw RuntimeException("foo")
                 }
             }
@@ -80,14 +80,14 @@ class EventuallyTest : WordSpec() {
          }
          "fail tests throw unexpected exception type"  {
             shouldThrow<NullPointerException> {
-               eventually(2.seconds, exceptionClass = IOException::class) {
+               eventually(2.seconds, IOException::class) {
                   (null as String?)!!.length
                }
             }
          }
          "pass tests that throws FileNotFoundException for some time"  {
             val end = System.currentTimeMillis() + 150
-            eventually(5.days) {
+            eventually(5.days, FileNotFoundException::class) {
                if (System.currentTimeMillis() < end)
                   throw FileNotFoundException("foo")
             }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
@@ -46,14 +46,14 @@ class EventuallyTest : WordSpec() {
          }
          "pass tests that completed within the time allowed" {
             val end = System.currentTimeMillis() + 150
-            eventually(1.seconds, RuntimeException::class) {
+            eventually(1.seconds) {
                if (System.currentTimeMillis() < end)
                   throw RuntimeException("foo")
             }
          }
          "fail tests that do not complete within the time allowed" {
             shouldThrow<AssertionError> {
-                eventually(150.milliseconds, RuntimeException::class) {
+                eventually(150.milliseconds) {
                     throw RuntimeException("foo")
                 }
             }
@@ -80,14 +80,14 @@ class EventuallyTest : WordSpec() {
          }
          "fail tests throw unexpected exception type"  {
             shouldThrow<NullPointerException> {
-               eventually(2.seconds, IOException::class) {
+               eventually(2.seconds, exceptionClass = IOException::class) {
                   (null as String?)!!.length
                }
             }
          }
          "pass tests that throws FileNotFoundException for some time"  {
             val end = System.currentTimeMillis() + 150
-            eventually(5.days, FileNotFoundException::class) {
+            eventually(5.days) {
                if (System.currentTimeMillis() < end)
                   throw FileNotFoundException("foo")
             }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
@@ -16,7 +16,7 @@ import kotlin.time.TimeSource
  * Runs a function until it doesn't throw as long as the specified duration hasn't passed
  */
 suspend fun <T> eventually(duration: Duration, f: suspend () -> T): T =
-   eventually(EventuallyConfig(duration = duration, exceptionClass = Throwable::class), f = f)
+   eventually(EventuallyConfig(duration = duration), f = f)
 
 suspend fun <T : Any> eventually(
    duration: Duration,
@@ -39,7 +39,7 @@ suspend fun <T> eventually(
 ): T = eventually(EventuallyConfig(duration = duration, interval), listener = listener, f = f)
 
 suspend fun <T> eventually(duration: Duration, poll: Duration, f: suspend () -> T): T =
-   eventually(EventuallyConfig(duration = duration, interval = poll.fixed(), exceptionClass = Throwable::class), f = f)
+   eventually(EventuallyConfig(duration = duration, interval = poll.fixed()), f = f)
 
 /**
  * Runs a function until it doesn't throw the specified exception as long as the specified duration hasn't passed

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
@@ -152,7 +152,7 @@ data class EventuallyConfig(
    val duration: Duration = Duration.INFINITE,
    val interval: Interval = 25.milliseconds.fixed(),
    val retries: Int = Int.MAX_VALUE,
-   val exceptionClass: KClass<out Throwable>? = null,
+   val exceptionClass: KClass<out Throwable>? = Throwable::class,
 ) {
    init {
       require(retries > 0) { "Retries should not be less than one" }


### PR DESCRIPTION
Why some `eventually` methods has it set to `Throwable` and some doesn't? I suggest to remove it. Or if we want to keep it, put it as defaualt value to `EventuallyConfig`'sa constructor instead of `null`.