### PR TITLE
Use TestDispatcher inside beforeInvocation callbacks

### DIFF
--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/replay.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/replay.kt
@@ -3,7 +3,5 @@ package io.kotest.mpp
 expect suspend fun replay(
    times: Int,
    threads: Int,
-   before: suspend (Int) -> Unit,
-   after: suspend (Int) -> Unit ,
    action: suspend (Int) -> Unit
 )

--- a/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/replay.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/replay.kt
@@ -3,14 +3,10 @@ package io.kotest.mpp
 actual suspend fun replay(
    times: Int,
    threads: Int,
-   before: suspend (Int) -> Unit,
-   after: suspend (Int) -> Unit,
    action: suspend (Int) -> Unit,
 ) {
    require(threads == 1) { "Cannot run Native tests on multiple threads. Use the built in kotlin function repeat(n)" }
    repeat(times) {
-      before(it)
       action(it)
-      after(it)
    }
 }

--- a/kotest-common/src/jsMain/kotlin/io/kotest/mpp/replay.kt
+++ b/kotest-common/src/jsMain/kotlin/io/kotest/mpp/replay.kt
@@ -3,14 +3,10 @@ package io.kotest.mpp
 actual suspend fun replay(
    times: Int,
    threads: Int,
-   before: suspend (Int) -> Unit,
-   after: suspend (Int) -> Unit,
    action: suspend (Int) -> Unit
 ) {
    require(threads == 1) { "Cannot run JS tests on multiple threads. Use the built in kotlin function repeat(n)" }
    repeat(times) {
-      before(it)
       action(it)
-      after(it)
    }
 }

--- a/kotest-common/src/jvmMain/kotlin/io/kotest/mpp/replay.kt
+++ b/kotest-common/src/jvmMain/kotlin/io/kotest/mpp/replay.kt
@@ -8,15 +8,11 @@ import java.util.concurrent.atomic.AtomicReference
 actual suspend fun replay(
    times: Int,
    threads: Int,
-   before: suspend (Int) -> Unit,
-   after: suspend (Int) -> Unit,
    action: suspend (Int) -> Unit
 ) {
    if (threads == 1) {
       repeat(times) {
-         before(it)
          action(it)
-         after(it)
       }
    } else {
       val executor = Executors.newFixedThreadPool(threads, NamedThreadFactory("replay-%d"))
@@ -25,12 +21,9 @@ actual suspend fun replay(
          executor.submit {
             runBlocking {
                try {
-                  before(k)
                   action(k)
                } catch (t: Throwable) {
                   error.compareAndSet(null, t)
-               } finally {
-                  after(k)
                }
             }
          }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -71,10 +71,15 @@ class TestCaseExecutor(
          CoroutineLoggingInterceptor(configuration),
          if (platform == Platform.JVM) blockedThreadTimeoutInterceptor(configuration, timeMark) else null,
          TimeoutInterceptor(timeMark),
-         TestInvocationInterceptor(configuration.registry, timeMark),
-         InvocationTimeoutInterceptor,
-         if (platform == Platform.JVM && testCase.config.testCoroutineDispatcher) TestDispatcherInterceptor() else null,
-         if (platform != Platform.JS && testCase.config.coroutineTestScope) TestCoroutineInterceptor() else null,
+         TestInvocationInterceptor(
+            configuration.registry,
+            timeMark,
+            listOfNotNull(
+               InvocationTimeoutInterceptor,
+               if (platform == Platform.JVM && testCase.config.testCoroutineDispatcher) TestDispatcherInterceptor() else null,
+               if (platform != Platform.JS && testCase.config.coroutineTestScope) TestCoroutineInterceptor() else null,
+            )
+         ),
          CoroutineDebugProbeInterceptor,
       )
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestInvocationInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestInvocationInterceptor.kt
@@ -11,9 +11,10 @@ import io.kotest.mpp.replay
 import kotlinx.coroutines.coroutineScope
 import kotlin.time.Duration
 
-class TestInvocationInterceptor(
+internal class TestInvocationInterceptor(
    registry: ExtensionRegistry,
    private val timeMark: TimeMarkCompat,
+   private val invocationInterceptors: List<TestExecutionInterceptor>,
 ) : TestExecutionInterceptor {
 
    private val extensions = TestExtensions(registry)
@@ -22,7 +23,7 @@ class TestInvocationInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: suspend (TestCase, TestScope) -> TestResult,
    ): TestResult {
       return try {
          // we wrap in a coroutine scope so that we wait for any user-launched coroutines to finish,
@@ -30,11 +31,9 @@ class TestInvocationInterceptor(
          coroutineScope {
             replay(
                testCase.config.invocations,
-               testCase.config.threads,
-               { extensions.beforeInvocation(testCase, it) },
-               { extensions.afterInvocation(testCase, it) }) {
-               test(testCase, scope)
-            }
+               testCase.config.threads
+            )
+            { runBeforeTestAfter(testCase, scope, it, test) }
          }
          logger.log { Pair(testCase.name.testName, "Test returned without error") }
          try {
@@ -50,5 +49,27 @@ class TestInvocationInterceptor(
             TestResult.Error(Duration.ZERO, t) // workaround for kotlin 1.5
          }
       }
+   }
+
+   private suspend fun runBeforeTestAfter(
+      testCase: TestCase,
+      scope: TestScope,
+      times: Int,
+      test: suspend (TestCase, TestScope) -> TestResult,
+   ) {
+      val executeWithBeforeAfter: suspend (TestCase, TestScope) -> TestResult = { tc, scope ->
+         try {
+            extensions.beforeInvocation(testCase, times)
+            test(testCase, scope)
+         } finally {
+            extensions.afterInvocation(testCase, times)
+         }
+      }
+
+      val wrappedTest = invocationInterceptors.foldRight(executeWithBeforeAfter) { ext, fn ->
+         { tc, sc -> ext.intercept(tc, sc, fn) }
+      }
+
+      wrappedTest(testCase, scope)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/TestDispatcherInLifecycleCallbacks.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/TestDispatcherInLifecycleCallbacks.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.kotest.engine.coroutines
+
+import io.kotest.core.listeners.BeforeInvocationListener
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.test.TestDispatcher
+
+@ExperimentalStdlibApi
+@ExperimentalCoroutinesApi
+class ProvideTestDispatcherInBeforeInvocation : FunSpec({
+   coroutineTestScope = true
+   var wasEverNotTestDispatcher = false
+
+   extension(object : BeforeInvocationListener {
+      override suspend fun beforeInvocation(testCase: TestCase, iteration: Int) {
+         val dispatcher = currentCoroutineContext()[CoroutineDispatcher]
+         wasEverNotTestDispatcher = wasEverNotTestDispatcher || dispatcher !is TestDispatcher
+
+      }
+   })
+
+   context("beforeInvocation should contain test dispatcher when test scope is enabled") {
+      test("nest me!") {
+         wasEverNotTestDispatcher.shouldBe(false)
+      }
+   }
+}
+)


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Currently `beforeInvocation` callback gets called before coroutine test scope is created. This means that there is no reliable callback where test dispatcher can get accessed.

PR attempts to fix that by moving `beforeInvocation` call after test dispatcher interceptor is triggered. Unfortunately, since that callback needs access to current execution index, I was forced to move TestDispatcherInterceptor calls to inside TestInvocationInterceptor. I would appreciate someone suggesting a better way to achieve this.

This fixes #3238