### PR TITLE
implement trampolines for flatmap, map, filter, merge.

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/map.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/map.kt
@@ -8,26 +8,69 @@ import io.kotest.property.map
 /**
  * Returns a new [Arb] which takes its elements from the receiver and maps them using the supplied function.
  */
-fun <A, B> Arb<A>.map(f: (A) -> B): Arb<B> = object : Arb<B>() {
-
-   override fun edgecase(rs: RandomSource): B? = this@map.edgecase(rs)?.let(f)
-
-   override fun sample(rs: RandomSource): Sample<B> =
-      this@map.sample(rs).let {
-         Sample(f(it.value), it.shrinks.map(f))
+fun <A, B> Arb<A>.map(fn: (A) -> B): Arb<B> = trampoline { sampleA ->
+   object : Arb<B>() {
+      override fun edgecase(rs: RandomSource): B? = fn(sampleA.value)
+      override fun sample(rs: RandomSource): Sample<B> {
+         val value = fn(sampleA.value)
+         val shrinks = sampleA.shrinks.map(fn)
+         return Sample(value, shrinks)
       }
+   }
 }
 
 /**
  * Returns a new [Arb] which takes its elements from the receiver and maps them using the supplied function.
  */
-fun <A, B> Arb<A>.flatMap(f: (A) -> Arb<B>): Arb<B> = object : Arb<B>() {
+fun <A, B> Arb<A>.flatMap(fn: (A) -> Arb<B>): Arb<B> = trampoline { fn(it.value) }
 
-   override fun edgecase(rs: RandomSource): B? {
-      // generate an edge case, map it to another arb, and generate an edge case again
-      val a = this@flatMap.edgecase(rs) ?: this@flatMap.next(rs)
-      return f(a).edgecase(rs)
+/**
+ * Returns a new [TrampolineArb] from the receiver [Arb] which composes the operations of [next] lambda
+ * using a trampoline method. This allows [next] function to be executed without exhausting call stack.
+ */
+internal fun <A, B> Arb<A>.trampoline(next: (Sample<A>) -> Arb<B>): Arb<B> = when (this) {
+   is TrampolineArb -> thunk(next)
+   else -> TrampolineArb(this).thunk(next)
+}
+
+/**
+ * The [TrampolineArb] is a special Arb that exchanges call stack with heap.
+ * In a nutshell, this arb stores command chains to be applied to the original arb inside a list.
+ * This technique is an imperative reduction of Free Monads. This eliminates the need of creating intermediate
+ * Trampoline Monad and tail-recursive function on those which can be expensive.
+ * This minimizes the amount of code and unnecessary object allocation during sample generation in the expense of typesafety.
+ *
+ * This is an internal implementation. Do not use this TrampolineArb as is and please do not expose this
+ * to users outside of the library. For library maintainers, please use the [Arb.trampoline] extension function.
+ * The extension function will provide some type-guardrails to workaround the loss of types within this Arb.
+ */
+@Suppress("UNCHECKED_CAST")
+internal class TrampolineArb<A>(val first: Arb<A>) : Arb<A>() {
+   private val commandList: MutableList<(Sample<Any>) -> Arb<Any>> = mutableListOf()
+
+   fun <A, B> thunk(fn: (Sample<A>) -> Arb<B>): TrampolineArb<B> {
+      val nextFn: (Sample<A>) -> Arb<B> = { fn(it) }
+      commandList.add(nextFn as (Sample<Any>) -> Arb<Any>)
+      return this as TrampolineArb<B>
    }
 
-   override fun sample(rs: RandomSource): Sample<B> = f(this@flatMap.sample(rs).value).sample(rs)
+   override fun edgecase(rs: RandomSource): A? {
+      var currentArb = first as Arb<Any>
+      for (command in commandList) {
+         val currentEdge = currentArb.edgecase(rs) ?: currentArb.sample(rs).value
+         currentArb = command(Sample(currentEdge))
+      }
+
+      return currentArb.edgecase(rs) as A?
+   }
+
+   override fun sample(rs: RandomSource): Sample<A> {
+      var currentArb = first as Arb<Any>
+      for (command in commandList) {
+         val currentSample = currentArb.sample(rs)
+         currentArb = command(currentSample)
+      }
+
+      return currentArb.sample(rs) as Sample<A>
+   }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BuilderTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
@@ -55,6 +56,17 @@ class BuilderTest : FunSpec() {
       }
 
       context("arbitrary builder using restricted continuation") {
+         test("should be stack safe") {
+            val arb: Arb<Int> = arbitrary {
+               (1..100000).map {
+                  Arb.int().bind()
+               }.last()
+            }
+
+            val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234)) }
+            result shouldBe -1486934023
+         }
+
          test("should be equivalent to chaining flatMaps") {
             val arbFlatMaps: Arb<String> =
                Arb.string(5, Codepoint.alphanumeric()).withEdgecases("edge1", "edge2").flatMap { first ->

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FilterTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FilterTest.kt
@@ -1,16 +1,21 @@
 package com.sksamuel.kotest.property.arbitrary
 
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotBeIn
+import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.Sample
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.of
+import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.take
 import io.kotest.property.arbitrary.withEdgecases
 
@@ -53,5 +58,14 @@ class FilterTest : FunSpec({
             it.value() shouldNotBeIn oddNumbers
          }
       }
+   }
+
+   test("Arb.filter composition should not exhaust call stack") {
+      var arb: Arb<Int> = Arb.of(0, 1)
+      repeat(10000) {
+         arb = arb.filter { it == 0 }
+      }
+      val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234L)) }
+      result shouldBe 0
    }
 })

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FlatMapTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FlatMapTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
@@ -100,6 +101,20 @@ class FlatMapTest : FunSpec() {
          }
          val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234L)) }
          result shouldBe 49
+      }
+
+      test("should yield a new immutable arb") {
+         val firstArb: Arb<Int> =  Arb.int(-3..3)
+         val secondArb: Arb<Int> = firstArb.flatMap { Arb.int(10..30) }
+         val thirdArb: Arb<String> = secondArb.flatMap { Arb.string(3, Codepoint.alphanumeric()) }
+
+         firstArb shouldNotBeSameInstanceAs secondArb
+         firstArb shouldNotBeSameInstanceAs thirdArb
+         secondArb shouldNotBeSameInstanceAs thirdArb
+
+         firstArb.single(RandomSource.seeded(1234L)) shouldBe 3
+         secondArb.single(RandomSource.seeded(1234L)) shouldBe 28
+         thirdArb.single(RandomSource.seeded(1234L)) shouldBe "tID"
       }
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FlatMapTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FlatMapTest.kt
@@ -1,7 +1,9 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
@@ -85,6 +87,19 @@ class FlatMapTest : FunSpec() {
                3,
                22
             )
+      }
+
+      test("Arb.flatMap composition should not exhaust call stack") {
+         var arb: Arb<Int> = Arb.int(-3..3)
+         repeat(10000) {
+            arb = arb.flatMap { value ->
+               Arb.int(-3..3).flatMap {
+                  Arb.of(value + it)
+               }
+            }
+         }
+         val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234L)) }
+         result shouldBe 49
       }
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -10,6 +11,7 @@ import io.kotest.property.arbitrary.IntShrinker
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.withEdgecases
 import java.util.concurrent.atomic.AtomicInteger
@@ -46,5 +48,14 @@ class MapTest : FunSpec({
          "119",
          "120"
       )
+   }
+
+   test("Arb.map composition should not exhaust call stack") {
+      var arb: Arb<Int> = Arb.of(0)
+      repeat(10000) {
+         arb = arb.map { value -> value + 1 }
+      }
+      val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234L)) }
+      result shouldBe 10000
    }
 })

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/MergeTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/MergeTest.kt
@@ -1,7 +1,13 @@
 package com.sksamuel.kotest.property.exhaustive
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.merge
+import io.kotest.property.arbitrary.of
+import io.kotest.property.arbitrary.single
 import io.kotest.property.exhaustive.exhaustive
 import io.kotest.property.exhaustive.merge
 
@@ -26,5 +32,14 @@ class MergeTest : FunSpec({
          Common.Foo(3),
          Common.Bar(6)
       )
+   }
+
+   test("Arb.merge composition should not exhaust call stack") {
+      var arb: Arb<Int> = Arb.of(0)
+      repeat(100) {
+         arb = arb.merge(Arb.of(1))
+      }
+      val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234L)) }
+      result shouldBe 1
    }
 })


### PR DESCRIPTION
### in this PR
- implement trampolines for flatmap, map, filter, merge.
- Remove suspension point allocation in single shot builder.

fixes #2896 

### Context:
`Arb.flatMap`, `Arb.map`, `Arb.filter` and `Arb.merge` was previously implemented using callbacks, where it creates a new arb which `.edgecase` and `.sample` function directly calls the receiver arb's function. While this works for shallow nestings, on bigger nestings and more complex structures this approach can easily exhaust the call stack.

In this PR i implemented a simple trampoline to transform the receiver `Arb<A>` to `TrampolineArb<A>`. `TrampolineArb<A>` stores the initial arb and all subsequent operation chains inside a list, which will be executed in order of application. This allows us to compose a longer chain of flatMaps without blowing up the stack. Visually it looks like this:
```kotlin
receiverArb
  .flatMap { value -> fn1(value) } 
  .flatMap { value -> fn2(value) } 
  ...
  .flatMap { value -> fnN(value) } 

// translated to
`TrampolineArb(receiverArb)`
[
  () -> Arb0
  (sampleOrEdgecase) -> Arb1,
  (sampleOrEdgecase) -> Arb2,
  ...
  (sampleOrEdgecase) -> ArbN
]
```
That function will then be computed by collapsing the function list from left to right and applying the random source from the context of `.sample(rs)` or `.edgecase(rs)`. If one is familiar with the trampoline implementation of Free Monad, this more or less the same mechanism implemented without tail recursion and trampoline data type. 

Similarly within `arbitrary { }` builder, it appears that suspensions also has a limit on the number of suspension points that can be stored. Since Continuations are single-shot anyway, we can instead pass in the type of action that the call site needs, e.g. whether it is an edgecase generation or sample generation. This way we can get rid of the `.resume()` call within the `.bind()` in favour of just a simple return. 
