### PR TITLE
feat(Exhaustive.cartesian): support up to 12 args to Exhaustive.cartesian for arity parity with checkAll & forAll

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/cartesian.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/cartesian.kt
@@ -129,3 +129,242 @@ fun <A, B, C, D, E, F> Exhaustive.Companion.cartesian(
    }
    return fs.exhaustive()
 }
+
+
+fun <A, B, C, D, E, F, G> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: (A, B, C, D, E, F) -> G
+): Exhaustive<G> {
+   val gs = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.map { _f ->
+                     g(_a, _b, _c, _d, _e, _f)
+                  }
+               }
+            }
+         }
+      }
+   }
+   return gs.exhaustive()
+}
+
+fun <A, B, C, D, E, F, G, H> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: Exhaustive<G>,
+   h: (A, B, C, D, E, F, G) -> H
+): Exhaustive<H> {
+   val hs = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.flatMap { _f ->
+                     g.values.map { _g ->
+                        h(_a, _b, _c, _d, _e, _f, _g)
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   return hs.exhaustive()
+}
+
+fun <A, B, C, D, E, F, G, H, I> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: Exhaustive<G>,
+   h: Exhaustive<H>,
+   i: (A, B, C, D, E, F, G, H) -> I
+): Exhaustive<I> {
+   val `is` = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.flatMap { _f ->
+                     g.values.flatMap { _g ->
+                        h.values.map { _h ->
+                           i(_a, _b, _c, _d, _e, _f, _g, _h)
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   return `is`.exhaustive()
+}
+
+fun <A, B, C, D, E, F, G, H, I, J> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: Exhaustive<G>,
+   h: Exhaustive<H>,
+   i: Exhaustive<I>,
+   j: (A, B, C, D, E, F, G, H, I) -> J
+): Exhaustive<J> {
+   val js = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.flatMap { _f ->
+                     g.values.flatMap { _g ->
+                        h.values.flatMap { _h ->
+                           i.values.map { _i ->
+                              j(_a, _b, _c, _d, _e, _f, _g, _h, _i)
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   return js.exhaustive()
+}
+
+fun <A, B, C, D, E, F, G, H, I, J, K> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: Exhaustive<G>,
+   h: Exhaustive<H>,
+   i: Exhaustive<I>,
+   j: Exhaustive<J>,
+   k: (A, B, C, D, E, F, G, H, I, J) -> K
+): Exhaustive<K> {
+   val ks = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.flatMap { _f ->
+                     g.values.flatMap { _g ->
+                        h.values.flatMap { _h ->
+                           i.values.flatMap { _i ->
+                              j.values.map { _j ->
+                                 k(_a, _b, _c, _d, _e, _f, _g, _h, _i, _j)
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   return ks.exhaustive()
+}
+
+fun <A, B, C, D, E, F, G, H, I, J, K, L> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: Exhaustive<G>,
+   h: Exhaustive<H>,
+   i: Exhaustive<I>,
+   j: Exhaustive<J>,
+   k: Exhaustive<K>,
+   l: (A, B, C, D, E, F, G, H, I, J, K) -> L
+): Exhaustive<L> {
+   val ls = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.flatMap { _f ->
+                     g.values.flatMap { _g ->
+                        h.values.flatMap { _h ->
+                           i.values.flatMap { _i ->
+                              j.values.flatMap { _j ->
+                                 k.values.map { _k ->
+                                    l(_a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k)
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   return ls.exhaustive()
+}
+
+fun <A, B, C, D, E, F, G, H, I, J, K, L, M> Exhaustive.Companion.cartesian(
+   a: Exhaustive<A>,
+   b: Exhaustive<B>,
+   c: Exhaustive<C>,
+   d: Exhaustive<D>,
+   e: Exhaustive<E>,
+   f: Exhaustive<F>,
+   g: Exhaustive<G>,
+   h: Exhaustive<H>,
+   i: Exhaustive<I>,
+   j: Exhaustive<J>,
+   k: Exhaustive<K>,
+   l: Exhaustive<L>,
+   m: (A, B, C, D, E, F, G, H, I, J, K, L) -> M
+): Exhaustive<M> {
+   val ms = a.values.flatMap { _a ->
+      b.values.flatMap { _b ->
+         c.values.flatMap { _c ->
+            d.values.flatMap { _d ->
+               e.values.flatMap { _e ->
+                  f.values.flatMap { _f ->
+                     g.values.flatMap { _g ->
+                        h.values.flatMap { _h ->
+                           i.values.flatMap { _i ->
+                              j.values.flatMap { _j ->
+                                 k.values.flatMap { _k ->
+                                    l.values.map { _l ->
+                                       m(_a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l)
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+   return ms.exhaustive()
+}

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/CartesianTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/CartesianTest.kt
@@ -212,5 +212,129 @@ class CartesianTest : FunSpec() {
             Tuple4(a = 2, b = "c", c = false, d = 'q'),
          )
       }
+
+      test("Exhaustive.cartesian arity 5") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e -> "$a$b$c$d$e".toInt(2) }
+         e.values.shouldHaveSize(32)
+         e.values shouldBe (0..31).toList()
+      }
+
+      test("Exhaustive.cartesian arity 6") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f -> "$a$b$c$d$e$f".toInt(2) }
+         e.values.shouldHaveSize(64)
+         e.values shouldBe (0..63).toList()
+      }
+
+      test("Exhaustive.cartesian arity 7") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f, g -> "$a$b$c$d$e$f$g".toInt(2) }
+         e.values.shouldHaveSize(128)
+         e.values shouldBe (0..127).toList()
+      }
+
+      test("Exhaustive.cartesian arity 8") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f, g, h -> "$a$b$c$d$e$f$g$h".toInt(2) }
+         e.values.shouldHaveSize(256)
+         e.values shouldBe (0..255).toList()
+      }
+
+      test("Exhaustive.cartesian arity 9") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f, g, h, i -> "$a$b$c$d$e$f$g$h$i".toInt(2) }
+         e.values.shouldHaveSize(512)
+         e.values shouldBe (0..511).toList()
+      }
+
+      test("Exhaustive.cartesian arity 10") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f, g, h, i, j -> "$a$b$c$d$e$f$g$h$i$j".toInt(2) }
+         e.values.shouldHaveSize(1024)
+         e.values shouldBe (0..1023).toList()
+      }
+
+      test("Exhaustive.cartesian arity 11") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f, g, h, i, j, k -> "$a$b$c$d$e$f$g$h$i$j$k".toInt(2) }
+         e.values.shouldHaveSize(2048)
+         e.values shouldBe (0..2047).toList()
+      }
+
+      test("Exhaustive.cartesian arity 12") {
+         val e = Exhaustive.cartesian(
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+            Exhaustive.of(0, 1),
+         ) { a, b, c, d, e, f, g, h, i, j, k, l -> "$a$b$c$d$e$f$g$h$i$j$k$l".toInt(2) }
+         e.values.shouldHaveSize(4096)
+         e.values shouldBe (0..4095).toList()
+      }
    }
 }


### PR DESCRIPTION
`Exhaustive.cartesian` is a more explicit alternative to generating the full matrix of possible combinations when all generators are Exhaustive, and so it should support the same number of arguments as checkAll/forAll

also relates to #3233 as this function could be used to simplify the all-exhaustive cartesion branches there, however that would require either changing `Exhaustive.Companion.cartesian` to be suspending, or make NTuple args then forEach on the result.