### PR TITLE
Fix for issue-3306 - Removing default location for htmlReporter and using the default value from the constructor

### DIFF
--- a/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlReporter.kt
+++ b/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlReporter.kt
@@ -16,7 +16,6 @@ class HtmlReporter(
 ) : ProjectListener {
 
    companion object {
-      const val DefaultLocation = "./reports/tests/test/"
       const val DefaultResultsLocation = "./build/test-results/test"
       const val BuildDirKey = "gradle.build.dir"
    }
@@ -74,7 +73,7 @@ class HtmlReporter(
       return if (buildDir != null)
          Paths.get(buildDir).resolve(outputDir)
       else
-         Paths.get(DefaultLocation)
+         Paths.get("./$outputDir")
    }
 
    private fun write(text: String, path: String) {


### PR DESCRIPTION
## Context

#3306 

1) The `outputDir` customizable field in HTMLReporter does not work if the `gradle.build.dir` system property is not set.

2) Running tests using the kotest sidebar menu will produce reports in top level directory even when `gradle.build.dir` system property is set in `build.gradle` and a different `outputDir` is used (probably because the kotest sidebar execution context doesn't have the `gradle.build.dir` system property set).

## Root Cause

In HTMLReporter, if the `gradle.build.dir` system property [is not set](https://github.com/kotest/kotest/blob/master/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlReporter.kt#L77), a DefaultLocation is used and ignores the `outputDir` field

## Changes Made
Removing the DefaultLocation variable and replacing it's usage with `outputDir`.


## Expected Result
When a user does not specify an `outputDir`, the default string from the constructor will be used and there is no change in logic.

When a user does specify an `outputDir`, the html report will be placed within the specified `outputDir`

