### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -8,6 +8,9 @@ on:
          - '*.md'
          - '*.yml'
 
+permissions:
+  contents: read
+
 jobs:
    build:
       strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
       branches:
          - release/*
 
+permissions:
+  contents: read
+
 jobs:
    linux:
       runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,8 +6,13 @@ on:
          - master
       paths:
          - 'documentation/**'
+permissions:
+  contents: read
+
 jobs:
    deploy:
+      permissions:
+        contents: write  # for Git to git push
       runs-on: ubuntu-latest
       steps:
          -  uses: actions/checkout@v3

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,6 +10,9 @@ on:
       branches:
          - master
 
+permissions:
+  contents: read
+
 jobs:
    linux_tests:
       if: github.repository == 'kotest/kotest'

--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -18,6 +18,9 @@ env:
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
    GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
+permissions:
+  contents: read
+
 jobs:
    publish_base:
       runs-on: ubuntu-latest

--- a/.github/workflows/release_multiplatform_plugin_gradle.yml
+++ b/.github/workflows/release_multiplatform_plugin_gradle.yml
@@ -11,6 +11,9 @@ env:
    RELEASE_VERSION: ${{ github.event.inputs.version }}
    GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
+permissions:
+  contents: read
+
 jobs:
    release-plugin:
       runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
