### PR TITLE
Updated docs on Pitest extension for Maven users

### DIFF
--- a/documentation/versioned_docs/version-5.3/extensions/pitest.md
+++ b/documentation/versioned_docs/version-5.3/extensions/pitest.md
@@ -8,6 +8,8 @@ slug: pitest.html
 
 The Mutation Testing tool [Pitest](https://pitest.org/) is integrated with Kotest via an extension module.
 
+## Gradle configuration
+
 After [configuring](https://gradle-pitest-plugin.solidsoft.info/) Pitest,
 add the `io.kotest.extensions:kotest-extensions-pitest` module to your dependencies as well:
 
@@ -28,3 +30,36 @@ configure<PitestPluginExtension> {
 ```
 
 This should set everything up, and running `./gradlew pitest` will generate reports in the way you configured.
+
+## Maven configuration
+
+First of all, you need to configure the [Maven Pitest plugin](https://pitest.org/quickstart/maven/):
+
+```xml
+<plugin>
+    <groupId>org.pitest</groupId>
+    <artifactId>pitest-maven</artifactId>
+    <version>${pitest-maven.version}</version>
+    <configuration>
+        <targetClasses>...</targetClasses>
+        <coverageThreshold>...</coverageThreshold>
+        ... other configurations as needed        
+    </configuration>
+</plugin>
+```
+
+Then add the dependency on Pitest Kotest extension:
+
+```xml
+<dependencies>
+  ... the other Kotest dependencies like kotest-runner-junit5-jvm 
+  <dependency>
+    <groupId>io.kotest.extensions</groupId>
+    <artifactId>kotest-extensions-pitest</artifactId>
+    <version>${kotest-extensions-pitest.version}</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>
+```
+
+This should be enough to be able to run Pitest and get the reports as described in the [Maven Pitest plugin](https://pitest.org/quickstart/maven/).


### PR DESCRIPTION
Following the conversation in #2913 , I'm updating the Pitest extension docs to get more clarity on how it should be configured for Maven users.

This PR is the same as #2955 , to target kotest 5.3 docs.