### PR TITLE
mod TestCoroutineInterceptor to use runTest on K/N

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
@@ -1,0 +1,28 @@
+package io.kotest.engine.test.interceptors
+
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.core.test.TestScope
+import io.kotest.engine.test.scopes.withCoroutineContext
+import io.kotest.mpp.Logger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+
+@ExperimentalCoroutinesApi
+actual class TestCoroutineInterceptor : TestExecutionInterceptor {
+
+   private val logger = Logger(TestCoroutineInterceptor::class)
+
+   override suspend fun intercept(
+      testCase: TestCase,
+      scope: TestScope,
+      test: suspend (TestCase, TestScope) -> TestResult
+   ): TestResult {
+      var result: TestResult = TestResult.Ignored
+      logger.log { Pair(testCase.name.testName, "Switching context to coroutines runTest") }
+      runTest {
+         result = test(testCase, scope.withCoroutineContext(this.coroutineContext))
+      }
+      return result
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/TestDispatcherInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/TestDispatcherInterceptor.kt
@@ -11,11 +11,3 @@ actual class TestDispatcherInterceptor : TestExecutionInterceptor {
       test: suspend (TestCase, TestScope) -> TestResult
    ): TestResult = test(testCase, scope)
 }
-
-actual class TestCoroutineInterceptor : TestExecutionInterceptor {
-   override suspend fun intercept(
-      testCase: TestCase,
-      scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
-   ): TestResult = test(testCase, scope)
-}


### PR DESCRIPTION
I offered option to support K/N (https://github.com/kotest/kotest/issues/3206)

but nothings effects to TestScope, because `runTest` method was used only jvm
so, I mod TestCoroutineInterceptor to use runTest on `desktopMain` source sets. 
