### PR TITLE
Fix issue using compiler plugin with Kotlin 1.7.20.

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/IrFileExtensions.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/IrFileExtensions.kt
@@ -1,6 +1,12 @@
 package io.kotest.framework.multiplatform.embeddablecompiler
 
+import org.jetbrains.kotlin.ir.IrElement
+import org.jetbrains.kotlin.ir.declarations.IrDeclaration
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationBase
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationContainer
+import org.jetbrains.kotlin.ir.declarations.IrDeclarationParent
 import org.jetbrains.kotlin.ir.declarations.IrFile
+import org.jetbrains.kotlin.ir.visitors.IrElementVisitor
 import java.io.File
 
 // These extension properties are available in org.jetbrains.kotlin.ir.declarations, but were moved from one file to
@@ -10,3 +16,29 @@ import java.io.File
 // See https://github.com/kotest/kotest/issues/3060 and https://youtrack.jetbrains.com/issue/KT-52888 for more information.
 internal val IrFile.path: String get() = fileEntry.name
 internal val IrFile.name: String get() = File(path).name
+
+// These extension methods were moved from org.jetbrains.kotlin.backend.common.ir to org.jetbrains.kotlin.ir.util in Kotlin 1.7.20.
+// (see https://github.com/JetBrains/kotlin/commit/f3252334b2ef679aa40e94002d9e65b1b76e95b6)
+// For similar reasons to above, we've copied them here so the compiler plugin can work with Kotlin 1.6, 1.7.0 and 1.7.20.
+fun IrDeclarationContainer.addChild(declaration: IrDeclaration) {
+   this.declarations += declaration
+   declaration.setDeclarationsParent(this)
+}
+
+fun <T : IrElement> T.setDeclarationsParent(parent: IrDeclarationParent): T {
+   accept(SetDeclarationsParentVisitor, parent)
+   return this
+}
+
+object SetDeclarationsParentVisitor : IrElementVisitor<Unit, IrDeclarationParent> {
+   override fun visitElement(element: IrElement, data: IrDeclarationParent) {
+      if (element !is IrDeclarationParent) {
+         element.acceptChildren(this, data)
+      }
+   }
+
+   override fun visitDeclaration(declaration: IrDeclarationBase, data: IrDeclarationParent) {
+      declaration.parent = data
+      super.visitDeclaration(declaration, data)
+   }
+}

--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/Transformer.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/Transformer.kt
@@ -2,7 +2,6 @@ package io.kotest.framework.multiplatform.embeddablecompiler
 
 import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
-import org.jetbrains.kotlin.backend.common.ir.addChild
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.toLogger
 import org.jetbrains.kotlin.ir.IrStatement

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/test/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePluginSpec.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/test/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePluginSpec.kt
@@ -17,7 +17,8 @@ class KotestMultiplatformCompilerGradlePluginSpec : ShouldSpec({
 
    setOf(
       "1.6.21",
-      "1.7.0"
+      "1.7.0",
+      "1.7.20"
    ).forEach { kotlinVersion ->
       context("when the project targets Kotlin version $kotlinVersion") {
          val testProjectPath = Paths.get("test-project").toAbsolutePath()


### PR DESCRIPTION
Another set of extension methods were moved in Kotlin 1.7.20, breaking backwards compatibility with earlier versions.