### PR TITLE
fix typos in docs/framework

### DIFF
--- a/documentation/docs/framework/conditional/gradle.md
+++ b/documentation/docs/framework/conditional/gradle.md
@@ -5,7 +5,7 @@ slug: conditional-tests-with-gradle.html
 sidebar_label: Gradle
 ---
 
-Kotest suports two ways to filter tests from the command line using Gradle. The first is the standard --tests flag
+Kotest supports two ways to filter tests from the command line using Gradle. The first is the standard --tests flag
 that gradle supports, and the second is a kotest specific system property.
 
 

--- a/documentation/docs/framework/datatesting/data_driven_testing.md
+++ b/documentation/docs/framework/datatesting/data_driven_testing.md
@@ -34,7 +34,7 @@ returns true if the input values are valid triples (_a squared + b squared = c s
 fun isPythagTriple(a: Int, b: Int, c: Int): Boolean = a * a + b * b == c * c
 ```
 
-Since we need more than one element per row (we need 3), we start by definining a data class that will hold a single _
+Since we need more than one element per row (we need 3), we start by defining a data class that will hold a single _
 row_ of values (in our case, the two inputs, and the expected result).
 
 ```kotlin
@@ -64,7 +64,7 @@ class MyTests : FunSpec({
 Notice that because we are using data classes, the input row can be destructured into the member properties.
 When this is executed, we will have 4 test cases in our input, one for each input row.
 
-Kotest will automatically generate a test case for each input row, as if you had manually written a seperate test case
+Kotest will automatically generate a test case for each input row, as if you had manually written a separate test case
 for each.
 
 ![data test example output](datatest1.png)

--- a/documentation/docs/framework/datatesting/nested.md
+++ b/documentation/docs/framework/datatesting/nested.md
@@ -47,7 +47,7 @@ context("each service should support all http methods") {
     val methods = listOf("GET", "POST", "PUT")
 
     withData(services) { service ->
-       withData<String>({ "should suppport HTTP $it" }, methods) { method ->
+       withData<String>({ "should support HTTP $it" }, methods) { method ->
           // test service against method
        }
     }

--- a/documentation/docs/framework/lifecycle_hooks.md
+++ b/documentation/docs/framework/lifecycle_hooks.md
@@ -9,7 +9,7 @@ It is extremely common in tests to want to perform some action before and after 
 It is in these _lifecycle hooks_ that you would perform any setup/teardown logic required for a test.
 
 Kotest provides a rich assortment of hooks that can be defined directly inside a spec.
-For more advanced cases, such as writing distributable plugins or re-usuable hooks, one can use [extensions](extensions/extensions.md).
+For more advanced cases, such as writing distributable plugins or re-usable hooks, one can use [extensions](extensions/extensions.md).
 
 At the end of this section is a list of the available hooks and when they are executed.
 

--- a/documentation/docs/framework/writing_tests.md
+++ b/documentation/docs/framework/writing_tests.md
@@ -38,7 +38,7 @@ but is essentially just a different keyword used for the outer tests.
 
 For example, in _Describe Spec_, the outer tests are created using the `describe` function and
 inner tests using the `it` function.
-Javascript and Ruby developers will instantly recongize this style as it is commonly used in testing frameworks
+JavaScript and Ruby developers will instantly recognize this style as it is commonly used in testing frameworks
 for those languages.
 
 ```kotlin


### PR DESCRIPTION
Found some typos in the documents, so I fixed them.