### PR TITLE
Kotest Gradle plugin [part 2]: use configurable property for Kotest compiler plugin version

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
    kotlin("jvm")
    `maven-publish`
    `java-gradle-plugin`
+   `kotlin-dsl`
    alias(libs.plugins.gradle.plugin.publish)
 }
 
@@ -23,16 +24,17 @@ repositories {
 }
 
 dependencies {
-   compileOnly(gradleApi())
-   compileOnly(libs.kotlin.gradle.plugin)
+   implementation(libs.kotlin.gradle.plugin)
 
    testImplementation(project(Projects.Assertions.Core))
    testImplementation(project(Projects.Framework.api))
    testImplementation(project(Projects.Framework.engine))
    testImplementation(project(Projects.JunitRunner))
+
+   testImplementation(libs.mockk)
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
    // Build these libraries ahead of time so that the test project doesn't try to build them itself (if it tries to build them while we are as well, this can lead to conflicts)
    setOf(
       Projects.Assertions.Core,
@@ -73,20 +75,63 @@ tasks.withType<Test> {
    }
 }
 
-tasks {
-   pluginBundle {
-      website = "https://kotest.io"
-      vcsUrl = "https://github.com/kotest"
-      tags = listOf("kotest", "kotlin", "testing", "integrationTesting", "javascript")
-   }
-   gradlePlugin {
-      plugins {
-         create("KotestMultiplatformCompilerGradlePlugin") {
-            id = "io.kotest.multiplatform"
-            implementationClass = "io.kotest.framework.multiplatform.gradle.KotestMultiplatformCompilerGradlePlugin"
-            displayName = "Kotest Multiplatform Compiler Plugin"
-            description = "Adds support for Javascript and Native tests in Kotest"
-         }
+
+pluginBundle {
+   website = "https://kotest.io"
+   vcsUrl = "https://github.com/kotest"
+   tags = listOf("kotest", "kotlin", "testing", "integrationTesting", "javascript")
+}
+
+
+gradlePlugin {
+   plugins {
+      create("KotestMultiplatformCompilerGradlePlugin") {
+         id = "io.kotest.multiplatform"
+         implementationClass = "io.kotest.framework.multiplatform.gradle.KotestMultiplatformCompilerGradlePlugin"
+         displayName = "Kotest Multiplatform Compiler Plugin"
+         description = "Adds support for Javascript and Native tests in Kotest"
       }
    }
+}
+
+
+val kotestPluginConstantsFileContents = resources.text.fromString(
+   """
+      |// Generated file, do not edit manually
+      |@file:org.gradle.api.Generated
+      |
+      |package io.kotest.framework.multiplatform.gradle
+      |
+      |const val KOTEST_COMPILER_PLUGIN_VERSION: String = "${Ci.gradleVersion}"
+      |
+   """.trimMargin()
+)
+
+val updateKotestPluginConstants by tasks.registering(Sync::class) {
+
+   from(kotestPluginConstantsFileContents) {
+      rename { "kotestPluginConstants.kt" }
+      into("io/kotest/framework/multiplatform/gradle/")
+   }
+   into(layout.buildDirectory.dir("generated/src/main/kotlin/"))
+
+   doFirst {
+      logger.debug(
+         """
+            Updating Kotest Gradle plugin constants
+            ${kotestPluginConstantsFileContents.asString().prependIndent("  > ")}
+         """.trimIndent()
+      )
+   }
+}
+
+
+sourceSets.main {
+   java.srcDir(updateKotestPluginConstants.map { it.destinationDir })
+}
+
+
+tasks.clean {
+   delete("$projectDir/test-project/build/")
+   delete("$projectDir/test-project/.gradle/")
 }

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/main/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePlugin.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/main/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePlugin.kt
@@ -72,7 +72,7 @@ abstract class KotestMultiplatformCompilerGradlePlugin @Inject constructor(
 
       return when {
          !kotestExtension.kotestCompilerPluginVersion.isPresent -> {
-            logger.warn("Warning: Kotest plugin has been added to $project, but could not determine Kotest engine version. Kotest will not be enabled.")
+            logger.warn("Warning: the Kotest plugin has been added to $project, but kotestCompilerPluginVersion has been set to null. Kotest will not be enabled.")
             false
          }
 

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/main/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePlugin.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/main/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePlugin.kt
@@ -1,11 +1,13 @@
-@file:Suppress("unused")
-
 package io.kotest.framework.multiplatform.gradle
 
+import javax.inject.Inject
 import org.gradle.api.Project
-import org.gradle.api.artifacts.Dependency
-import org.gradle.api.provider.Property
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.findByType
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
@@ -13,93 +15,73 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.plugin.mpp.AbstractKotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJsCompilation
 
-class KotestMultiplatformCompilerGradlePlugin : KotlinCompilerPluginSupportPlugin {
+abstract class KotestMultiplatformCompilerGradlePlugin @Inject constructor(
+   private val providers: ProviderFactory,
+) : KotlinCompilerPluginSupportPlugin {
+
+   private val logger: Logger = Logging.getLogger(this::class.java)
 
    companion object {
+      const val kotestPluginExtensionName = "kotest"
       const val compilerPluginId = "io.kotest.multiplatform"
       const val KotestGroupId = "io.kotest"
       const val KotestEmbeddableCompilerArtifactId = "kotest-framework-multiplatform-plugin-embeddable-compiler"
       const val KotestNativeArtifactId = "kotest-framework-multiplatform-plugin-legacy-native"
-      const val missingProjectValError = "Project is not initialized"
-      const val engineDepPrefix = "kotest-framework-engine"
-   }
-
-   private var target: Project? = null
-   private var extension: KotestPluginExtension? = null
-
-   override fun apply(target: Project) {
-      super.apply(target)
-      this.target = target
-      extension = target.extensions.create("kotest", KotestPluginExtension::class.java)
    }
 
    /**
-    * Returns the version to use for the compiler plugins.
+    * For use in [getPluginArtifact] and [getPluginArtifactForNative], as an instance of the targeted Gradle [Project]
+    * is not available there.
     *
-    * Takes the version from the gradle extension configuration first, or if not
-    * specified, then defaults to using the same version as the engine dependency.
+    * In [isApplicable] a [Project] instance is available, so fetch the extension 'normally'. This helps ensure the
+    * Gradle API is used correctly.
     */
-   private val version: String? by lazy {
-      val versionFromExtension = extension?.compilerPluginVersion?.orNull
-      if (versionFromExtension != null) {
-         println("Kotest compiler plugin [$versionFromExtension]")
-         return@lazy versionFromExtension
-      }
+   private var kotestExtension: KotestPluginExtension? = null
 
-      val engineDep = engineDeps().firstOrNull() ?: error("Cannot determine Kotest compiler plugin version if no Kotest engine dependencies are present")
-      val version = engineDep.version ?: return@lazy null
-
-      if (version.contains("LOCAL")) {
-         println("Detected dev engine version [$version]")
-      }
-
-      return@lazy version
+   override fun apply(target: Project) {
+      kotestExtension = target.createKotestExtension()
    }
 
-   private fun engineDeps(): List<Dependency> {
-      val project = target ?: error(missingProjectValError)
-
-      return project.configurations
-         .flatMap { it.all }
-         .flatMap { it.dependencies }
-         .filter { it.group == KotestGroupId && it.name.startsWith(engineDepPrefix) }
+   private fun Project.createKotestExtension(): KotestPluginExtension {
+      return extensions.create<KotestPluginExtension>(kotestPluginExtensionName).apply {
+         kotestCompilerPluginVersion.convention(KOTEST_COMPILER_PLUGIN_VERSION)
+      }
    }
 
    override fun getCompilerPluginId() = compilerPluginId
 
    override fun getPluginArtifact(): SubpluginArtifact =
-      SubpluginArtifact(KotestGroupId, KotestEmbeddableCompilerArtifactId, version)
+      SubpluginArtifact(
+         KotestGroupId,
+         KotestEmbeddableCompilerArtifactId,
+         kotestExtension?.kotestCompilerPluginVersion?.orNull,
+      )
 
    // This will soon be deprecated and removed, see https://youtrack.jetbrains.com/issue/KT-51301.
    override fun getPluginArtifactForNative(): SubpluginArtifact =
-      SubpluginArtifact(KotestGroupId, KotestNativeArtifactId, version)
+      SubpluginArtifact(
+         KotestGroupId,
+         KotestNativeArtifactId,
+         kotestExtension?.kotestCompilerPluginVersion?.orNull,
+      )
 
    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
+      val project = kotlinCompilation.target.project
+      val kotestExtension = project.extensions.findByType<KotestPluginExtension>()
+         ?: error("Could not find Kotest extension in $project")
+
       return when {
-         // if we can't find a version to use then we won't apply to this module
-         engineDeps().isEmpty() -> {
-            println("Warning: Kotest plugin has been added to project $target, but the project does not contain a Kotest engine dependency. Kotest will not be enabled.")
+         !kotestExtension.kotestCompilerPluginVersion.isPresent -> {
+            logger.warn("Warning: Kotest plugin has been added to $project, but could not determine Kotest engine version. Kotest will not be enabled.")
             false
          }
-         version == null -> {
-            println("Warning: Kotest plugin has been added to project $target, and the project does contain a Kotest engine dependency, but no explicit dependency version has been provided. Kotest will not be enabled.")
-            false
-         }
-         kotlinCompilation is KotlinJsCompilation -> true
-         kotlinCompilation is AbstractKotlinNativeCompilation -> true
-         else -> false
+
+         kotlinCompilation is KotlinJsCompilation               -> true
+         kotlinCompilation is AbstractKotlinNativeCompilation   -> true
+         else                                                   -> false
       }
    }
 
-   override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
-      return kotlinCompilation.target.project.provider { emptyList() }
-   }
-}
-
-abstract class KotestPluginExtension {
-   abstract val compilerPluginVersion: Property<String>
-
-   init {
-      compilerPluginVersion.convention(null as String?)
-   }
+   override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> =
+      providers.provider { emptyList() }
 }

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/main/kotlin/io/kotest/framework/multiplatform/gradle/KotestPluginExtension.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/main/kotlin/io/kotest/framework/multiplatform/gradle/KotestPluginExtension.kt
@@ -1,0 +1,14 @@
+package io.kotest.framework.multiplatform.gradle
+
+import org.gradle.api.provider.Property
+
+abstract class KotestPluginExtension {
+   /**
+    * The version of the Kotest compiler plugin required by the embeddable Kotlin 1.7 compiler.
+    *
+    * Defaults to [KOTEST_COMPILER_PLUGIN_VERSION].
+    *
+    * See: ["Unified compiler plugin ABI with JVM and JS IR backends"](https://kotlinlang.org/docs/whatsnew17.html#unified-compiler-plugin-abi-with-jvm-and-js-ir-backends)
+    */
+   abstract val kotestCompilerPluginVersion: Property<String>
+}

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/test/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePluginTest.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/test/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePluginTest.kt
@@ -1,0 +1,38 @@
+package io.kotest.framework.multiplatform.gradle
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.gradle.api.Project
+import org.gradle.api.provider.ProviderFactory
+
+
+class KotestMultiplatformCompilerGradlePluginTest : BehaviorSpec({
+
+   Given("KotestMultiplatformCompilerGradlePlugin") {
+
+      val kotestPlugin = kotestMultiplatformCompilerGradlePluginInstance()
+
+      When("plugin is applied to a project") {
+         val projectMock: Project = mockk {
+            every { extensions } returns mockk {
+               every { create<KotestPluginExtension>("kotest", any()) } returns mockk(relaxed = true)
+            }
+         }
+
+         Then("expect it creates KotestPluginExtension") {
+            kotestPlugin.apply(projectMock)
+
+            verify(exactly = 1) { projectMock.extensions }
+         }
+      }
+   }
+})
+
+
+private fun kotestMultiplatformCompilerGradlePluginInstance(
+   providerFactoryMock: ProviderFactory = mockk(),
+) = object : KotestMultiplatformCompilerGradlePlugin(
+   providerFactoryMock,
+) {}


### PR DESCRIPTION
(Breaking down https://github.com/kotest/kotest/pull/3156 into smaller PRs)

Depends on https://github.com/kotest/kotest/pull/3167

Add configurable `kotestCompilerPluginVersion` to Kotest extension.

Resolves #3153

More thorough tests are included in #3163

- adjust code to use `kotestCompilerPluginVersion` property
- generate default value for k`otestCompilerPluginVersion` - `KOTEST_COMPILER_PLUGIN_VERSION`
- minor Gradle formatting, configuration avoidance updates
- update dependencies (Gradle dependencies are automatically added by `kotlin-dsl`)
- add basic test (mostly to get rid of the `@Suppress("unused")`)
- move `KotestPluginExtension` to new separate file
- add `kotlin-dsl` plugin (better compatibility with Gradle embedded version, adds Gradle Kotlin DSL library to better match how `gradle.kts` works)