### PR TITLE
Remove commons-io:commons-io dependency #3364

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,6 @@
 blockhound = "1.0.7.RELEASE"
 classgraph = "4.8.154"
 commons-lang3 = "3.12.0"
-commons-io = "2.11.0"
 gradle-test-logger-plugin = "3.2.0"
 java-diff-utils = "4.12"
 jdom2 = "2.0.6.1"
@@ -23,7 +22,6 @@ rgxgen = "1.4"
 shadowjar = "7.1.2"
 
 [libraries]
-apache-commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 apache-commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
 blockhound = { module = "io.projectreactor.tools:blockhound", version.ref = "blockhound" }
 classgraph = { module = "io.github.classgraph:classgraph", version.ref = "classgraph" }

--- a/kotest-extensions/build.gradle.kts
+++ b/kotest-extensions/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
             implementation(projects.kotestFramework.kotestFrameworkApi)
             implementation(projects.kotestFramework.kotestFrameworkEngine)
             implementation(projects.kotestCommon)
-            implementation(libs.apache.commons.io)
             implementation(libs.mockk)
          }
       }


### PR DESCRIPTION
Was only used for TeeOutputStream, which is easily handwritten.

Original `write` methods were synchronized using the Java `synchronized` keyword, so I've done the same but in the kotlin style :)