### PR TITLE
Fix tolerance matchers for negative values.

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Tolerance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Tolerance.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.math.abs
+import kotlin.math.absoluteValue
 
 /**
  * Creates a matcher for the interval [[this] - [tolerance] , [this] + [tolerance]]
@@ -38,7 +39,7 @@ data class Percentage(val value: Double)
  * ```
  */
 infix fun Double.plusOrMinus(tolerance: Percentage): ToleranceMatcher {
-   val realValue = this * tolerance.value / 100
+   val realValue = (this * tolerance.value / 100).absoluteValue
    return ToleranceMatcher(this, realValue)
 }
 
@@ -107,7 +108,7 @@ fun Double.shouldNotBeWithinPercentageOf(other: Double, percentage: Double) {
 }
 
 fun beWithinPercentageOf(other: Double, percentage: Double) = object : Matcher<Double> {
-   private val tolerance = other.times(percentage / 100)
+   private val tolerance = other.times(percentage / 100).absoluteValue
    private val range = (other - tolerance)..(other + tolerance)
 
    override fun test(value: Double) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/matchers.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
+import kotlin.math.absoluteValue
 
 fun exactly(d: Float): Matcher<Float> = object : Matcher<Float> {
    override fun test(value: Float) =
@@ -98,7 +99,7 @@ fun Float.shouldNotBeWithinPercentageOf(other: Float, percentage: Double) {
 }
 
 fun beWithinPercentageOf(other: Float, percentage: Double) = object : Matcher<Float> {
-   private val tolerance = other.times(percentage / 100)
+   private val tolerance = other.times(percentage / 100).absoluteValue
    private val range = (other - tolerance)..(other + tolerance)
 
    override fun test(value: Float) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/matchers.kt
@@ -99,7 +99,7 @@ fun Float.shouldNotBeWithinPercentageOf(other: Float, percentage: Double) {
 }
 
 fun beWithinPercentageOf(other: Float, percentage: Double) = object : Matcher<Float> {
-   private val tolerance = other.times(percentage / 100).absoluteValue
+   private val tolerance = other.times(percentage / 100).absoluteValue.toFloat()
    private val range = (other - tolerance)..(other + tolerance)
 
    override fun test(value: Float) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/IntMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/IntMatchers.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
+import kotlin.math.absoluteValue
 
 /**
  * Verifies that the given integer is between a and b inclusive.
@@ -117,13 +118,12 @@ fun Int.shouldNotBeWithinPercentageOf(other: Int, percentage: Double) {
 }
 
 fun beWithinPercentageOf(other: Int, percentage: Double) = object : Matcher<Int> {
-   private val tolerance = other.times(percentage / 100)
+   private val tolerance = other.times(percentage / 100).absoluteValue
    private val range = (other - tolerance)..(other + tolerance)
 
    override fun test(value: Int) = MatcherResult(
       value.toDouble() in range,
       { "$value should be in $range" },
-      {
-         "$value should not be in $range"
-      })
+      { "$value should not be in $range" },
+   )
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/LongMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/LongMatchers.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import kotlin.math.absoluteValue
 
 fun lt(x: Long) = beLessThan(x)
 fun beLessThan(x: Long) = object : Matcher<Long> {
@@ -86,7 +87,7 @@ fun Long.shouldNotBeWithinPercentageOf(other: Long, percentage: Double) {
 }
 
 fun beWithinPercentageOf(other: Long, percentage: Double) = object : Matcher<Long> {
-   private val tolerance = other.times(percentage / 100)
+   private val tolerance = other.times(percentage / 100).absoluteValue
    private val range = (other - tolerance)..(other + tolerance)
 
    override fun test(value: Long) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/doubles/DoubleToleranceTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/doubles/DoubleToleranceTest.kt
@@ -9,9 +9,6 @@ import io.kotest.matchers.doubles.shouldBeWithinPercentageOf
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
-import io.kotest.property.RandomSource
-import io.kotest.property.arbitrary.bind
-import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.numericDouble
 import io.kotest.property.checkAll
 
@@ -41,9 +38,9 @@ class DoubleToleranceTest : FunSpec({
    context("Percentage") {
 
       test("Match equal numbers") {
-         Arb.bind(Arb.double(), Arb.double(0.0, 5.0)) { value, percentage ->
+         checkAll(Arb.numericDouble(), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
             value.shouldBeWithinPercentageOf(value, percentage)
-         }.sample(RandomSource.default())
+         }
       }
 
       test("Refuse negative percentage") {
@@ -53,11 +50,11 @@ class DoubleToleranceTest : FunSpec({
       }
 
       test("Match close enough numbers") {
-         Arb.bind(Arb.double(), Arb.double(0.0, 5.0)) { value, percentage ->
+         checkAll(Arb.numericDouble(), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
             val delta = value.times(percentage / 100)
             (value + delta).shouldBeWithinPercentageOf(value, percentage)
             (value - delta).shouldBeWithinPercentageOf(value, percentage)
-         }.sample(RandomSource.default())
+         }
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/doubles/DoubleToleranceTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/doubles/DoubleToleranceTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.doubles.shouldBeWithinPercentageOf
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.Arb
+import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.numericDouble
@@ -32,6 +33,9 @@ class DoubleToleranceTest : FunSpec({
    test("Allow for percentage tolerance") {
       1.5 shouldBe (1.0 plusOrMinus 50.percent)
       1.5 shouldNotBe (2.0 plusOrMinus 10.percent)
+
+      -1.5 shouldBe (-1.0 plusOrMinus 50.percent)
+      -1.5 shouldNotBe (-2.0 plusOrMinus 10.percent)
    }
 
    context("Percentage") {
@@ -39,7 +43,7 @@ class DoubleToleranceTest : FunSpec({
       test("Match equal numbers") {
          Arb.bind(Arb.double(), Arb.double(0.0, 5.0)) { value, percentage ->
             value.shouldBeWithinPercentageOf(value, percentage)
-         }
+         }.sample(RandomSource.default())
       }
 
       test("Refuse negative percentage") {
@@ -50,9 +54,10 @@ class DoubleToleranceTest : FunSpec({
 
       test("Match close enough numbers") {
          Arb.bind(Arb.double(), Arb.double(0.0, 5.0)) { value, percentage ->
-            value.shouldBeWithinPercentageOf((value - value.times(percentage / 100)), percentage)
-            value.shouldBeWithinPercentageOf((value + value.times(percentage / 100)), percentage)
-         }
+            val delta = value.times(percentage / 100)
+            (value + delta).shouldBeWithinPercentageOf(value, percentage)
+            (value - delta).shouldBeWithinPercentageOf(value, percentage)
+         }.sample(RandomSource.default())
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatPercentageTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatPercentageTest.kt
@@ -4,18 +4,17 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.floats.shouldBeWithinPercentageOf
 import io.kotest.property.Arb
-import io.kotest.property.RandomSource
-import io.kotest.property.arbitrary.bind
-import io.kotest.property.arbitrary.double
-import io.kotest.property.arbitrary.float
+import io.kotest.property.arbitrary.numericDouble
+import io.kotest.property.arbitrary.numericFloat
+import io.kotest.property.checkAll
 
 class FloatPercentageTest : FunSpec() {
    init {
       context("Percentage") {
          test("Match equal numbers") {
-            Arb.bind(Arb.float(), Arb.double(0.0, 5.0)) { value, percentage ->
+            checkAll(Arb.numericFloat(), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
                value.shouldBeWithinPercentageOf(value, percentage)
-            }.sample(RandomSource.default())
+            }
          }
 
          test("Refuse negative percentage") {
@@ -25,11 +24,11 @@ class FloatPercentageTest : FunSpec() {
          }
 
          test("Match close enough numbers") {
-            Arb.bind(Arb.float(), Arb.double(0.0, 5.0)) { value, percentage ->
+            checkAll(Arb.numericFloat(), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
                val delta = (percentage / 100).times(value).toFloat()
                (value + delta).shouldBeWithinPercentageOf(value, percentage)
                (value - delta).shouldBeWithinPercentageOf(value, percentage)
-            }.sample(RandomSource.default())
+            }
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatPercentageTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatPercentageTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.floats.shouldBeWithinPercentageOf
 import io.kotest.property.Arb
+import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.float
@@ -14,7 +15,7 @@ class FloatPercentageTest : FunSpec() {
          test("Match equal numbers") {
             Arb.bind(Arb.float(), Arb.double(0.0, 5.0)) { value, percentage ->
                value.shouldBeWithinPercentageOf(value, percentage)
-            }
+            }.sample(RandomSource.default())
          }
 
          test("Refuse negative percentage") {
@@ -25,9 +26,10 @@ class FloatPercentageTest : FunSpec() {
 
          test("Match close enough numbers") {
             Arb.bind(Arb.float(), Arb.double(0.0, 5.0)) { value, percentage ->
-               value.shouldBeWithinPercentageOf((value - value.times(percentage / 100).toFloat()), percentage)
-               value.shouldBeWithinPercentageOf((value + value.times(percentage / 100)).toFloat(), percentage)
-            }
+               val delta = (percentage / 100).times(value).toFloat()
+               (value + delta).shouldBeWithinPercentageOf(value, percentage)
+               (value - delta).shouldBeWithinPercentageOf(value, percentage)
+            }.sample(RandomSource.default())
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ints/ToleranceMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ints/ToleranceMatcherTest.kt
@@ -4,17 +4,16 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeWithinPercentageOf
 import io.kotest.property.Arb
-import io.kotest.property.RandomSource
-import io.kotest.property.arbitrary.bind
-import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.numericDouble
+import io.kotest.property.checkAll
 
 class ToleranceMatcherTest : FunSpec({
 
    test("Match equal numbers") {
-      Arb.bind(Arb.int(), Arb.double(0.0, 5.0)) { value, percentage ->
+      checkAll(Arb.int(-1000, 1000), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
          value.shouldBeWithinPercentageOf(value, percentage)
-      }.sample(RandomSource.default())
+      }
    }
 
    test("Refuse negative percentage") {
@@ -24,10 +23,10 @@ class ToleranceMatcherTest : FunSpec({
    }
 
    test("Match close enough numbers") {
-      Arb.bind(Arb.int(), Arb.double(0.0, 5.0)) { value, percentage ->
+      checkAll(Arb.int(-1000, 1000), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
          val delta = (percentage / 100).times(value).toInt()
          (value + delta).shouldBeWithinPercentageOf(value, percentage)
          (value - delta).shouldBeWithinPercentageOf(value, percentage)
-      }.sample(RandomSource.default())
+      }
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/longs/ToleranceMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/longs/ToleranceMatcherTest.kt
@@ -1,33 +1,34 @@
-package com.sksamuel.kotest.matchers.ints
+package com.sksamuel.kotest.matchers.longs
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.ints.shouldBeWithinPercentageOf
+import io.kotest.matchers.longs.shouldBeWithinPercentageOf
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.double
-import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.long
 
 class ToleranceMatcherTest : FunSpec({
 
    test("Match equal numbers") {
-      Arb.bind(Arb.int(), Arb.double(0.0, 5.0)) { value, percentage ->
+      Arb.bind(Arb.long(), Arb.double(0.0, 5.0)) { value, percentage ->
          value.shouldBeWithinPercentageOf(value, percentage)
       }.sample(RandomSource.default())
    }
 
    test("Refuse negative percentage") {
       shouldThrow<IllegalArgumentException> {
-         1.shouldBeWithinPercentageOf(1, -0.1)
+         1L.shouldBeWithinPercentageOf(1, -0.1)
       }
    }
 
    test("Match close enough numbers") {
-      Arb.bind(Arb.int(), Arb.double(0.0, 5.0)) { value, percentage ->
-         val delta = (percentage / 100).times(value).toInt()
+      Arb.bind(Arb.long(), Arb.double(0.0, 5.0)) { value, percentage ->
+         val delta = (percentage / 100).times(value).toLong()
          (value + delta).shouldBeWithinPercentageOf(value, percentage)
          (value - delta).shouldBeWithinPercentageOf(value, percentage)
       }.sample(RandomSource.default())
    }
 })
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/longs/ToleranceMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/longs/ToleranceMatcherTest.kt
@@ -4,17 +4,16 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.longs.shouldBeWithinPercentageOf
 import io.kotest.property.Arb
-import io.kotest.property.RandomSource
-import io.kotest.property.arbitrary.bind
-import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.numericDouble
+import io.kotest.property.checkAll
 
 class ToleranceMatcherTest : FunSpec({
 
    test("Match equal numbers") {
-      Arb.bind(Arb.long(), Arb.double(0.0, 5.0)) { value, percentage ->
+      checkAll(Arb.long(), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
          value.shouldBeWithinPercentageOf(value, percentage)
-      }.sample(RandomSource.default())
+      }
    }
 
    test("Refuse negative percentage") {
@@ -24,11 +23,11 @@ class ToleranceMatcherTest : FunSpec({
    }
 
    test("Match close enough numbers") {
-      Arb.bind(Arb.long(), Arb.double(0.0, 5.0)) { value, percentage ->
+      checkAll(Arb.long(-1000L, 1000L), Arb.numericDouble(Double.MIN_VALUE, 5.0)) { value, percentage ->
          val delta = (percentage / 100).times(value).toLong()
          (value + delta).shouldBeWithinPercentageOf(value, percentage)
          (value - delta).shouldBeWithinPercentageOf(value, percentage)
-      }.sample(RandomSource.default())
+      }
    }
 })
 


### PR DESCRIPTION
This PR fixes tolerance matchers for negative values.

Previously, these constructions would fail for any negative `y`, and any numeric `x`:

- `x shouldBe (y plusOrMinus z)`
- `x.shouldBeWithinPercentageOf(y, z)`

There were existing tests for this, but they appear not to have been running. When `Arb.sample()` was called for unmodified existing tests, they consistently failed.

`Long.shouldBeWithinPercentageOf(...)` also was untested, so this PR adds some tests for it.

Fixes: #3095