### PR TITLE
Fix issue where compiler plugins aren't published.

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-js/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-js/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("kotest-publishing-conventions")
 }
 
 kotlin {

--- a/kotest-framework/kotest-framework-multiplatform-plugin-native/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-native/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("kotest-publishing-conventions")
 }
 
 kotlin {


### PR DESCRIPTION
This seems to have been accidentally removed in #3024.

`kotest-framework-standalone` is also not being published - should it be published?