### PR TITLE
IJ language injection

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-multiplatform-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-multiplatform-library-conventions.gradle.kts
@@ -4,3 +4,14 @@ plugins {
    id("kotest-native-conventions")
    id("kotest-publishing-conventions")
 }
+
+kotlin {
+   sourceSets {
+      all {
+         languageSettings {
+            optIn("kotlin.RequiresOptIn")
+            optIn("io.kotest.common.KotestInternal")
+         }
+      }
+   }
+}

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -26,7 +26,10 @@ tasks.withType<Test>().configureEach {
 
 tasks.withType<KotlinCompile>().configureEach {
    kotlinOptions {
-      freeCompilerArgs = freeCompilerArgs + "-Xopt-in=kotlin.RequiresOptIn"
+      freeCompilerArgs = freeCompilerArgs + listOf(
+         "-opt-in=kotlin.RequiresOptIn",
+         "-opt-in=io.kotest.common.KotestInternal",
+      )
       jvmTarget = "1.8"
       apiVersion = "1.6"
       languageVersion = "1.6"

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlin.reflect.KClass
+import org.intellij.lang.annotations.Language
 
 @OptIn(ExperimentalSerializationApi::class)
 internal val pretty by lazy { Json { prettyPrint = true; prettyPrintIndent = "  " } }
@@ -22,11 +23,13 @@ internal val pretty by lazy { Json { prettyPrint = true; prettyPrintIndent = "  
  * regardless of order.
  *
  */
-infix fun String?.shouldMatchJson(expected: String?) = this should matchJson(expected)
-infix fun String?.shouldNotMatchJson(expected: String?) = this shouldNot matchJson(expected)
+infix fun String?.shouldMatchJson(@Language("json") expected: String?) =
+   this should matchJson(expected)
 
-@OptIn(ExperimentalSerializationApi::class)
-fun matchJson(expected: String?) = object : Matcher<String?> {
+infix fun String?.shouldNotMatchJson(@Language("json") expected: String?) =
+   this shouldNot matchJson(expected)
+
+fun matchJson(@Language("json") expected: String?) = object : Matcher<String?> {
    override fun test(value: String?): MatcherResult {
       val actualJson = try {
          value?.let(pretty::parseToJsonElement)
@@ -59,7 +62,6 @@ fun matchJson(expected: String?) = object : Matcher<String?> {
    }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 fun beValidJson() = object : Matcher<String?> {
    override fun test(value: String?): MatcherResult {
       return try {
@@ -79,7 +81,6 @@ fun beValidJson() = object : Matcher<String?> {
    }
 }
 
-@OptIn(ExperimentalSerializationApi::class)
 fun beJsonType(kClass: KClass<*>) = object : Matcher<String?> {
 
    override fun test(value: String?): MatcherResult {
@@ -107,18 +108,18 @@ fun beJsonType(kClass: KClass<*>) = object : Matcher<String?> {
  * regardless of order.
  *
  */
-fun String.shouldEqualJson(expected: String, mode: CompareMode, order: CompareOrder) =
+fun String.shouldEqualJson(@Language("json") expected: String, mode: CompareMode, order: CompareOrder) =
    this.shouldEqualJson(expected, legacyOptions(mode, order))
 
-fun String.shouldEqualJson(expected: String, options: CompareJsonOptions) {
+fun String.shouldEqualJson(@Language("json") expected: String, options: CompareJsonOptions) {
    val (e, a) = parse(expected, this)
    a should equalJson(e, options)
 }
 
-fun String.shouldNotEqualJson(expected: String, mode: CompareMode, order: CompareOrder) =
+fun String.shouldNotEqualJson(@Language("json") expected: String, mode: CompareMode, order: CompareOrder) =
    this.shouldNotEqualJson(expected, legacyOptions(mode, order))
 
-fun String.shouldNotEqualJson(expected: String, options: CompareJsonOptions) {
+fun String.shouldNotEqualJson(@Language("json") expected: String, options: CompareJsonOptions) {
    val (e, a) = parse(expected, this)
    a shouldNot equalJson(e, options)
 }

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/MatchTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/MatchTest.kt
@@ -144,6 +144,7 @@ class MatchTest : StringSpec() {
 
       }
 
+      @Suppress("JsonStandardCompliance") // invalid JSON is desired in this test
       "test json equality throws with invalid expected json" {
          shouldThrow<AssertionError> {
             """
@@ -255,7 +256,7 @@ class MatchTest : StringSpec() {
                       }
                     ]
                   }
-            """
+            """.trimIndent()
             )
          }.message shouldStartWith "expected: expected json to be valid json: "
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
@@ -8,8 +8,9 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.contracts.contract
+import org.intellij.lang.annotations.Language
 
-infix fun String?.shouldContainJsonKey(path: String) {
+infix fun String?.shouldContainJsonKey(@Language("JSONPath") path: String) {
    contract {
       returns() implies (this@shouldContainJsonKey != null)
    }
@@ -17,7 +18,9 @@ infix fun String?.shouldContainJsonKey(path: String) {
    this should containJsonKey(path)
 }
 
-infix fun String.shouldNotContainJsonKey(path: String) = this shouldNot containJsonKey(path)
+infix fun String.shouldNotContainJsonKey(@Language("JSONPath") path: String) =
+   this shouldNot containJsonKey(path)
+
 fun containJsonKey(path: String) = object : Matcher<String?> {
 
    override fun test(value: String?): MatcherResult {
@@ -38,8 +41,7 @@ fun containJsonKey(path: String) = object : Matcher<String?> {
       return MatcherResult(
          passed,
          { "$sub should contain the path $path" },
-         {
-            "$sub should not contain the path $path"
-         })
+         { "$sub should not contain the path $path" },
+      )
    }
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -8,8 +8,9 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.contracts.contract
+import org.intellij.lang.annotations.Language
 
-inline fun <reified T> String?.shouldContainJsonKeyValue(path: String, value: T) {
+inline fun <reified T> String?.shouldContainJsonKeyValue(@Language("JSONPath") path: String, value: T) {
    contract {
       returns() implies (this@shouldContainJsonKeyValue != null)
    }
@@ -17,10 +18,10 @@ inline fun <reified T> String?.shouldContainJsonKeyValue(path: String, value: T)
    this should containJsonKeyValue(path, value)
 }
 
-inline fun <reified T> String.shouldNotContainJsonKeyValue(path: String, value: T) =
+inline fun <reified T> String.shouldNotContainJsonKeyValue(@Language("JSONPath") path: String, value: T) =
    this shouldNot containJsonKeyValue(path, value)
 
-inline fun <reified T> containJsonKeyValue(path: String, t: T) = object : Matcher<String?> {
+inline fun <reified T> containJsonKeyValue(@Language("JSONPath") path: String, t: T) = object : Matcher<String?> {
    override fun test(value: String?): MatcherResult {
       val sub = when (value) {
          null -> value

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
@@ -9,8 +9,9 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.contracts.contract
+import org.intellij.lang.annotations.Language
 
-infix fun String?.shouldMatchJsonResource(resource: String) {
+infix fun String?.shouldMatchJsonResource(@Language("file-reference") resource: String) {
    contract {
       returns() implies (this@shouldMatchJsonResource != null)
    }
@@ -18,7 +19,8 @@ infix fun String?.shouldMatchJsonResource(resource: String) {
    this should matchJsonResource(resource)
 }
 
-infix fun String.shouldNotMatchJsonResource(resource: String) = this shouldNot matchJsonResource(resource)
+infix fun String.shouldNotMatchJsonResource(@Language("file-reference") resource: String) =
+   this shouldNot matchJsonResource(resource)
 
 fun matchJsonResource(resource: String) = object : Matcher<String?> {
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JvmJsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JvmJsonAssertionsTest.kt
@@ -11,7 +11,9 @@ import io.kotest.assertions.shouldFail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
 
+@Language("json")
 const val json = """{
     "store": {
         "book": [

--- a/kotest-common/src/commonMain/kotlin/io/kotest/common/injectLanguage.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/common/injectLanguage.kt
@@ -1,0 +1,64 @@
+@file:Suppress("PackageDirectoryMismatch")
+
+package org.intellij.lang.annotations
+
+import io.kotest.common.KotestInternal
+
+// This class is a workaround for injecting language annotations in multiple Kotlin targets,
+// because the original org.intellij.lang.annotations.Language is JVM only.
+// https://github.com/JetBrains/java-annotations/issues/34
+
+/**
+ * Specifies that an element of the program represents a string that is a source code on a specified language.
+ * Code editors may use this annotation to enable syntax highlighting, code completion and other features
+ * inside the literals that assigned to the annotated variables, passed as arguments to the annotated parameters,
+ * or returned from the annotated methods.
+ *
+ * This annotation also could be used as a meta-annotation, to define derived annotations for convenience.
+ * E.g. the following annotation could be defined to annotate the strings that represent Java methods:
+ *
+ * ```java
+ *   @Language(value = "JAVA", prefix = "class X{", suffix = "}")
+ *   @interface JavaMethod {}
+ * ```
+ *
+ * Note that using the derived annotation as meta-annotation is not supported.
+ * Meta-annotation works only one level deep.
+ *
+ * See https://www.jetbrains.com/help/idea/using-language-injections.html
+ *
+ * @param[value] Language name like `"JAVA"`, `"HTML"`, `"XML"`, `"RegExp"`, etc.
+ * The complete list of supported languages is not specified.
+ * However, at least the following languages should be recognized:
+ *
+ * * `"JAVA"` - Java programming language
+ * * `"HTML"`
+ * * `"XML"`
+ * * `"RegExp"` - Regular expression supported by Java [java.util.regex.Pattern]
+ *
+ * @param[prefix] A constant prefix that is assumed to be implicitly added before the literal.
+ * This helps to apply proper highlighting when the program element represents only a part of the valid program.
+ * E.g. if the method parameter accepts a Java method, it could be annotated as
+ *
+ * ```
+ * void methodProcessor(@Language(value="JAVA", prefix="class X {", suffix="}")
+ * ```
+ * @param[suffix] A constant suffix that is assumed to be implicitly added after the literal.
+ * See [prefix] for details.
+ */
+@KotestInternal
+@Retention(AnnotationRetention.BINARY)
+@Target(
+   AnnotationTarget.FUNCTION,
+   AnnotationTarget.PROPERTY_GETTER,
+   AnnotationTarget.PROPERTY_SETTER,
+   AnnotationTarget.FIELD,
+   AnnotationTarget.VALUE_PARAMETER,
+   AnnotationTarget.LOCAL_VARIABLE,
+   AnnotationTarget.ANNOTATION_CLASS,
+)
+expect annotation class Language(
+   val value: String,
+   val prefix: String = "",
+   val suffix: String = "",
+)

--- a/kotest-common/src/desktopMain/kotlin/io/kotest/common/injectLanguage.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/common/injectLanguage.kt
@@ -1,0 +1,21 @@
+@file:Suppress("PackageDirectoryMismatch")
+package org.intellij.lang.annotations
+
+import io.kotest.common.KotestInternal
+
+@KotestInternal
+@Retention(AnnotationRetention.BINARY)
+@Target(
+   AnnotationTarget.FUNCTION,
+   AnnotationTarget.PROPERTY_GETTER,
+   AnnotationTarget.PROPERTY_SETTER,
+   AnnotationTarget.FIELD,
+   AnnotationTarget.VALUE_PARAMETER,
+   AnnotationTarget.LOCAL_VARIABLE,
+   AnnotationTarget.ANNOTATION_CLASS,
+)
+actual annotation class Language actual constructor(
+   actual val value: String,
+   actual val prefix: String,
+   actual val suffix: String
+)

--- a/kotest-common/src/jsMain/kotlin/io/kotest/common/injectLanguage.kt
+++ b/kotest-common/src/jsMain/kotlin/io/kotest/common/injectLanguage.kt
@@ -1,0 +1,21 @@
+@file:Suppress("PackageDirectoryMismatch")
+package org.intellij.lang.annotations
+
+import io.kotest.common.KotestInternal
+
+@KotestInternal
+@Retention(AnnotationRetention.BINARY)
+@Target(
+   AnnotationTarget.FUNCTION,
+   AnnotationTarget.PROPERTY_GETTER,
+   AnnotationTarget.PROPERTY_SETTER,
+   AnnotationTarget.FIELD,
+   AnnotationTarget.VALUE_PARAMETER,
+   AnnotationTarget.LOCAL_VARIABLE,
+   AnnotationTarget.ANNOTATION_CLASS,
+)
+actual annotation class Language actual constructor(
+   actual val value: String,
+   actual val prefix: String,
+   actual val suffix: String
+)

--- a/kotest-common/src/jvmMain/kotlin/io/kotest/common/injectLanguage.kt
+++ b/kotest-common/src/jvmMain/kotlin/io/kotest/common/injectLanguage.kt
@@ -1,0 +1,21 @@
+@file:Suppress("PackageDirectoryMismatch")
+package org.intellij.lang.annotations
+
+import io.kotest.common.KotestInternal
+
+@KotestInternal
+@Retention(AnnotationRetention.BINARY)
+@Target(
+   AnnotationTarget.FUNCTION,
+   AnnotationTarget.PROPERTY_GETTER,
+   AnnotationTarget.PROPERTY_SETTER,
+   AnnotationTarget.FIELD,
+   AnnotationTarget.VALUE_PARAMETER,
+   AnnotationTarget.LOCAL_VARIABLE,
+   AnnotationTarget.ANNOTATION_CLASS,
+)
+actual annotation class Language actual constructor(
+   actual val value: String,
+   actual val prefix: String,
+   actual val suffix: String
+)


### PR DESCRIPTION
Partial fix for #2916 

Re-implements `@Language` to be Kotlin-multiplatform, [using workaround suggested by JetBrains](https://github.com/JetBrains/java-annotations/issues/34).

This injection makes the assertions easier to use, as IntelliJ will provide highlighting, autocompletion, and quick fixes ([read more about language injection](https://www.jetbrains.com/help/idea/using-language-injections.html)).

### TODO

- [ ] Verify that there is no clash on JVM between Kotest's `@Language` and IntelliJ's implementation


### Examples

<img width="736" alt="image" src="https://user-images.githubusercontent.com/897017/210420828-2257fb81-9da1-4930-84a9-9d45b321f722.png">

<img width="612" alt="image" src="https://user-images.githubusercontent.com/897017/210421162-1ca870a0-1b4f-4d6a-b84e-91f483bad5f8.png">

### Further improvements

Languages aren't injected into 

* receivers https://youtrack.jetbrains.com/issue/KTIJ-12951/
* infix parameters 
   <img width="577" alt="image" src="https://user-images.githubusercontent.com/897017/210421340-89520461-e7ff-4f84-9282-a374c466e621.png">

Perhaps the Kotest IJ plugin could correct implement the language injections to work with Kotlin.

### Related

* https://github.com/kotest/kotest-intellij-plugin/pull/218 - this PR tried to add the language injections on a per-function basis, but I don't think it worked once the plugin was released.