### PR TITLE
Added new aliases for shouldEqualJson which accepts a configuration fun

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -1,7 +1,5 @@
 package io.kotest.assertions.json
 
-import io.kotest.assertions.Actual
-import io.kotest.assertions.Expected
 import io.kotest.matchers.ComparableMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
@@ -51,8 +49,26 @@ data class JsonTree(val root: JsonNode, val raw: String)
 infix fun String.shouldEqualJson(expected: String): Unit =
    this.shouldEqualJson(expected, defaultCompareJsonOptions)
 
+/**
+ * Configures [CompareJsonOptions] with the given block, which should also return the expected value
+ */
+infix fun String.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String) {
+   val options = CompareJsonOptions()
+   val expected = options.configureAndProvideExpected()
+   this.shouldEqualJson(expected, options)
+}
+
 infix fun String.shouldNotEqualJson(expected: String): Unit =
    this.shouldNotEqualJson(expected, defaultCompareJsonOptions)
+
+/**
+ * Configures [CompareJsonOptions] with the given block, which should also return the expected value
+ */
+infix fun String.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String) {
+   val options = CompareJsonOptions()
+   val expected = options.configureAndProvideExpected()
+   this.shouldNotEqualJson(expected, options)
+}
 
 fun String.shouldEqualJson(expected: String, mode: CompareMode) =
    shouldEqualJson(expected, legacyOptions(mode, CompareOrder.Strict))

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -2,7 +2,9 @@ package com.sksamuel.kotest.tests.json
 
 import io.kotest.assertions.json.CompareMode
 import io.kotest.assertions.json.CompareOrder
+import io.kotest.assertions.json.TypeCoercion
 import io.kotest.assertions.json.shouldEqualJson
+import io.kotest.assertions.json.shouldNotEqualJson
 import io.kotest.assertions.shouldFail
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.string.shouldStartWith
@@ -236,15 +238,29 @@ expected:<{
          )
       }
 
-
-      test("comparing boolean to string with lenient mode") {
+      context("comparing boolean to string with lenient mode") {
          val a = """ { "a" : "foo", "b" : true } """
          val b = """ { "a" : "foo", "b" : "true" } """
-         a.shouldEqualJson(b, CompareMode.Lenient)
-
          val c = """ { "a" : "foo", "b" : false } """
          val d = """ { "a" : "foo", "b" : "false" } """
-         c.shouldEqualJson(d, CompareMode.Lenient)
+
+         test("Check new block-style configuration options") {
+            a shouldEqualJson {
+               typeCoercion = TypeCoercion.Enabled
+               b
+            }
+
+            a shouldNotEqualJson {
+               typeCoercion = TypeCoercion.Disabled
+               b
+            }
+         }
+
+
+         test("Using old CompareMode flags") {
+            a.shouldEqualJson(b, CompareMode.Lenient)
+            c.shouldEqualJson(d, CompareMode.Lenient)
+         }
       }
 
       test("comparing long to string with lenient mode") {
@@ -739,7 +755,8 @@ expected:<{
          a.shouldEqualJson(b)
          shouldFail {
             a.shouldEqualJson(b, CompareOrder.Strict)
-         }.shouldHaveMessage("""The top level object expected field 0 to be 'sku' but was 'id'
+         }.shouldHaveMessage(
+            """The top level object expected field 0 to be 'sku' but was 'id'
 
 expected:<{
   "sku": "RIND-TOTEO-001-MCF",
@@ -755,7 +772,8 @@ expected:<{
   "requires_shipping": true,
   "taxable": true,
   "featured_image": null
-}>""")
+}>"""
+         )
       }
    }
 }


### PR DESCRIPTION
In line with discussion in https://github.com/kotest/kotest/issues/3161#issuecomment-1215835513