### PR TITLE
Fix json compareArrays

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
@@ -268,7 +268,12 @@ internal fun compareArrays(
          fun findMatchingIndex(element: JsonNode): Int? {
             for (i in availableIndexes()) {
                // Comparison with no error -> matching element
-               val isMatch = compare(path + "[$i]", expected.elements[i], element, options) == null
+               val isMatch = compare(
+                  path = path + "[$i]",
+                  expected = expected.elements[i],
+                  actual = element,
+                  options = options
+               ) == null
 
                if (isMatch) {
                   return i

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
@@ -268,7 +268,7 @@ internal fun compareArrays(
          fun findMatchingIndex(element: JsonNode): Int? {
             for (i in availableIndexes()) {
                // Comparison with no error -> matching element
-               val isMatch = compare(path + "[$i]", element, expected.elements[i], options) == null
+               val isMatch = compare(path + "[$i]", expected.elements[i], element, options) == null
 
                if (isMatch) {
                   return i


### PR DESCRIPTION
In the original `expected` was in place of `actual` and vice versa.

It rendered `fieldComparison = Lenient` useless if there was an array in the json, because after flipping, it expected additional fields in `actual` to be in `expected`.