### PR TITLE
Set Sonatype snapshots Maven repo as 'snapshotsOnly'

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
 repositories {
    mavenCentral()
    mavenLocal()
-   maven("https://oss.sonatype.org/content/repositories/snapshots/")
+   maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+      mavenContent { snapshotsOnly() }
+   }
    google()
    gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
 }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -11,7 +11,9 @@ version = Ci.publishVersion
 repositories {
    mavenCentral()
    mavenLocal()
-   maven("https://oss.sonatype.org/content/repositories/snapshots/")
+   maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+      mavenContent { snapshotsOnly() }
+   }
    google()
    gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
 }


### PR DESCRIPTION
I expect that this should improve build performance, as Gradle won't scan the repo for dependencies unless it's looking for a snapshot dependency, of which there are fewer.

https://docs.gradle.org/current/userguide/declaring_repositories.html#maven_repository_filtering