### PR TITLE
Fix random spec sorter creating invalid comparator

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/sorters.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/sorters.kt
@@ -30,7 +30,8 @@ object LexicographicSpecSorter : SpecSorter {
  * An implementation of [SpecExecutionOrder] which will order specs randomly.
  */
 class RandomSpecSorter(private val random: Random) : SpecSorter {
-   override fun compare(a: KClass<out Spec>, b: KClass<out Spec>): Int = random.nextInt()
+   override fun compare(a: KClass<out Spec>, b: KClass<out Spec>): Int = 0
+   override fun sort(specs: List<SpecRef>): List<SpecRef> = specs.shuffled(random)
 }
 
 /**
@@ -41,7 +42,7 @@ class RandomSpecSorter(private val random: Random) : SpecSorter {
  * Note: Runtime annotations are not supported on Native or JS so on those platforms
  * this sort order is a no-op.
  */
-expect object AnnotatedSpecSorter :SpecSorter
+expect object AnnotatedSpecSorter : SpecSorter
 
 /**
  * An implementation of [SpecExecutionOrder] which will order specs that failed on the last run,

--- a/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/spec/SpecSorterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/spec/SpecSorterTest.kt
@@ -1,0 +1,19 @@
+package com.sksamuel.kotest.engine.spec
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.spec.RandomSpecSorter
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random
+
+class SpecSorterTest : FunSpec({
+   context("random spec sorter") {
+      test("should not throw 'Comparison method violates its general contract' with consistent ordering") {
+         val seed = 2342731194744841942L
+         val specRefs: List<SpecRef> = generateSequence { SpecRef.Reference(FunSpec::class) }.take(100).toList()
+         val ordered = shouldNotThrowAny { RandomSpecSorter(Random(seed)).sort(specRefs) }
+         ordered shouldBe specRefs.shuffled(Random(seed))
+      }
+   }
+})


### PR DESCRIPTION
### In this PR
- Fix the implementation of `RandomSpecSorter::sort` to use `list.shuffled` instead of comparator.

fixes #2839 