### PR TITLE
BigDecimal arb can return edgecases outside min max limits #2834

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
@@ -4,7 +4,7 @@ import io.kotest.property.Arb
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-internal val bigDecimalEdgecases = listOf(
+internal val bigDecimalDefaultEdgecases = listOf(
    BigDecimal(0.0),
    // BigDecimal compareTo and equals are not consistent
    BigDecimal("0.00"),
@@ -15,7 +15,7 @@ internal val bigDecimalEdgecases = listOf(
 )
 
 fun Arb.Companion.bigDecimal(): Arb<BigDecimal> {
-   return arbitrary(bigDecimalEdgecases) {
+   return arbitrary(bigDecimalDefaultEdgecases) {
       if (it.random.nextInt() % 2 == 0) {
          BigDecimal(it.random.nextLong()) * BigDecimal(it.random.nextDouble())
       } else {
@@ -28,8 +28,11 @@ fun Arb.Companion.bigDecimal(scale: Int, roundingMode: RoundingMode) =
    bigDecimal().map { it.setScale(scale, roundingMode) }
 
 fun Arb.Companion.bigDecimal(min: BigDecimal, max: BigDecimal): Arb<BigDecimal> {
-   return arbitrary(bigDecimalEdgecases) {
+   val boundedEdgecases = bigDecimalDefaultEdgecases
+      .filter { min <= it && it < max }
+      .plus(min)
+
+   return arbitrary(boundedEdgecases) {
       min.add(BigDecimal(Math.random()).multiply(max.subtract(min)))
    }
 }
-

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/bigdecimal.kt
@@ -33,6 +33,6 @@ fun Arb.Companion.bigDecimal(min: BigDecimal, max: BigDecimal): Arb<BigDecimal> 
       .plus(min)
 
    return arbitrary(boundedEdgecases) {
-      min.add(BigDecimal(Math.random()).multiply(max.subtract(min)))
+      min.add(BigDecimal(it.random.nextDouble()).multiply(max.subtract(min)))
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
@@ -4,8 +4,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.concurrent.shouldCompleteWithin
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BigDecimalTest.kt
@@ -1,14 +1,17 @@
 package com.sksamuel.kotest.property.arbitrary
 
-import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.concurrent.shouldCompleteWithin
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bigDecimal
-import io.kotest.property.arbitrary.bigDecimalEdgecases
+import io.kotest.property.arbitrary.bigDecimalDefaultEdgecases
+import io.kotest.property.arbitrary.edgecases
 import io.kotest.property.arbitrary.take
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -38,8 +41,29 @@ class BigDecimalTest : FunSpec({
       }
    }
 
-   test("bigDecimalEdgecases should contain zeros with differing precision") {
-      bigDecimalEdgecases.shouldContain(BigDecimal("0.00"))
-      bigDecimalEdgecases.shouldContain(BigDecimal("0"))
+   test("bigDecimalDefaultEdgecases should contain zeros with differing precision") {
+      bigDecimalDefaultEdgecases.shouldContain(BigDecimal("0.00"))
+      bigDecimalDefaultEdgecases.shouldContain(BigDecimal("0"))
    }
+
+   test("Arb.bigDecimal(min, max) should always contain min as edgecase but not max") {
+      val min = BigDecimal.valueOf(123)
+      val max = BigDecimal.valueOf(555)
+
+      val actualEdgecases = Arb.bigDecimal(min = min, max = max).edgecases()
+      actualEdgecases.shouldContain(min)
+      actualEdgecases.shouldNotContain(max)
+   }
+
+   test("Arb.bigDecimal(min, max) should only include default edgecases that are in range [min, max)") {
+      val min = BigDecimal.valueOf(0)
+      val max = BigDecimal.valueOf(5)
+
+      val expectedEdgecases = bigDecimalDefaultEdgecases
+         .filter { min <= it && it < max }
+
+      Arb.bigDecimal(min = min, max = max).edgecases().shouldContainAll(expectedEdgecases)
+   }
+
+
 })


### PR DESCRIPTION
  Edgecases for Arb.bigDecimal(min, max) are now always contrained to be in range [min, max)
  Min is now added as edgecase for Arb.bigDecimal(min, max)