### PR TITLE
Fix compilation failures for Kotlin/Native projects that use Kotlin 1.7 and the Kotest Gradle plugin.

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-native/src/jvmMain/kotlin/io/kotest/framework/multiplatform/native/SpecIrGenerationExtension.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-native/src/jvmMain/kotlin/io/kotest/framework/multiplatform/native/SpecIrGenerationExtension.kt
@@ -20,12 +20,12 @@ import org.jetbrains.kotlin.ir.builders.irVararg
 import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
-import org.jetbrains.kotlin.ir.declarations.name
 import org.jetbrains.kotlin.ir.util.constructors
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import java.io.File
 import java.util.concurrent.CopyOnWriteArrayList
 
 class SpecIrGenerationExtension(private val messageCollector: MessageCollector) : IrGenerationExtension {
@@ -124,3 +124,11 @@ class SpecIrGenerationExtension(private val messageCollector: MessageCollector) 
       }, null)
    }
 }
+
+// These extension properties are available in org.jetbrains.kotlin.ir.declarations, but were moved from one file to
+// another in Kotlin 1.7. This breaks backwards compatibility with earlier versions of Kotlin.
+// So instead of using the provided implementations, we've copied them here, so we can work with both Kotlin 1.7+ and earlier
+// versions without issue.
+// See https://github.com/kotest/kotest/issues/3060 and https://youtrack.jetbrains.com/issue/KT-52888 for more information.
+private val IrFile.path: String get() = fileEntry.name
+private val IrFile.name: String get() = File(path).name

--- a/kotest-framework/kotest-framework-multiplatform-plugin-native/src/jvmMain/kotlin/io/kotest/framework/multiplatform/native/SpecIrGenerationExtension.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-native/src/jvmMain/kotlin/io/kotest/framework/multiplatform/native/SpecIrGenerationExtension.kt
@@ -8,7 +8,6 @@ import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.toLogger
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
-import org.jetbrains.kotlin.ir.builders.IrBlockBuilder
 import org.jetbrains.kotlin.ir.builders.IrSingleStatementBuilder
 import org.jetbrains.kotlin.ir.builders.Scope
 import org.jetbrains.kotlin.ir.builders.declarations.addGetter
@@ -23,9 +22,7 @@ import org.jetbrains.kotlin.ir.declarations.IrFile
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.ir.declarations.name
 import org.jetbrains.kotlin.ir.util.constructors
-import org.jetbrains.kotlin.ir.util.file
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
-import org.jetbrains.kotlin.ir.util.irCall
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name


### PR DESCRIPTION
Resolves https://github.com/kotest/kotest/issues/3060, and replaces https://github.com/kotest/kotest/pull/3064.

See https://youtrack.jetbrains.com/issue/KT-52888/KotlinNative-17-breaks-backwards-compatability-for-compiler-plugins#focus=Comments-27-6206997.0-0 for an explanation of this change.

It would be good to set up some tests to cover this behaviour, but in the interests of keeping this PR small, I haven't added any as there doesn't seem to be an established way of doing this.