### PR TITLE
Add new matchers (shouldCloseTo)

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -259,12 +259,12 @@ Matchers provided by the `kotest-assertions-core` module.
 
 
 
-| Instant                                                ||
-|--------------------------------------------------------| ---- |
-| `instant.shouldBeAfter(anotherInstant)`                | Asserts that the instant is after anotherInstant |
-| `instant.shouldBeBefore(anotherInstant)`               | Asserts that the instant is before anotherInstant |
-| `instant.shouldBeBetween(fromInstant, toInstant)`      | Asserts that the instant is between fromInstant and toInstant |
-| `instant.shouldBeCloseTo(anotherInstant, point, unit)` | Asserts that the instant is close To anotherInstant with as the point by the unit type |
+| Instant                                               ||
+|-------------------------------------------------------| ---- |
+| `instant.shouldBeAfter(anotherInstant)`               | Asserts that the instant is after anotherInstant |
+| `instant.shouldBeBefore(anotherInstant)`              | Asserts that the instant is before anotherInstant |
+| `instant.shouldBeBetween(fromInstant, toInstant)`     | Asserts that the instant is between fromInstant and toInstant |
+| `instant.shouldBeCloseTo(anotherInstant, duration)`   | Asserts that the instant is close To anotherInstant in range by duration |
 
 | Timestamp                                               ||
 |---------------------------------------------------------| ---- |

--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -264,7 +264,7 @@ Matchers provided by the `kotest-assertions-core` module.
 | `instant.shouldBeAfter(anotherInstant)`                | Asserts that the instant is after anotherInstant |
 | `instant.shouldBeBefore(anotherInstant)`               | Asserts that the instant is before anotherInstant |
 | `instant.shouldBeBetween(fromInstant, toInstant)`      | Asserts that the instant is between fromInstant and toInstant |
-| `instant.shouldBeCloseTo(anotherInstant, point, unit)` | Asserts that the instant is close To another Instant with as the point by the unit type |
+| `instant.shouldBeCloseTo(anotherInstant, point, unit)` | Asserts that the instant is close To anotherInstant with as the point by the unit type |
 
 | Timestamp                                               ||
 |---------------------------------------------------------| ---- |

--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -259,11 +259,12 @@ Matchers provided by the `kotest-assertions-core` module.
 
 
 
-| Instant                                           ||
-|---------------------------------------------------| ---- |
-| `instant.shouldBeAfter(anotherInstant)`           | Asserts that the instant is after anotherInstant |
-| `instant.shouldBeBefore(anotherInstant)`          | Asserts that the instant is before anotherInstant |
-| `instant.shouldBeBetween(fromInstant, toInstant)` | Asserts that the instant is between fromInstant and toInstant |
+| Instant                                                ||
+|--------------------------------------------------------| ---- |
+| `instant.shouldBeAfter(anotherInstant)`                | Asserts that the instant is after anotherInstant |
+| `instant.shouldBeBefore(anotherInstant)`               | Asserts that the instant is before anotherInstant |
+| `instant.shouldBeBetween(fromInstant, toInstant)`      | Asserts that the instant is between fromInstant and toInstant |
+| `instant.shouldBeCloseTo(anotherInstant, point, unit)` | Asserts that the instant is close To another Instant with as the point by the unit type |
 
 | Timestamp                                               ||
 |---------------------------------------------------------| ---- |

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -44,8 +44,8 @@ fun closeTo(anotherInstant: Instant, point: Long, unit: ChronoUnit) = object : M
       val diff = kotlin.math.abs(value.toEpochMilli() - anotherInstant.toEpochMilli())
       return MatcherResult(
          diff <= Duration.of(point, unit).toMillis(),
-         { "Expected $value to be close to $point${unit.name}, but it's not." },
-         { "$value is not close as $point${unit.name} to $anotherInstant." }
+         { "Expected $value to be close to $anotherInstant in range by $point${unit.name}, but it's not." },
+         { "$value is not close to $anotherInstant in range by $point${unit.name} " }
       )
    }
 }
@@ -87,14 +87,14 @@ fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this sho
 fun Instant.shouldNotBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldNotBe between(fromInstant, toInstant)
 
 /**
- * Assert that [Instant] is close as value of point by type to [anotherInstant].
+ * Assert that [Instant] is close to in range by value of point and type to [anotherInstant].
  * @see [shouldBeCloseTo]
  * */
 fun Instant.shouldBeCloseTo(anotherInstant: Instant, point: Long, unit: ChronoUnit) =
    this shouldBe closeTo(anotherInstant, point, unit)
 
 /**
- * Assert that [Instant] is not close as value of point by type to [anotherInstant].
+ * Assert that [Instant] is not close to in range by value of point and type to [anotherInstant].
  * @see [shouldNotBeCloseTo]
  * */
 fun Instant.shouldNotBeCloseTo(anotherInstant: Instant, point: Long, unit: ChronoUnit) =

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -5,7 +5,9 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
+import java.time.Duration
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 fun before(anotherInstant: Instant) = object : Matcher<Instant> {
    override fun test(value: Instant): MatcherResult {
@@ -33,6 +35,17 @@ fun between(fromInstant: Instant, toInstant: Instant) = object : Matcher<Instant
          value.isAfter(fromInstant) && value.isBefore(toInstant),
          { "$value should be after $fromInstant and before $toInstant" },
          { "$value should not be be after $fromInstant and before $toInstant" }
+      )
+   }
+}
+
+fun closeTo(anotherInstant: Instant, point: Long, unit: ChronoUnit) = object : Matcher<Instant> {
+   override fun test(value: Instant): MatcherResult {
+      val diff = kotlin.math.abs(value.toEpochMilli() - anotherInstant.toEpochMilli())
+      return MatcherResult(
+         diff <= Duration.of(point, unit).toMillis(),
+         { "Expected $value to be close to $point${unit.name}, but it's not." },
+         { "$value is not close as $point${unit.name} to $anotherInstant." }
       )
    }
 }
@@ -72,3 +85,17 @@ fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this sho
  * @see [shouldNotBeBetween]
  * */
 fun Instant.shouldNotBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldNotBe between(fromInstant, toInstant)
+
+/**
+ * Assert that [Instant] is close as value of point by type to [anotherInstant].
+ * @see [shouldBeCloseTo]
+ * */
+fun Instant.shouldBeCloseTo(anotherInstant: Instant, point: Long, unit: ChronoUnit) =
+   this shouldBe closeTo(anotherInstant, point, unit)
+
+/**
+ * Assert that [Instant] is not close as value of point by type to [anotherInstant].
+ * @see [shouldNotBeCloseTo]
+ * */
+fun Instant.shouldNotBeCloseTo(anotherInstant: Instant, point: Long, unit: ChronoUnit) =
+   this shouldNotBe closeTo(anotherInstant, point, unit)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -12,7 +12,8 @@ import io.kotest.matchers.date.shouldNotBeCloseTo
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.time.Instant
-import java.time.temporal.ChronoUnit
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.nanoseconds
 
 class InstantMatcherTest : FreeSpec() {
    init {
@@ -91,20 +92,20 @@ class InstantMatcherTest : FreeSpec() {
          futureInstant.shouldNotBeBetween(pastInstant, currentInstant)
       }
 
-      "current instant and 100 nanos ago instant should be close to 100 nanoseconds each other" {
+      "current instant and 5 nanos ago instant should be close to 5 nanoseconds each other" {
          val currentInstant = Instant.now()
-         val hundredNanosAgoInstant = currentInstant.minusNanos(100L)
+         val hundredNanosAgoInstant = currentInstant.minusNanos(5L)
 
-         currentInstant.shouldBeCloseTo(hundredNanosAgoInstant, 100L, ChronoUnit.NANOS)
-         hundredNanosAgoInstant.shouldBeCloseTo(currentInstant, 100L, ChronoUnit.NANOS)
+         currentInstant.shouldBeCloseTo(hundredNanosAgoInstant, 5L.nanoseconds)
+         hundredNanosAgoInstant.shouldBeCloseTo(currentInstant, 5L.nanoseconds)
       }
 
       "current instant and 1500 millis ago instant should not be close to 1000 millis each other" {
          val currentInstant = Instant.now()
          val someMillisAgoInstant = currentInstant.minusMillis(1500L)
 
-         currentInstant.shouldNotBeCloseTo(someMillisAgoInstant, 1000L, ChronoUnit.MILLIS)
-         someMillisAgoInstant.shouldNotBeCloseTo(currentInstant, 1000L, ChronoUnit.MILLIS)
+         currentInstant.shouldNotBeCloseTo(someMillisAgoInstant, 1000L.milliseconds)
+         someMillisAgoInstant.shouldNotBeCloseTo(currentInstant, 1000L.milliseconds)
       }
 
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -91,7 +91,7 @@ class InstantMatcherTest : FreeSpec() {
          futureInstant.shouldNotBeBetween(pastInstant, currentInstant)
       }
 
-      "100nanos ago instant and current instant should be close to 100nanos each other" {
+      "current instant and 100 nanos ago instant should be close to 100 nanoseconds each other" {
          val currentInstant = Instant.now()
          val hundredNanosAgoInstant = currentInstant.minusNanos(100L)
 
@@ -99,12 +99,12 @@ class InstantMatcherTest : FreeSpec() {
          hundredNanosAgoInstant.shouldBeCloseTo(currentInstant, 100L, ChronoUnit.NANOS)
       }
 
-      "1500millis ago instant and current instant should not be close to 1000millis each other" {
+      "current instant and 1500 millis ago instant should not be close to 1000 millis each other" {
          val currentInstant = Instant.now()
-         val hundredNanosAgoInstant = currentInstant.minusMillis(1500L)
+         val someMillisAgoInstant = currentInstant.minusMillis(1500L)
 
-         currentInstant.shouldNotBeCloseTo(hundredNanosAgoInstant, 1000L, ChronoUnit.MILLIS)
-         hundredNanosAgoInstant.shouldNotBeCloseTo(currentInstant, 1000L, ChronoUnit.MILLIS)
+         currentInstant.shouldNotBeCloseTo(someMillisAgoInstant, 1000L, ChronoUnit.MILLIS)
+         someMillisAgoInstant.shouldNotBeCloseTo(currentInstant, 1000L, ChronoUnit.MILLIS)
       }
 
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/instantMatcherTest.kt
@@ -4,12 +4,15 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.date.shouldBeAfter
 import io.kotest.matchers.date.shouldBeBefore
 import io.kotest.matchers.date.shouldBeBetween
+import io.kotest.matchers.date.shouldBeCloseTo
 import io.kotest.matchers.date.shouldNotBeAfter
 import io.kotest.matchers.date.shouldNotBeBefore
 import io.kotest.matchers.date.shouldNotBeBetween
+import io.kotest.matchers.date.shouldNotBeCloseTo
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 class InstantMatcherTest : FreeSpec() {
    init {
@@ -86,6 +89,22 @@ class InstantMatcherTest : FreeSpec() {
          val futureInstant = currentInstant.plusMillis(30000)
 
          futureInstant.shouldNotBeBetween(pastInstant, currentInstant)
+      }
+
+      "100nanos ago instant and current instant should be close to 100nanos each other" {
+         val currentInstant = Instant.now()
+         val hundredNanosAgoInstant = currentInstant.minusNanos(100L)
+
+         currentInstant.shouldBeCloseTo(hundredNanosAgoInstant, 100L, ChronoUnit.NANOS)
+         hundredNanosAgoInstant.shouldBeCloseTo(currentInstant, 100L, ChronoUnit.NANOS)
+      }
+
+      "1500millis ago instant and current instant should not be close to 1000millis each other" {
+         val currentInstant = Instant.now()
+         val hundredNanosAgoInstant = currentInstant.minusMillis(1500L)
+
+         currentInstant.shouldNotBeCloseTo(hundredNanosAgoInstant, 1000L, ChronoUnit.MILLIS)
+         hundredNanosAgoInstant.shouldNotBeCloseTo(currentInstant, 1000L, ChronoUnit.MILLIS)
       }
 
    }


### PR DESCRIPTION
Hello bro,

issue - [#3183 ](https://github.com/kotest/kotest/issues/3183)

i request the addition of the "shouldCloseTo" function, inspired by "closeTo" provided by various matcher libraries such as "hamcrest" and "assertj".

The newly added Instant::shouldCloseTo function is to check that value and otherInstant are as close as the developer expected. As well as me, other developers will often use it in situations where they cannot accurately capture the stubbed time.

Although it is a function that is frequently used, I know that kotest does not provide it, so I until used extensions function in my code, but I raise this PR because I think it has sufficient usage and versatility.

In order to reconsider the need for this feature, Instant has implemented it first, but if this PR is Approved and proves necessary, they want to add it to all Datetime forms.

Thank you.