### PR TITLE
fix misleading error message when `Arb.of` is given an empty list

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/collections.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/collections.kt
@@ -12,7 +12,10 @@ import kotlin.random.nextInt
  * Returns an [Arb] whose values are chosen randomly from those in the supplied collection.
  * May not cover all items. If you want an exhaustive selection from the list, see [Exhaustive.collection]
  */
-fun <T> Arb.Companion.element(collection: Collection<T>): Arb<T> = arbitrary { collection.random(it.random) }
+fun <T> Arb.Companion.element(collection: Collection<T>): Arb<T> {
+   require(collection.isNotEmpty()) { "The supplied collection must not be empty." }
+   return arbitrary { collection.random(it.random) }
+}
 
 /**
  * Alias for [element]
@@ -23,7 +26,10 @@ fun <T> Arb.Companion.of(collection: Collection<T>): Arb<T> = element(collection
  * Returns an [Arb] whose values are chosen randomly from those in the supplied collection.
  * May not cover all items. If you want an exhaustive selection from the list, see [Exhaustive.collection]
  */
-fun <T> Arb.Companion.element(vararg collection: T): Arb<T> = arbitrary { collection.random(it.random) }
+fun <T> Arb.Companion.element(vararg collection: T): Arb<T> {
+   require(collection.isNotEmpty()) { "The supplied collection must not be empty." }
+   return arbitrary { collection.random(it.random) }
+}
 
 /**
  * Alias for [element]

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.inspectors.forAll
@@ -10,6 +11,7 @@ import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.Exhaustive
+import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.edgecases
 import io.kotest.property.arbitrary.int
@@ -18,11 +20,32 @@ import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.positiveInt
 import io.kotest.property.arbitrary.set
 import io.kotest.property.arbitrary.single
+import io.kotest.property.arbitrary.take
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.constant
 import io.kotest.property.forAll
 
 class CollectionsTest : DescribeSpec({
+
+   describe("Arb.element should") {
+      it("not construct an arb from an empty list") {
+         shouldThrow<IllegalArgumentException> { Arb.of(emptyList<String>()) }
+      }
+
+      it("not construct an arb from an empty vararg") {
+         shouldThrow<IllegalArgumentException> { Arb.of<String>() }
+      }
+
+      it("yield a random sample from the provided collection") {
+         val expected = listOf("bar", "foo", "baz", "foo", "baz")
+         Arb.of(listOf("foo", "bar", "baz")).take(5, RandomSource.seeded(1234L)).toList() shouldBe expected
+      }
+
+      it("yield a random sample from the provided vararg") {
+         val expected = listOf("bar", "foo", "baz", "foo", "baz")
+         Arb.of("foo", "bar", "baz").take(5, RandomSource.seeded(1234L)).toList() shouldBe expected
+      }
+   }
 
    describe("Arb.list should") {
 


### PR DESCRIPTION
fixes #3193 