### PR TITLE
Make length of collection snippet included in assertion errors configurable

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
@@ -37,7 +37,7 @@ fun <T, C : Collection<T>> contain(t: T, verifier: Equality<T> = Equality.defaul
       value.any { verifier.verify(it, t).areEqual() },
       {
          "Collection should contain element ${t.print().value} based on ${verifier.name()}; " +
-            "listing some elements ${value.take(5)}"
+            "but the collection is ${value.print().value}"
       },
       { "Collection should not contain element ${t.print().value} based on ${verifier.name()}" }
    )

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.collections
 
+import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -27,8 +28,8 @@ fun <T> containAll(ts: Collection<T>): Matcher<Collection<T>> = object : Matcher
       val passed = missing.isEmpty()
 
       val failure =
-         { "Collection should contain all of ${ts.printed().value} but was missing ${missing.printed().value}" }
-      val negFailure = { "Collection should not contain all of ${ts.printed().value}" }
+         { "Collection should contain all of ${ts.print().value} but was missing ${missing.print().value}" }
+      val negFailure = { "Collection should not contain all of ${ts.print().value}" }
 
       return MatcherResult(passed, failure, negFailure)
    }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -50,23 +50,25 @@ fun <T, C : Collection<T>> containExactly(expected: C): Matcher<C?> = neverNullM
       val extra = actual.filterNot { expected.contains(it) }
 
       val sb = StringBuilder()
-      sb.append("Expecting: ${expected.printed().value} but was: ${actual.printed().value}")
+      sb.append("Expecting: ${expected.print().value} but was: ${actual.print().value}")
       sb.append("\n")
       if (missing.isNotEmpty()) {
          sb.append("Some elements were missing: ")
-         sb.append(missing.printed().value)
+         sb.append(missing.print().value)
          if (extra.isNotEmpty()) {
             sb.append(" and some elements were unexpected: ")
-            sb.append(extra.printed().value)
+            sb.append(extra.print().value)
          }
       } else if (extra.isNotEmpty()) {
          sb.append("Some elements were unexpected: ")
-         sb.append(extra.printed().value)
+         sb.append(extra.print().value)
       }
+
+      sb.appendLine()
       sb.toString()
    }
 
-   val negatedFailureMessage = { "Collection should not contain exactly ${expected.printed().value}" }
+   val negatedFailureMessage = { "Collection should not contain exactly ${expected.print().value}" }
 
    if (actual.size <= AssertionsConfig.maxCollectionEnumerateSize && expected.size <= AssertionsConfig.maxCollectionEnumerateSize) {
       ComparableMatcherResult(
@@ -96,9 +98,3 @@ fun <T> Array<T>?.shouldNotContainExactly(vararg expected: T) = this?.asList() s
 
 infix fun <T, C : Collection<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
 fun <T> Collection<T>?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
-
-fun <T, C : Collection<T>> C.printed(): Printed {
-   val expectedPrinted = take(20).joinToString(",\n  ", prefix = "[\n  ", postfix = "\n]") { it.print().value }
-   val expectedMore = if (size > 20) " ... (plus ${size - 20} more)" else ""
-   return Printed("$expectedPrinted$expectedMore")
-}

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.collections
 
+import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.neverNullMatcher
@@ -22,8 +23,8 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
 
    MatcherResult(
       subsequenceIndex == subsequence.size,
-      { "${actual.printed().value} did not contain the elements ${subsequence.printed().value} in order" },
-      { "${actual.printed().value} should not contain the elements ${subsequence.printed().value} in order" }
+      { "${actual.print().value} did not contain the elements ${subsequence.print().value} in order" },
+      { "${actual.print().value} should not contain the elements ${subsequence.print().value} in order" }
    )
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -18,8 +18,8 @@ fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L>
    override fun test(value: L) =
       MatcherResult(
          value[index] == element,
-         { "Collection should contain ${element.print().value} at index $index" },
-         { "Collection should not contain ${element.print().value} at index $index" }
+         { "Collection ${value.print().value} should contain ${element.print().value} at index $index" },
+         { "Collection ${value.print().value} should not contain ${element.print().value} at index $index" }
       )
 }
 
@@ -55,9 +55,9 @@ infix fun <T> Collection<T>.shouldExist(p: (T) -> Boolean) = this should exist(p
 fun <T> exist(p: (T) -> Boolean) = object : Matcher<Collection<T>> {
    override fun test(value: Collection<T>) = MatcherResult(
       value.any { p(it) },
-      { "Collection should contain an element that matches the predicate $p" },
+      { "Collection ${value.print().value} should contain an element that matches the predicate $p" },
       {
-         "Collection should not contain an element that matches the predicate $p"
+         "Collection ${value.print().value} should not contain an element that matches the predicate $p"
       })
 }
 
@@ -99,8 +99,8 @@ fun <T> containAnyOf(ts: Collection<T>) = object : Matcher<Collection<T>> {
       if (ts.isEmpty()) throwEmptyCollectionError()
       return MatcherResult(
          ts.any { it in value },
-         { "Collection should contain any of ${ts.joinToString(separator = ", ", limit = 10) { it.print().value }}" },
-         { "Collection should not contain any of ${ts.joinToString(separator = ", ", limit = 10) { it.print().value }}" }
+         { "Collection ${value.print().value} should contain any of ${ts.print().value}" },
+         { "Collection ${value.print().value} should not contain any of ${ts.print().value}" }
       )
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/size.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/size.kt
@@ -87,9 +87,9 @@ infix fun <T> Collection<T>.shouldHaveAtLeastSize(n: Int): Collection<T> {
 fun <T> atLeastSize(n: Int) = object : Matcher<Collection<T>> {
    override fun test(value: Collection<T>) = MatcherResult(
       value.size >= n,
-      { "Collection should contain at least $n elements" },
+      { "Collection ${value.print().value} should contain at least $n elements" },
       {
-         "Collection should contain less than $n elements"
+         "Collection ${value.print().value} should contain less than $n elements"
       })
 }
 
@@ -111,9 +111,9 @@ infix fun <T> Collection<T>.shouldHaveAtMostSize(n: Int): Collection<T> {
 fun <T> atMostSize(n: Int) = object : Matcher<Collection<T>> {
    override fun test(value: Collection<T>) = MatcherResult(
       value.size <= n,
-      { "Collection should contain at most $n elements" },
+      { "Collection ${value.print().value} should contain at most $n elements" },
       {
-         "Collection should contain more than $n elements"
+         "Collection ${value.print().value} should contain more than $n elements"
       })
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.collections
 
+import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -33,8 +34,8 @@ fun <T> startWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
 
       return MatcherResult(
          valueSlice == expectedSlice,
-         { "List should start with ${expectedSlice.printed().value} but was ${valueSlice.printed().value}" },
-         { "List should not start with ${expectedSlice.printed().value}" }
+         { "List should start with ${expectedSlice.print().value} but was ${valueSlice.print().value}" },
+         { "List should not start with ${expectedSlice.print().value}" }
       )
    }
 }
@@ -68,8 +69,8 @@ fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
 
       return MatcherResult(
          valueSlice == expectedSlice,
-         { "List should end with ${expectedSlice.printed().value} but was ${valueSlice.printed().value}" },
-         { "List should not end with ${expectedSlice.printed().value}" }
+         { "List should end with ${expectedSlice.print().value} but was ${valueSlice.print().value}" },
+         { "List should not end with ${expectedSlice.print().value}" }
       )
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/ExtractTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/ExtractTest.kt
@@ -32,11 +32,7 @@ class ExtractTest : WordSpec() {
         shouldThrowAny {
           extracting(persons) { name }
               .shouldContainAll("<Some name that is wrong>")
-        }.message shouldBe """Collection should contain all of [
-  "<Some name that is wrong>"
-] but was missing [
-  "<Some name that is wrong>"
-]"""
+        }.message shouldBe """Collection should contain all of ["<Some name that is wrong>"] but was missing ["<Some name that is wrong>"]"""
       }
 
     }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -188,7 +188,7 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                longList.shouldNotBeSorted()
-            }.shouldHaveMessage("List [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...] and 980 more should not be sorted")
+            }.shouldHaveMessage("List [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 980 more] should not be sorted")
          }
       }
 
@@ -306,7 +306,7 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                col should contain(4)
-            }.shouldHaveMessage("Collection should contain element 4 based on object equality; listing some elements [1, 2, 3]")
+            }.shouldHaveMessage("Collection should contain element 4 based on object equality; but the collection is [1, 2, 3]")
          }
       }
 
@@ -322,7 +322,7 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                col should contain(3, verifier)
-            }.shouldHaveMessage("Collection should contain element 3 based on object equality; listing some elements [1, 2, 3.0]")
+            }.shouldHaveMessage("Collection should contain element 3 based on object equality; but the collection is [1, 2, 3.0]")
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -188,7 +188,7 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                longList.shouldNotBeSorted()
-            }.shouldHaveMessage("List [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 980 more] should not be sorted")
+            }.shouldHaveMessage("List [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 980 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)] should not be sorted")
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -484,15 +484,15 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                list.shouldHaveAtLeastSize(4)
-            }.shouldHaveMessage("Collection should contain at least 4 elements")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain at least 4 elements")
 
             shouldThrow<AssertionError> {
                list shouldHave atLeastSize(4)
-            }.shouldHaveMessage("Collection should contain at least 4 elements")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain at least 4 elements")
 
             shouldThrow<AssertionError> {
                list shouldNotHave atLeastSize(2)
-            }.shouldHaveMessage("Collection should contain less than 2 elements")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain less than 2 elements")
          }
       }
 
@@ -515,15 +515,15 @@ class CollectionMatchersTest : WordSpec() {
 
             shouldThrow<AssertionError> {
                list.shouldHaveAtMostSize(2)
-            }.shouldHaveMessage("Collection should contain at most 2 elements")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain at most 2 elements")
 
             shouldThrow<AssertionError> {
                list shouldHave atMostSize(2)
-            }.shouldHaveMessage("Collection should contain at most 2 elements")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain at most 2 elements")
 
             shouldThrow<AssertionError> {
                list shouldNotHave atMostSize(4)
-            }.shouldHaveMessage("Collection should contain more than 4 elements")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain more than 4 elements")
          }
       }
 
@@ -631,7 +631,7 @@ class CollectionMatchersTest : WordSpec() {
          "Fail when no element is in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldContainAnyOf(4)
-            }.shouldHaveMessage("Collection should contain any of 4")
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain any of [4]")
          }
       }
 
@@ -649,13 +649,13 @@ class CollectionMatchersTest : WordSpec() {
          "Fail when one element is in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldNotContainAnyOf(1)
-            }.shouldHaveMessage("Collection should not contain any of 1")
+            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
          }
 
          "Fail when all elements are in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldNotContainAnyOf(1, 2, 3)
-            }.shouldHaveMessage("Collection should not contain any of 1, 2, 3")
+            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1, 2, 3]")
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
@@ -35,13 +35,7 @@ class InOrderTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf<Number>(1L, 2L) should containsInOrder(listOf<Number>(1, 2))
-            }.shouldHaveMessage("""[
-  1L,
-  2L
-] did not contain the elements [
-  1,
-  2
-] in order""")
+            }.shouldHaveMessage("""[1L, 2L] did not contain the elements [1, 2] in order""")
          }
          "support iterables with vararg" {
             val actual = listOf(1, 2, 3, 4, 5).asIterable()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
@@ -50,13 +50,7 @@ class ShouldContainAllTest : WordSpec() {
          "print missing elements" {
             shouldThrow<AssertionError> {
                listOf<Number>(1, 2).shouldContainAll(listOf<Number>(1L, 2L))
-            }.shouldHaveMessage("""Collection should contain all of [
-  1L,
-  2L
-] but was missing [
-  1L,
-  2L
-]""")
+            }.shouldHaveMessage("""Collection should contain all of [1L, 2L] but was missing [1L, 2L]""")
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -81,22 +81,12 @@ class ShouldContainExactlyTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf<Any>(1L, 2L).shouldContainExactly(listOf<Any>(1, 2))
-            }.shouldHaveMessage(
-               """Expecting: [
-  1,
-  2
-] but was: [
-  1L,
-  2L
-]
-Some elements were missing: [
-  1,
-  2
-] and some elements were unexpected: [
-  1L,
-  2L
-]expected:<[1, 2]> but was:<[1L, 2L]>"""
-            )
+            } shouldHaveMessage
+               """
+                  |Expecting: [1, 2] but was: [1L, 2L]
+                  |Some elements were missing: [1, 2] and some elements were unexpected: [1L, 2L]
+                  |expected:<[1, 2]> but was:<[1L, 2L]>
+               """.trimMargin()
          }
 
          "print dataclasses" {
@@ -109,17 +99,12 @@ Some elements were missing: [
                   Blonde("foo", true, 23423, inputPath),
                   Blonde("woo", true, 97821, inputPath)
                )
-            }.message?.trim() shouldBe ("""Expecting: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath)
-] but was: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath),
-  Blonde(a=goo, b=true, c=51984, p=$expectedPath)
-]
-Some elements were unexpected: [
-  Blonde(a=goo, b=true, c=51984, p=$expectedPath)
-]expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]>""")
+            }.message?.trim() shouldBe
+               """
+                  |Expecting: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]
+                  |Some elements were unexpected: [Blonde(a=goo, b=true, c=51984, p=$expectedPath)]
+                  |expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]>
+               """.trimMargin()
          }
 
          "include extras when too many" {
@@ -130,17 +115,12 @@ Some elements were unexpected: [
                   Blonde("foo", true, 23423, inputPath),
                   Blonde("woo", true, 97821, inputPath)
                )
-            }.message?.trim() shouldBe (
-               """Expecting: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath)
-] but was: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath)
-]
-Some elements were missing: [
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath)
-]expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath)]>"""
-               )
+            }.message?.trim() shouldBe
+               """
+                  |Expecting: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath)]
+                  |Some elements were missing: [Blonde(a=woo, b=true, c=97821, p=$expectedPath)]
+                  |expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath)]>
+               """.trimMargin()
          }
 
          "include missing when too few" {
@@ -152,18 +132,12 @@ Some elements were missing: [
                ).shouldContainExactly(
                   Blonde("woo", true, 97821, inputPath)
                )
-            }.message?.trim() shouldBe ("""Expecting: [
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath)
-] but was: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=hoo, b=true, c=96915, p=$expectedPath)
-]
-Some elements were missing: [
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath)
-] and some elements were unexpected: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=hoo, b=true, c=96915, p=$expectedPath)
-]expected:<[Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]>""")
+            }.message?.trim() shouldBe
+               """
+                  |Expecting: [Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]
+                  |Some elements were missing: [Blonde(a=woo, b=true, c=97821, p=$expectedPath)] and some elements were unexpected: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]
+                  |expected:<[Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]>
+               """.trimMargin()
          }
 
          "include missing and extras when not the right amount" {
@@ -175,20 +149,12 @@ Some elements were missing: [
                   Blonde("woo", true, 97821, inputPath),
                   Blonde("goo", true, 51984, inputPath)
                )
-            }.message?.trim() shouldBe """Expecting: [
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath),
-  Blonde(a=goo, b=true, c=51984, p=$expectedPath)
-] but was: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=hoo, b=true, c=96915, p=$expectedPath)
-]
-Some elements were missing: [
-  Blonde(a=woo, b=true, c=97821, p=$expectedPath),
-  Blonde(a=goo, b=true, c=51984, p=$expectedPath)
-] and some elements were unexpected: [
-  Blonde(a=foo, b=true, c=23423, p=$expectedPath),
-  Blonde(a=hoo, b=true, c=96915, p=$expectedPath)
-]expected:<[Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]>"""
+            }.message?.trim() shouldBe
+               """
+                  |Expecting: [Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]
+                  |Some elements were missing: [Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)] and some elements were unexpected: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]
+                  |expected:<[Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]>
+               """.trimMargin()
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
@@ -56,7 +56,7 @@ class ShouldContainTest : WordSpec({
       "print errors unambiguously for long lists"  {
          shouldThrow<AssertionError> {
             listOf<Any>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21).shouldContain(listOf<Any>(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L))
-         }.shouldHaveMessage("Collection should contain element [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, ...and 1 more] based on object equality; but the collection is [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 1 more]")
+         }.shouldHaveMessage("Collection should contain element [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, ...and 1 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)] based on object equality; but the collection is [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 1 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)]")
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
@@ -50,7 +50,13 @@ class ShouldContainTest : WordSpec({
       "print errors unambiguously"  {
          shouldThrow<AssertionError> {
             listOf<Any>(1, 2).shouldContain(listOf<Any>(1L, 2L))
-         }.shouldHaveMessage("Collection should contain element [1L, 2L] based on object equality; listing some elements [1, 2]")
+         }.shouldHaveMessage("Collection should contain element [1L, 2L] based on object equality; but the collection is [1, 2]")
+      }
+
+      "print errors unambiguously for long lists"  {
+         shouldThrow<AssertionError> {
+            listOf<Any>(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21).shouldContain(listOf<Any>(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L))
+         }.shouldHaveMessage("Collection should contain element [1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, ...and 1 more] based on object equality; but the collection is [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 1 more]")
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -25,31 +25,12 @@ class StartWithEndWithTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf(1L, 2L) should startWith(listOf(1L, 3L))
-            }.shouldHaveMessage(
-               """
-                  |List should start with [
-                  |  1L,
-                  |  3L
-                  |] but was [
-                  |  1L,
-                  |  2L
-                  |]
-               """.trimMargin()
-            )
+            }.shouldHaveMessage("List should start with [1L, 3L] but was [1L, 2L]")
          }
          "print errors unambiguously when the actual value is empty"  {
             shouldThrow<AssertionError> {
                emptyList<Long>() should startWith(listOf(1L, 3L))
-            }.shouldHaveMessage(
-               """
-                  |List should start with [
-                  |  1L,
-                  |  3L
-                  |] but was [
-                  |${"  "}
-                  |]
-               """.trimMargin()
-            )
+            }.shouldHaveMessage("List should start with [1L, 3L] but was []")
          }
       }
 
@@ -65,31 +46,12 @@ class StartWithEndWithTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf(1L, 2L, 3L, 4L) should endWith(listOf(1L, 3L))
-            }.shouldHaveMessage(
-               """
-                  |List should end with [
-                  |  1L,
-                  |  3L
-                  |] but was [
-                  |  3L,
-                  |  4L
-                  |]
-               """.trimMargin()
-            )
+            }.shouldHaveMessage("List should end with [1L, 3L] but was [3L, 4L]")
          }
          "print errors unambiguously when the actual value is empty"  {
             shouldThrow<AssertionError> {
                emptyList<Long>() should endWith(listOf(1L, 3L))
-            }.shouldHaveMessage(
-               """
-                  |List should end with [
-                  |  1L,
-                  |  3L
-                  |] but was [
-                  |${"  "}
-                  |]
-               """.trimMargin()
-            )
+            }.shouldHaveMessage("List should end with [1L, 3L] but was []")
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -19,16 +19,21 @@ object AssertionsConfig {
    val maxCollectionEnumerateSize: Int
       get() = sysprop("kotest.assertions.collection.enumerate.size")?.toIntOrNull() ?: 20
 
-   val maxCollectionPrintSize: Configurable<Int> = Configurable<Int>("kotest.assertions.collection.print.size", 20, String::toInt)
+   val maxCollectionPrintSize: ConfigValue<Int> = EnvironmentConfigValue<Int>("kotest.assertions.collection.print.size", 20, String::toInt)
 }
 
-class Configurable<T>(
+interface ConfigValue<T> {
+   val sourceDescription: String
+   val value: T
+}
+
+class EnvironmentConfigValue<T>(
    private val name: String,
-   val defaultValue: T,
+   private val defaultValue: T,
    val converter: (String) -> T
-) {
-   val sourceDescription: String = ConfigurationLoader.getSourceDescription(name)
-   val value: T = loadValue()
+): ConfigValue<T> {
+   override val sourceDescription: String = ConfigurationLoader.getSourceDescription(name)
+   override val value: T = loadValue()
 
    private fun loadValue(): T {
       val loaded = ConfigurationLoader.getValue(name) ?: return defaultValue

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -23,7 +23,7 @@ object AssertionsConfig {
 }
 
 interface ConfigValue<T> {
-   val sourceDescription: String
+   val sourceDescription: String?
    val value: T
 }
 
@@ -32,7 +32,7 @@ class EnvironmentConfigValue<T>(
    private val defaultValue: T,
    val converter: (String) -> T
 ): ConfigValue<T> {
-   override val sourceDescription: String = ConfigurationLoader.getSourceDescription(name)
+   override val sourceDescription: String? = ConfigurationLoader.getSourceDescription(name)
    override val value: T = loadValue()
 
    private fun loadValue(): T {
@@ -48,7 +48,7 @@ class EnvironmentConfigValue<T>(
 
 internal expect object ConfigurationLoader {
    fun getValue(name: String): String?
-   fun getSourceDescription(name: String): String
+   fun getSourceDescription(name: String): String?
 }
 
 class KotestConfigurationException(message: String, cause: Throwable?) : RuntimeException(message, cause)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -18,4 +18,32 @@ object AssertionsConfig {
 
    val maxCollectionEnumerateSize: Int
       get() = sysprop("kotest.assertions.collection.enumerate.size")?.toIntOrNull() ?: 20
+
+   val maxCollectionPrintSize: Configurable<Int> = Configurable<Int>("kotest.assertions.collection.print.size", 20, String::toInt)
 }
+
+class Configurable<T>(
+   private val name: String,
+   val defaultValue: T,
+   val converter: (String) -> T
+) {
+   val sourceDescription: String = ConfigurationLoader.getSourceDescription(name)
+   val value: T = loadValue()
+
+   private fun loadValue(): T {
+      val loaded = ConfigurationLoader.getValue(name) ?: return defaultValue
+
+      try {
+         return converter(loaded)
+      } catch (e: Exception) {
+         throw KotestConfigurationException("Could not load value from $sourceDescription: $e", e)
+      }
+   }
+}
+
+internal expect object ConfigurationLoader {
+   fun getValue(name: String): String?
+   fun getSourceDescription(name: String): String
+}
+
+class KotestConfigurationException(message: String, cause: Throwable?) : RuntimeException(message, cause)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -5,10 +5,10 @@ import io.kotest.mpp.sysprop
 object AssertionsConfig {
 
    val showDataClassDiff: Boolean
-      get() = sysprop("kotest.assertions.show-data-class-diffs", "true").toBoolean()
+      get() = sysprop("kotest.assertions.show-data-class-diffs", true)
 
    val largeStringDiffMinSize: Int
-      get() = sysprop("kotest.assertions.multi-line-diff-size", "50").toInt()
+      get() = sysprop("kotest.assertions.multi-line-diff-size", 50)
 
    val multiLineDiff: String
       get() = sysprop("kotest.assertions.multi-line-diff", "")

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
@@ -1,13 +1,14 @@
 package io.kotest.assertions.print
 
 import io.kotest.assertions.AssertionsConfig
+import io.kotest.assertions.ConfigValue
 
-class ListPrint<T> : Print<List<T>> {
+class ListPrint<T>(private val limitConfigValue: ConfigValue<Int> = AssertionsConfig.maxCollectionPrintSize) : Print<List<T>> {
    override fun print(a: List<T>): Printed = print(a, 0)
 
    override fun print(a: List<T>, level: Int): Printed {
       return if (a.isEmpty()) Printed("[]") else {
-         val limit = AssertionsConfig.maxCollectionPrintSize.value
+         val limit = limitConfigValue.value
          val remainingItems = a.size - limit
 
          return a.joinToString(
@@ -15,7 +16,7 @@ class ListPrint<T> : Print<List<T>> {
             prefix = "[",
             postfix = "]",
             limit = limit,
-            truncated = "...and $remainingItems more (set ${AssertionsConfig.maxCollectionPrintSize.sourceDescription} to see more / less items)"
+            truncated = "...and $remainingItems more (set ${limitConfigValue.sourceDescription} to see more / less items)"
          ) {
             when {
                it is Iterable<*> && it.toList() == a && a.size == 1 -> a[0].toString()

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
@@ -1,21 +1,21 @@
 package io.kotest.assertions.print
 
+import io.kotest.assertions.AssertionsConfig
+
 class ListPrint<T> : Print<List<T>> {
-
-   private val maxCollectionSnippetSize = 20
-
    override fun print(a: List<T>): Printed = print(a, 0)
 
    override fun print(a: List<T>, level: Int): Printed {
       return if (a.isEmpty()) Printed("[]") else {
-         val remainingItems = a.size - maxCollectionSnippetSize
+         val limit = AssertionsConfig.maxCollectionPrintSize.value
+         val remainingItems = a.size - limit
 
          return a.joinToString(
             separator = ", ",
             prefix = "[",
             postfix = "]",
-            limit = maxCollectionSnippetSize,
-            truncated = "...and $remainingItems more"
+            limit = limit,
+            truncated = "...and $remainingItems more (set ${AssertionsConfig.maxCollectionPrintSize.sourceDescription} to see more / less items)"
          ) {
             when {
                it is Iterable<*> && it.toList() == a && a.size == 1 -> a[0].toString()

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
@@ -10,16 +10,12 @@ class ListPrint<T> : Print<List<T>> {
       return if (a.isEmpty()) Printed("[]") else {
          val remainingItems = a.size - maxCollectionSnippetSize
 
-         val suffix = when {
-            remainingItems <= 0 -> "]"
-            else -> "] and $remainingItems more"
-         }
-
          return a.joinToString(
             separator = ", ",
             prefix = "[",
-            postfix = suffix,
-            limit = maxCollectionSnippetSize
+            postfix = "]",
+            limit = maxCollectionSnippetSize,
+            truncated = "...and $remainingItems more"
          ) {
             when {
                it is Iterable<*> && it.toList() == a && a.size == 1 -> a[0].toString()

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
@@ -10,13 +10,14 @@ class ListPrint<T>(private val limitConfigValue: ConfigValue<Int> = AssertionsCo
       return if (a.isEmpty()) Printed("[]") else {
          val limit = limitConfigValue.value
          val remainingItems = a.size - limit
+         val limitHint = if (limitConfigValue.sourceDescription == null) "" else " (set ${limitConfigValue.sourceDescription} to see more / less items)"
 
          return a.joinToString(
             separator = ", ",
             prefix = "[",
             postfix = "]",
             limit = limit,
-            truncated = "...and $remainingItems more (set ${limitConfigValue.sourceDescription} to see more / less items)"
+            truncated = "...and $remainingItems more$limitHint"
          ) {
             when {
                it is Iterable<*> && it.toList() == a && a.size == 1 -> a[0].toString()

--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
@@ -1,0 +1,10 @@
+package io.kotest.assertions
+
+import io.kotest.mpp.env
+
+internal actual object ConfigurationLoader {
+   actual fun getValue(name: String): String? = env(environmentVariableName(name))
+   actual fun getSourceDescription(name: String): String = "the '${environmentVariableName(name)}' environment variable"
+
+   private fun environmentVariableName(name: String): String = name.replace(".", "_")
+}

--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
@@ -4,7 +4,7 @@ import io.kotest.mpp.env
 
 internal actual object ConfigurationLoader {
    actual fun getValue(name: String): String? = env(environmentVariableName(name))
-   actual fun getSourceDescription(name: String): String = "the '${environmentVariableName(name)}' environment variable"
+   actual fun getSourceDescription(name: String): String? = "the '${environmentVariableName(name)}' environment variable"
 
    private fun environmentVariableName(name: String): String = name.replace(".", "_")
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
@@ -1,0 +1,10 @@
+package io.kotest.assertions
+
+import io.kotest.mpp.env
+
+internal actual object ConfigurationLoader {
+   actual fun getValue(name: String): String? = env(environmentVariableName(name))
+   actual fun getSourceDescription(name: String): String = "the '${environmentVariableName(name)}' environment variable"
+
+   private fun environmentVariableName(name: String): String = name.replace(".", "_")
+}

--- a/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
@@ -3,8 +3,8 @@ package io.kotest.assertions
 import io.kotest.mpp.env
 
 internal actual object ConfigurationLoader {
-   actual fun getValue(name: String): String? = env(environmentVariableName(name))
-   actual fun getSourceDescription(name: String): String = "the '${environmentVariableName(name)}' environment variable"
+   actual fun getValue(name: String): String? = null // Environment variables aren't (yet) supported on Kotlin/JS.
+   actual fun getSourceDescription(name: String): String? = null
 
    private fun environmentVariableName(name: String): String = name.replace(".", "_")
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
@@ -1,0 +1,8 @@
+package io.kotest.assertions
+
+import io.kotest.mpp.sysprop
+
+internal actual object ConfigurationLoader {
+   actual fun getValue(name: String): String? = System.getProperty(name)
+   actual fun getSourceDescription(name: String): String = "the '$name' JVM property"
+}

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ConfigurationLoader.kt
@@ -4,5 +4,5 @@ import io.kotest.mpp.sysprop
 
 internal actual object ConfigurationLoader {
    actual fun getValue(name: String): String? = System.getProperty(name)
-   actual fun getSourceDescription(name: String): String = "the '$name' JVM property"
+   actual fun getSourceDescription(name: String): String? = "the '$name' JVM property"
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/LargeArrayShouldBeTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/LargeArrayShouldBeTest.kt
@@ -719,8 +719,8 @@ class LargeArrayShouldBeTest : FunSpec({
 
       shouldThrowAny {
          a shouldBe b
-      }.message shouldBe """Element differ at index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...and 279 more]
+      }.message shouldBe """Element differ at index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...and 279 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)]
                             |Unexpected elements from index 359
-                            |expected:<[0, 1, 0, 0, -1, -37, 0, 67, 0, 8, 6, 6, 7, 6, 5, 8, 7, 7, 7, 9, ...and 324 more]> but was:<[-1, -40, -1, -32, 0, 16, 74, 70, 73, 70, 0, 1, 2, 0, 0, 1, 0, 1, 0, 0, ...and 340 more]>""".trimMargin()
+                            |expected:<[0, 1, 0, 0, -1, -37, 0, 67, 0, 8, 6, 6, 7, 6, 5, 8, 7, 7, 7, 9, ...and 324 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)]> but was:<[-1, -40, -1, -32, 0, 16, 74, 70, 73, 70, 0, 1, 2, 0, 0, 1, 0, 1, 0, 0, ...and 340 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)]>""".trimMargin()
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/LargeArrayShouldBeTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/LargeArrayShouldBeTest.kt
@@ -719,8 +719,8 @@ class LargeArrayShouldBeTest : FunSpec({
 
       shouldThrowAny {
          a shouldBe b
-      }.message shouldBe """Element differ at index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...] and 279 more
+      }.message shouldBe """Element differ at index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...and 279 more]
                             |Unexpected elements from index 359
-                            |expected:<[0, 1, 0, 0, -1, -37, 0, 67, 0, 8, 6, 6, 7, 6, 5, 8, 7, 7, 7, 9, ...] and 324 more> but was:<[-1, -40, -1, -32, 0, 16, 74, 70, 73, 70, 0, 1, 2, 0, 0, 1, 0, 1, 0, 0, ...] and 340 more>""".trimMargin()
+                            |expected:<[0, 1, 0, 0, -1, -37, 0, 67, 0, 8, 6, 6, 7, 6, 5, 8, 7, 7, 7, 9, ...and 324 more]> but was:<[-1, -40, -1, -32, 0, 16, 74, 70, 73, 70, 0, 1, 2, 0, 0, 1, 0, 1, 0, 0, ...and 340 more]>""".trimMargin()
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/CollectionsPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/CollectionsPrintTest.kt
@@ -28,6 +28,6 @@ class CollectionsPrintTest : FunSpec({
    }
 
    test("print should limit items") {
-      List(1000) { it }.print().value shouldBe "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...and 980 more]"
+      List(1000) { it }.print().value shouldBe "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...and 980 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)]"
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/CollectionsPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/CollectionsPrintTest.kt
@@ -28,6 +28,6 @@ class CollectionsPrintTest : FunSpec({
    }
 
    test("print should limit items") {
-      List(1000) { it }.print().value shouldBe "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...] and 980 more"
+      List(1000) { it }.print().value shouldBe "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, ...and 980 more]"
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/ListPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/ListPrintTest.kt
@@ -1,0 +1,51 @@
+package io.kotest.assertions.print
+
+import io.kotest.assertions.ConfigValue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class ListPrintTest : FunSpec({
+   context("when a collection size limit has been set") {
+      val config = TestConfigValue(5, "the test config value")
+      val printer = ListPrint<String>(config)
+
+      test("should format an empty list correctly") {
+         printer.print(emptyList(), 0).value shouldBe "[]"
+      }
+
+      test("should format a single item list correctly") {
+         printer.print(listOf("value"), 0).value shouldBe """["value"]"""
+      }
+
+      test("should include all items when formatting a list shorter than the provided limit") {
+         printer.print(listOf("a", "b", "c"), 0).value shouldBe """["a", "b", "c"]"""
+      }
+
+      test("should include all items when formatting a list with the same length as the provided limit") {
+         printer.print(listOf("a", "b", "c", "d", "e"), 0).value shouldBe """["a", "b", "c", "d", "e"]"""
+      }
+
+      test("should only included a limited number of items when formatting a list longer than the provided limit") {
+         printer.print(listOf("a", "b", "c", "d", "e", "f", "g"), 0).value shouldBe """["a", "b", "c", "d", "e", ...and 2 more (set the test config value to see more / less items)]"""
+      }
+   }
+
+   context("when the collection size limit has been disabled") {
+      val config = TestConfigValue(-1, "the test config value")
+      val printer = ListPrint<String>(config)
+
+      test("should format an empty list correctly") {
+         printer.print(emptyList(), 0).value shouldBe "[]"
+      }
+
+      test("should format a single item list correctly") {
+         printer.print(listOf("value"), 0).value shouldBe """["value"]"""
+      }
+
+      test("should include all items when formatting a long list") {
+         printer.print(listOf("a", "b", "c", "d", "e", "f", "g"), 0).value shouldBe """["a", "b", "c", "d", "e", "f", "g"]"""
+      }
+   }
+})
+
+class TestConfigValue<T>(override val value: T, override val sourceDescription: String) : ConfigValue<T>

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/ListPrintTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/print/ListPrintTest.kt
@@ -6,27 +6,38 @@ import io.kotest.matchers.shouldBe
 
 class ListPrintTest : FunSpec({
    context("when a collection size limit has been set") {
-      val config = TestConfigValue(5, "the test config value")
-      val printer = ListPrint<String>(config)
+      context("and a description of the source of the limit is available") {
+         val config = TestConfigValue(5, "the test config value")
+         val printer = ListPrint<String>(config)
 
-      test("should format an empty list correctly") {
-         printer.print(emptyList(), 0).value shouldBe "[]"
+         test("should format an empty list correctly") {
+            printer.print(emptyList(), 0).value shouldBe "[]"
+         }
+
+         test("should format a single item list correctly") {
+            printer.print(listOf("value"), 0).value shouldBe """["value"]"""
+         }
+
+         test("should include all items when formatting a list shorter than the provided limit") {
+            printer.print(listOf("a", "b", "c"), 0).value shouldBe """["a", "b", "c"]"""
+         }
+
+         test("should include all items when formatting a list with the same length as the provided limit") {
+            printer.print(listOf("a", "b", "c", "d", "e"), 0).value shouldBe """["a", "b", "c", "d", "e"]"""
+         }
+
+         test("should only include a limited number of items when formatting a list longer than the provided limit") {
+            printer.print(listOf("a", "b", "c", "d", "e", "f", "g"), 0).value shouldBe """["a", "b", "c", "d", "e", ...and 2 more (set the test config value to see more / less items)]"""
+         }
       }
 
-      test("should format a single item list correctly") {
-         printer.print(listOf("value"), 0).value shouldBe """["value"]"""
-      }
+      context("and a description of the source of the limit is not available") {
+         val config = TestConfigValue(5, null)
+         val printer = ListPrint<String>(config)
 
-      test("should include all items when formatting a list shorter than the provided limit") {
-         printer.print(listOf("a", "b", "c"), 0).value shouldBe """["a", "b", "c"]"""
-      }
-
-      test("should include all items when formatting a list with the same length as the provided limit") {
-         printer.print(listOf("a", "b", "c", "d", "e"), 0).value shouldBe """["a", "b", "c", "d", "e"]"""
-      }
-
-      test("should only included a limited number of items when formatting a list longer than the provided limit") {
-         printer.print(listOf("a", "b", "c", "d", "e", "f", "g"), 0).value shouldBe """["a", "b", "c", "d", "e", ...and 2 more (set the test config value to see more / less items)]"""
+         test("should not include a hint on how to configure the limit when the list is longer than the limit") {
+            printer.print(listOf("a", "b", "c", "d", "e", "f", "g"), 0).value shouldBe """["a", "b", "c", "d", "e", ...and 2 more]"""
+         }
       }
    }
 
@@ -48,4 +59,4 @@ class ListPrintTest : FunSpec({
    }
 })
 
-class TestConfigValue<T>(override val value: T, override val sourceDescription: String) : ConfigValue<T>
+class TestConfigValue<T>(override val value: T, override val sourceDescription: String?) : ConfigValue<T>

--- a/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/sysprop.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/sysprop.kt
@@ -1,4 +1,7 @@
 package io.kotest.mpp
 
+import platform.posix.getenv
+import kotlinx.cinterop.toKString
+
 actual fun sysprop(name: String): String? = null
-actual fun env(name: String): String? = null
+actual fun env(name: String): String? = getenv(name)?.toKString()


### PR DESCRIPTION
Replacement for #2827.

Summary of changes:
* All collection matchers now use `print()` to format collections, which ends up using `ListPrint`
* Added a new `AssertionsConfig.maxCollectionPrintSize` property, which takes its value from the `kotest.assertions.collection.print.size` system property on the JVM, and the `kotest_assertions_collection_print_size` environment variable when running on Kotlin/Native.
* `ListPrint` now respects the value of `AssertionsConfig.maxCollectionPrintSize` when printing lists, and includes a hint on how to configure the limit

~~Still to be done:~~
* ~~Add implementation of `env()` for Kotlin/JS: I have never used Kotlin/JS before and my Googling is not finding an answer for this. Is there an easy way to get an environment variable in Kotlin/JS? `process.env` doesn't seem to be accessible.~~

Future improvements:
* I haven't added any tests for Kotlin/Native as this doesn't seem to be set up and seemed like quite a large task outside the scope of this PR.
* I haven't touched the other values in `AssertionsConfig`, but these could potentially use `ConfigValue` as well.