### PR TITLE
minor tidy up of buildSrc convention plugins

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -1,30 +1,18 @@
 plugins {
    signing
-   `java-library`
    `maven-publish`
 }
 
 val javadocJar by tasks.registering(Jar::class) {
    group = JavaBasePlugin.DOCUMENTATION_GROUP
-   description = "Assembles java doc to jar"
+   description = "Empty Javadoc Jar (required by Maven Central)"
    archiveClassifier.set("javadoc")
-   from(tasks.javadoc)
 }
 
 val ossrhUsername: String by project
 val ossrhPassword: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
-
-signing {
-   useGpgCmd()
-   if (signingKey != null && signingPassword != null) {
-      useInMemoryPgpKeys(signingKey, signingPassword)
-   }
-   if (Ci.isRelease) {
-      sign(publishing.publications)
-   }
-}
 
 publishing {
    repositories {
@@ -69,5 +57,15 @@ publishing {
             }
          }
       }
+   }
+}
+
+signing {
+   useGpgCmd()
+   if (signingKey != null && signingPassword != null) {
+      useInMemoryPgpKeys(signingKey, signingPassword)
+   }
+   if (Ci.isRelease) {
+      sign(publishing.publications)
    }
 }

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -4,23 +4,11 @@ plugins {
    `maven-publish`
 }
 
-val publications: PublicationContainer = (extensions.getByName("publishing") as PublishingExtension).publications
-
-val javadoc = tasks.named("javadoc")
-
-val javadocJar by tasks.creating(Jar::class) {
+val javadocJar by tasks.registering(Jar::class) {
    group = JavaBasePlugin.DOCUMENTATION_GROUP
    description = "Assembles java doc to jar"
    archiveClassifier.set("javadoc")
-   from(javadoc)
-}
-
-publishing {
-   publications.withType<MavenPublication>().forEach {
-      it.apply {
-         artifact(javadocJar)
-      }
-   }
+   from(tasks.javadoc)
 }
 
 val ossrhUsername: String by project
@@ -31,21 +19,20 @@ val signingPassword: String? by project
 signing {
    useGpgCmd()
    if (signingKey != null && signingPassword != null) {
-      @Suppress("UnstableApiUsage")
       useInMemoryPgpKeys(signingKey, signingPassword)
    }
    if (Ci.isRelease) {
-      sign(publications)
+      sign(publishing.publications)
    }
 }
 
 publishing {
    repositories {
       maven {
-         val releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-         val snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
          name = "deploy"
-         url = if (Ci.isRelease) releasesRepoUrl else snapshotsRepoUrl
+         val releasesRepoUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+         val snapshotsRepoUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+         url = uri(if (Ci.isRelease) releasesRepoUrl else snapshotsRepoUrl)
          credentials {
             username = System.getenv("OSSRH_USERNAME") ?: ossrhUsername
             password = System.getenv("OSSRH_PASSWORD") ?: ossrhPassword
@@ -53,33 +40,32 @@ publishing {
       }
    }
 
-   publications.withType<MavenPublication>().forEach {
-      it.apply {
-         //if (Ci.isRelease)
-         pom {
-            name.set("Kotest")
-            description.set("Kotlin Test Framework")
-            url.set("https://github.com/kotest/kotest")
+   publications.withType<MavenPublication>().configureEach {
+      artifact(javadocJar)
 
-            scm {
-               connection.set("scm:git:https://github.com/kotest/kotest/")
-               developerConnection.set("scm:git:https://github.com/sksamuel/")
-               url.set("https://github.com/kotest/kotest/")
+      pom {
+         name.set("Kotest")
+         description.set("Kotlin Test Framework")
+         url.set("https://github.com/kotest/kotest")
+
+         scm {
+            connection.set("scm:git:https://github.com/kotest/kotest/")
+            developerConnection.set("scm:git:https://github.com/sksamuel/")
+            url.set("https://github.com/kotest/kotest/")
+         }
+
+         licenses {
+            license {
+               name.set("Apache-2.0")
+               url.set("https://opensource.org/licenses/Apache-2.0")
             }
+         }
 
-            licenses {
-               license {
-                  name.set("Apache-2.0")
-                  url.set("https://opensource.org/licenses/Apache-2.0")
-               }
-            }
-
-            developers {
-               developer {
-                  id.set("sksamuel")
-                  name.set("Stephen Samuel")
-                  email.set("sam@sksamuel.com")
-               }
+         developers {
+            developer {
+               id.set("sksamuel")
+               name.set("Stephen Samuel")
+               email.set("sam@sksamuel.com")
             }
          }
       }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -20,7 +20,7 @@ testlogger {
    showPassed = false
 }
 
-tasks.withType<Test>() {
+tasks.withType<Test>().configureEach {
    useJUnitPlatform()
 
    filter {
@@ -38,11 +38,11 @@ tasks.withType<KotlinCompile>().configureEach {
 }
 
 kotlin {
-   sourceSets {
-      all {
-         languageSettings.optIn("kotlin.time.ExperimentalTime")
-         languageSettings.optIn("kotlin.experimental.ExperimentalTypeInference")
-         languageSettings.optIn("kotlin.contracts.ExperimentalContracts")
+   sourceSets.configureEach {
+      languageSettings {
+         optIn("kotlin.time.ExperimentalTime")
+         optIn("kotlin.experimental.ExperimentalTypeInference")
+         optIn("kotlin.contracts.ExperimentalContracts")
       }
    }
 }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -30,7 +30,7 @@ tasks.withType<Test>().configureEach {
 
 tasks.withType<KotlinCompile>().configureEach {
    kotlinOptions {
-      freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+      freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
       jvmTarget = "1.8"
       apiVersion = "1.6"
       languageVersion = "1.6"


### PR DESCRIPTION
Some minor config updates

* use Kotlin DSL accessors, like `tasks.javadoc`
* use [Gradle config avoidance API](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) (replace `forEach {}` with `configureEach {}`
* merge related code blocks (`publications.withType<MavenPublication>().configureEach {}` was in there twice)