### PR TITLE
haveElementAt Matcher throw ArrayIndexOutOfBoundsException

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -13,14 +13,6 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.jvm.JvmName
 
-/**
- * Verifies that this collection contains the sub collections provided in the exact given order.
- *
- * So, for example, listOf(1,2,3) contains exactly the sub collections:
- *
- * [], [1], [2], [3], [1,2], [2,3] and [1,2,3].
- *
- */
 @JvmName("shouldContainExactly_iterable")
 infix fun <T> Iterable<T>?.shouldContainExactly(expected: Iterable<T>) =
    this?.toList() should containExactly(expected.toList())

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -17,7 +17,7 @@ fun <T> List<T>.shouldNotHaveElementAt(index: Int, element: T) = this shouldNot 
 fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L> {
    override fun test(value: L) =
       MatcherResult(
-         value[index] == element,
+         index < value.size && value[index] == element,
          { "Collection ${value.print().value} should contain ${element.print().value} at index $index" },
          { "Collection ${value.print().value} should not contain ${element.print().value} at index $index" }
       )

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -148,6 +148,7 @@ class CollectionMatchersTest : WordSpec() {
             listOf("a", "b", "c") should haveElementAt(1, "b")
             listOf("a", "b", "c") shouldNot haveElementAt(1, "c")
             listOf("a", "b", null) should haveElementAt(2, null)
+            listOf("a", "b", null) shouldNot haveElementAt(3, null)
 
             listOf("a", "b", "c").shouldHaveElementAt(1, "b")
             listOf("a", "b", "c").shouldNotHaveElementAt(1, "c")


### PR DESCRIPTION
ArrayIndexOutOfBoundsException when testing with following:
```
listOf("a", "b", null) shouldNot haveElementAt(10, null)
```
Expect to have a positive result, since index 10 does not exist