### PR TITLE
add doc for matchAll

### DIFF
--- a/doc/matchers/core.md
+++ b/doc/matchers/core.md
@@ -47,7 +47,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `map.shouldContainValue(value)` | Asserts that the map contains at least one mapping where the value is `value`. |
 | `map.shouldContainValues(values)` | Asserts that the map contains all the given values. |
 | `map.shouldBeEmpty()` | Asserts that this map is empty. |
-| `map.shouldMatchAll("k1" to {it shouldBe "v1"}, "k2" to {it shouldBe "v2}, ...)`|  Asserts that all the entries in the map can be matched with the provided matchers, and no extra. |
+| `map.shouldMatchAll("k1" to {it shouldBe "v1"}, "k2" to {it shouldBe "v2"}, ...)`|  Asserts that all the entries in the map can be matched with the provided matchers, and no extra. |
 
 
 | Strings ||

--- a/doc/matchers/core.md
+++ b/doc/matchers/core.md
@@ -47,6 +47,8 @@ Matchers provided by the `kotest-assertions-core` module.
 | `map.shouldContainValue(value)` | Asserts that the map contains at least one mapping where the value is `value`. |
 | `map.shouldContainValues(values)` | Asserts that the map contains all the given values. |
 | `map.shouldBeEmpty()` | Asserts that this map is empty. |
+| `map.shouldMatchAll("k1" to {it shouldBe "v1"}, "k2" to {it shouldBe "v2}, ...)`|  Asserts that all the entries in the map can be matched with the provided matchers, and no extra. |
+
 
 | Strings ||
 | -------- | ---- |

--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -53,7 +53,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `map.shouldContainValue(value)`     | Asserts that the map contains at least one mapping where the value is `value`. |
 | `map.shouldContainValues(values)`   | Asserts that the map contains all the given values. |
 | `map.shouldBeEmpty()`               | Asserts that this map is empty. |
-| `map.shouldMatchAll("k1" to {it shouldBe "v1"}, "k2" to {it shouldBe "v2}, ...)`|  Asserts that all the entries in the map can be matched with the provided matchers, and no extra. |
+| `map.shouldMatchAll("k1" to {it shouldBe "v1"}, "k2" to {it shouldBe "v2"}, ...)`|  Asserts that all the entries in the map can be matched with the provided matchers, and no extra. |
 
 
 | Strings                                     ||

--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -53,6 +53,8 @@ Matchers provided by the `kotest-assertions-core` module.
 | `map.shouldContainValue(value)`     | Asserts that the map contains at least one mapping where the value is `value`. |
 | `map.shouldContainValues(values)`   | Asserts that the map contains all the given values. |
 | `map.shouldBeEmpty()`               | Asserts that this map is empty. |
+| `map.shouldMatchAll("k1" to {it shouldBe "v1"}, "k2" to {it shouldBe "v2}, ...)`|  Asserts that all the entries in the map can be matched with the provided matchers, and no extra. |
+
 
 | Strings                                     ||
 |---------------------------------------------| ---- |


### PR DESCRIPTION
the PR
https://github.com/kotest/kotest/pull/3065
added a new map matcher. this PR adds some documentation for it
