### PR TITLE
docs: mention Native platforms on the framework main page

### DIFF
--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -12,8 +12,8 @@ const features = [
       imageUrl: 'img/undraw_docusaurus_mountain.svg',
       description: (
          <>
-            The Kotest test framework enables test to be laid out in a fluid way and execute them on the JVM or
-            Javascript.
+            The Kotest test framework enables test to be laid out in a fluid way and execute them on JVM, Javascript,
+            or native platforms.
 
             <br/><br/>
 


### PR DESCRIPTION
Even though https://kotest.io/ mentions "multi-platform", it limits itself to `JVM or Javascript`.

This can be a bit deceiving and lead people to think that native targets are not supported before digging deeper into docs and understanding that this isn't the case.

This PR adds a mention to "native platforms".


How it currently looks on the website, with "Jvm or Javascript" highlighted:
![grafik](https://user-images.githubusercontent.com/9389043/162767861-828370d3-5db6-4e69-ac45-6f6adf9e15f3.png)