### PR TITLE
Adds FieldsEqualityCheckConfig to wrap multiple config option for shouldBeEqualToComparingFields matcher.

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -312,14 +312,34 @@ fun <T : Any> beEqualToIgnoringFields(
  * @param other the other class to which equality need to be checked.
  * @param ignorePrivateFields specify whether private fields should be ignored in equality check or not, default value is true
  * @param ignoreComputedFields specify whether computed fields should be ignored in equality check or not, default value is true
+ * @param useDefaultShouldBeForFields fully qualified name of data type for which we need to use default shouldBe, default empty.
  *
  * */
+@Deprecated(
+   message = "This will be removed in Kotest 7.0",
+   replaceWith = ReplaceWith("shouldBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> T.shouldBeEqualToComparingFields(
    other: T,
    ignorePrivateFields: Boolean = true,
-   ignoreComputedFields: Boolean = true
+   ignoreComputedFields: Boolean = true,
+   useDefaultShouldBeForFields: List<String> = emptyList(),
 ) {
-   this should beEqualComparingFields(other, ignorePrivateFields, emptyList(), ignoreComputedFields)
+   shouldBeEqualToComparingFields(
+      other, FieldsEqualityCheckConfig(
+         ignorePrivateFields = ignorePrivateFields,
+         ignoreComputedFields = ignoreComputedFields,
+         propertiesToExclude = emptyList(),
+         useDefaultShouldBeForFields = useDefaultShouldBeForFields
+      )
+   )
+}
+
+fun <T : Any> T.shouldBeEqualToComparingFields(
+   other: T,
+   fieldsEqualityCheckConfig: FieldsEqualityCheckConfig = FieldsEqualityCheckConfig()
+) {
+   this should beEqualComparingFields(other, fieldsEqualityCheckConfig)
 }
 
 /**
@@ -337,6 +357,10 @@ fun <T : Any> T.shouldBeEqualToComparingFields(
  * @param ignoreProperty fields which should be ignored during equality check
  * @param ignoreProperties fields which should be ignored during equality check
  * */
+@Deprecated(
+   message = "This will be removed in Kotest 7.0",
+   replaceWith = ReplaceWith("shouldBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> T.shouldBeEqualToComparingFieldsExcept(
    other: T,
    ignorePrivateFields: Boolean,
@@ -344,14 +368,20 @@ fun <T : Any> T.shouldBeEqualToComparingFieldsExcept(
    vararg ignoreProperties: KProperty<*>,
    ignoreComputedFields: Boolean = true
 ) {
-   this should beEqualComparingFields(
+   shouldBeEqualToComparingFields(
       other,
-      ignorePrivateFields,
-      listOf(ignoreProperty) + ignoreProperties,
-      ignoreComputedFields
+      FieldsEqualityCheckConfig(
+         ignorePrivateFields = ignorePrivateFields,
+         ignoreComputedFields = ignoreComputedFields,
+         propertiesToExclude = listOf(ignoreProperty) + ignoreProperties,
+      )
    )
 }
 
+@Deprecated(
+   message = "This will be removed in Kotest 7.0",
+   replaceWith = ReplaceWith("shouldNotBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> T.shouldNotBeEqualToComparingFieldsExcept(
    other: T,
    ignorePrivateFields: Boolean,
@@ -359,44 +389,76 @@ fun <T : Any> T.shouldNotBeEqualToComparingFieldsExcept(
    vararg ignoreProperties: KProperty<*>,
    includeComputedProperties: Boolean = false
 ) {
-   this shouldNot beEqualComparingFields(
+   shouldNotBeEqualToComparingFields(
       other,
-      ignorePrivateFields,
-      listOf(ignoreProperty) + ignoreProperties,
-      includeComputedProperties
+      FieldsEqualityCheckConfig(
+         ignorePrivateFields = ignorePrivateFields,
+         ignoreComputedFields = !includeComputedProperties,
+         propertiesToExclude = listOf(ignoreProperty) + ignoreProperties
+      )
    )
 }
 
+@Deprecated(
+   message = "This will be removed in Kotest 7.0",
+   replaceWith = ReplaceWith("shouldBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> T.shouldBeEqualToComparingFieldsExcept(
    other: T,
    ignoreProperty: KProperty<*>,
    vararg ignoreProperties: KProperty<*>
 ) {
-   this should beEqualComparingFields(other, true, listOf(ignoreProperty) + ignoreProperties, true)
+   shouldBeEqualToComparingFields(
+      other,
+      FieldsEqualityCheckConfig(propertiesToExclude = listOf(ignoreProperty) + ignoreProperties)
+   )
 }
 
+@Deprecated(
+   message = "This will be removed in Kotest 7.0",
+   replaceWith = ReplaceWith("shouldNotBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> T.shouldNotBeEqualToComparingFieldsExcept(
    other: T,
    ignoreProperty: KProperty<*>,
    vararg ignoreProperties: KProperty<*>
 ) {
-   this should beEqualComparingFields(other, true, listOf(ignoreProperty) + ignoreProperties, true)
+   shouldNotBeEqualToComparingFields(
+      other,
+      FieldsEqualityCheckConfig(propertiesToExclude = listOf(ignoreProperty) + ignoreProperties)
+   )
 }
 
 infix fun <T : Any> T.shouldBeEqualToComparingFields(other: T) {
-   this.shouldBeEqualToComparingFields(other, true)
+   shouldBeEqualToComparingFields(other, FieldsEqualityCheckConfig())
 }
 
 infix fun <T : Any> T.shouldNotBeEqualToComparingFields(other: T) {
-   this shouldNot beEqualComparingFields(other, true, emptyList(), true)
+   this shouldNot beEqualComparingFields(other, FieldsEqualityCheckConfig())
 }
 
+fun <T : Any> T.shouldNotBeEqualToComparingFields(
+   other: T,
+   fieldsEqualityCheckConfig: FieldsEqualityCheckConfig
+) {
+   this shouldNot beEqualComparingFields(other, fieldsEqualityCheckConfig)
+}
+
+@Deprecated(
+   message = "This will be removed in Kotest 7.0",
+   replaceWith = ReplaceWith("shouldNotBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> T.shouldNotBeEqualToComparingFields(
    other: T,
    ignorePrivateFields: Boolean = true,
    ignoreComputedFields: Boolean = true
 ) {
-   this shouldNot beEqualComparingFields(other, ignorePrivateFields, emptyList(), ignoreComputedFields)
+   shouldNotBeEqualToComparingFields(
+      other, FieldsEqualityCheckConfig(
+         ignorePrivateFields = ignorePrivateFields,
+         ignoreComputedFields = ignoreComputedFields
+      )
+   )
 }
 
 private typealias PropertyPredicate = (KProperty<*>) -> Boolean
@@ -408,36 +470,53 @@ private val nonPrivate: PropertyPredicate = { it.visibility != KVisibility.PRIVA
 private infix fun PropertyPredicate.and(other: PropertyPredicate) =
    { property: KProperty<*> -> this(property) && other(property) }
 
+@Deprecated(
+   message = "This will be removed in Kotest 6.0",
+   replaceWith = ReplaceWith("beEqualComparingFields(other, fieldEqualityCheckConfig)")
+)
 fun <T : Any> beEqualComparingFields(
    other: T,
    ignorePrivateFields: Boolean,
    propertiesToExclude: List<KProperty<*>>,
    ignoreComputedFields: Boolean,
-) = object : Matcher<T> {
-   override fun test(value: T): MatcherResult {
-      val (failed, fieldsToCompare) = checkEqualityOfFieldsRecursively(
-         value,
-         other,
-         ignorePrivateFields,
-         ignoreComputedFields,
-         propertiesToExclude
-      )
+   useDefaultShouldBeForFields: List<String> = emptyList(),
+) = beEqualComparingFields(
+   other, FieldsEqualityCheckConfig(
+      ignorePrivateFields = ignorePrivateFields,
+      ignoreComputedFields = ignoreComputedFields,
+      propertiesToExclude = propertiesToExclude,
+      useDefaultShouldBeForFields = useDefaultShouldBeForFields,
+   )
+)
 
-      return MatcherResult(
-         failed.isEmpty(),
-         {
-            """Expected ${value.print().value} to equal ${other.print().value}
+fun <T : Any> beEqualComparingFields(
+   other: T,
+   fieldsEqualityCheckConfig: FieldsEqualityCheckConfig
+): Matcher<T> {
+   return object : Matcher<T> {
+      override fun test(value: T): MatcherResult {
+         val (failed, fieldsToCompare) = checkEqualityOfFieldsRecursively(
+            value,
+            other,
+            fieldsEqualityCheckConfig,
+         )
+
+         return MatcherResult(
+            failed.isEmpty(),
+            {
+               """Expected ${value.print().value} to equal ${other.print().value}
             | Using fields: ${fieldsToCompare.joinToString(", ") { it.name }}
             | Value differ at:
             | ${failed.withIndex().joinToString("\n") { "${it.index + 1}) ${it.value}" }}
          """.trimMargin()
-         },
-         {
-            """Expected ${value.print().value} to not equal ${other.print().value}
+            },
+            {
+               """Expected ${value.print().value} to not equal ${other.print().value}
             | Using fields: ${fieldsToCompare.joinToString(", ") { it.name }}
          """.trimMargin()
-         }
-      )
+            }
+         )
+      }
    }
 }
 
@@ -455,15 +534,13 @@ private fun <T> checkEqualityOfFields(fields: List<KProperty<*>>, value: T, othe
 private fun <T> checkEqualityOfFieldsRecursively(
    value: T,
    other: T,
-   ignorePrivateFields: Boolean,
-   ignoreComputedFields: Boolean,
-   propertiesToExclude: List<KProperty<*>>,
+   config: FieldsEqualityCheckConfig,
    level: Int = 1
 ): Pair<List<String>, List<KProperty1<out T, *>>> {
    val predicates = listOfNotNull(
-      if (ignorePrivateFields) nonPrivate else null,
-      if (ignoreComputedFields) nonComputed else null,
-      { it !in propertiesToExclude }
+      if (config.ignorePrivateFields) nonPrivate else null,
+      if (config.ignoreComputedFields) nonComputed else null,
+      { it !in config.propertiesToExclude }
    ).reduce { a, b -> a and b }
 
    val fields = value!!::class.memberProperties
@@ -476,10 +553,10 @@ private fun <T> checkEqualityOfFieldsRecursively(
    return fields.mapNotNull {
       val actual = it.getter.call(value)
       val expected = it.getter.call(other)
-      val typeName = it.returnType.toString()
+      val typeName = it.returnType.toString().replace("?", "")
       val heading = "${it.name}:"
 
-      if (actual == null || expected == null || typeName.startsWith("kotlin") || typeName.startsWith("java") ) {
+      if (requiresUseOfDefaultEq(actual, expected, typeName, config.useDefaultShouldBeForFields)) {
          val throwable = eq(actual, expected)
          if (throwable != null) {
             "$heading\n${"\t".repeat(level + 1)}${throwable.message}"
@@ -490,9 +567,7 @@ private fun <T> checkEqualityOfFieldsRecursively(
          val (errorMessage, _) = checkEqualityOfFieldsRecursively(
             actual,
             expected,
-            ignorePrivateFields,
-            ignoreComputedFields,
-            propertiesToExclude,
+            config,
             level + 1
          )
          if (errorMessage.isEmpty()) {
@@ -504,4 +579,23 @@ private fun <T> checkEqualityOfFieldsRecursively(
       }
    } to fields
 }
+
+private fun requiresUseOfDefaultEq(
+   actual: Any?,
+   expected: Any?,
+   typeName: String,
+   useDefaultEqualForFields: List<String>
+): Boolean {
+   val expectedOrActualIsNull = actual == null || expected == null
+   val typeIsJavaOrKotlinBuiltIn by lazy { typeName.startsWith("kotlin") || typeName.startsWith("java") }
+   return expectedOrActualIsNull || typeIsJavaOrKotlinBuiltIn || useDefaultEqualForFields.contains(typeName)
+}
+
+data class FieldsEqualityCheckConfig(
+   val ignorePrivateFields: Boolean = true,
+   val ignoreComputedFields: Boolean = true,
+   val propertiesToExclude: List<KProperty<*>> = emptyList(),
+   val useDefaultShouldBeForFields: List<String> = emptyList()
+)
+
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -303,16 +303,17 @@ fun <T : Any> beEqualToIgnoringFields(
 /**
  * Matcher that compares values without using field by field comparison.
  *
- * This matcher should be used to check equality of two class for which you want to consider there fields for equality
- * instead of its equals method.
+ * This matcher should be used to check equality of two class for which you want to consider their fields for equality
+ * instead of its `equals` method.
  *
- * This matcher recursively check equality of given values till we get a java or kotlin class. Once we get a java or kotlin
- * class the equality of that fields will be same as that we get with shouldBe matcher.
+ * This matcher recursively check equality of given values till we get a java class, kotlin class or fields for which we have
+ * specified to use default shouldBe. Once we get a java class, kotlin class or specified field the equality of that fields
+ * will be same as that we get with shouldBe matcher.
  *
  * @param other the other class to which equality need to be checked.
  * @param ignorePrivateFields specify whether private fields should be ignored in equality check or not, default value is true
  * @param ignoreComputedFields specify whether computed fields should be ignored in equality check or not, default value is true
- * @param useDefaultShouldBeForFields fully qualified name of data type for which we need to use default shouldBe, default empty.
+ * @param useDefaultShouldBeForFields fully qualified names of data type for which we need to use default shouldBe, default empty list.
  *
  * */
 @Deprecated(
@@ -335,6 +336,43 @@ fun <T : Any> T.shouldBeEqualToComparingFields(
    )
 }
 
+/**
+ *  Matcher that compares values without using field by field comparison.
+ *
+ * This matcher should be used to check equality of two class for which you want to consider their fields for equality
+ * instead of its `equals` method.
+ *
+ * This matcher recursively check equality of given values till we get a java class, kotlin class or fields for which we have
+ * specified to use default shouldBe. Once we get a java class, kotlin class or specified field the equality of that fields
+ * will be same as that we get with shouldBe matcher.
+ *
+ * @param other the other class to which equality need to be checked.
+ * @param fieldsEqualityCheckConfig the config to control the field by field comparison.
+ *
+ * @see FieldsEqualityCheckConfig
+ *
+ * Example:
+ *  ```
+ *  package org.foo.bar.domain
+ *
+ *  class ANestedClass(val name: String, val nestedField: AnotherNestedClass) {
+ *    private val id = UUID.randomUUID()
+ *  }
+ *  class AnotherNestedClass(val buffer: Buffer) {
+ *    val aComputedField: Int
+ *      get() = Random.nextInt()
+ *  }
+ *  class SomeClass(val name: String, val randomId: UUID ,val nestedField: ANestedClass)
+ *
+ *
+ *  someClass.shouldBeEqualToComparingFields(anotherInstanceOfSomeClass, FieldsEqualityCheckConfig(
+ *    ignorePrivateFields = true,
+ *    ignoreComputedFields = true,
+ *    propertiesToExclude = listOf(SomeClass::randomId),
+ *    useDefaultShouldBeForFields = listOf("org.foo.bar.domain.AnotherNestedClass")
+ *  ))
+ *  ```
+ * */
 fun <T : Any> T.shouldBeEqualToComparingFields(
    other: T,
    fieldsEqualityCheckConfig: FieldsEqualityCheckConfig = FieldsEqualityCheckConfig()
@@ -591,6 +629,15 @@ private fun requiresUseOfDefaultEq(
    return expectedOrActualIsNull || typeIsJavaOrKotlinBuiltIn || useDefaultEqualForFields.contains(typeName)
 }
 
+/**
+ * A config for controlling the way shouldBeEqualToComparingFields compare fields.
+ *
+ * @property ignorePrivateFields specify whether to exclude private fields in comparison. Default true.
+ * @property ignoreComputedFields specify whether to exclude computed fields in comparison. Default true.
+ * @property propertiesToExclude specify which field to exclude in comparison. Default emptyList.
+ * @property useDefaultShouldBeForFields fully qualified name of data type for which we need to use default shouldBe
+ *                                       matcher instead of recursive field by field comparison.
+ * */
 data class FieldsEqualityCheckConfig(
    val ignorePrivateFields: Boolean = true,
    val ignoreComputedFields: Boolean = true,

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.equality.*
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.mockk.mockk
 import org.junit.jupiter.api.assertThrows
 import kotlin.random.Random
 import kotlin.reflect.KVisibility
@@ -136,6 +137,19 @@ class ReflectionKtTest : FunSpec() {
          val city2 = City("test", Hospital("test-hospital", Doctor("doc", 50, listOf())))
 
          city.shouldBeEqualToComparingFields(city2)
+      }
+
+      test("shouldBeEqualToComparingFieldByField check equality comparing field by field recursively using default shouldBe for given types") {
+         val doctor = mockk<Doctor>()
+         val city = City("test", Hospital("test-hospital", doctor))
+         val city2 = City("test", Hospital("test-hospital", doctor))
+
+         city.shouldBeEqualToComparingFields(
+            city2,
+            FieldsEqualityCheckConfig(
+               useDefaultShouldBeForFields = listOf("com.sksamuel.kotest.matchers.equality.ReflectionKtTest.Doctor")
+            )
+         )
       }
 
       test("shouldBeEqualToComparingFieldByField check equality comparing field by field recursively handling nullable fields") {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
@@ -171,7 +171,7 @@ class ReflectionKtTest : FunSpec() {
          person.setAddress("new address")
 
          val errorMessage = shouldThrow<AssertionError> {
-            person.shouldBeEqualToComparingFields(Person("foo"), ignorePrivateFields = false)
+            person.shouldBeEqualToComparingFields(Person("foo"), FieldsEqualityCheckConfig(ignorePrivateFields = false))
          }.message
 
          errorMessage shouldContain "Using fields: address, isExhausted, name"
@@ -185,14 +185,16 @@ class ReflectionKtTest : FunSpec() {
          person.isExhausted = true
          person.setAddress("new address")
 
-         person.shouldBeEqualToComparingFieldsExcept(
+         person.shouldBeEqualToComparingFields(
             Person("foo"),
-            Person::isExhausted
+            FieldsEqualityCheckConfig(propertiesToExclude = listOf(Person::isExhausted))
          )
-         person.shouldBeEqualToComparingFieldsExcept(
+         person.shouldBeEqualToComparingFields(
             Person("foo"),
-            true,
-            Person::isExhausted
+            FieldsEqualityCheckConfig(
+               ignorePrivateFields = true,
+               propertiesToExclude = listOf(Person::isExhausted)
+            )
          )
       }
 
@@ -202,10 +204,12 @@ class ReflectionKtTest : FunSpec() {
          person.setAddress("new address")
 
          val message = shouldThrow<AssertionError> {
-            person.shouldBeEqualToComparingFieldsExcept(
+            person.shouldBeEqualToComparingFields(
                Person("foo"),
-               false,
-               Person::isExhausted
+               FieldsEqualityCheckConfig(
+                  ignorePrivateFields = false,
+                  propertiesToExclude = listOf(Person::isExhausted)
+               )
             )
          }.message
          message shouldContain "Using fields: address, name"
@@ -230,7 +234,10 @@ class ReflectionKtTest : FunSpec() {
 
       test("shouldNotBeEqualToComparingFields should consider private fields") {
          shouldThrow<AssertionError> {
-            Person("foo").shouldNotBeEqualToComparingFields(Person("foo"), false)
+            Person("foo").shouldNotBeEqualToComparingFields(
+               Person("foo"),
+               FieldsEqualityCheckConfig(ignorePrivateFields = false)
+            )
          }.message shouldContain "Using fields: address, isExhausted, name"
       }
 
@@ -241,7 +248,10 @@ class ReflectionKtTest : FunSpec() {
 
       test("shouldBeEqualToComparingFields can include computed field") {
          shouldFail {
-            HasComputedField("foo").shouldBeEqualToComparingFields(HasComputedField("foo"), ignoreComputedFields = false)
+            HasComputedField("foo").shouldBeEqualToComparingFields(
+               HasComputedField("foo"),
+               FieldsEqualityCheckConfig(ignoreComputedFields = false)
+            )
          }.message shouldContain "Using fields: name, random"
       }
 


### PR DESCRIPTION
Adds a new option to use default shouldBe for fields for which fully qualified name is provided in config