### PR TITLE
Add missing brackets to example core matcher calls

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -24,7 +24,7 @@ Matchers provided by the `kotest-assertions-core` module.
 |---------------------------------------------| ---- |
 | `obj.shouldBeSameInstanceAs(other)`         | Compares objects by identity, that is, they are the same exact reference. |
 | `obj.shouldBeTypeOf<T>()`                   | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
-| `obj.shouldBeInstanceOf<T>`                 | Asserts that the given reference is of type T or a subclass of T. |
+| `obj.shouldBeInstanceOf<T>()`               | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
 | `obj.shouldBeNull()`                        | Asserts that a given reference is null.|
 

--- a/documentation/versioned_docs/version-5.2/assertions/core.md
+++ b/documentation/versioned_docs/version-5.2/assertions/core.md
@@ -24,7 +24,7 @@ Matchers provided by the `kotest-assertions-core` module.
 |---------------------------------------------| ---- |
 | `obj.shouldBeSameInstanceAs(other)`         | Compares objects by identity, that is, they are the same exact reference. |
 | `obj.shouldBeTypeOf<T>()`                   | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
-| `obj.shouldBeInstanceOf<T>`                 | Asserts that the given reference is of type T or a subclass of T. |
+| `obj.shouldBeInstanceOf<T>()`               | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
 | `obj.shouldBeNull()`                        | Asserts that a given reference is null.|
 

--- a/documentation/versioned_docs/version-5.3/assertions/core.md
+++ b/documentation/versioned_docs/version-5.3/assertions/core.md
@@ -24,7 +24,7 @@ Matchers provided by the `kotest-assertions-core` module.
 |---------------------------------------------| ---- |
 | `obj.shouldBeSameInstanceAs(other)`         | Compares objects by identity, that is, they are the same exact reference. |
 | `obj.shouldBeTypeOf<T>()`                   | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
-| `obj.shouldBeInstanceOf<T>`                 | Asserts that the given reference is of type T or a subclass of T. |
+| `obj.shouldBeInstanceOf<T>()`               | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
 | `obj.shouldBeNull()`                        | Asserts that a given reference is null.|
 

--- a/documentation/versioned_docs/version-5.4/assertions/core.md
+++ b/documentation/versioned_docs/version-5.4/assertions/core.md
@@ -24,7 +24,7 @@ Matchers provided by the `kotest-assertions-core` module.
 |---------------------------------------------| ---- |
 | `obj.shouldBeSameInstanceAs(other)`         | Compares objects by identity, that is, they are the same exact reference. |
 | `obj.shouldBeTypeOf<T>()`                   | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
-| `obj.shouldBeInstanceOf<T>`                 | Asserts that the given reference is of type T or a subclass of T. |
+| `obj.shouldBeInstanceOf<T>()`               | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
 | `obj.shouldBeNull()`                        | Asserts that a given reference is null.|
 

--- a/documentation/versioned_docs/version-5.5/assertions/core.md
+++ b/documentation/versioned_docs/version-5.5/assertions/core.md
@@ -24,7 +24,7 @@ Matchers provided by the `kotest-assertions-core` module.
 |---------------------------------------------| ---- |
 | `obj.shouldBeSameInstanceAs(other)`         | Compares objects by identity, that is, they are the same exact reference. |
 | `obj.shouldBeTypeOf<T>()`                   | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
-| `obj.shouldBeInstanceOf<T>`                 | Asserts that the given reference is of type T or a subclass of T. |
+| `obj.shouldBeInstanceOf<T>()`               | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
 | `obj.shouldBeNull()`                        | Asserts that a given reference is null.|
 


### PR DESCRIPTION
Looking at the docs I noticed the brackets were missing here, so here's a fix. Thanks for your great work!