### PR TITLE
matchAll for maps

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -163,8 +163,8 @@ fun <K, V> matchAll(vararg expected: Pair<K, (V) -> Unit>): Matcher<Map<K, V>> =
 
          return MatcherResult(
             missingKeys.isEmpty() && mismatches.isEmpty(),
-            { "Expected map to match all assertions. Missing keys were=$missingKeys, Mismatched values were=$mismatches }}" },
-            { "Expected map to not match all assertions.}}" },
+            { "Expected map to match all assertions. Missing keys were=$missingKeys, Mismatched values were=$mismatches." },
+            { "Expected map to not match all assertions." },
          )
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -137,3 +137,34 @@ class MapContainsMatcher<K, V>(
          })
    }
 }
+
+
+fun <K, V> matchAll(vararg expected: Pair<K, (V) -> Unit>): Matcher<Map<K, V>> =
+   object : Matcher<Map<K, V>> {
+
+      override fun test(value: Map<K, V>): MatcherResult {
+
+         val missingKeys = mutableListOf<K>()
+         val mismatches = mutableListOf<Pair<K, String?>>()
+
+         expected.forEach { (k, matcher) ->
+            val v = value[k]
+
+            if (v == null) {
+               missingKeys.add(k)
+            } else {
+               try {
+                  matcher(v)
+               } catch (e: AssertionError) {
+                  mismatches.add(Pair(k, e.message))
+               }
+            }
+         }
+
+         return MatcherResult(
+            missingKeys.isEmpty() && mismatches.isEmpty(),
+            { "Expected map to match all assertions. Missing keys were=$missingKeys, Mismatched values were=$mismatches }}" },
+            { "Expected map to not match all assertions.}}" },
+         )
+      }
+   }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -1,5 +1,8 @@
 package io.kotest.matchers.maps
 
+import io.kotest.assertions.ErrorCollectionMode
+import io.kotest.assertions.errorCollector
+import io.kotest.assertions.runWithMode
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.string.Diff
@@ -147,16 +150,18 @@ fun <K, V> matchAll(vararg expected: Pair<K, (V) -> Unit>): Matcher<Map<K, V>> =
          val missingKeys = mutableListOf<K>()
          val mismatches = mutableListOf<Pair<K, String?>>()
 
-         expected.forEach { (k, matcher) ->
-            val v = value[k]
+         errorCollector.runWithMode(ErrorCollectionMode.Hard) {
+            expected.forEach { (k, matcher) ->
+               val v = value[k]
 
-            if (v == null) {
-               missingKeys.add(k)
-            } else {
-               try {
-                  matcher(v)
-               } catch (e: AssertionError) {
-                  mismatches.add(Pair(k, e.message))
+               if (v == null) {
+                  missingKeys.add(k)
+               } else {
+                  try {
+                     matcher(v)
+                  } catch (e: AssertionError) {
+                     mismatches.add(Pair(k, e.message))
+                  }
                }
             }
          }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -64,3 +64,9 @@ fun beEmpty() = object : Matcher<Map<*, *>> {
       )
    }
 }
+
+
+
+fun <K, V> Map<K, V>.shouldMatchAll(vararg matchers: Pair<K, (V) -> Unit>) = this should matchAll(*matchers)
+fun <K, V> Map<K, V>.shouldNotMatchAll(vararg matchers: Pair<K, (V) -> Unit>) = this shouldNot matchAll(*matchers)
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -434,9 +434,9 @@ expected:<{
                assertSoftly {
                   mapOf("key" to "hi") should matchAll("key" to { it shouldHaveLength 4 })
                }
-            }.message shouldBe """
-               Expected map to match all assertions. Missing keys were=[key], Mismatched values were=[(key, "hi" should have length 4, but instead was 2)].
-            """.trimIndent()
+            }.also {
+               it.message shouldBe """Expected map to match all assertions. Missing keys were=[], Mismatched values were=[(key, "hi" should have length 4, but instead was 2)]."""
+            }
          }
 
          "empty map is not matched by matcher" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.matchers.maps
 
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.shouldFail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.and
@@ -7,6 +9,7 @@ import io.kotest.matchers.maps.*
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import io.kotest.matchers.string.shouldHaveLength
 import java.util.LinkedList
 
 class MapMatchersTest : WordSpec() {
@@ -114,7 +117,7 @@ class MapMatchersTest : WordSpec() {
       }
 
       "containAnyKeys" should {
-         "test that a map contains any of the given keys"{
+         "test that a map contains any of the given keys" {
             val map = mapOf("a" to 1, "b" to 2, "c" to 3)
             map should containAnyKeys("a", "x", "y")
             map should containAnyKeys("a", "b", "c")
@@ -133,7 +136,7 @@ class MapMatchersTest : WordSpec() {
       }
 
       "containAnyValues" should {
-         "test that a map contains any of the given values"{
+         "test that a map contains any of the given values" {
             val map = mapOf("a" to 1, "b" to 2, "c" to 3)
             map should containAnyValues(1, 23, 24)
             map should containAnyValues(1, 2, 3)
@@ -146,7 +149,7 @@ class MapMatchersTest : WordSpec() {
                map.shouldContainAnyValuesOf(4, 5)
             }
             shouldThrow<AssertionError> {
-               map.shouldNotContainAnyValuesOf(1,5)
+               map.shouldNotContainAnyValuesOf(1, 5)
             }
          }
       }
@@ -176,11 +179,12 @@ class MapMatchersTest : WordSpec() {
           |  missing keys:
           |    "\${'$'}a"
           |
-        """.trimMargin()
+            """.trimMargin()
          }
          "test when map contains extra entries" {
             mapOf("a" to 1, "b" to 2) should (
-               containAll(mapOf("a" to 1)) and containAll(mapOf("b" to 2)))
+               containAll(mapOf("a" to 1)) and containAll(mapOf("b" to 2))
+               )
          }
          "test assertion when map contains different value type" {
             val e = shouldThrow<AssertionError> {
@@ -200,7 +204,7 @@ class MapMatchersTest : WordSpec() {
           |      but was:
           |        1
           |
-        """.trimMargin()
+            """.trimMargin()
          }
          "test that a map with nested map contains all entries from the given map" {
             val map = mapOf("a" to mapOf("b" to 2))
@@ -224,7 +228,7 @@ class MapMatchersTest : WordSpec() {
           |          but was:
           |            2
           |
-        """.trimMargin()
+            """.trimMargin()
          }
          "test shouldNot assertion" {
             val e = shouldThrow<AssertionError> {
@@ -238,7 +242,7 @@ class MapMatchersTest : WordSpec() {
           |  mapOf("a" to 1)
           |but contains
           |
-        """.trimMargin()
+            """.trimMargin()
          }
       }
 
@@ -261,7 +265,7 @@ class MapMatchersTest : WordSpec() {
           |  extra keys:
           |    "a"
           |
-        """.trimMargin()
+            """.trimMargin()
          }
          "test shouldNot assertion" {
             val e = shouldThrow<AssertionError> {
@@ -279,7 +283,7 @@ class MapMatchersTest : WordSpec() {
           |  mapOf("a" to listOf(1))
           |but equals
           |
-        """.trimMargin()
+            """.trimMargin()
          }
       }
       "be empty" should {
@@ -380,7 +384,8 @@ to be equal to
   "Key10" = "Val101",
 ...
 }
-Values differed at keys Key2, Key3, Key4, Key5, Key6, Key7, Key8, Key9, Key10, Key11, ...""".trimMargin()
+Values differed at keys Key2, Key3, Key4, Key5, Key6, Key7, Key8, Key9, Key10, Key11, ...
+            """.trimMargin()
 
             val assertionError = shouldThrow<AssertionError> { map1 shouldBe map2 }
 
@@ -413,7 +418,6 @@ expected:<{
          }
       }
 
-
       "matchAll" should {
          "empty map is matched by empty matchers" {
             emptyMap<String, String>() should matchAll()
@@ -423,6 +427,16 @@ expected:<{
             shouldThrow<AssertionError> {
                emptyMap<String, String>() shouldNot matchAll()
             }
+         }
+
+         "works correctly within assertSoftly" {
+            shouldFail {
+               assertSoftly {
+                  mapOf("key" to "hi") should matchAll("key" to { it shouldHaveLength 4 })
+               }
+            }.message shouldBe """
+               Expected map to match all assertions. Missing keys were=[key], Mismatched values were=[(key, "hi" should have length 4, but instead was 2)].
+            """.trimIndent()
          }
 
          "empty map is not matched by matcher" {
@@ -455,5 +469,4 @@ expected:<{
          }
       }
    }
-
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -412,5 +412,42 @@ expected:<{
 }>"""
          }
       }
+
+
+      "matchAll" should {
+         "empty" {
+            emptyMap<String, String>() should matchAll()
+         }
+
+         "empty negated" {
+            emptyMap<String, String>() shouldNot matchAll("key" to { it shouldBe "value" })
+         }
+
+         "can match value" {
+            mapOf("key" to "value") should matchAll("key" to { it shouldBe "value" })
+         }
+
+         "match negated" {
+            mapOf("key" to "value") shouldNot matchAll("otherKey" to { it shouldBe "value" })
+            mapOf("key" to "value") shouldNot matchAll("key" to { it shouldBe "otherValue" })
+         }
+
+         "fail if key is not present" {
+            shouldThrow<AssertionError> {
+               mapOf("otherKey" to "value") should matchAll("key" to { it shouldBe "value" })
+            }.also {
+               println(it.message)
+            }
+         }
+
+         "fail if value is not matched" {
+            shouldThrow<AssertionError> {
+               kotlin.collections.mapOf("key" to "otherValue") should matchAll("key" to { it shouldBe "value" })
+            }.also {
+               kotlin.io.println(it.message)
+            }
+         }
+      }
    }
+
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -415,11 +415,17 @@ expected:<{
 
 
       "matchAll" should {
-         "empty" {
+         "empty map is matched by empty matchers" {
             emptyMap<String, String>() should matchAll()
          }
 
-         "empty negated" {
+         "empty map is matched by empty matchers - negated" {
+            shouldThrow<AssertionError> {
+               emptyMap<String, String>() shouldNot matchAll()
+            }
+         }
+
+         "empty map is not matched by matcher" {
             emptyMap<String, String>() shouldNot matchAll("key" to { it shouldBe "value" })
          }
 
@@ -436,15 +442,15 @@ expected:<{
             shouldThrow<AssertionError> {
                mapOf("otherKey" to "value") should matchAll("key" to { it shouldBe "value" })
             }.also {
-               println(it.message)
+               it.message shouldBe "Expected map to match all assertions. Missing keys were=[key], Mismatched values were=[]."
             }
          }
 
          "fail if value is not matched" {
             shouldThrow<AssertionError> {
-               kotlin.collections.mapOf("key" to "otherValue") should matchAll("key" to { it shouldBe "value" })
+               mapOf("key" to "otherValue") should matchAll("key" to { it shouldBe "value" })
             }.also {
-               kotlin.io.println(it.message)
+               it.message shouldBe """Expected map to match all assertions. Missing keys were=[], Mismatched values were=[(key, expected:<"value"> but was:<"otherValue">)]."""
             }
          }
       }


### PR DESCRIPTION
kotest provides the shouldMatchEachmatcher for collections. We found it helpful to have a similiar matcher for Maps

https://kotlinlang.slack.com/archives/CT0G9SD7Z/p1655739049356379