### PR TITLE
Add truthy & falsy to assertions documents

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -76,6 +76,8 @@ Matchers provided by the `kotest-assertions-core` module.
 | `str.shouldMatch(regex)`                    | Asserts that the string fully matches the given regex. |
 | `str.shouldStartWith("prefix")`             | Asserts that the string starts with the given prefix. The prefix can be equal to the string. This matcher is case sensitive. To make this case insensitive call `toLowerCase()` on the value before the matcher. |
 | `str.shouldBeEqualIgnoringCase(other)`      | Asserts that the string is equal to another string ignoring case. |
+| `str.shouldBeTruthy()`                      | Asserts that the string is truthy. Truthy is one of the followings: ["true", "yes", "y", "1"] |
+| `str.shouldBeFalsy()`                       | Asserts that the string is falsy. Falsy is one of the followings: ["false", "no", "n", "0"] |
 
 | Integers                            ||
 |-------------------------------------| ---- |


### PR DESCRIPTION
[Issue 2927-Add String truthy/falsy matchers to the documentation](https://github.com/kotest/kotest/issues/2927)

Truthy & falsy are not documented in [core-matchers assertion](https://kotest.io/docs/assertions/core-matchers.html).
Added those two to related document (documentation/docs/assertions/core.md).