### PR TITLE
Attempt to improve the error message for `containExactly` when used with non-stable sets

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.matchers.collections
 
-import io.kotest.assertions.shouldFail
+import io.kotest.assertions.shouldFailWithMessage
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
@@ -74,6 +74,25 @@ class ShouldContainExactlyTest : WordSpec() {
             }
          }
 
+         "Iterable with non-stable iteration order gives an informative message" {
+
+            // Ideally the last two newlines shouldn't be there, IMO.
+            val expectedMessage = """
+               Disallowed: Sets can only be compared to sets, unless both types provide a stable iteration order.
+               HashSet does not provide a stable iteration order and was compared with ArrayList which is not a Set
+
+
+            """.trimIndent()
+
+            shouldFailWithMessage(expectedMessage) {
+               hashSetOf(1, 2) shouldContainExactly listOf(1, 2)
+            }
+
+            shouldFailWithMessage(expectedMessage) {
+               listOf(1, 2) shouldContainExactly hashSetOf(1, 2)
+            }
+         }
+
          "test contains exactly for byte arrays" {
             listOf("hello".toByteArray()) shouldContainExactly listOf("hello".toByteArray())
             listOf("helloworld".toByteArray()) shouldNotContainExactly listOf("hello".toByteArray())
@@ -88,16 +107,6 @@ class ShouldContainExactlyTest : WordSpec() {
                   |Some elements were missing: [1, 2] and some elements were unexpected: [1L, 2L]
                   |expected:<[1, 2]> but was:<[1L, 2L]>
                """.trimMargin()
-         }
-
-         "informs user of illegal comparisons" {
-            shouldFail {
-               HashSet(setOf(1, 2, 3)) shouldContainExactly listOf(1, 2, 3)
-            }.message shouldBe """Disallowed: Set can be compared only to Set
-                           |May not compare HashSet with ArrayList
-                           |expected:<*> but was:<*>
-                           |
-                           |""".trimMargin()
          }
 
          "print dataclasses" {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/fail.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/fail.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 
 /**
  * Verifies that [block] throws an [AssertionError]
@@ -16,10 +17,36 @@ import io.kotest.assertions.throwables.shouldThrow
  *     }
  * ```
  *
+ * @returns the [AssertionError] that was thrown
  * @see shouldThrowAny
  * @see shouldThrow
  * @see shouldThrowExactly
  */
 inline fun shouldFail(block: () -> Any?): AssertionError = shouldThrow(block)
+
+/**
+ * Verifies that [block] throws an [AssertionError] with the expected [message]
+ *
+ * If [block] throws an [AssertionError] with the given [message], this method will pass.
+ * Otherwise, it will throw an error, as a failure was expected.
+ *
+ * This should be used mainly to check that an assertion fails, for example:
+ *
+ * ```
+ *     shouldFail {
+ *        1 shouldBe 2  // This should fail
+ *     }
+ * ```
+ *
+ * @returns the [AssertionError] that was thrown
+ * @see shouldFail
+ * @see shouldThrowAny
+ * @see shouldThrow
+ * @see shouldThrowExactly
+ */
+inline fun shouldFailWithMessage(message: String, block: () -> Any?): AssertionError =
+   shouldFail(block).also { t ->
+      t.message shouldBe message
+   }
 
 fun fail(msg: String): Nothing = throw failure(msg)

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/IterableEqTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/IterableEqTest.kt
@@ -74,9 +74,8 @@ class IterableEqTest : FunSpec({
       val error = IterableEq.equals(hs, listOf(1, 2, 3))
       assertSoftly {
          error.shouldNotBeNull()
-         error.message shouldBe """Disallowed: Set can be compared only to Set
-                                  |May not compare HashSet with ArrayList
-                                  |expected:<*> but was:<*>""".trimMargin()
+         error.message shouldBe """Disallowed: Sets can only be compared to sets, unless both types provide a stable iteration order.
+                                  |HashSet does not provide a stable iteration order and was compared with ArrayList which is not a Set""".trimMargin()
       }
    }
 
@@ -91,7 +90,7 @@ class IterableEqTest : FunSpec({
          error.shouldNotBeNull()
          error.message shouldBe """Disallowed typed contract
                                   |May not compare BareIterable with ArrayList
-                                  |expected:<*> but was:<*>""".trimMargin()
+                                  |""".trimMargin()
       }
    }
 
@@ -115,7 +114,7 @@ class IterableEqTest : FunSpec({
          error.shouldNotBeNull()
          error.message shouldBe """Disallowed promiscuous iterators
                                   |May not compare UnixPath with BareIterable
-                                  |expected:<*> but was:<*>""".trimMargin()
+                                  |""".trimMargin()
       }
    }
 
@@ -125,7 +124,7 @@ class IterableEqTest : FunSpec({
          error.shouldNotBeNull()
          error.message shouldBe """Disallowed promiscuous iterators
                                   |May not compare UnixPath with BareRecursiveIterable
-                                  |expected:<*> but was:<*>""".trimMargin()
+                                  |""".trimMargin()
       }
    }
 


### PR DESCRIPTION
See #3097 