### PR TITLE
Property test seed persisting: catch invalid seedPath exceptions

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
@@ -17,8 +17,8 @@ actual fun readSeed(path: TestPath): Long? {
       }
    } catch (e: Exception) {
       println("Error reading seed")
-       e.print()
-       null
+      e.print()
+      null
    }
 
 fun seedDirectory(): Path = Paths.get(System.getProperty("user.home")).resolve(".kotest").resolve("seeds")

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
@@ -8,16 +8,18 @@ import java.nio.file.Paths
 import kotlin.io.path.notExists
 
 actual fun readSeed(path: TestPath): Long? {
-   val p = seedPath(path)
-   if (p.notExists()) return null
    return try {
-      Files.readAllLines(p).firstOrNull()?.trim()?.toLongOrNull()
+      val p = seedPath(path)
+      if (p.notExists()) {
+         null
+      } else {
+         Files.readAllLines(p).firstOrNull()?.trim()?.toLongOrNull()
+      }
    } catch (e: Exception) {
       println("Error reading seed")
-      e.print()
-      null
+       e.print()
+       null
    }
-}
 
 fun seedDirectory(): Path = Paths.get(System.getProperty("user.home")).resolve(".kotest").resolve("seeds")
 
@@ -26,9 +28,9 @@ fun seedPath(path: TestPath): Path {
 }
 
 actual fun writeSeed(path: TestPath, seed: Long) {
-   val f = seedPath(path)
-   f.parent.toFile().mkdirs()
    try {
+      val f = seedPath(path)
+      f.parent.toFile().mkdirs()
       Files.write(f, seed.toString().encodeToByteArray())
    } catch (e: Exception) {
       println("Error writing seed")
@@ -37,8 +39,8 @@ actual fun writeSeed(path: TestPath, seed: Long) {
 }
 
 actual fun clearSeed(path: TestPath) {
-   val f = seedPath(path)
    try {
+      val f = seedPath(path)
       f.toFile().deleteRecursively()
    } catch (e: Exception) {
       println("Error clearing seed")

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
@@ -20,6 +20,7 @@ actual fun readSeed(path: TestPath): Long? {
       e.print()
       null
    }
+}
 
 fun seedDirectory(): Path = Paths.get(System.getProperty("user.home")).resolve(".kotest").resolve("seeds")
 


### PR DESCRIPTION
Prevent errors with invalid paths crashing the tests - Put the `seedPath(path)` call in the try/catch.

This will help, but not resolve, https://github.com/kotest/kotest/issues/3047