### PR TITLE
Update Spring docs for autoscan.disable=true

### DIFF
--- a/documentation/docs/extensions/spring.md
+++ b/documentation/docs/extensions/spring.md
@@ -47,7 +47,8 @@ In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. Thi
 ### Constructor Injection
 
 For constructor injection, Kotest automatically registers a `SpringAutowireConstructorExtension`
-when the spring module is added to the build.
+when the spring module is added to the build, assuming auto scan is enabled (see [Project Config](../framework/project-config.html)). If Auto scan is
+disabled, you will need to manually load the extension in your Project config.
 
 This extension will intercept each call to create a Spec instance
 and will autowire the beans declared in the primary constructor.

--- a/documentation/versioned_docs/version-5.5/extensions/spring.md
+++ b/documentation/versioned_docs/version-5.5/extensions/spring.md
@@ -46,8 +46,8 @@ In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. Thi
 
 ### Constructor Injection
 
-For constructor injection, Kotest automatically registers a `SpringAutowireConstructorExtension`
-when the spring module is added to the build.
+when the spring module is added to the build, assuming auto scan is enabled (see [Project Config](../framework/project-config.html)). If Auto scan is
+disabled, you will need to manually load the extension in your Project config.
 
 This extension will intercept each call to create a Spec instance
 and will autowire the beans declared in the primary constructor.


### PR DESCRIPTION
When auto scan is disabled, `SpringAutowireConstructorExtension` is not loaded. This PR updates the documentation to give a clue that it will need manually loading in your project config if auto scan is disabled.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
