### PR TITLE
Minor buildSrc formatting

### DIFF
--- a/buildSrc/.gitignore
+++ b/buildSrc/.gitignore
@@ -1,2 +1,0 @@
-.gradle/
-build/

--- a/buildSrc/README.md
+++ b/buildSrc/README.md
@@ -32,7 +32,7 @@ Adds a JVM target and sets basic JVM options
 Adds JS targets
 
 ## Kotest native conventions
-Adds native targets and creates a common native source set (desktopMain / desktopTest)
+Adds native targets and creates a common native source set (`desktopMain` / `desktopTest`)
 
 ## Kotest publishing conventions
 Adds everything related to signing and publishing the libraries

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "buildSrc"
+
 dependencyResolutionManagement {
    versionCatalogs {
       create("libs") {

--- a/buildSrc/src/main/kotlin/kotest-native-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-native-conventions.gradle.kts
@@ -1,8 +1,5 @@
 @file:Suppress("UNUSED_VARIABLE")
 
-import org.gradle.kotlin.dsl.kotlin
-import org.gradle.kotlin.dsl.project
-
 plugins {
    id("kotlin-conventions")
 }
@@ -41,132 +38,52 @@ kotlin {
             dependsOn(commonMain)
          }
 
-         val macosX64Main by getting {
-            dependsOn(desktopMain)
-         }
+         val macosX64Main by getting { dependsOn(desktopMain) }
+         val macosArm64Main by getting { dependsOn(desktopMain) }
 
-         val macosArm64Main by getting {
-            dependsOn(desktopMain)
-         }
+         val mingwX64Main by getting { dependsOn(desktopMain) }
 
-         val mingwX64Main by getting {
-            dependsOn(desktopMain)
-         }
+         val linuxX64Main by getting { dependsOn(desktopMain) }
 
-         val linuxX64Main by getting {
-            dependsOn(desktopMain)
-         }
+         val iosX64Main by getting { dependsOn(desktopMain) }
+         val iosArm64Main by getting { dependsOn(desktopMain) }
+         val iosArm32Main by getting { dependsOn(desktopMain) }
+         val iosSimulatorArm64Main by getting { dependsOn(desktopMain) }
 
-         val iosX64Main by getting {
-            dependsOn(desktopMain)
-         }
+         val watchosArm32Main by getting { dependsOn(desktopMain) }
+         val watchosArm64Main by getting { dependsOn(desktopMain) }
+         val watchosX86Main by getting { dependsOn(desktopMain) }
+         val watchosX64Main by getting { dependsOn(desktopMain) }
+         val watchosSimulatorArm64Main by getting { dependsOn(desktopMain) }
 
-         val iosArm64Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val iosArm32Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val iosSimulatorArm64Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val watchosArm32Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val watchosArm64Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val watchosX86Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val watchosX64Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val watchosSimulatorArm64Main by getting {
-            dependsOn(desktopMain)
-         }
-
-         val tvosMain by getting {
-            dependsOn(desktopMain)
-         }
-
-         val tvosSimulatorArm64Main by getting {
-            dependsOn(desktopMain)
-         }
+         val tvosMain by getting { dependsOn(desktopMain) }
+         val tvosSimulatorArm64Main by getting { dependsOn(desktopMain) }
 
          // Test sourcesets
          val commonTest by getting
 
-         val nativeTest by creating {
-            dependsOn(commonTest)
-         }
+         val nativeTest by creating { dependsOn(commonTest) }
 
-         val macosX64Test by getting {
-            dependsOn(nativeTest)
-         }
+         val macosX64Test by getting { dependsOn(nativeTest) }
+         val macosArm64Test by getting { dependsOn(nativeTest) }
 
-         val macosArm64Test by getting {
-            dependsOn(nativeTest)
-         }
+         val mingwX64Test by getting { dependsOn(nativeTest) }
 
-         val mingwX64Test by getting {
-            dependsOn(nativeTest)
-         }
+         val linuxX64Test by getting { dependsOn(nativeTest) }
 
-         val linuxX64Test by getting {
-            dependsOn(nativeTest)
-         }
+         val iosX64Test by getting { dependsOn(nativeTest) }
+         val iosArm64Test by getting { dependsOn(nativeTest) }
+         val iosArm32Test by getting { dependsOn(nativeTest) }
+         val iosSimulatorArm64Test by getting { dependsOn(nativeTest) }
 
-         val iosX64Test by getting {
-            dependsOn(nativeTest)
-         }
+         val watchosArm32Test by getting { dependsOn(nativeTest) }
+         val watchosArm64Test by getting { dependsOn(nativeTest) }
+         val watchosX86Test by getting { dependsOn(nativeTest) }
+         val watchosX64Test by getting { dependsOn(nativeTest) }
+         val watchosSimulatorArm64Test by getting { dependsOn(nativeTest) }
 
-         val iosArm64Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val iosArm32Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val iosSimulatorArm64Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val watchosArm32Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val watchosArm64Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val watchosX86Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val watchosX64Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val watchosSimulatorArm64Test by getting {
-            dependsOn(nativeTest)
-         }
-
-         val tvosTest by getting {
-            dependsOn(nativeTest)
-         }
-
-         val tvosSimulatorArm64Test by getting {
-            dependsOn(nativeTest)
-         }
+         val tvosTest by getting { dependsOn(nativeTest) }
+         val tvosSimulatorArm64Test by getting { dependsOn(nativeTest) }
       }
    } else {
       // Make sure every project has at least one valid target, otherwise Kotlin compiler will complain


### PR DESCRIPTION
Some minor, non-functional changes

* flatten the Kotlin multiplatform targets so more fit on a screen, and it's easier to quickly disable one by commenting out one line
* README: minor style change: desktopMain -> `desktopMain`, desktopTest -> `desktopTest`
* defined buildSrc root project name (prevents occasional Gradle complaint)
* removed buildSrc/.gitignore (ignores are already defined in root)