### PR TITLE
Kotlin 1.7 compat test - replace `measureTime` with manual duration measure

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,4 +68,3 @@ junit-jupiter = ["junit-jupiter-api", "junit-jupiter-engine"]
 gradle-plugin-publish = { id = "com.gradle.plugin-publish", version.ref = "plugin-publish" }
 shadowjar = { id = "com.github.johnrengelman.shadow", version = "7.1.2" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/timing/EventuallyTest.kt
@@ -171,7 +171,7 @@ class EventuallyTest : WordSpec() {
             counter.get().shouldBe(2)
          }
          "handle shouldNotBeNull" {
-            val mark = TimeSource.Monotonic.markNow()
+            val mark = TimeSource.Monotonic.markNow() // TODO #3052
             shouldThrow<java.lang.AssertionError> {
                 eventually(50.milliseconds) {
                     val str: String? = null

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -56,7 +56,7 @@ suspend fun <T, E : Throwable> retry(
    exceptionClass: KClass<E>,
    f: suspend () -> T
 ): T {
-   val mark = TimeSource.Monotonic.markNow()
+   val mark = TimeSource.Monotonic.markNow() // TODO #3052
    val end = mark.plus(timeout)
    var retrySoFar = 0
    var nextAwaitDuration = delay.inWholeMilliseconds
@@ -86,4 +86,3 @@ suspend fun <T, E : Throwable> retry(
       lastError
    )
 }
-

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -4,7 +4,7 @@ import io.kotest.mpp.bestName
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 import kotlinx.coroutines.delay
 
 /**
@@ -56,7 +56,7 @@ suspend fun <T, E : Throwable> retry(
    exceptionClass: KClass<E>,
    f: suspend () -> T
 ): T {
-   val mark = TimeSource.Monotonic.markNow() // TODO #3052
+   val mark = MonotonicTimeSourceCompat.markNow() // TODO #3052
    val end = mark.plus(timeout)
    var retrySoFar = 0
    var nextAwaitDuration = delay.inWholeMilliseconds

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/continually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/continually.kt
@@ -25,7 +25,7 @@ data class Continually<T> (
    val listener: ContinuallyListener<T> = ContinuallyListener.noop,
    ) {
    suspend operator fun invoke(f: SuspendingProducer<T>): T? {
-      val start = TimeSource.Monotonic.markNow()
+      val start = TimeSource.Monotonic.markNow() // TODO #3052
       val end = start.plus(duration)
       var times = 0
       var result: T? = null

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/continually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/continually.kt
@@ -4,10 +4,11 @@ import io.kotest.assertions.SuspendingProducer
 import io.kotest.assertions.failure
 import io.kotest.assertions.until.Interval
 import io.kotest.assertions.until.fixed
-import kotlinx.coroutines.delay
+import io.kotest.common.MonotonicTimeSourceCompat
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
-import kotlin.time.TimeSource
+import kotlinx.coroutines.delay
 
 data class ContinuallyState(val start: TimeMark, val end: TimeMark, val times: Int)
 
@@ -19,13 +20,13 @@ fun interface ContinuallyListener<in T> {
    }
 }
 
-data class Continually<T> (
+data class Continually<T>(
    val duration: Duration = Duration.INFINITE,
-   val interval: Interval = Duration.milliseconds(25).fixed(),
+   val interval: Interval = 25.milliseconds.fixed(),
    val listener: ContinuallyListener<T> = ContinuallyListener.noop,
-   ) {
+) {
    suspend operator fun invoke(f: SuspendingProducer<T>): T? {
-      val start = TimeSource.Monotonic.markNow() // TODO #3052
+      val start = MonotonicTimeSourceCompat.markNow() // TODO #3052
       val end = start.plus(duration)
       var times = 0
       var result: T? = null
@@ -50,11 +51,15 @@ data class Continually<T> (
    }
 }
 
-@Deprecated("Use continually with an interval, using Duration based poll is deprecated",
+@Deprecated(
+   "Use continually with an interval, using Duration based poll is deprecated",
    ReplaceWith("continually(duration, poll.fixed(), f = f)", "io.kotest.assertions.until.fixed")
 )
 suspend fun <T> continually(duration: Duration, poll: Duration, f: suspend () -> T) =
    continually(duration, poll.fixed(), f = f)
 
-suspend fun <T> continually(duration: Duration, interval: Interval = Duration.milliseconds(10).fixed(), f: suspend () -> T) =
-   Continually<T>(duration, interval).invoke(f)
+suspend fun <T> continually(
+   duration: Duration,
+   interval: Interval = 10.milliseconds.fixed(),
+   f: suspend () -> T
+) = Continually<T>(duration, interval).invoke(f)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
@@ -5,12 +5,12 @@ import io.kotest.assertions.errorCollector
 import io.kotest.assertions.failure
 import io.kotest.assertions.until.Interval
 import io.kotest.assertions.until.fixed
-import kotlinx.coroutines.delay
+import io.kotest.common.MonotonicTimeSourceCompat
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
-import kotlin.time.TimeSource
+import kotlinx.coroutines.delay
 
 /**
  * Runs a function until it doesn't throw as long as the specified duration hasn't passed
@@ -78,7 +78,7 @@ suspend fun <T> eventually(
    f: suspend () -> T,
 ): T {
 
-   val start = TimeSource.Monotonic.markNow() // TODO #3052
+   val start = MonotonicTimeSourceCompat.markNow() // TODO #3052
    val end = start.plus(config.duration)
    var times = 0
    var firstError: Throwable? = null
@@ -120,7 +120,7 @@ suspend fun <T> eventually(
       }
       times++
       lastInterval = config.interval.next(times)
-      val delayMark = TimeSource.Monotonic.markNow() // TODO #3052
+      val delayMark = MonotonicTimeSourceCompat.markNow() // TODO #3052
       delay(lastInterval)
       lastDelayPeriod = delayMark.elapsedNow()
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/timing/eventually.kt
@@ -78,7 +78,7 @@ suspend fun <T> eventually(
    f: suspend () -> T,
 ): T {
 
-   val start = TimeSource.Monotonic.markNow()
+   val start = TimeSource.Monotonic.markNow() // TODO #3052
    val end = start.plus(config.duration)
    var times = 0
    var firstError: Throwable? = null
@@ -120,7 +120,7 @@ suspend fun <T> eventually(
       }
       times++
       lastInterval = config.interval.next(times)
-      val delayMark = TimeSource.Monotonic.markNow()
+      val delayMark = TimeSource.Monotonic.markNow() // TODO #3052
       delay(lastInterval)
       lastDelayPeriod = delayMark.elapsedNow()
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
@@ -2,7 +2,7 @@ package io.kotest.assertions.until
 
 import io.kotest.assertions.failure
 import kotlin.time.Duration
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 import kotlinx.coroutines.delay
 
 fun interface UntilListener<in T> {
@@ -114,7 +114,7 @@ suspend fun <T> until(
    f: suspend () -> T
 ): T {
 
-   val start = TimeSource.Monotonic.markNow() // TODO #3052
+   val start = MonotonicTimeSourceCompat.markNow() // TODO #3052
    val end = start.plus(duration)
    var times = 0
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
@@ -114,7 +114,7 @@ suspend fun <T> until(
    f: suspend () -> T
 ): T {
 
-   val start = TimeSource.Monotonic.markNow()
+   val start = TimeSource.Monotonic.markNow() // TODO #3052
    val end = start.plus(duration)
    var times = 0
 

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/UntilTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/UntilTest.kt
@@ -64,7 +64,7 @@ class UntilTest : FunSpec({
    }
 
    test("until with predicate and interval") {
-      val start = TimeSource.Monotonic.markNow()
+      val start = TimeSource.Monotonic.markNow() // TODO #3052
       var attempts = 0
       var t = ""
        until(1.seconds, 10.milliseconds.fixed(), { t == "xxxx" }) {
@@ -96,7 +96,7 @@ class UntilTest : FunSpec({
    }
 
    test("until should support fibonacci intervals") {
-      val start = TimeSource.Monotonic.markNow()
+      val start = TimeSource.Monotonic.markNow() // TODO #3052
       var t = ""
       var attempts = 0
       val result = until(10.seconds, 10.milliseconds.fibonacci(), { t == "xxxxxx" }) {

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/UntilTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/UntilTest.kt
@@ -13,7 +13,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 
 class UntilTest : FunSpec({
 
@@ -64,7 +64,7 @@ class UntilTest : FunSpec({
    }
 
    test("until with predicate and interval") {
-      val start = TimeSource.Monotonic.markNow() // TODO #3052
+      val start = MonotonicTimeSourceCompat.markNow() // TODO #3052
       var attempts = 0
       var t = ""
        until(1.seconds, 10.milliseconds.fixed(), { t == "xxxx" }) {
@@ -96,7 +96,7 @@ class UntilTest : FunSpec({
    }
 
    test("until should support fibonacci intervals") {
-      val start = TimeSource.Monotonic.markNow() // TODO #3052
+      val start = MonotonicTimeSourceCompat.markNow() // TODO #3052
       var t = ""
       var attempts = 0
       val result = until(10.seconds, 10.milliseconds.fibonacci(), { t == "xxxxxx" }) {

--- a/kotest-common/src/commonMain/kotlin/io/kotest/common/timing.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/common/timing.kt
@@ -1,0 +1,58 @@
+package io.kotest.common
+
+import io.kotest.mpp.timeInMillis
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.jvm.JvmInline
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+
+/**
+ * Executes the given [block] and returns elapsed time in milliseconds.
+ */
+@KotestInternal
+@SoftDeprecated("temp fix for breaking change in Kotlin 1.6 -> 1.7")
+inline fun measureTimeMillisCompat(block: () -> Unit): Long {
+   contract {
+      callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+   }
+   val start = timeInMillis()
+   block()
+   return timeInMillis() - start
+}
+
+
+@KotestInternal
+@SoftDeprecated("temp fix for breaking change in Kotlin 1.6 -> 1.7")
+@JvmInline
+value class ValueTimeMarkCompat internal constructor(internal val startMillis: Long)  {
+
+     fun elapsedNow(): Duration = MonotonicTimeSourceCompat.elapsedFrom(this)
+
+     operator fun plus(duration: Duration): ValueTimeMarkCompat =
+      MonotonicTimeSourceCompat.adjustReading(this, duration)
+
+     operator fun minus(duration: Duration): ValueTimeMarkCompat =
+      MonotonicTimeSourceCompat.adjustReading(this, -duration)
+
+     fun hasPassedNow(): Boolean = !elapsedNow().isNegative()
+
+     fun hasNotPassedNow(): Boolean = elapsedNow().isNegative()
+}
+
+
+@KotestInternal
+@SoftDeprecated("temp fix for breaking change in Kotlin 1.6 -> 1.7")
+object MonotonicTimeSourceCompat  {
+
+     fun markNow(): ValueTimeMarkCompat = ValueTimeMarkCompat(timeInMillis())
+
+   fun elapsedFrom(timeMark: ValueTimeMarkCompat): Duration =
+      (timeInMillis() - timeMark.startMillis).milliseconds
+
+   fun adjustReading(timeMark: ValueTimeMarkCompat, duration: Duration): ValueTimeMarkCompat =
+      ValueTimeMarkCompat(timeMark.startMillis + duration.inWholeMilliseconds)
+}

--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
@@ -3,9 +3,10 @@ package io.kotest.mpp
 import kotlin.reflect.KClass
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimeMark
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 
-val start by lazy { TimeSource.Monotonic.markNow() } // TODO #3052
+val start by lazy { MonotonicTimeSourceCompat.markNow() } // TODO #3052
+val startMillis by lazy { timeInMillis() } // TODO #3052
 
 @PublishedApi
 internal fun isLoggingEnabled() =

--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
@@ -5,7 +5,7 @@ import kotlin.time.ExperimentalTime
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
-val start by lazy { TimeSource.Monotonic.markNow() }
+val start by lazy { TimeSource.Monotonic.markNow() } // TODO #3052
 
 @PublishedApi
 internal fun isLoggingEnabled() =

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecFinishedInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecFinishedInterceptor.kt
@@ -4,7 +4,8 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.TestEngineListener
-import kotlin.time.measureTimedValue
+import io.kotest.mpp.timeInMillis
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A [SpecRefInterceptor] that invokes the [specFinished] test engine listener callbacks.
@@ -16,7 +17,9 @@ internal class SpecFinishedInterceptor(private val listener: TestEngineListener)
       ref: SpecRef,
       fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
    ): Result<Map<TestCase, TestResult>> {
-      val (value, duration) = measureTimedValue { fn(ref) }
+      val start = timeInMillis()
+      val value = fn(ref)
+      val duration = (timeInMillis() - start).milliseconds
       return value
          .onSuccess { listener.specFinished(ref.kclass, TestResult.Success(duration)) }
          .onFailure { listener.specFinished(ref.kclass, TestResult.Error(duration, it)) }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -3,6 +3,7 @@
 package io.kotest.engine.test
 
 import io.kotest.common.ExperimentalKotest
+import io.kotest.common.MonotonicTimeSourceCompat
 import io.kotest.common.Platform
 import io.kotest.common.platform
 import io.kotest.core.concurrency.CoroutineDispatcherFactory
@@ -31,7 +32,6 @@ import io.kotest.engine.test.interceptors.coroutineDispatcherFactoryInterceptor
 import io.kotest.engine.test.interceptors.coroutineErrorCollectorInterceptor
 import io.kotest.mpp.Logger
 import kotlin.time.Duration
-import kotlin.time.TimeSource
 
 /**
  * Executes a single [TestCase].
@@ -49,7 +49,7 @@ class TestCaseExecutor(
    private val logger = Logger(TestCaseExecutor::class)
 
    suspend fun execute(testCase: TestCase, testScope: TestScope): TestResult {
-      val timeMark = TimeSource.Monotonic.markNow() // TODO #3052
+      val timeMark = MonotonicTimeSourceCompat.markNow() // TODO #3052
 
       val interceptors = listOfNotNull(
          TestPathContextInterceptor,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -49,7 +49,7 @@ class TestCaseExecutor(
    private val logger = Logger(TestCaseExecutor::class)
 
    suspend fun execute(testCase: TestCase, testScope: TestScope): TestResult {
-      val timeMark = TimeSource.Monotonic.markNow()
+      val timeMark = TimeSource.Monotonic.markNow() // TODO #3052
 
       val interceptors = listOfNotNull(
          TestPathContextInterceptor,

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/ExceptionCapturingTestExecutionInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/ExceptionCapturingTestExecutionInterceptor.kt
@@ -26,7 +26,7 @@ class ExceptionCapturingTestExecutionInterceptorTest : FunSpec({
       )
       val context = TerminalTestScope(tc, coroutineContext)
 
-      ExceptionCapturingInterceptor(TimeSource.Monotonic.markNow())
+      ExceptionCapturingInterceptor(TimeSource.Monotonic.markNow()) // TODO #3052
          .intercept(tc, context) { _, _ -> throw AssertionError("boom") }
          .isFailure.shouldBeTrue()
 
@@ -44,7 +44,7 @@ class ExceptionCapturingTestExecutionInterceptorTest : FunSpec({
       )
       val context = TerminalTestScope(tc, coroutineContext)
 
-      ExceptionCapturingInterceptor(TimeSource.Monotonic.markNow())
+      ExceptionCapturingInterceptor(TimeSource.Monotonic.markNow()) // TODO #3052
          .intercept(tc, context) { _, _ -> error("boom") }
          .isError.shouldBeTrue()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/ExceptionCapturingTestExecutionInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/ExceptionCapturingTestExecutionInterceptor.kt
@@ -10,7 +10,7 @@ import io.kotest.core.test.TestType
 import io.kotest.engine.test.interceptors.ExceptionCapturingInterceptor
 import io.kotest.engine.test.scopes.TerminalTestScope
 import io.kotest.matchers.booleans.shouldBeTrue
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 
 class ExceptionCapturingTestExecutionInterceptorTest : FunSpec({
 
@@ -26,7 +26,7 @@ class ExceptionCapturingTestExecutionInterceptorTest : FunSpec({
       )
       val context = TerminalTestScope(tc, coroutineContext)
 
-      ExceptionCapturingInterceptor(TimeSource.Monotonic.markNow()) // TODO #3052
+      ExceptionCapturingInterceptor(MonotonicTimeSourceCompat.markNow()) // TODO #3052
          .intercept(tc, context) { _, _ -> throw AssertionError("boom") }
          .isFailure.shouldBeTrue()
 
@@ -44,7 +44,7 @@ class ExceptionCapturingTestExecutionInterceptorTest : FunSpec({
       )
       val context = TerminalTestScope(tc, coroutineContext)
 
-      ExceptionCapturingInterceptor(TimeSource.Monotonic.markNow()) // TODO #3052
+      ExceptionCapturingInterceptor(MonotonicTimeSourceCompat.markNow()) // TODO #3052
          .intercept(tc, context) { _, _ -> error("boom") }
          .isError.shouldBeTrue()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TimeoutInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TimeoutInterceptorTest.kt
@@ -28,7 +28,7 @@ class TimeoutInterceptorTest : FunSpec() {
             TestType.Test,
          )
 
-         TimeoutInterceptor(TimeSource.Monotonic.markNow()).intercept(
+         TimeoutInterceptor(TimeSource.Monotonic.markNow()).intercept( // TODO #3052
             tc.copy(config = tc.config.copy(timeout = 1.milliseconds)),
             NoopTestScope(tc, coroutineContext)
          ) { _, _ ->

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TimeoutInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TimeoutInterceptorTest.kt
@@ -13,7 +13,7 @@ import io.kotest.engine.test.scopes.NoopTestScope
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 
 class TimeoutInterceptorTest : FunSpec() {
    init {
@@ -28,7 +28,7 @@ class TimeoutInterceptorTest : FunSpec() {
             TestType.Test,
          )
 
-         TimeoutInterceptor(TimeSource.Monotonic.markNow()).intercept( // TODO #3052
+         TimeoutInterceptor(MonotonicTimeSourceCompat.markNow()).intercept( // TODO #3052
             tc.copy(config = tc.config.copy(timeout = 1.milliseconds)),
             NoopTestScope(tc, coroutineContext)
          ) { _, _ ->

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/Constraints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/Constraints.kt
@@ -28,7 +28,7 @@ fun interface Constraints {
        * Returns a [Constraints] that executes the property test for a certain duration.
        */
       fun duration(duration: Duration) = object : Constraints {
-         val mark = TimeSource.Monotonic.markNow().plus(duration)
+         val mark = TimeSource.Monotonic.markNow().plus(duration) // TODO #3052
          override fun evaluate(): Boolean {
             return mark.hasNotPassedNow()
          }
@@ -39,7 +39,3 @@ fun interface Constraints {
 fun Constraints.and(other: Constraints) = Constraints { this@and.evaluate() && other.evaluate() }
 
 fun Constraints.or(other: Constraints) = Constraints { this@or.evaluate() || other.evaluate() }
-
-
-
-

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/Constraints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/Constraints.kt
@@ -1,7 +1,7 @@
 package io.kotest.property
 
 import kotlin.time.Duration
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 
 /**
  * Controls iterations of a property test.
@@ -28,7 +28,7 @@ fun interface Constraints {
        * Returns a [Constraints] that executes the property test for a certain duration.
        */
       fun duration(duration: Duration) = object : Constraints {
-         val mark = TimeSource.Monotonic.markNow().plus(duration) // TODO #3052
+         val mark = MonotonicTimeSourceCompat.markNow() + duration // TODO #3052
          override fun evaluate(): Boolean {
             return mark.hasNotPassedNow()
          }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigConstraintsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigConstraintsTest.kt
@@ -12,7 +12,7 @@ import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
 import io.kotest.property.internal.proptest
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.TimeSource
+import io.kotest.common.MonotonicTimeSourceCompat
 
 class PropTestConfigConstraintsTest : FunSpec() {
    init {
@@ -276,7 +276,7 @@ class PropTestConfigConstraintsTest : FunSpec() {
 
       test("PropTestConfig constraints should support durations") {
          val config = PropTestConfig(constraints = Constraints.duration(200.milliseconds))
-         val start = TimeSource.Monotonic.markNow() // TODO #3052
+         val start = MonotonicTimeSourceCompat.markNow() // TODO #3052
          checkAll(config, Arb.string()) { _ -> }
          // we should have exited around 200 millis
          start.elapsedNow().inWholeMilliseconds.shouldBeGreaterThan(150)

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigConstraintsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigConstraintsTest.kt
@@ -276,7 +276,7 @@ class PropTestConfigConstraintsTest : FunSpec() {
 
       test("PropTestConfig constraints should support durations") {
          val config = PropTestConfig(constraints = Constraints.duration(200.milliseconds))
-         val start = TimeSource.Monotonic.markNow()
+         val start = TimeSource.Monotonic.markNow() // TODO #3052
          checkAll(config, Arb.string()) { _ -> }
          // we should have exited around 200 millis
          start.elapsedNow().inWholeMilliseconds.shouldBeGreaterThan(150)


### PR DESCRIPTION
Just a quick stab at fixing the issue here: https://github.com/kotest/kotest/issues/2960

This might help compatibility with 1.6 and 1.7