### PR TITLE
JsonArray contains validation

### DIFF
--- a/documentation/docs/assertions/json/schema.md
+++ b/documentation/docs/assertions/json/schema.md
@@ -8,7 +8,7 @@ sidebar_label: Schema matchers
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|
 | `shouldMatchSchema` | Validates that a `String` or `kotlinx.serialization.JsonElement` matches a `JsonSchema`. See description below for details on constructing schemas. | Multiplatform |
 
-## Defining Schemas
+## Parsing Schema
 
 A subset of [JSON Schemas](https://json-schema.org/) can be defined either by parsing a textual schema. Example:
 
@@ -62,7 +62,23 @@ val personSchema = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently missing support for:
+## Building Schema
+
+### Array
+
+Arrays are used for ordered elements. In JSON, each element in an array may be of a different type.
+
+#### Length (minItems and maxItems)
+
+The length of the array can be specified using the `minItems` and `maxItems` keywords. The value of each keyword must be a
+non-negative number and defaults are 0 and Int.MAX_VALUE
+```kotlin
+val lengthBoundedSchema = jsonSchema {
+  array(minItems = 0, maxItems = 1) { number() }
+}
+```
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
 
 * $defs and $refs
 * Recursive schemas

--- a/documentation/docs/assertions/json/schema.md
+++ b/documentation/docs/assertions/json/schema.md
@@ -78,6 +78,15 @@ val lengthBoundedSchema = jsonSchema {
 }
 ```
 
+#### Uniqueness
+
+A schema can ensure that each of the items in an array is unique. Simply set the `uniqueItems` keyword to true.
+```kotlin
+val uniqueArray = jsonSchema {
+  array(uniqueItems = true) { number() }
+}
+```
+
 ⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
 
 * $defs and $refs

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
@@ -1,5 +1,6 @@
 package io.kotest.assertions.json
 
+@kotlinx.serialization.Serializable
 sealed class JsonNode {
 
    fun type() = when (this) {

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
@@ -1,6 +1,8 @@
 package io.kotest.assertions.json
 
-@kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializable
+
+@Serializable
 sealed class JsonNode {
 
    fun type() = when (this) {

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -52,7 +52,11 @@ data class JsonSchema(
    internal interface JsonNumber
 
    @Serializable
-   data class JsonArray(val elementType: JsonSchemaElement) : JsonSchemaElement {
+   data class JsonArray(
+      val minItems: Int = 0,
+      val maxItems: Int = Int.MAX_VALUE,
+      val elementType: JsonSchemaElement
+   ) : JsonSchemaElement {
       override fun typeName() = "array"
    }
 
@@ -208,10 +212,14 @@ fun JsonSchema.Builder.obj(dsl: JsonSchema.JsonObjectBuilder.() -> Unit = {}) =
 
 /**
  * Defines a [JsonSchema.JsonArray] node where the elements are of the type provided by [typeBuilder].
+iI * The length of the array can be specified using the [minItems] and [maxItems] keywords.
+ *
+ * @param minItems - minimum array length, default value is 0
+ * @param maxItems - maximum array length, default value is [Int.MAX_VALUE]
  */
 @ExperimentalKotest
-fun JsonSchema.Builder.array(typeBuilder: () -> JsonSchemaElement) =
-   JsonSchema.JsonArray(typeBuilder())
+fun JsonSchema.Builder.array(minItems: Int = 0, maxItems: Int = Int.MAX_VALUE, typeBuilder: () -> JsonSchemaElement) =
+   JsonSchema.JsonArray(minItems, maxItems, typeBuilder())
 
 @ExperimentalKotest
 fun jsonSchema(

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -214,8 +214,8 @@ fun JsonSchema.Builder.obj(dsl: JsonSchema.JsonObjectBuilder.() -> Unit = {}) =
  * Defines a [JsonSchema.JsonArray] node where the elements are of the type provided by [typeBuilder].
  * The length of the array can be specified using the [minItems] and [maxItems] keywords.
  *
- * [minItems] - minimum array length, default value is 0
- * [maxItems] - maximum array length, default value is [Int.MAX_VALUE]
+ * @param minItems - minimum array length, default value is 0
+ * @param maxItems - maximum array length, default value is [Int.MAX_VALUE]
  */
 @ExperimentalKotest
 fun JsonSchema.Builder.array(minItems: Int = 0, maxItems: Int = Int.MAX_VALUE, typeBuilder: () -> JsonSchemaElement) =

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -212,10 +212,10 @@ fun JsonSchema.Builder.obj(dsl: JsonSchema.JsonObjectBuilder.() -> Unit = {}) =
 
 /**
  * Defines a [JsonSchema.JsonArray] node where the elements are of the type provided by [typeBuilder].
-iI * The length of the array can be specified using the [minItems] and [maxItems] keywords.
+ * The length of the array can be specified using the [minItems] and [maxItems] keywords.
  *
- * @param minItems - minimum array length, default value is 0
- * @param maxItems - maximum array length, default value is [Int.MAX_VALUE]
+ * [minItems] - minimum array length, default value is 0
+ * [maxItems] - maximum array length, default value is [Int.MAX_VALUE]
  */
 @ExperimentalKotest
 fun JsonSchema.Builder.array(minItems: Int = 0, maxItems: Int = Int.MAX_VALUE, typeBuilder: () -> JsonSchemaElement) =

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -1,10 +1,14 @@
 package io.kotest.assertions.json.schema
 
+import ContainsSpec
 import io.kotest.assertions.json.JsonNode
 import io.kotest.assertions.json.JsonNode.*
 import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.Matcher
+import io.kotest.matchers.collections.containAnyOf
 import io.kotest.matchers.sequences.beUnique
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
 
 @DslMarker
@@ -56,6 +60,7 @@ data class JsonSchema(
       val minItems: Int = 0,
       val maxItems: Int = Int.MAX_VALUE,
       val matcher: Matcher<Sequence<JsonNode>>? = null,
+      val contains: ContainsSpec? = null,
       val elementType: JsonSchemaElement,
    ) : JsonSchemaElement {
       override fun typeName() = "array"
@@ -218,10 +223,14 @@ fun JsonSchema.Builder.obj(dsl: JsonSchema.JsonObjectBuilder.() -> Unit = {}) =
  */
 @ExperimentalKotest
 fun JsonSchema.Builder.array(
-   minItems: Int = 0, maxItems: Int = Int.MAX_VALUE, uniqueItems: Boolean = false, typeBuilder: () -> JsonSchemaElement
+   minItems: Int = 0,
+   maxItems: Int = Int.MAX_VALUE,
+   uniqueItems: Boolean = false,
+   contains: ContainsSpec? = null,
+   typeBuilder: () -> JsonSchemaElement
 ): JsonSchema.JsonArray {
    val matcher: Matcher<Sequence<JsonNode>>? = if (uniqueItems) beUnique() else null
-   return JsonSchema.JsonArray(minItems, maxItems, matcher, typeBuilder())
+   return JsonSchema.JsonArray(minItems, maxItems, matcher, contains, typeBuilder())
 }
 
 @ExperimentalKotest
@@ -230,3 +239,5 @@ fun jsonSchema(
 ): JsonSchema = JsonSchema(
    JsonSchema.Builder.rootBuilder()
 )
+
+fun JsonSchema.Builder.containsSpec(schema: JsonSchema.Builder.() -> JsonSchemaElement) = ContainsSpec(schema())

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/specs.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/specs.kt
@@ -1,0 +1,6 @@
+import io.kotest.assertions.json.schema.JsonSchema
+import io.kotest.assertions.json.schema.JsonSchemaElement
+import kotlinx.serialization.Serializable
+
+@kotlinx.serialization.Serializable
+data class ContainsSpec(val schema: JsonSchemaElement)

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/io/kotest/assertions/json/schema/ArraySchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/io/kotest/assertions/json/schema/ArraySchemaTest.kt
@@ -74,5 +74,16 @@ class ArraySchemaTest : FunSpec(
             $ => Expected items between 0 and 1, but was 2
          """.trimIndent()
       }
+
+      test("Array not unique") {
+         val array = "[1,1]"
+         val uniqueArray = jsonSchema {
+            array(uniqueItems = true) { number() }
+         }
+         array shouldNotMatchSchema uniqueArray
+         shouldFail { array shouldMatchSchema uniqueArray }.message shouldBe """
+            $ => Sequence should be Unique
+         """.trimIndent()
+      }
    }
 )

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/io/kotest/assertions/json/schema/ArraySchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/io/kotest/assertions/json/schema/ArraySchemaTest.kt
@@ -52,5 +52,27 @@ class ArraySchemaTest : FunSpec(
             $[2].age => Expected number, but was undefined
          """.trimIndent()
       }
+
+      test("Array size smaller than minItems") {
+         val array = "[1]"
+         val sizeBoundedArray = jsonSchema {
+            array(minItems = 2, maxItems = 3) { number() }
+         }
+         array shouldNotMatchSchema sizeBoundedArray
+         shouldFail { array shouldMatchSchema sizeBoundedArray }.message shouldBe """
+            $ => Expected items between 2 and 3, but was 1
+         """.trimIndent()
+      }
+
+      test("Array size larger than maxItems") {
+         val array = "[1,2]"
+         val sizeBoundedArray = jsonSchema {
+            array(minItems = 0, maxItems = 1) { number() }
+         }
+         array shouldNotMatchSchema sizeBoundedArray
+         shouldFail { array shouldMatchSchema sizeBoundedArray }.message shouldBe """
+            $ => Expected items between 0 and 1, but was 2
+         """.trimIndent()
+      }
    }
 )

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/io/kotest/assertions/json/schema/ArraySchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/io/kotest/assertions/json/schema/ArraySchemaTest.kt
@@ -37,7 +37,7 @@ class ArraySchemaTest : FunSpec(
 
       test("array with partial inner match is not ok") {
          val missingAge =
-         """
+            """
             [
                { "name": "bob" },
                { "name": "bob", "age": 3 },
@@ -84,6 +84,25 @@ class ArraySchemaTest : FunSpec(
          shouldFail { array shouldMatchSchema uniqueArray }.message shouldBe """
             $ => Sequence should be Unique
          """.trimIndent()
+      }
+
+      test("Array not contains string") {
+         val array = "[1,1]"
+         val containsStringArray = jsonSchema {
+            array(contains = containsSpec { string() }) { number() }
+         }
+         array shouldNotMatchSchema containsStringArray
+         shouldFail { array shouldMatchSchema containsStringArray }.message shouldBe """
+            $ => Expected any item of type string
+         """.trimIndent()
+      }
+
+      test("Array contains strings and numbers") {
+         val array = "[\"life\", \"universe\", \"everything\", 42]\n"
+         val containsStringArray = jsonSchema {
+            array(contains = containsSpec { number() }) { number() }
+         }
+         array shouldMatchSchema containsStringArray
       }
    }
 )


### PR DESCRIPTION
**This PR is blocked by https://github.com/kotest/kotest/pull/2987** 

I've tried to implement suggestion from https://github.com/kotest/kotest/issues/2978#issuecomment-1129184204. 

As I wrote in comment https://github.com/kotest/kotest/issues/2977#issuecomment-1133717454 I was wondering how to deal with multiple `elementType`. In this PR I left availability to use two but if contains is not null then we don't look at `JsonArray.elementType`. 

Additional question is where `ContainSpec` should be placed?