### PR TITLE
fix: [kotest-assertions-json] `shouldContainJsonKey` should be true for keys with `null` values

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
@@ -25,8 +25,9 @@ fun containJsonKey(path: String) = object : Matcher<String?> {
          else -> if (value.length < 50) value.trim() else value.substring(0, 50).trim() + "..."
       }
 
-      val passed = try {
-         value != null && JsonPath.read<String>(value, path) != null
+      val passed = value != null && try {
+         JsonPath.read<String>(value, path)
+         true
       } catch (t: PathNotFoundException) {
          false
       }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JvmJsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JvmJsonAssertionsTest.kt
@@ -116,4 +116,10 @@ class JvmJsonAssertionsTest : StringSpec({
          use(nullableJson)
       }
    }
+
+   "test key with null value" {
+      val testJson1 = """ { "nullable" : null } """
+      testJson1.shouldContainJsonKey("$.nullable")
+      testJson1.shouldContainJsonKeyValue("$.nullable", null as Any?)
+   }
 })


### PR DESCRIPTION
We noticed that for a JSON object which contains property with `null` values like this:

```json
{
  "nullable": null
}
```

the `shouldContainJsonKey("nullable")` matcher would throw even though the key was present, which was against our expectations.

The changes in this PR will make `shouldContainJsonKey(:)` not throw for keys with `null` values. **_This is a breaking change ⚠️,_** as tests relying on the previous behavior may break.