### PR TITLE
Support binding properties to specific Arbs when doing reflective binding

### DIFF
--- a/documentation/docs/proptest/reflective_arbs.md
+++ b/documentation/docs/proptest/reflective_arbs.md
@@ -47,5 +47,30 @@ Reflective binding is supported for:
 * `LocalDate`, `LocalDateTime`, `LocalTime`, `Period`, `Instant` from `java.time`
 * `BigDecimal`, `BigInteger`
 * Collections (`Set`, `List`, `Map`)
-* Classes for which an Arb has been provided through `providedArbs`
+* Properties and types for which an Arb has been provided through `providedArbs`, see below
 
+## Provided Arbs
+
+When doing reflective binding, Kotest supports a builder API to provide `Arb`s for specific types (classes) and properties.
+Binding specific properties allow greater control in cases where types might be more widely used, like primitives for instance.
+
+Example:
+
+```kotlin
+data class User(
+  val name: String,
+  val password: String,
+  val age: Int,
+)
+
+// in some spec
+context("Some tests with an arbitrary user") {
+  checkAll(Arb.bind<User> {
+    bind(User::name to Arb.string(1..10))
+    bind(User::password to Arb.string(24..80)) // binds a specific property to an arb
+    bind(Int::class to Arb.int(0..100))  // binds a type to an arb
+  }) { user ->
+    // ...
+  }
+}
+```

--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -1066,8 +1066,8 @@ public final class io/kotest/property/arbitrary/IntsKt {
 }
 
 public final class io/kotest/property/arbitrary/JvmbindKt {
+	public static final fun bind (Lio/kotest/property/Arb$Companion;Ljava/util/Map;Ljava/util/Map;Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)Lio/kotest/property/Arb;
 	public static final fun bind (Lio/kotest/property/Arb$Companion;Ljava/util/Map;Lkotlin/reflect/KClass;)Lio/kotest/property/Arb;
-	public static final fun bind (Lio/kotest/property/Arb$Companion;Ljava/util/Map;Lkotlin/reflect/KClass;Lkotlin/reflect/KType;)Lio/kotest/property/Arb;
 }
 
 public final class io/kotest/property/arbitrary/ListShrinker : io/kotest/property/Shrinker {
@@ -1157,6 +1157,14 @@ public final class io/kotest/property/arbitrary/NullKt {
 	public static final fun orNull (Lio/kotest/property/Arb;D)Lio/kotest/property/Arb;
 	public static final fun orNull (Lio/kotest/property/Arb;Lkotlin/jvm/functions/Function1;)Lio/kotest/property/Arb;
 	public static synthetic fun orNull$default (Lio/kotest/property/Arb;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/property/Arb;
+}
+
+public final class io/kotest/property/arbitrary/ProvidedArbsBuilder {
+	public fun <init> ()V
+	public final fun bindClass (Lkotlin/Pair;)V
+	public final fun bindProperty (Lkotlin/Pair;)V
+	public final fun getClassArbs ()Ljava/util/Map;
+	public final fun getPropertyArbs ()Ljava/util/Map;
 }
 
 public final class io/kotest/property/arbitrary/RangeKt {
@@ -1251,8 +1259,8 @@ public final class io/kotest/property/arbitrary/StringsjvmKt {
 }
 
 public final class io/kotest/property/arbitrary/TargetDefaultForClassNameKt {
-	public static final fun targetDefaultForType (Ljava/util/Map;Lkotlin/reflect/KType;)Lio/kotest/property/Arb;
-	public static synthetic fun targetDefaultForType$default (Ljava/util/Map;Lkotlin/reflect/KType;ILjava/lang/Object;)Lio/kotest/property/Arb;
+	public static final fun targetDefaultForType (Ljava/util/Map;Ljava/util/Map;Lkotlin/reflect/KType;)Lio/kotest/property/Arb;
+	public static synthetic fun targetDefaultForType$default (Ljava/util/Map;Ljava/util/Map;Lkotlin/reflect/KType;ILjava/lang/Object;)Lio/kotest/property/Arb;
 }
 
 public final class io/kotest/property/arbitrary/TimezoneKt {

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
@@ -9,7 +9,6 @@ import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.full.valueParameters
 import kotlin.reflect.typeOf
 
 /**
@@ -30,10 +29,13 @@ import kotlin.reflect.typeOf
  * - Collections (Set, List, Map) of types that fall into this category
  * - Classes for which an [Arb] has been provided through [providedArbs]
  */
-inline fun <reified T : Any> Arb.Companion.bind(
-   providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(),
-   arbsForProperties: Map<KProperty1<*, *>, Arb<*>> = emptyMap()
-): Arb<T> = bind(providedArbs, arbsForProperties, T::class, typeOf<T>())
+inline fun <reified T : Any> Arb.Companion.bind(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap()): Arb<T> =
+   bind(providedArbs, emptyMap(), T::class, typeOf<T>())
+
+inline fun <reified T : Any> Arb.Companion.bind(builder: ProvidedArbsBuilder.() -> Unit): Arb<T> =
+   ProvidedArbsBuilder().apply(builder).run {
+      bind(classArbs, propertyArbs, T::class, typeOf<T>())
+   }
 
 /**
  * Alias for [Arb.Companion.bind]
@@ -55,10 +57,13 @@ inline fun <reified T : Any> Arb.Companion.bind(
  * - Collections (Set, List, Map) of types that fall into this category
  * - Classes for which an [Arb] has been provided through [providedArbs]
  */
-inline fun <reified T : Any> Arb.Companion.data(
-   providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(),
-   arbsForProps: Map<KProperty1<*, *>, Arb<*>> = emptyMap(),
-): Arb<T> = Arb.bind(providedArbs, arbsForProps)
+inline fun <reified T : Any> Arb.Companion.data(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap()): Arb<T> =
+   Arb.bind(providedArbs)
+
+inline fun <reified T : Any> Arb.Companion.data(builder: ProvidedArbsBuilder.() -> Unit): Arb<T> =
+   ProvidedArbsBuilder().apply(builder).run {
+      bind(classArbs, propertyArbs, T::class, typeOf<T>())
+   }
 
 /**
  * **Do not call directly**
@@ -85,10 +90,9 @@ fun <T : Any> Arb.Companion.bind(
 @DelicateKotest
 fun <T : Any> Arb.Companion.bind(
    providedArbs: Map<KClass<*>, Arb<*>>,
-   arbsForProperties: Map<KProperty1<*, *>, Arb<*>>,
    kclass: KClass<T>
 ): Arb<T> {
-   return forClassUsingConstructor(providedArbs, arbsForProperties, kclass)
+   return forClassUsingConstructor(providedArbs, emptyMap(), kclass)
 }
 
 internal fun <T : Any> Arb.Companion.forClassUsingConstructor(
@@ -144,4 +148,22 @@ internal fun Arb.Companion.forType(
    return (type.classifier as? KClass<*>)?.let { providedArbs[it] ?: defaultForClass(it) }
       ?: GlobalArbResolver.resolve(type)
       ?: targetDefaultForType(providedArbs, arbsForProperties, type)
+}
+
+class ProvidedArbsBuilder {
+   private val _classArbs = mutableMapOf<KClass<*>, Arb<*>>()
+   private val _propertyArbs = mutableMapOf<KProperty1<*, *>, Arb<*>>()
+
+   val classArbs: Map<KClass<*>, Arb<*>> get() = _classArbs
+   val propertyArbs: Map<KProperty1<*, *>, Arb<*>> get() = _propertyArbs
+
+   @JvmName("bindClass")
+   fun bind(mapping: Pair<KClass<*>, Arb<*>>) {
+      _classArbs[mapping.first] = mapping.second
+   }
+
+   @JvmName("bindProperty")
+   fun bind(mapping: Pair<KProperty1<*, *>, Arb<*>>) {
+      _propertyArbs[mapping.first] = mapping.second
+   }
 }

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -16,6 +16,8 @@ import java.time.YearMonth
 import java.time.ZonedDateTime
 import java.util.Date
 import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.javaType
@@ -26,7 +28,11 @@ import kotlin.reflect.typeOf
 @Deprecated("This logic has moved to ArbResolver and this function will be removed in 5.6. Since 5.5")
 actual inline fun <reified A> targetDefaultForClass(): Arb<A>? = targetDefaultForType(type = typeOf<A>()) as Arb<A>?
 
-fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type: KType): Arb<*>? {
+fun targetDefaultForType(
+   providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(),
+   arbsForProps: Map<KProperty1<*, *>, Arb<*>> = emptyMap(),
+   type: KType
+): Arb<*>? {
    when (type) {
       typeOf<Instant>(), typeOf<Instant?>() -> Arb.instant()
       typeOf<Date>(), typeOf<Date?>() -> Arb.javaDate()
@@ -46,7 +52,7 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
    return when {
       clazz.isSubclassOf(List::class) -> {
          val upperBound = type.arguments.first().type ?: error("No bound for List")
-         Arb.list(Arb.forType(providedArbs, upperBound) as Arb<*>)
+         Arb.list(Arb.forType(providedArbs, arbsForProps, upperBound) as Arb<*>)
       }
       clazz.java.isArray -> {
          val upperBound = type.arguments.first().type ?: error("No bound for Array")
@@ -67,7 +73,7 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
             Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
          } else if(upperBoundKClass != null && upperBoundKClass.isSealed) {
             val maxElements = upperBoundKClass.sealedSubclasses.size
-            Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
+            Arb.set(Arb.forType(providedArbs, arbsForProps, upperBound) as Arb<*>, 0..maxElements)
          } else {
             Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>)
          }
@@ -75,13 +81,13 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
       clazz.isSubclassOf(Pair::class) -> {
          val first = type.arguments[0].type ?: error("No bound for first type parameter of Pair")
          val second = type.arguments[1].type ?: error("No bound for second type parameter of Pair")
-         Arb.pair(Arb.forType(providedArbs, first)!!, Arb.forType(providedArbs, second)!!)
+         Arb.pair(Arb.forType(providedArbs, arbsForProps, first)!!, Arb.forType(providedArbs, arbsForProps, second)!!)
       }
       clazz.isSubclassOf(Map::class) -> {
          // map key type can have or have not variance
          val first = type.arguments[0].type ?: error("No bound for first type parameter of Map<K, V>")
          val second = type.arguments[1].type ?: error("No bound for second type parameter of Map<K, V>")
-         Arb.map(Arb.forType(providedArbs, first)!!, Arb.forType(providedArbs, second)!!)
+         Arb.map(Arb.forType(providedArbs, arbsForProps, first)!!, Arb.forType(providedArbs, arbsForProps, second)!!)
       }
       clazz.isSubclassOf(Enum::class) -> {
          Arb.of(Class.forName(clazz.java.name).enumConstants.map { it as Enum<*> })
@@ -89,11 +95,11 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
       clazz.objectInstance != null -> Arb.constant(clazz.objectInstance!!)
       clazz.isSealed -> {
          Arb.choice(clazz.sealedSubclasses.map { subclass ->
-            subclass.objectInstance?.let { Arb.constant(it) } ?: Arb.forClassUsingConstructor(providedArbs, subclass)
+            subclass.objectInstance?.let { Arb.constant(it) } ?: Arb.forClassUsingConstructor(providedArbs, arbsForProps, subclass)
          })
       }
       else -> {
-        Arb.forClassUsingConstructor(providedArbs, clazz)
+        Arb.forClassUsingConstructor(providedArbs, arbsForProps, clazz)
       }
    }
 }

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -56,7 +56,7 @@ fun targetDefaultForType(
       }
       clazz.java.isArray -> {
          val upperBound = type.arguments.first().type ?: error("No bound for Array")
-         Arb.array(Arb.forType(providedArbs, upperBound) as Arb<*>) {
+         Arb.array(Arb.forType(providedArbs, arbsForProps, upperBound) as Arb<*>) {
             val upperBoundKClass = (upperBound.classifier as? KClass<*>) ?: error("No classifier for $upperBound")
             val array = java.lang.reflect.Array.newInstance(upperBoundKClass.javaObjectType, this.size) as Array<Any?>
             for ((i, item) in this.withIndex()) {
@@ -70,12 +70,12 @@ fun targetDefaultForType(
          val upperBoundKClass = (upperBound.classifier as? KClass<*>)
          if (upperBoundKClass != null && upperBoundKClass.isSubclassOf(Enum::class)) {
             val maxElements = Class.forName(upperBoundKClass.java.name).enumConstants.size
-            Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
+            Arb.set(Arb.forType(providedArbs, arbsForProps, upperBound) as Arb<*>, 0..maxElements)
          } else if(upperBoundKClass != null && upperBoundKClass.isSealed) {
             val maxElements = upperBoundKClass.sealedSubclasses.size
             Arb.set(Arb.forType(providedArbs, arbsForProps, upperBound) as Arb<*>, 0..maxElements)
          } else {
-            Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>)
+            Arb.set(Arb.forType(providedArbs, arbsForProps, upperBound) as Arb<*>)
          }
       }
       clazz.isSubclassOf(Pair::class) -> {

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/resolution/platformArbResolver.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/resolution/platformArbResolver.kt
@@ -8,6 +8,6 @@ internal actual fun platformArbResolver(): ArbResolver = JvmArbResolver
 
 object JvmArbResolver : ArbResolver {
    override fun resolve(type: KType): Arb<*>? {
-      return targetDefaultForType(emptyMap(), type)
+      return targetDefaultForType(emptyMap(), emptyMap(),  type)
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BindTest.kt
@@ -20,7 +20,6 @@ import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.boolean
-import io.kotest.property.arbitrary.data
 import io.kotest.property.arbitrary.double
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.map
@@ -31,10 +30,6 @@ import io.kotest.property.arbitrary.take
 import io.kotest.property.arbitrary.withEdgecases
 import io.kotest.property.arbitrary.zip
 import io.kotest.property.checkAll
-import kotlin.reflect.KProperty1
-import kotlin.reflect.full.primaryConstructor
-import kotlin.reflect.full.valueParameters
-import kotlin.reflect.typeOf
 import io.kotest.matchers.doubles.beGreaterThan as gtd
 
 class BindTest : StringSpec({
@@ -44,7 +39,7 @@ class BindTest : StringSpec({
    data class FooD(val a: String, val b: Int, val c: Double, val d: Int)
    data class FooE(val a: String, val b: Int, val c: Double, val d: Int, val e: Boolean)
 
-   "Bind using param" {
+   "Bind using properties" {
       data class Person(val id: Int, val name: String)
       data class Family(val name: String, val persons: List<Person>)
 
@@ -64,10 +59,10 @@ class BindTest : StringSpec({
 //      println(someProp.parameters)
 
 
-      checkAll(Arb.bind<Family>(arbsForProperties = mapOf(
-         Family::name to Arb.string().map { s -> "Flanders-$s" },
-         Person::id to Arb.positiveInt(),
-      ))) { family ->
+      checkAll(Arb.bind<Family> {
+         bind(Family::name to Arb.string().map { s -> "Flanders-$s" })
+         bind(Person::id to Arb.positiveInt())
+      }) { family ->
          family.name.shouldStartWith("Flanders-")
          family.persons.forAll {
             it.name.shouldNotStartWith("Flanders-")


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Adds the method: 
```kotlin
inline fun <reified T : Any> Arb.Companion.bind(builder: ProvidedArbsBuilder.() -> Unit): Arb<T>
```

Which lets us construct reflective arbs while providing arbs to be used for various classes **and properties**. Previously this capability existed but one could only provide a default arb per class. This becomes inconvenient for commonly used types like `Int`, `String`, etc.

The new method proposes a builder syntax, like:

```kotlin
   "Bind using properties" {

      data class Person(val id: Int, val name: String)
      data class Family(val name: String, val persons: List<Person>)

      checkAll(Arb.bind<Family> {
         // Create a binding for the `name` property on Family to always 
         // generate a String prefixed with Flanders 
         bind(Family::name to Arb.string().map { s -> "Flanders-$s" })
     
         // Bind the `id` property of `Person` to generate positive ints
         bind(Person::id to Arb.positiveInt())
  
         // Binding using class is also still possible. 
         // Included for completeness but completely useless for the test.
         bind(Double::class to Arb.double())
      }) { family ->
         family.name.shouldStartWith("Flanders-")
         family.persons.forAll {
            it.name.shouldNotStartWith("Flanders-")
            it.id shouldBeGreaterThan 0
         }
      }

   }
```

### Work-around 
If one wishes to achieve the same result with currently available methods, you would have to first create the `Arb<Person>` and explicitly bind it to `Person::class` during reflective binding, like:

```kotlin
   "Bind WITHOUT using properties" {

      data class Person(val id: Int, val name: String)
      data class Family(val name: String, val persons: List<Person>)
    
      val personArb = Arb.bind<Person>(mapOf(Int::class to Arb.positiveInt())
 
      checkAll(Arb.bind<Family>(mapOf(Person::class to personArb)) { family ->
         family.name.shouldStartWith("Flanders-")
         family.persons.forAll {
            it.name.shouldNotStartWith("Flanders-")
            it.id shouldBeGreaterThan 0
         }
      }

   }
``` 
In a scenario with deeper nesting or more type-reuse this might be incredibly inconvenient.
