### PR TITLE
Fix compilation error in example

### DIFF
--- a/doc/reference_3.2.md
+++ b/doc/reference_3.2.md
@@ -306,7 +306,7 @@ object TimerListener : TestListener {
   }
 
   override fun afterTest(testCase: TestCase, result: TestResult): Unit {
-    println("Duration of ${testCase.description} = " + (System.currentTimeMillis() - started))
+    println("Duration of ${testCase.descriptor} = " + (System.currentTimeMillis() - started))
   }
 }
 ```

--- a/doc/reference_3.3.md
+++ b/doc/reference_3.3.md
@@ -344,7 +344,7 @@ object TimerListener : TestListener {
   }
 
   override fun afterTest(testCase: TestCase, result: TestResult): Unit {
-    println("Duration of ${testCase.description} = " + (System.currentTimeMillis() - started))
+    println("Duration of ${testCase.descriptor} = " + (System.currentTimeMillis() - started))
   }
 }
 ```

--- a/documentation/docs/framework/extensions/examples.md
+++ b/documentation/docs/framework/extensions/examples.md
@@ -39,7 +39,7 @@ object TimerListener : BeforeTestListener, AfterTestListener {
   }
 
   override fun afterTest(testCase: TestCase, result: TestResult): Unit {
-    println("Duration of ${testCase.description} = " + (System.currentTimeMillis() - started))
+    println("Duration of ${testCase.descriptor} = " + (System.currentTimeMillis() - started))
   }
 }
 ```


### PR DESCRIPTION
https://kotest.io/docs/framework/extensions/extension-examples.html

The code listed above didn't compile with `io.kotest:kotest-framework-api-jvm:5.1.0`.
So I fixed the documents.

I think this pull request introduced the relevant change.
https://github.com/kotest/kotest/pull/2509/files#diff-22ba5bc340d94549bb752f5c91e426910e50d63f4f816490635c98937a0af482