### PR TITLE
Matcher support startsWith regex

### DIFF
--- a/doc/matchers/core.md
+++ b/doc/matchers/core.md
@@ -60,6 +60,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `str.shouldBeInteger([radix])` | Asserts that the string contains an integer and returns it. |
 | `str.shouldContainOnlyOnce(substring)` | Asserts that the string contains the substring exactly once. |
 | `str.shouldEndWith("suffix")` | Asserts that the string ends with the given suffix. The suffix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
+| `str.shouldEndWith("regex")`             | Asserts that the string end with the given regex.       |
 | `str.shouldHaveLength(length)` | Asserts that the string has the given length. |
 | `str.shouldHaveLineCount(count)` | Asserts that the string contains the given number of lines. Similar to `str.split("\n").length.shouldBe(n)` |
 | `str.shouldHaveMaxLength(max)` | Asserts that the string is no longer than the given max length. |
@@ -67,6 +68,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `str.shouldHaveSameLengthAs(length)` | Asserts that the string has the same length as another string. |
 | `str.shouldMatch(regex)` | Asserts that the string fully matches the given regex. |
 | `str.shouldStartWith("prefix")` | Asserts that the string starts with the given prefix. The prefix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
+| `str.shouldStartWith("regex")`        | Asserts that the string starts with the given regex.       |
 | `str.shouldBeEqualIgnoringCase(other)` | Asserts that the string is equal to another string ignoring case. |
 
 | Integers ||

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/end.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/end.kt
@@ -25,3 +25,18 @@ fun endWith(suffix: CharSequence): Matcher<CharSequence?> = neverNullMatcher { v
          "${value.print().value} should not end with ${suffix.print().value}"
       })
 }
+
+infix fun <A : CharSequence?> A.shouldEndWith(regex: Regex): A {
+   this should endWith(regex)
+   return this
+}
+
+fun endWith(regex: Regex): Matcher<CharSequence?> = neverNullMatcher { value ->
+   val endWithRegex = ".*${regex.pattern}$".toRegex()
+   MatcherResult(
+      value matches endWithRegex,
+      { "${value.print().value} should end with regex ${regex.pattern}" },
+      {
+         "${value.print().value} should not end with regex ${regex.pattern}"
+      })
+}

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
@@ -35,3 +35,19 @@ fun startWith(prefix: CharSequence): Matcher<CharSequence?> = neverNullMatcher {
       { msg },
       { notmsg })
 }
+
+infix fun <A : CharSequence?> A.shouldStartWith(regex: Regex): A {
+   this should startWith(regex)
+   return this
+}
+
+@OptIn(ExperimentalStdlibApi::class)
+fun startWith(regex: Regex): Matcher<CharSequence?> = neverNullMatcher { value ->
+   val ok = regex.matchesAt(value, 0)
+   MatcherResult(
+      ok,
+      { "${value.print().value} should start with regex ${regex.pattern}" },
+      {
+         "${value.print().value} should not start with regex ${regex.pattern}"
+      })
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/EndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/EndWithTest.kt
@@ -8,6 +8,8 @@ import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.endWith
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldNotEndWith
+import io.kotest.matchers.string.shouldStartWith
+import io.kotest.matchers.string.startWith
 
 @Suppress("RedundantNullableReturnType")
 class EndWithTest : FreeSpec() {
@@ -22,12 +24,16 @@ class EndWithTest : FreeSpec() {
             "hello" shouldEndWith "lo"
             "hello" shouldEndWith "o"
             "hello" shouldNotEndWith "w"
+            "hello" shouldEndWith "(lo|sa)".toRegex()
             "" should endWith("")
             shouldThrow<AssertionError> {
                "" should endWith("h")
             }
             shouldThrow<AssertionError> {
                "hello" should endWith("goodbye")
+            }
+            shouldThrow<AssertionError> {
+               "hello" should endWith("(el|lol)".toRegex())
             }
          }
          "work with char seqs" {
@@ -64,6 +70,11 @@ class EndWithTest : FreeSpec() {
             shouldThrow<AssertionError> {
                null shouldEndWith "o"
             }.message shouldBe "Expecting actual not to be null"
+         }
+         "should show should end with regex in error message" {
+            shouldThrow<AssertionError> {
+               "hello" should endWith("(e|ol)".toRegex())
+            }.message shouldBe "\"hello\" should end with regex (e|ol)"
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StartWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StartWithTest.kt
@@ -19,6 +19,7 @@ class StartWithTest : FreeSpec() {
             "hello" shouldStartWith ""
             "hello" shouldStartWith "h"
             "hello" shouldStartWith "he"
+            "hello" shouldStartWith "(he|hi)".toRegex()
             "hello" shouldNotStartWith "w"
             "hello" shouldNotStartWith "wo"
             "" should startWith("")
@@ -27,6 +28,9 @@ class StartWithTest : FreeSpec() {
             }
             shouldThrow<AssertionError> {
                "hello" should startWith("goodbye")
+            }
+            shouldThrow<AssertionError> {
+               "hello" should startWith("(el|lo)".toRegex())
             }
          }
          "work with char seqs" {
@@ -52,6 +56,11 @@ class StartWithTest : FreeSpec() {
                "la tour eiffel" should startWith("la tour tower london")
             }.message shouldBe "\"la tour eiffel\" should start with \"la tour tower london\" (diverged at index 8)"
          }
+         "should show should start with regex in error message" {
+            shouldThrow<AssertionError> {
+               "hello" should startWith("(e|lo)".toRegex())
+            }.message shouldBe "\"hello\" should start with regex (e|lo)"
+         }
          "should fail if value is null" {
             shouldThrow<AssertionError> {
                null should startWith("h")
@@ -69,5 +78,6 @@ class StartWithTest : FreeSpec() {
                null shouldNotStartWith "w"
             }.message shouldBe "Expecting actual not to be null"
          }
-      }   }
+      }
+   }
 }


### PR DESCRIPTION
Solution is based on **matches** matcher since I don't see **startsWith** method in Kotlin stdlib. If this is not acceptable then I'll find another way.
I've also prepared tests and updated documentation.

I also noticed that there would be need to write similar method in **endsWith** matcher. Are you able to prepare task for that?

Closes feature/gh-2892