### PR TITLE
Adjust Kotest test assertions to be runnable on Windows

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/IterableEqTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/IterableEqTest.kt
@@ -34,6 +34,12 @@ private class BareRecursiveIterable(size: Int, offset: Int): Iterable<BareRecurs
    override fun toString(): String = "${this::class.simpleName}@{$top,$count}"
 }
 
+private val expectedPath = if (System.getProperty("os.name").lowercase().contains("win")) {
+   "WindowsPath"
+} else {
+   "UnixPath"
+}
+
 class IterableEqTest : FunSpec({
 
    test("should give null for two equal sets") {
@@ -113,17 +119,18 @@ class IterableEqTest : FunSpec({
       assertSoftly {
          error.shouldNotBeNull()
          error.message shouldBe """Disallowed promiscuous iterators
-                                  |May not compare UnixPath with BareIterable
+                                  |May not compare $expectedPath with BareIterable
                                   |""".trimMargin()
       }
    }
 
    test("should give error for promiscuous iterables when recursive") {
       val error = IterableEq.equals(Paths.get("foo"), BareRecursiveIterable(1,0))
+      System.getProperty("os")
       assertSoftly {
          error.shouldNotBeNull()
          error.message shouldBe """Disallowed promiscuous iterators
-                                  |May not compare UnixPath with BareRecursiveIterable
+                                  |May not compare $expectedPath with BareRecursiveIterable
                                   |""".trimMargin()
       }
    }

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -103,19 +103,19 @@ gradlePlugin {
 }
 
 
-val kotestPluginConstantsFileContents = resources.text.fromString(
-   """
-      |// Generated file, do not edit manually
-      |@file:org.gradle.api.Generated
-      |
-      |package io.kotest.framework.multiplatform.gradle
-      |
-      |const val KOTEST_COMPILER_PLUGIN_VERSION: String = "${Ci.gradleVersion}"
-      |
-   """.trimMargin()
-)
-
 val updateKotestPluginConstants by tasks.registering(Sync::class) {
+
+   val kotestPluginConstantsFileContents: TextResource = resources.text.fromString(
+      """
+         |// Generated file, do not edit manually
+         |@file:org.gradle.api.Generated
+         |
+         |package io.kotest.framework.multiplatform.gradle
+         |
+         |const val KOTEST_COMPILER_PLUGIN_VERSION: String = "${Ci.gradleVersion}"
+         |
+      """.trimMargin()
+   )
 
    from(kotestPluginConstantsFileContents) {
       rename { "kotestPluginConstants.kt" }

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -35,37 +35,41 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach {
-   // Build these libraries ahead of time so that the test project doesn't try to build them itself (if it tries to build them while we are as well, this can lead to conflicts)
-   setOf(
-      projects.kotestAssertions.kotestAssertionsCore,
-      projects.kotestFramework.kotestFrameworkApi,
-      projects.kotestFramework.kotestFrameworkEngine,
-   ).map { project ->
-      project.dependencyProject.path
-   }.forEach { projectPath ->
+   enabled = !project.hasProperty(Ci.JVM_ONLY)
+
+   if (!project.hasProperty(Ci.JVM_ONLY)) {
+      // Build these libraries ahead of time so that the test project doesn't try to build them itself (if it tries to build them while we are as well, this can lead to conflicts)
       setOf(
-         "jvmJar",
-         "compileKotlinLinuxX64",
-         "compileKotlinMacosX64",
-         "compileKotlinMacosArm64",
-         "compileKotlinMingwX64",
-      ).forEach { task ->
-         dependsOn("$projectPath:$task")
+         projects.kotestAssertions.kotestAssertionsCore,
+         projects.kotestFramework.kotestFrameworkApi,
+         projects.kotestFramework.kotestFrameworkEngine,
+      ).map { project ->
+         project.dependencyProject.path
+      }.forEach { projectPath ->
+         setOf(
+            "jvmJar",
+            "compileKotlinLinuxX64",
+            "compileKotlinMacosX64",
+            "compileKotlinMacosArm64",
+            "compileKotlinMingwX64",
+         ).forEach { task ->
+            dependsOn("$projectPath:$task")
+         }
       }
-   }
 
-   setOf(
-      projects.kotestRunner.kotestRunnerJunit5,
-      projects.kotestFramework.kotestFrameworkMultiplatformPluginEmbeddableCompiler,
-      projects.kotestFramework.kotestFrameworkMultiplatformPluginLegacyNative,
-   ).map { project ->
-      project.dependencyProject.path
-   }.forEach { project ->
-      dependsOn("$project:jvmJar")
-   }
+      setOf(
+         projects.kotestRunner.kotestRunnerJunit5,
+         projects.kotestFramework.kotestFrameworkMultiplatformPluginEmbeddableCompiler,
+         projects.kotestFramework.kotestFrameworkMultiplatformPluginLegacyNative,
+      ).map { project ->
+         project.dependencyProject.path
+      }.forEach { project ->
+         dependsOn("$project:jvmJar")
+      }
 
-   dependsOn("jar")
-   dependsOn(":kotlinNpmInstall")
+      dependsOn("jar")
+      dependsOn(":kotlinNpmInstall")
+   }
 
    useJUnitPlatform()
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/stats/CollectTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/stats/CollectTest.kt
@@ -27,7 +27,7 @@ class CollectTest : FunSpec() {
             }
          }
          stdout.shouldContain("Statistics: [collecting stats] (1000 iterations, 1 args)")
-         stdout.shouldContain(
+         stdout.lines().joinToString(separator = "\n").shouldContain(
             """
 HALF_DOWN                                                     142 (14%)
 HALF_UP                                                       141 (14%)
@@ -52,7 +52,7 @@ DOWN                                                          107 (11%)
          stdout.shouldContain("Statistics: [collecting labelled stats] (1000 iterations, 1 args)")
          stdout.shouldContain("Statistics: [collecting labelled stats] (1000 iterations, 1 args) [mylabel]")
          stdout.shouldContain("Statistics: [collecting labelled stats] (1000 iterations, 1 args) [mylabel2]")
-         stdout.shouldContain(
+         stdout.lines().joinToString(separator = "\n").shouldContain(
             """
 HALF_DOWN                                                     142 (14%)
 HALF_UP                                                       141 (14%)


### PR DESCRIPTION
When I run the tests on my Windows machine, I get several failing tests because the test assertions are Unix only.

I also adjusted the Gradle tests to only run when the required tasks are present. This is a bit of a hack, and should be fixed by implementing Gradle TestKit tests #3163

related #3161 

I've enabled the `jvmOnly` flag so I might have missed some tests