### PR TITLE
fix Arb.map to honor minSize parameter in both generation and shrinks

### DIFF
--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
@@ -1,14 +1,19 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.alphanumeric
 import io.kotest.property.arbitrary.edgecases
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.pair
+import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.string
 import io.kotest.property.arbitrary.take
 import io.kotest.property.arbitrary.withEdgecases
@@ -41,6 +46,61 @@ class MapsTest : FunSpec({
             Pair(7, "edge"),
             Pair(5, "LOFBhzunuV")
          )
+      }
+   }
+
+   context("Arb.map with individual key arb and value arb") {
+      test("should generate map of a specified size") {
+         val arbMap = Arb.map(Arb.int(1..10), Arb.string(1..10, Codepoint.alphanumeric()), minSize = 5, maxSize = 10)
+         val maps = arbMap.take(1000, RandomSource.seeded(12345L)).toList()
+         maps.forAll { it.size shouldBeInRange 5..10 }
+      }
+
+      test("should produce shrinks that adhere to minimum size") {
+         val arbMap = Arb.map(Arb.int(1..10), Arb.string(1..10, Codepoint.alphanumeric()), minSize = 5, maxSize = 10)
+         val maps = arbMap.samples(RandomSource.seeded(12345L)).take(100).toList()
+         val shrinks = maps.flatMap { it.shrinks.children.value }
+         shrinks.forAll { it.value().size shouldBeInRange 5..10 }
+      }
+
+      test("should throw when the cardinality of the key arbitrary does not satisfy the required minimum size") {
+         val arbKey = Arb.int(1..3)
+         val arbMap = Arb.map(arbKey, Arb.string(1..10), minSize = 5, maxSize = 10)
+         shouldThrowWithMessage<IllegalArgumentException>(
+            "the minimum size requirement of 5 could not be satisfied after 90 consecutive samples"
+         ) {
+            arbMap.single(RandomSource.seeded(1234L))
+         }
+      }
+   }
+
+
+   context("Arb.map with arb pair") {
+      test("should generate map of a specified size") {
+         val arbPair = Arb.pair(Arb.int(1..10), Arb.string(1..10, Codepoint.alphanumeric()))
+         val arbMap = Arb.map(arbPair, minSize = 5, maxSize = 10)
+         val maps = arbMap.take(100, RandomSource.seeded(12345L)).toList()
+         maps.forAll { it.size shouldBeInRange 5..10 }
+      }
+
+      test("should produce shrinks that adhere to minimum size") {
+         val arbPair = Arb.pair(Arb.int(1..10), Arb.string(1..10, Codepoint.alphanumeric()))
+         val arbMap = Arb.map(arbPair, minSize = 5, maxSize = 10)
+         val maps = arbMap.samples(RandomSource.seeded(12345L)).take(100).toList()
+         val shrinks = maps.flatMap { it.shrinks.children.value }
+         shrinks.forAll {
+            it.value().size shouldBeInRange 5..10
+         }
+      }
+
+      test("should throw when the cardinality of the key arbitrary does not satisfy the required minimum size") {
+         val arbPair = Arb.pair(Arb.int(1..3), Arb.string(1..10, Codepoint.alphanumeric()))
+         val arbMap = Arb.map(arbPair, minSize = 5, maxSize = 10)
+         shouldThrowWithMessage<IllegalArgumentException>(
+            "the minimum size requirement of 5 could not be satisfied after 90 consecutive samples"
+         ) {
+            arbMap.single(RandomSource.seeded(1234L))
+         }
       }
    }
 })


### PR DESCRIPTION
### In this PR
- Implements the logic used in Arb.set to Arb.map.
- Fix MapShrinker to filter out shrinks that are lower than minSize
- tests for Arb.map

potentially fixes #2889 