### PR TITLE
Use the original failure when ErrorCollector contains single failure

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -151,21 +151,8 @@ fun ErrorCollector.throwCollectedErrors() {
 /**
  * All errors currently collected in the [ErrorCollector] are returned as a single [MultiAssertionError].
  */
-fun ErrorCollector.collectiveError(): AssertionError? {
-   val failures = errors()
-   clear()
-   return if (failures.isNotEmpty()) {
-      if (failures.size == 1) {
-         AssertionError(failures[0].message).also {
-            stacktraces.cleanStackTrace(it)
-         }
-      } else {
-         MultiAssertionError(failures).also {
-            stacktraces.cleanStackTrace(it) // cleans the creation of MultiAssertionError
-         }
-      }
-   } else null
-}
+expect fun ErrorCollector.collectiveError(): AssertionError?
+
 
 inline fun <reified T> ErrorCollector.runWithMode(mode: ErrorCollectionMode, block: () -> T): T =
    getCollectionMode().let { original ->

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -163,3 +163,12 @@ inline fun <reified T> ErrorCollector.runWithMode(mode: ErrorCollectionMode, blo
          setCollectionMode(original)
       }
    }
+
+internal fun List<Throwable>.toAssertionError(): AssertionError? =
+   when (size) {
+      0 -> null
+      1 -> AssertionError(this[0].message)
+      else -> MultiAssertionError(this)
+   }?.let {
+      stacktraces.cleanStackTrace(it)
+   }

--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -1,6 +1,23 @@
 package io.kotest.assertions
 
+import io.kotest.mpp.stacktraces
 import kotlin.native.concurrent.SharedImmutable
 
 @SharedImmutable
 actual val errorCollector: ErrorCollector = NoopErrorCollector
+
+actual fun ErrorCollector.collectiveError(): AssertionError? {
+   val failures = errors()
+   clear()
+   return if (failures.isNotEmpty()) {
+      if (failures.size == 1) {
+         AssertionError(failures[0].message).also {
+            stacktraces.cleanStackTrace(it)
+         }
+      } else {
+         MultiAssertionError(failures).also {
+            stacktraces.cleanStackTrace(it) // cleans the creation of MultiAssertionError
+         }
+      }
+   } else null
+}

--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -9,15 +9,5 @@ actual val errorCollector: ErrorCollector = NoopErrorCollector
 actual fun ErrorCollector.collectiveError(): AssertionError? {
    val failures = errors()
    clear()
-   return if (failures.isNotEmpty()) {
-      if (failures.size == 1) {
-         AssertionError(failures[0].message).also {
-            stacktraces.cleanStackTrace(it)
-         }
-      } else {
-         MultiAssertionError(failures).also {
-            stacktraces.cleanStackTrace(it) // cleans the creation of MultiAssertionError
-         }
-      }
-   } else null
+   return failures.toAssertionError()
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/errorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/errorCollector.kt
@@ -1,5 +1,23 @@
 package io.kotest.assertions
 
+import io.kotest.mpp.stacktraces
+
 actual val errorCollector: ErrorCollector = JsErrorCollector
 
 object JsErrorCollector : BasicErrorCollector()
+
+actual fun ErrorCollector.collectiveError(): AssertionError? {
+   val failures = errors()
+   clear()
+   return if (failures.isNotEmpty()) {
+      if (failures.size == 1) {
+         AssertionError(failures[0].message).also {
+            stacktraces.cleanStackTrace(it)
+         }
+      } else {
+         MultiAssertionError(failures).also {
+            stacktraces.cleanStackTrace(it) // cleans the creation of MultiAssertionError
+         }
+      }
+   } else null
+}

--- a/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/errorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jsMain/kotlin/io/kotest/assertions/errorCollector.kt
@@ -9,15 +9,6 @@ object JsErrorCollector : BasicErrorCollector()
 actual fun ErrorCollector.collectiveError(): AssertionError? {
    val failures = errors()
    clear()
-   return if (failures.isNotEmpty()) {
-      if (failures.size == 1) {
-         AssertionError(failures[0].message).also {
-            stacktraces.cleanStackTrace(it)
-         }
-      } else {
-         MultiAssertionError(failures).also {
-            stacktraces.cleanStackTrace(it) // cleans the creation of MultiAssertionError
-         }
-      }
-   } else null
+   return failures.toAssertionError()
 }
+

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -2,7 +2,6 @@
 
 package io.kotest.assertions
 
-import io.kotest.mpp.stacktraces
 import kotlinx.coroutines.CopyableThreadContextElement
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -66,11 +65,7 @@ private class ErrorCollectorContextElement(private val coroutineLocalErrorCollec
 actual fun ErrorCollector.collectiveError(): AssertionError? {
    val failures = errors()
    clear()
-   return when {
-      failures.isEmpty() -> null
-      failures.singleOrNull() is AssertionFailedError -> failures.single() as AssertionFailedError
-      failures.size == 1 -> AssertionError(failures.single().message).also { stacktraces.cleanStackTrace(it) }
-      else -> MultiAssertionError(failures).also { stacktraces.cleanStackTrace(it) } // cleans the creation of MultiAssertionError
-   }
+   return if (failures.size == 1 && failures[0] is AssertionFailedError) failures[0] as AssertionFailedError
+   else failures.toAssertionError()
 }
 

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/ErrorCollectorTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/ErrorCollectorTests.kt
@@ -1,0 +1,21 @@
+package com.sksamuel.kotest
+
+import io.kotest.assertions.AssertionFailedError
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+class ErrorCollectorTests : FreeSpec(
+   {
+      "Single assertion failed, returns the original failure" {
+         shouldThrow<AssertionFailedError> {
+            assertSoftly {
+               1 shouldBe 1
+               1 shouldBe 2
+            }
+         }
+      }
+   }
+)


### PR DESCRIPTION
fixes #3236 

`AssertionFailedError` is JVM-specific, so had to move some stuff to expect/actuals.