### PR TITLE
SortedBy matcher

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -166,6 +166,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `collection.shouldHaveAtLeastSize(n)`           | Asserts that the collection has at least size n.                                                                                                                  |
 | `collection.shouldHaveAtMostSize(n)`            | Asserts that the collection has at most size n.                                                                                                                   |
 | `list.shouldBeSorted()`                         | Asserts that the list is sorted.                                                                                                                                  |
+| `list.shouldBeSortedBy { transform }`           | Asserts that the list is sorted by the value after applying the transform.                                                                                        |
 | `list.shouldContainInOrder(other)`              | Asserts that this list contains the given list in order. Other elements may appear either side of the given list.                                                 |
 | `list.shouldExistInOrder({ element }, ...)`     | Asserts that this list contains elements matching the predicates in order. Other elements may appear around or between the elements matching the predicates.      |
 | `list.shouldHaveElementAt(index, element)`      | Asserts that this list contains the given element at the given position.                                                                                          |

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -53,9 +53,12 @@ fun <T> singleElement(p: (T) -> Boolean): Matcher<Collection<T>> = object : Matc
 }
 
 fun <T : Comparable<T>> beSorted(): Matcher<List<T>> = sorted()
-fun <T : Comparable<T>> sorted(): Matcher<List<T>> = object : Matcher<List<T>> {
+fun <T : Comparable<T>> sorted(): Matcher<List<T>> = sortedBy { it }
+
+fun <T, E : Comparable<E>> beSortedBy(transform: (T) -> E): Matcher<List<T>> = sortedBy(transform)
+fun <T, E : Comparable<E>> sortedBy(transform: (T) -> E): Matcher<List<T>> = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
-      val failure = value.withIndex().firstOrNull { (i, it) -> i != value.lastIndex && it > value[i + 1] }
+      val failure = value.withIndex().firstOrNull { (i, it) -> i != value.lastIndex && transform(it) > transform(value[i + 1]) }
       val elementMessage = when (failure) {
          null -> ""
          else -> ". Element ${failure.value} at index ${failure.index} was greater than element ${value[failure.index + 1]}"

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sorted.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sorted.kt
@@ -56,6 +56,36 @@ fun <T : Comparable<T>> List<T>.shouldNotBeSorted(): List<T> {
    return this
 }
 
+fun <T, E : Comparable<E>> Iterable<T>.shouldBeSortedBy(transform: (T) -> E): Iterable<T> {
+   toList().shouldBeSortedBy(transform)
+   return this
+}
+
+fun <T, E : Comparable<E>> Array<T>.shouldBeSortedBy(transform: (T) -> E): Array<T> {
+   asList().shouldBeSortedBy(transform)
+   return this
+}
+
+fun <T, E : Comparable<E>> List<T>.shouldBeSortedBy(transform: (T) -> E): List<T> {
+   this should beSortedBy(transform)
+   return this
+}
+
+fun <T, E : Comparable<E>> Iterable<T>.shouldNotBeSortedBy(transform: (T) -> E): Iterable<T> {
+   toList().shouldNotBeSortedBy(transform)
+   return this
+}
+
+fun <T, E : Comparable<E>> Array<T>.shouldNotBeSortedBy(transform: (T) -> E): Array<T> {
+   asList().shouldNotBeSortedBy(transform)
+   return this
+}
+
+fun <T, E : Comparable<E>> List<T>.shouldNotBeSortedBy(transform: (T) -> E): List<T> {
+   this shouldNot beSortedBy(transform)
+   return this
+}
+
 infix fun <T> Iterable<T>.shouldBeSortedWith(comparator: Comparator<in T>): Iterable<T> {
    toList().shouldBeSortedWith(comparator)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -37,6 +37,7 @@ import io.kotest.matchers.collections.shouldBeSameSizeAs
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldBeSmallerThan
 import io.kotest.matchers.collections.shouldBeSorted
+import io.kotest.matchers.collections.shouldBeSortedBy
 import io.kotest.matchers.collections.shouldBeSortedWith
 import io.kotest.matchers.collections.shouldBeStrictlyDecreasing
 import io.kotest.matchers.collections.shouldBeStrictlyDecreasingWith
@@ -62,6 +63,7 @@ import io.kotest.matchers.collections.shouldNotBeMonotonicallyIncreasing
 import io.kotest.matchers.collections.shouldNotBeMonotonicallyIncreasingWith
 import io.kotest.matchers.collections.shouldNotBeSingleton
 import io.kotest.matchers.collections.shouldNotBeSorted
+import io.kotest.matchers.collections.shouldNotBeSortedBy
 import io.kotest.matchers.collections.shouldNotBeSortedWith
 import io.kotest.matchers.collections.shouldNotBeStrictlyDecreasing
 import io.kotest.matchers.collections.shouldNotBeStrictlyDecreasingWith
@@ -178,6 +180,8 @@ class CollectionMatchersTest : WordSpec() {
 
       "sorted" should {
          "test that a collection is sorted" {
+            emptyList<Int>() shouldBe sorted<Int>()
+            listOf(1) shouldBe sorted<Int>()
             listOf(1, 2, 3, 4) shouldBe sorted<Int>()
 
             shouldThrow<AssertionError> {
@@ -201,6 +205,23 @@ class CollectionMatchersTest : WordSpec() {
             shouldThrow<AssertionError> {
                longList.shouldNotBeSorted()
             }.shouldHaveMessage("List [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 980 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)] should not be sorted")
+         }
+      }
+
+      "sortedBy" should {
+         val items = listOf(
+            1 to "I",
+            2 to "II",
+            4 to "IV",
+            5 to "V",
+            6 to "VI",
+            9 to "IX",
+            10 to "X"
+         )
+
+         "compare by the tranformed value" {
+            items.shouldBeSortedBy { it.first }
+            items.shouldNotBeSortedBy { it.second }
          }
       }
 


### PR DESCRIPTION
Adding a `sortedBy` turned out to be surprisingly easy 👏 

The old `sorted()` simply forwards to the new `sortedBy` with the identity function `{ it }`.

Closes #2940 