### PR TITLE
style: simplify NeverNullMatcher

### DIFF
--- a/kotest-assertions/kotest-assertions-api/src/commonMain/kotlin/io/kotest/matchers/Matcher.kt
+++ b/kotest-assertions/kotest-assertions-api/src/commonMain/kotlin/io/kotest/matchers/Matcher.kt
@@ -67,41 +67,24 @@ infix fun <T> Matcher<T>.or(other: Matcher<T>): Matcher<T> = Matcher {
  * The matcher returned by [invert] will _also_ assert that the value is not `null`. Use this for matchers that
  * should fail on `null` values, whether called with `should` or `shouldNot`.
  */
-internal abstract class NeverNullMatcher<T : Any?> : Matcher<T?> {
-   final override fun test(value: T?): MatcherResult {
-      return if (value == null) invoke(false, { "Expecting actual not to be null" }, { "" })
-      else testNotNull(value)
-   }
-
-   override fun invert(): Matcher<T?> = object : NeverNullMatcher<T?>() {
-      override fun testNotNull(value: T?): MatcherResult {
-         if (value == null) return invoke(false, { "Expecting actual not to be null" }, { "" })
-         val result = this@NeverNullMatcher.testNotNull(value)
-         return invoke(!result.passed(), { result.negatedFailureMessage() }, { result.failureMessage() })
+private class NeverNullMatcher<T : Any?>(
+   private val next: Matcher<T>
+) : Matcher<T?> {
+   override fun test(value: T?): MatcherResult =
+      when (value) {
+         null -> MatcherResult(false, { "Expecting actual not to be null" }, { "" })
+         else -> next.test(value)
       }
-   }
 
-   abstract fun testNotNull(value: T): MatcherResult
-
-   companion object {
-      /**
-       * Create matcher with the given function to evaluate the value and return a MatcherResult
-       *
-       * @param tester The function that evaluates a value and returns a MatcherResult
-       */
-      inline operator fun <T : Any> invoke(crossinline tester: (T) -> MatcherResult) = object : NeverNullMatcher<T>() {
-         override fun testNotNull(value: T) = tester(value)
-      }
-   }
+   override fun invert(): Matcher<T?> =
+      // invert the next matcher, but not the null check
+      NeverNullMatcher(next.invert())
 }
 
-fun <T : Any> neverNullMatcher(t: (T) -> MatcherResult): Matcher<T?> {
-   return object : NeverNullMatcher<T>() {
-      override fun testNotNull(value: T): MatcherResult {
-         return t(value)
-      }
-   }
-}
+fun <T : Any> neverNullMatcher(t: (T) -> MatcherResult): Matcher<T?> =
+   NeverNullMatcher(
+      Matcher { t(it) }
+   )
 
 /**
  * An instance of [MatcherResult] contains the result of an evaluation of a [Matcher].


### PR DESCRIPTION
This is PR makes the code smaller and easier to understand.

By the way, can you clarify why do you use `invoke` methods on `companion object` instead of a regular constructor?
