### PR TITLE
Remove deprecated listeners override

### DIFF
--- a/documentation/docs/extensions/html_reporter.md
+++ b/documentation/docs/extensions/html_reporter.md
@@ -25,15 +25,13 @@ class ProjectConfig : AbstractProjectConfig() {
 
    override val specExecutionOrder = SpecExecutionOrder.Annotated
 
-   override fun listeners(): List<Listener> {
-      return listOf(
-         JunitXmlReporter(
+    override fun extensions(): List<Extension> = listOf(
+        JunitXmlReporter(
             includeContainers = false,
-            useTestPathAsName = true
-         ),
-         HtmlReporter()
-      )
-   }
+            useTestPathAsName = true,
+        ),
+        HtmlReporter()
+    )
 }
 ```
 


### PR DESCRIPTION
`listeners` are deprecated and will be removed. I suggest we update the HTML generator documentation