### PR TITLE
Invoking After/before each for dynamic tests

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestExtensions.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestExtensions.kt
@@ -77,7 +77,7 @@ internal class TestExtensions(private val registry: ExtensionRegistry) {
          }.mapError { ExtensionException.BeforeContainerException(it) }.exceptionOrNull()
       } + be.mapNotNull {
          runCatching {
-            if (testCase.type == TestType.Test) it.beforeEach(testCase)
+            if (testCase.type in arrayOf(TestType.Test, TestType.Dynamic) ) it.beforeEach(testCase)
          }.mapError { ExtensionException.BeforeEachException(it) }.exceptionOrNull()
       } + bt.mapNotNull {
          runCatching {
@@ -120,7 +120,7 @@ internal class TestExtensions(private val registry: ExtensionRegistry) {
          }.mapError { ExtensionException.AfterContainerException(it) }.exceptionOrNull()
       } + ae.mapNotNull {
          runCatching {
-            if (testCase.type == TestType.Test) it.afterEach(testCase, result)
+            if (testCase.type in arrayOf(TestType.Test, TestType.Dynamic)) it.afterEach(testCase, result)
          }.mapError { ExtensionException.AfterEachException(it) }.exceptionOrNull()
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/AfterEachTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/AfterEachTest.kt
@@ -1,0 +1,53 @@
+package com.sksamuel.kotest.engine.extensions.test
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+
+class AfterEachFunSpecTest : FunSpec() {
+   val a = AtomicInteger(0)
+
+   init {
+
+      afterEach {
+         a.incrementAndGet()
+      }
+
+      context("container1") {
+         withData(1,2,3){} // Increment 3 times
+      }
+
+      context("container2") {
+         test("a") {} // Increment once
+      }
+
+      afterProject {
+         a.get() shouldBe 4
+      }
+   }
+}
+
+class AfterEachDescribeSpecTest : DescribeSpec() {
+   val a = AtomicInteger(0)
+
+   init {
+
+      afterEach {
+         a.incrementAndGet()
+      }
+
+      describe("container1") {
+         withData(1,2,3) {} // Increment 3 times
+      }
+
+      describe("container2") {
+         it("a") {}// Increments once
+      }
+
+      afterProject {
+         a.get() shouldBe 4
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/BeforeEachTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/BeforeEachTest.kt
@@ -1,0 +1,53 @@
+package com.sksamuel.kotest.engine.extensions.test
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+
+class BeforeEachFunSpecTest : FunSpec() {
+   val a = AtomicInteger(0)
+
+   init {
+
+      beforeEach {
+         a.incrementAndGet()
+      }
+
+      context("container1") {
+         withData(1,2,3){} // Increment 3 times
+      }
+
+      context("container2") {
+         test("a") {} // Increment once
+      }
+
+      afterProject {
+         a.get() shouldBe 4
+      }
+   }
+}
+
+class BeforeEachDescribeSpecTest : DescribeSpec() {
+   val a = AtomicInteger(0)
+
+   init {
+
+      beforeEach {
+         a.incrementAndGet()
+      }
+
+      describe("container1") {
+         withData(1,2,3) {} // Increment 3 times
+      }
+
+      describe("container2") {
+         it("a") {}// Increments once
+      }
+
+      afterProject {
+         a.get() shouldBe 4
+      }
+   }
+}


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

fixes #3290 

Invokes `beforeEach` / `afterEach` between each case of a data-driven test (`withData`)