### PR TITLE
Add validated.shouldBeInvalid(v) to Arrow docs

### DIFF
--- a/documentation/docs/assertions/arrow.md
+++ b/documentation/docs/assertions/arrow.md
@@ -42,3 +42,4 @@ In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, ple
 | `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
 | `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
 | `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
+| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v |


### PR DESCRIPTION
It's here: https://github.com/kotest/kotest-extensions-arrow/blob/9b4aa4670c04707383ad958c19cd9e008d10c826/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Validated.kt#L180-L181