### PR TITLE
Add missing concrete parameter name

### DIFF
--- a/documentation/docs/assertions/custom.md
+++ b/documentation/docs/assertions/custom.md
@@ -43,8 +43,8 @@ would need to be something like `"string should not have length 8"`
 First we build out our matcher type:
 
 ```kotlin
-fun haveLength(length: Int) = Matcher<String> {
-  return MatcherResult(
+fun haveLength(length: Int) = Matcher<String> { value ->
+  MatcherResult(
     value.length == length,
     { "string had length ${value.length} but we expected length $length" },
     { "string should not have length $length" },

--- a/documentation/versioned_docs/version-5.5/assertions/custom.md
+++ b/documentation/versioned_docs/version-5.5/assertions/custom.md
@@ -44,7 +44,7 @@ First we build out our matcher type:
 
 ```kotlin
 fun haveLength(length: Int) = Matcher<String> { value ->
-  return MatcherResult(
+  MatcherResult(
     value.length == length,
     { "string had length ${value.length} but we expected length $length" },
     { "string should not have length $length" },

--- a/documentation/versioned_docs/version-5.5/assertions/custom.md
+++ b/documentation/versioned_docs/version-5.5/assertions/custom.md
@@ -43,7 +43,7 @@ would need to be something like `"string should not have length 8"`
 First we build out our matcher type:
 
 ```kotlin
-fun haveLength(length: Int) = Matcher<String> {
+fun haveLength(length: Int) = Matcher<String> { value ->
   return MatcherResult(
     value.length == length,
     { "string had length ${value.length} but we expected length $length" },


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Just fix two errors in the kotlin example.
