### PR TITLE
kotest-framework-api: Fix KDoc links, code blocks, spellings

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/Tag.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/Tag.kt
@@ -13,7 +13,7 @@ package io.kotest.core
  * different packages) are treated as the same single tag.
  *
  * For example, if you create a Tag `com.sksamuel.kotest.SuperTag` then the tag name will
- * simply be SuperTag.
+ * simply be `SuperTag`.
  *
  * Therefore, the tags `com.sksamuel.kotest.SuperTag` and `io.kotest.SuperTag` would be
  * considered equal.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -54,7 +54,7 @@ abstract class TestConfiguration {
 
    /**
     * Sets an assertion mode which is applied to every test.
-    * If null, then the project default is used.
+    * If `null`, then the project default is used.
     */
    var assertions: AssertionMode? = null
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/AutoScan.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/AutoScan.kt
@@ -1,6 +1,6 @@
 package io.kotest.core.annotation
 
 /**
- * Add this annotation to [Extension]s and they will be registered automatically for all specs.
+ * Add this annotation to [io.kotest.core.extensions.Extension]s and they will be registered automatically for all specs.
  */
 annotation class AutoScan

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/Describe.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/Describe.kt
@@ -1,7 +1,7 @@
 package io.kotest.core.annotation
 
 /**
- * Attach this annotation to a spec class to add human readable details on what that spec is testing.
+ * Attach this annotation to a spec class to add human-readable details on what that spec is testing.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/DisplayName.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/DisplayName.kt
@@ -2,7 +2,7 @@ package io.kotest.core.annotation
 
 /**
  * Note: This name must be globally unique. Two specs, even in different packages,
- * cannot share the same name, so if @DisplayName is used, developers must ensure it does not
+ * cannot share the same name, so if `@DisplayName` is used, developers must ensure it does not
  * clash with another spec.
  *
  * This annotation only works on JVM targets. On other targets this annotation will be ignored.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/Ignored.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/Ignored.kt
@@ -3,7 +3,7 @@ package io.kotest.core.annotation
 /**
  * Attach to a [io.kotest.core.spec.Spec], and that spec won't be instantiated or executed.
  */
-// @Inherited TODO Not supported by Kotlin yet
+// @Inherited TODO Not supported by Kotlin yet https://youtrack.jetbrains.com/issue/KT-22265
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Ignored(val reason: String = "")

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -8,6 +8,7 @@ import io.kotest.core.listeners.ProjectListener
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.names.TestNameCase
 import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.test.AssertionMode
 import io.kotest.core.test.TestCaseOrder
@@ -18,7 +19,7 @@ import kotlin.time.Duration
 
 /**
  * Project-wide configuration. Extensions returned by an
- * instance of this class will be applied to all [Spec] and [TestCase]s.
+ * instance of this class will be applied to all [io.kotest.core.spec.Spec] and [io.kotest.core.test.TestCase]s.
  *
  * Create an object or class that is derived from this class and place it in your source.
  *
@@ -26,11 +27,12 @@ import kotlin.time.Duration
  *
  * For example, you could create this object and place the source in `src/main/kotlin/my/test/package`.
  *
+ * ```
  * object KotestProjectConfig : AbstractProjectConfig() {
  *    override val failOnEmptyTestSuite = true
  *    override val testCaseOrder = TestCaseOrder.Random
  * }
- *
+ * ```
  */
 abstract class AbstractProjectConfig {
 
@@ -99,11 +101,11 @@ abstract class AbstractProjectConfig {
     * that callbacks all operate on the same thread. In other words, a spec is sticky
     * in regard to the execution thread.
     *
-    * Increasing this value to k > 1, means that k threads are created, allowing different
-    * specs to execute on different threads. For n specs, if you set this value to k, then
-    * on average, each thread will service n/k specs.
+    * Increasing this value to `k > 1`, means that `k` threads are created, allowing different
+    * specs to execute on different threads. For `n` specs, if you set this value to `k`, then
+    * on average, each thread will service `n/k` specs.
     *
-    * An alternative way to enable this is the system property kotest.framework.parallelism
+    * An alternative way to enable this is the system property `kotest.framework.parallelism`
     * which will always (if defined) take priority over the value here.
     *
     * Note: For backwards compatibility, setting this value to > 1 will implicitly set
@@ -127,7 +129,7 @@ abstract class AbstractProjectConfig {
 
    /**
     * Sets the order of top level tests in a spec.
-    * The value set here will be used unless overriden in a [Spec].
+    * The value set here will be used unless overridden in a [Spec].
     * The value in a [Spec] is always taken in preference to the value here.
     * Nested tests will always be executed in discovery order.
     *
@@ -144,7 +146,7 @@ abstract class AbstractProjectConfig {
 
    /**
     * Override this value and set it to true if you want all tests to behave as if they
-    * were operating in an [assertSoftly] block.
+    * were operating in an [io.kotest.assertions.assertSoftly] block.
     */
    open val globalAssertSoftly: Boolean? = null
 
@@ -252,11 +254,12 @@ abstract class AbstractProjectConfig {
    open var displayFullTestPath: Boolean? = null
 
    /**
-    * If set to true then the test engine will install a [TestDispatcher].
+    * If set to true then the test engine will install a
+    * [`TestDispatcher`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/).
     *
     * This can be retrieved via `delayController` in your tests.
     *
-    * @see https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
+    * See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
     */
    @ExperimentalKotest
    open var testCoroutineDispatcher: Boolean = Defaults.testCoroutineDispatcher
@@ -272,7 +275,8 @@ abstract class AbstractProjectConfig {
     * [ProjectListener.beforeProject] methods.
     */
    @Deprecated(message = "use beforeProject supports suspension", replaceWith = ReplaceWith("beforeProject"))
-   open fun beforeAll() {}
+   open fun beforeAll() {
+   }
 
    /**
     * Executed after the last test of the project, but before the
@@ -285,5 +289,6 @@ abstract class AbstractProjectConfig {
     * [ProjectListener.afterProject] methods.
     */
    @Deprecated(message = "use afterProject which supports suspension", replaceWith = ReplaceWith("afterProject"))
-   open fun afterAll() {}
+   open fun afterAll() {
+   }
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -18,8 +18,8 @@ import kotlin.reflect.KClass
 import kotlin.time.Duration
 
 /**
- * Project-wide configuration. Extensions returned by an
- * instance of this class will be applied to all [io.kotest.core.spec.Spec] and [io.kotest.core.test.TestCase]s.
+ * Project-wide configuration. Extensions returned by an instance of this class will be applied
+ * to all [Spec]s and [TestCase][io.kotest.core.test.TestCase]s.
  *
  * Create an object or class that is derived from this class and place it in your source.
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -121,7 +121,10 @@ abstract class AbstractProjectConfig {
     * This file is used on subsequent test runs to run the failed specs first.
     *
     * To enable this feature, set this to true, or set the system property
-    * 'kotest.write.specfailures=true'
+    *
+    * ```properties
+    * kotest.write.specfailures=true
+    * ```
     *
     * Note: This is a JVM platform only option.
     */
@@ -151,15 +154,17 @@ abstract class AbstractProjectConfig {
    open val globalAssertSoftly: Boolean? = null
 
    /**
-    * Override this value and set it to false if you want to disable autoscanning of extensions
+    * Override this value and set it to false if you want to disable auto-scanning of extensions
     * and listeners.
     *
-    *  Note: This is a JVM platform only option.
+    * Note: This is a JVM platform only option.
     */
    open val autoScanEnabled: Boolean? = null
 
    /**
-    * Override this value with a list of classes for which @autoscan is disabled.
+    * Override this value with a list of classes for which
+    * [@AutoScan][io.kotest.core.annotation.AutoScan]
+    * is disabled.
     *
     *  Note: This is a JVM platform only option.
     */
@@ -190,36 +195,39 @@ abstract class AbstractProjectConfig {
    open val assertionMode: AssertionMode? = null
 
    /**
-    * Any [ResolvedTestConfig] set here is used as the default for tests, unless overriden in a spec,
+    * Any [ResolvedTestConfig] set here is used as the default for tests, unless overridden in a spec,
     * or in a test itself. In other words the order is test -> spec -> project config default -> kotest default
     */
    open val defaultTestCaseConfig: TestCaseConfig? = null
 
    /**
     * Some specs have DSLs that include "prefix" words in the test name.
-    * For example, when using ExpectSpec like this:
+    * For example, when using [io.kotest.core.spec.style.ExpectSpec] like this:
     *
+    * ```
     * expect("this test 1") {
     *   feature("this test 2") {
     *   }
     * }
+    * ```
     *
     * Will result in:
-    *
+    * ```text
     * Expect: this test 1
     *   Feature: this test 2
-    *
+    * ```
     * From 4.2, this feature can be disabled by setting this value to false.
     * Then the output of the previous test would be:
-    *
+    * ```text
     * this test 1
     *   this test 2
+    * ```
     */
    open val includeTestScopePrefixes: Boolean? = null
 
    /**
-    * The casing of the tests' names can be adjusted using different strategies. It affects tests'
-    * prefixes (I.e.: Given, When, Then) and tests' titles.
+    * The casing of test names can be adjusted using different strategies. It affects test
+    * prefixes (I.e.: Given, When, Then) and test titles.
     *
     * This setting's options are defined in [TestNameCase]. Check the previous enum for the
     * available options and examples.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -66,7 +66,7 @@ class ProjectConfiguration {
    var globalAssertSoftly: Boolean = Defaults.globalAssertSoftly
 
    /**
-    * The casing of the tests' names can be adjusted using different strategies. It affects test
+    * The casing of test names can be adjusted using different strategies. It affects test
     * prefixes (I.e.: Given, When, Then) and test titles.
     *
     * This setting's options are defined in [TestNameCase].

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -281,7 +281,7 @@ class ProjectConfiguration {
     *    test this 2
     * ```
     *
-    * Defaults to `null`, which is the default.
+    * Defaults to `null`, which is to let the [Spec] style determine whether to include affixes.
     */
    var includeTestScopeAffixes: Boolean? = Defaults.defaultIncludeTestScopeAffixes
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -45,7 +45,7 @@ class ProjectConfiguration {
     *
     * Defaults to [Defaults.writeSpecFailureFile].
     *
-    * Note: Only has an effect on the JVM.
+    * Note: Only has an effect on JVM.
     */
    var writeSpecFailureFile: Boolean = Defaults.writeSpecFailureFile
 
@@ -54,20 +54,20 @@ class ProjectConfiguration {
     *
     * Defaults to [Defaults.specFailureFilePath].
     *
-    * Note: Only has an effect on the JVM.
+    * Note: Only has an effect on JVM.
     */
    var specFailureFilePath: String = Defaults.specFailureFilePath
 
    /**
-    * If true, then all test cases are implicitly wrapped in an assertSoftly call.
+    * If true, then all test cases are implicitly wrapped in an [io.kotest.assertions.assertSoftly] call.
     *
     * Defaults to [Defaults.globalAssertSoftly].
     */
    var globalAssertSoftly: Boolean = Defaults.globalAssertSoftly
 
    /**
-    * The casing of the tests' names can be adjusted using different strategies. It affects tests'
-    * prefixes (I.e.: Given, When, Then) and tests' titles.
+    * The casing of the tests' names can be adjusted using different strategies. It affects test
+    * prefixes (I.e.: Given, When, Then) and test titles.
     *
     * This setting's options are defined in [TestNameCase].
     *
@@ -194,7 +194,7 @@ class ProjectConfiguration {
     *
     * This value is used if a timeout is not specified in the test case itself.
     *
-    * Defaults to [Defaults.defaultInvocationTimeout].
+    * Defaults to [Defaults.defaultInvocationTimeoutMillis].
     */
    var invocationTimeout: Long? = null
 
@@ -218,11 +218,12 @@ class ProjectConfiguration {
    var severity: TestCaseSeverityLevel = Defaults.severity
 
    /**
-    * If set to true then the test engine will install a [TestDispatcher].
+    * If set to true then the test engine will install a
+    * [`TestDispatcher`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/).
     *
     * This can be retrieved via `delayController` in your tests.
     *
-    * @see https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
+    * See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
     */
    @ExperimentalKotest
    @Deprecated("Replaced with coroutineTestScope. Deprecated since 5.3")
@@ -259,22 +260,28 @@ class ProjectConfiguration {
     *
     * For example, when using ExpectSpec like this:
     *
+    * ```
     * expect("this test 1") {
     *   feature("this test 2") {
     *   }
     * }
+    * ```
     *
     * If prefixes are enabled, the output would be:
     *
+    * ```text
     * Expect: this test 1
     *   Feature: this test 2
+    * ```
     *
     * And if disabled, the output would be:
     *
+    * ```text
     * this test 1
     *    test this 2
+    * ```
     *
-    * Defaults to null, which is to use the default.
+    * Defaults to `null`, which is the default.
     */
    var includeTestScopeAffixes: Boolean? = Defaults.defaultIncludeTestScopeAffixes
 
@@ -284,7 +291,7 @@ class ProjectConfiguration {
     *
     * Defaults to [Defaults.displaySpecIfNoActiveTests]
     *
-    * Note: This only works for JUnit and Intellij runners.
+    * Note: This only works for JUnit and IntelliJ runners.
     */
    var displaySpecIfNoActiveTests: Boolean = Defaults.displaySpecIfNoActiveTests
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/descriptors/descriptor.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/descriptors/descriptor.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
 typealias TestPath = io.kotest.common.TestPath
 
 /**
- * A parseable, stable, consistent identifer for a test element.
+ * A parseable, stable, consistent identifier for a test element.
  *
  * The id should not depend on runtime configuration and should not change between test runs,
  * unless the test, or a parent test, has been modified by the user.
@@ -67,22 +67,22 @@ sealed interface Descriptor {
    }
 
    /**
-    * Returns true if this descriptor is for a class based test file.
+    * Returns `true` if this descriptor is for a class based test file.
     */
    fun isSpec() = this is SpecDescriptor
 
    /**
-    * Returns true if this descriptor is for a test case.
+    * Returns `true` if this descriptor is for a test case.
     */
    fun isTestCase() = this is TestDescriptor
 
    /**
-    * Returns true if this descriptor represents a root test case.
+    * Returns `true` if this descriptor represents a root test case.
     */
    fun isRootTest() = this is TestDescriptor && this.parent.isSpec()
 
    /**
-    * Returns true if this type equals that type. For example
+    * Returns `true` if this type equals that type. For example
     * if this is a spec and the rhs is also spec
     */
    fun isEqualType(that: Descriptor): Boolean {
@@ -110,7 +110,7 @@ sealed interface Descriptor {
    fun chain() = parents() + this
 
    /**
-    * Returns true if this descriptor is the immediate parent of the given [descriptor].
+    * Returns `true` if this descriptor is the immediate parent of the given [descriptor].
     */
    fun isParentOf(descriptor: Descriptor): Boolean = when (descriptor) {
       is SpecDescriptor -> false // nothing can be the parent of a spec
@@ -118,7 +118,7 @@ sealed interface Descriptor {
    }
 
    /**
-    * Returns true if this descriptor is ancestor (1..nth-parent) of the given [descriptor].
+    * Returns `true` if this descriptor is ancestor (1..nth-parent) of the given [descriptor].
     */
    fun isAncestorOf(descriptor: Descriptor): Boolean = when (descriptor) {
       is SpecDescriptor -> false // nothing can be an ancestor of a spec
@@ -126,17 +126,17 @@ sealed interface Descriptor {
    }
 
    /**
-    * Returns true if this descriptor is the immediate child of the given [descriptor].
+    * Returns `true` if this descriptor is the immediate child of the given [descriptor].
     */
    fun isChildOf(descriptor: Descriptor): Boolean = descriptor.isParentOf(this)
 
    /**
-    * Returns true if this descriptor is a child, grandchild, etc of the given [descriptor].
+    * Returns `true` if this descriptor is a child, grandchild, etc of the given [descriptor].
     */
    fun isDescendentOf(descriptor: Descriptor): Boolean = descriptor.isAncestorOf(this)
 
    /**
-    * Returns true if this instance is on the path to the given description. That is, if this
+    * Returns `true` if this instance is on the path to the given description. That is, if this
     * instance is either an ancestor of, of the same as, the given description.
     */
    fun isOnPath(description: Descriptor): Boolean =

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/Extension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/Extension.kt
@@ -5,11 +5,13 @@ package io.kotest.core.extensions
  * with the Kotest Engine, changing the behavior of the engine
  * at runtime.
  *
- * In Kotest we use the nomenclature Extension and Listener. Listeners
- * are extension's themselves, but we use this term for callbacks that
+ * In Kotest we use the nomenclature `Extension` and `Listener`. `Listeners`
+ * are extensions themselves, but we use this term for callbacks that
  * receive events but do not change the behavior of the engine.
  *
- * Which should I use? - Always use a listener if you can - they are
+ * ### Which should I use?
+ *
+ * Always use a listener if you can - they are
  * simpler. Only use an extension if you need to adjust the runtime
  * behavior of the engine, such as when writing an advanced plugin.
  */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/MountableExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/MountableExtension.kt
@@ -10,6 +10,7 @@ import io.kotest.core.spec.Spec
  *
  * For example:
  *
+ * ```
  * class MyTest : FunSpec() {
  *  init {
  *   val kafka = install(EmbeddedKafka) {
@@ -17,9 +18,10 @@ import io.kotest.core.spec.Spec
  *   }
  *  }
  * }
+ * ```
  *
  * Here `kafka` is a materialized value that contains details of the host/port of the
- * started kafka instance and `EmbeddedKafka` is the extension itself.
+ * started Kafka instance and `EmbeddedKafka` is the extension itself.
  *
  */
 interface MountableExtension<CONFIG, MATERIALIZED> : Extension {
@@ -35,6 +37,7 @@ interface MountableExtension<CONFIG, MATERIALIZED> : Extension {
  *
  * For example:
  *
+ * ```
  * class MyTest : FunSpec() {
  *  init {
  *   val kafka = install(EmbeddedKafka) {
@@ -42,9 +45,10 @@ interface MountableExtension<CONFIG, MATERIALIZED> : Extension {
  *   }
  *  }
  * }
+ * ```
  *
  * Here `kafka` is a materialized value that contains details of the host/port of the
- * started kafka instance and `EmbeddedKafka` is the extension itself.
+ * started Kafka instance and `EmbeddedKafka` is the extension itself.
  *
  */
 interface LazyMountableExtension<CONFIG, MATERIALIZED> : Extension {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/RuntimeTagExpressionExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/RuntimeTagExpressionExtension.kt
@@ -5,10 +5,11 @@ import io.kotest.core.TagExpression
 /**
  * Allows including/excluding tags at runtime using a tag expression.
  *
- * Eg, inside project config or a project listener, you can do:
+ * E.g., inside project config or a project listener, you can do:
  *
+ * ```
  * RuntimeTagExpressionExtension.expression = "linux & mysql"
- *
+ * ```
  */
 class RuntimeTagExpressionExtension(private val expression: String) : TagExtension {
    override fun tags(): TagExpression = TagExpression(expression)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExecutionOrderExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExecutionOrderExtension.kt
@@ -9,7 +9,7 @@ import io.kotest.core.spec.SpecRef
  * invoked but the order of invocation is undefined.
  *
  * If no [SpecExecutionOrderExtension]s are registered, then specs will be
- * sorted using the value of [specExecutionOrder] defined in configuration.
+ * sorted using the value of [io.kotest.core.config.AbstractProjectConfig.specExecutionOrder] defined in configuration.
  */
 interface SpecExecutionOrderExtension {
    fun sort(specs: List<SpecRef>): List<SpecRef>

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
@@ -26,7 +26,7 @@ interface SpecExtension : Extension {
     *
     * @param process callback function required to continue spec processing
     */
-   @Deprecated("This function had ambigious specifications. Instead prefer intercept(spec: Spec, execute: suspend (Spec) -> Unit) which is guaranteed to run once per spec instance or use SpecRefExtension which runs once per spec class. This function was deprecated in 5.0")
+   @Deprecated("This function had ambiguous specifications. Instead prefer intercept(spec: Spec, execute: suspend (Spec) -> Unit) which is guaranteed to run once per spec instance or use SpecRefExtension which runs once per spec class. This function was deprecated in 5.0")
    suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
       process()
    }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/TagExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/TagExtension.kt
@@ -5,14 +5,14 @@ import io.kotest.core.TagExpression
 /**
  * Provides [TagExpression] to be used by the Test Engine in determining active tests.
  *
- * A [Tag] can be added to any test and then specific tags can be included
+ * A [io.kotest.core.Tag] can be added to any test and then specific tags can be included
  * or excluded via [TagExtension] instances, which will cause tests that do not
  * match to be skipped.
  *
  * Note: If multiple extensions are registered then all returned
  * [TagExpression] are combined using ORs
  *
- * The [SystemPropertyTagExtension] is automatically registered which
+ * The [io.kotest.engine.extensions.SystemPropertyTagExtension] is automatically registered which
  * includes and excludes tags using the system properties
  * 'kotest.tags.include' and 'kotest.tags.exclude'.
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/TestCaseExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/TestCaseExtension.kt
@@ -17,7 +17,7 @@ interface TestCaseExtension : Extension {
     * Allows implementations to add logic around a [TestCase] as well as
     * control if (or when) the test is executed.
     *
-    * The supplied `execute` function should be invoked if implementations wish to
+    * The supplied [execute] function should be invoked if implementations wish to
     * execute the test case.
     *
     * This function accepts the test case instance to be executed, which is normally
@@ -25,15 +25,16 @@ interface TestCaseExtension : Extension {
     *
     * This allows you to change config for example:
     *
-    * `execute(testCase.copy(config = ...))`
-    *
-    * Typically, the result recieved from invoking [execute] will be the result
+    * ```
+    * execute(testCase.copy(config = ...))
+    * ```
+    * Typically, the result received from invoking [execute] will be the result
     * returned, but this is not required. Implementations may wish to
     * skip the test case and return a result without executing the test, or they
     * may wish to inspect the test and return a different result to that received.
     *
     * Note: A test cannot be skipped after it has been executed. Executing a test
-    * and then returning [TestStatus.Ignored] may result in an error.
+    * and then returning [io.kotest.core.test.TestStatus.Ignored] may result in an error.
     *
     * @param testCase the [TestCase] under interception
     *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/factory/TestFactoryConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/factory/TestFactoryConfiguration.kt
@@ -7,7 +7,7 @@ import io.kotest.core.spec.style.scopes.RootScope
 /**
  * A [TestFactoryConfiguration] extends [TestConfiguration] with the ability to register
  * [DynamicRootTest]s. This class shouldn't be used directly, but as the base for a particular
- * layout style, eg [FunSpecTestFactoryConfiguration].
+ * layout style, e.g. [io.kotest.core.spec.style.FunSpecTestFactoryConfiguration].
  */
 abstract class TestFactoryConfiguration : TestConfiguration(), RootScope {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/SpecFilter.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/SpecFilter.kt
@@ -4,7 +4,7 @@ import io.kotest.core.extensions.Extension
 import kotlin.reflect.KClass
 
 /**
- * A [SpecFilter] can be used to filter [Spec] classes before they are instantiated.
+ * A [SpecFilter] can be used to filter [io.kotest.core.spec.Spec] classes before they are instantiated.
  * These filters are passed to the Kotest Engine at runtime.
  */
 interface SpecFilter : Extension {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
@@ -5,18 +5,22 @@ import io.kotest.core.spec.Spec
 interface AfterSpecListener : Listener {
 
    /**
-    * Is invoked after the [TestCase]s that are part of a particular
+    * Is invoked after the [io.kotest.core.test.TestCase]s that are part of a particular
     * [Spec] instance have completed.
     *
     * If a spec is instantiated multiple times - for example, if
-    * [InstancePerTest] or [InstancePerLeaf] isolation modes are used,
+    * [InstancePerTest][io.kotest.core.spec.IsolationMode.InstancePerTest]
+    * or
+    * [InstancePerLeaf][io.kotest.core.spec.IsolationMode.InstancePerLeaf]
+    * isolation modes are used,
     * then this callback will be invoked for each instantiated spec,
     * after the tests that are applicable to that spec instance have
     * returned.
     *
     * This callback should be used if you need to perform cleanup
     * after each individual spec instance. If you simply need to
-    * perform cleanup once per class file, then use [finalizeSpec].
+    * perform cleanup once per class file, then use
+    * [`finalizeSpec`][io.kotest.core.listeners.TestListener.finalizeSpec].
     *
     * @param spec the [Spec] instance.
     */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
@@ -20,7 +20,7 @@ interface AfterSpecListener : Listener {
     * This callback should be used if you need to perform cleanup
     * after each individual spec instance. If you simply need to
     * perform cleanup once per class file, then use
-    * [`finalizeSpec`][io.kotest.core.listeners.TestListener.finalizeSpec].
+    * [finalizeSpec][io.kotest.core.listeners.TestListener.finalizeSpec].
     *
     * @param spec the [Spec] instance.
     */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/BeforeSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/BeforeSpecListener.kt
@@ -11,9 +11,9 @@ interface BeforeSpecListener : Listener {
     * This callback is only invoked if the spec has active tests. If all tests in a spec
     * are disabled, or the spec has no tests defined, then this listener will NOT be invoked.
     *
-    * Any errors in this listener will be propaged to the engine and further execution, including
+    * Any errors in this listener will be propagated to the engine and further execution, including
     * [AfterSpecListener]s will be skipped. If you wish have before/after control even in the
-    * case of exceptions, then consider using the [SpecInterceptExtension].
+    * case of exceptions, then consider using the [io.kotest.engine.spec.interceptor.SpecInterceptor].
     *
     * If a spec is instantiated multiple times - for example, if
     * [io.kotest.core.spec.IsolationMode.InstancePerTest] or

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/IgnoredSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/IgnoredSpecListener.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.KClass
 /**
  * Invoked if a [Spec] was skipped.
  *
- * This can be because the spec was annotated with [`@Ignored`][io.kotest.core.annotation.Ignored],
- * or because the spec failed to pass an [`@EnabledIf`][io.kotest.core.annotation.EnabledIf] predicate, and so on.
+ * This can be because the spec was annotated with [@Ignored][io.kotest.core.annotation.Ignored],
+ * or because the spec failed to pass an [@EnabledIf][io.kotest.core.annotation.EnabledIf] predicate, and so on.
  */
 interface IgnoredSpecListener : Extension {
    suspend fun ignoredSpec(kclass: KClass<*>, reason: String?)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/IgnoredSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/IgnoredSpecListener.kt
@@ -7,8 +7,8 @@ import kotlin.reflect.KClass
 /**
  * Invoked if a [Spec] was skipped.
  *
- * This can be because the spec was annotatd with @Ignored, or because the spec
- * failed to pass an @EnabledIf predicate, and so on.
+ * This can be because the spec was annotated with [`@Ignored`][io.kotest.core.annotation.Ignored],
+ * or because the spec failed to pass an [`@EnabledIf`][io.kotest.core.annotation.EnabledIf] predicate, and so on.
  */
 interface IgnoredSpecListener : Extension {
    suspend fun ignoredSpec(kclass: KClass<*>, reason: String?)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/PrepareSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/PrepareSpecListener.kt
@@ -19,8 +19,11 @@ interface PrepareSpecListener : Listener {
     * execute the tests for that spec.
     *
     * Regardless of how many times the spec is instantiated,
-    * for example, if [InstancePerTest] or [InstancePerLeaf] isolation
-    * modes are used, this callback will only be invoked once.
+    * for example, if
+    * [InstancePerTest][io.kotest.core.spec.IsolationMode.InstancePerTest]
+    * or
+    * [InstancePerLeaf][io.kotest.core.spec.IsolationMode.InstancePerLeaf]
+    * isolation modes are used, this callback will only be invoked once.
     *
     * @param kclass the [Spec] class
     */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
@@ -4,9 +4,9 @@ import io.kotest.core.test.TestCase
 
 @Deprecated("Renamed to IgnoredSpecListener. Deprecated since 5.0")
 typealias SpecIgnoredListner = IgnoredSpecListener
+// 'Listner' is intentionally misspelled to match the original from 4.6
+// https://github.com/kotest/kotest/blob/2853bf6e2e7d7c136fd2748da100b75e5d050c29/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/spec.kt#L49
 
-@Deprecated("Renamed to IgnoredSpecListener. Deprecated since 5.0")
-typealias SpecIgnoredListener = IgnoredSpecListener
 
 /**
  * A [TestListener] contains functions that are invoked as part of the lifecycle of a [TestCase].

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
@@ -5,6 +5,9 @@ import io.kotest.core.test.TestCase
 @Deprecated("Renamed to IgnoredSpecListener. Deprecated since 5.0")
 typealias SpecIgnoredListner = IgnoredSpecListener
 
+@Deprecated("Renamed to IgnoredSpecListener. Deprecated since 5.0")
+typealias SpecIgnoredListener = IgnoredSpecListener
+
 /**
  * A [TestListener] contains functions that are invoked as part of the lifecycle of a [TestCase].
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterTest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterTest.kt
@@ -39,7 +39,7 @@ interface AfterTestListener : Listener {
    suspend fun afterTest(testCase: TestCase, result: TestResult): Unit = Unit
 
    /**
-    * Alias for afterTest
+    * Alias for [afterTest]
     */
    suspend fun afterAny(testCase: TestCase, result: TestResult): Unit = Unit
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
@@ -10,7 +10,7 @@ interface BeforeInvocationListener : Listener {
     * some setup / teardown between runs.
     *
     * If you are running a test with the default single invocation then this callback is effectively the
-    * same as [`beforeTest`][io.kotest.core.TestConfiguration.beforeTest].
+    * same as [beforeTest][io.kotest.core.TestConfiguration.beforeTest].
     *
     * Note: If you have set multiple invocations _and_ multiple threads, then these callbacks could be
     * invoked concurrently.
@@ -26,7 +26,7 @@ interface AfterInvocationListener : Listener {
     * some setup / teardown between runs.
     *
     * If you are running a test with the default single invocation then this callback is effectively the
-    * same as [`afterTest`][io.kotest.core.TestConfiguration.afterTest].
+    * same as [afterTest][io.kotest.core.TestConfiguration.afterTest].
     *
     * Note: If you have set multiple invocations _and_ multiple threads, then these callbacks could be
     * invoked concurrently.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
@@ -10,7 +10,7 @@ interface BeforeInvocationListener : Listener {
     * some setup / teardown between runs.
     *
     * If you are running a test with the default single invocation then this callback is effectively the
-    * same as [beforeTest].
+    * same as [`beforeTest`][io.kotest.core.TestConfiguration.beforeTest].
     *
     * Note: If you have set multiple invocations _and_ multiple threads, then these callbacks could be
     * invoked concurrently.
@@ -26,7 +26,7 @@ interface AfterInvocationListener : Listener {
     * some setup / teardown between runs.
     *
     * If you are running a test with the default single invocation then this callback is effectively the
-    * same as [afterTest].
+    * same as [`afterTest`][io.kotest.core.TestConfiguration.afterTest].
     *
     * Note: If you have set multiple invocations _and_ multiple threads, then these callbacks could be
     * invoked concurrently.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/names/TestNameCase.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/names/TestNameCase.kt
@@ -3,10 +3,10 @@ package io.kotest.core.names
 /**
  * Test naming strategies to adjust test name case.
  *
- * @property AsIs For: should("Happen SOMETHING") yields: should Happen SOMETHING
- * @property Sentence For: should("Happen SOMETHING") yields: Should happen SOMETHING
- * @property InitialLowercase For: should("Happen SOMETHING") yields: should happen SOMETHING
- * @property Lowercase For: should("Happen SOMETHING") yields: should happen something
+ * @property AsIs For: `should("Happen SOMETHING")` yields: `should Happen SOMETHING`
+ * @property Sentence For: `should("Happen SOMETHING")` yields: `Should happen SOMETHING`
+ * @property InitialLowercase For: `should("Happen SOMETHING")` yields: `should happen SOMETHING`
+ * @property Lowercase For: `should("Happen SOMETHING")` yields: `should happen something`
  */
 enum class TestNameCase {
    AsIs,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/names/names.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/names/names.kt
@@ -14,7 +14,7 @@ package io.kotest.core.names
  * @param bang if the test name was specified with `!` prefix
  * @param prefix if the test style includes a test name prefix, such as "should"
  * @param suffix if the test style includes a test name suffix, such as "when"
- * @param defaultAffixes if the test style recommends test affixes by default, such as [`BehaviorSpec`][io.kotest.core.spec.style.BehaviorSpec]
+ * @param defaultAffixes if the test style recommends test affixes by default, such as [BehaviorSpec][io.kotest.core.spec.style.BehaviorSpec]
  */
 data class TestName(
    val testName: String,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/names/names.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/names/names.kt
@@ -4,17 +4,17 @@ package io.kotest.core.names
  * Models the name of a [io.kotest.core.test.TestCase] as entered by a user.
  *
  * A test case can sometimes have a prefix and/or suffix set by the spec style,
- * eg when using BehaviorSpec or WordSpec. Note that the prefix or suffix should include
+ * e.g. when using BehaviorSpec or WordSpec. Note that the prefix or suffix should include
  * any whitespace required.
  *
- * Test names can be prefixed with ! or f: to indicate bang or focus respectively.
+ * Test names can be prefixed with `!` or `f:` to indicate bang or focus respectively.
  *
  * @param testName the name exactly as the user entered it but with focus or bang stripped
- * @param focus if the test name was specified with f: prefix
- * @param bang if the test name was specified with ! prefix
+ * @param focus if the test name was specified with `f:` prefix
+ * @param bang if the test name was specified with `!` prefix
  * @param prefix if the test style includes a test name prefix, such as "should"
  * @param suffix if the test style includes a test name suffix, such as "when"
- * @param defaultAffixes if the test style recommends test affixes by default, such as BehaviorSpec
+ * @param defaultAffixes if the test style recommends test affixes by default, such as [`BehaviorSpec`][io.kotest.core.spec.style.BehaviorSpec]
  */
 data class TestName(
    val testName: String,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/IsolationMode.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/IsolationMode.kt
@@ -4,7 +4,7 @@ enum class IsolationMode {
 
    /**
     * A single instance of the [Spec] class is instantiated,
-    * and then used for every [TestCase].
+    * and then used for every [io.kotest.core.test.TestCase].
     *
     * Test cases will be executed as soon as they are discovered.
     */
@@ -12,11 +12,12 @@ enum class IsolationMode {
 
    /**
     * A new instance of the [Spec] class is instantiated for every
-    * [TestCase] - both containers and leaf tests - and they are
+    * [io.kotest.core.test.TestCase] - both containers and leaf tests - and they are
     * executed once the previous test has completed.
     *
     * For example, in the following test plan:
     *
+    * ```
     * "this test" {
     *   println("a")
     *   "nested test" {
@@ -26,24 +27,29 @@ enum class IsolationMode {
     *     println("c")
     *   }
     * }
+    * ```
     *
     * The output will be:
+    *
+    * ```text
     * a
     * a
     * b
     * a
     * c
+    * ```
     *
     */
    InstancePerTest,
 
    /**
     * A new instance of the [Spec] class is instantiated for every
-    * leaf [TestCase]. Container test cases are executed only as
+    * leaf [io.kotest.core.test.TestCase]. Container test cases are executed only as
     * part of the path to a leaf test.
     *
     * For example, in the following test plan:
     *
+    * ```
     * "this test" {
     *   println("a")
     *   "nested test" {
@@ -53,12 +59,16 @@ enum class IsolationMode {
     *     println("c")
     *   }
     * }
+    * ```
     *
     * The output will be:
+    *
+    * ```text
     * a
     * b
     * a
     * c
+    * ```
     */
    InstancePerLeaf
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -40,9 +40,15 @@ import kotlin.js.JsName
  *
  * For example, to set a default timeout for all tests in a spec, one can do either:
  *
- * `timeout = 100.seconds`
+ * ```
+ * timeout = 100.seconds
+ * ```
  *
- * or `override fun timeout() = 100.seconds`
+ * or
+ *
+ * ```
+ * override fun timeout() = 100.seconds
+ * ```
  *
  * The former is useful for declaring inside an init block and the latter useful for outside.
  * They are functionally equivalent.
@@ -52,11 +58,15 @@ import kotlin.js.JsName
  *
  * For example, to apply a before-test callback, one can do either:
  *
- * `beforeTest { println("bonjour!") }`
+ * ```
+ * beforeTest { println("bonjour!") }
+ * ```
  *
  * or
  *
- * `override fun beforeTest() { println("bonjour!") }`
+ * ```
+ * override fun beforeTest() { println("bonjour!") }
+ * ```
  *
  * Functions to register [AutoCloseable] instances can be found in [AutoClosing].
  *
@@ -110,7 +120,7 @@ abstract class Spec : TestConfiguration() {
    open fun testCaseOrder(): TestCaseOrder? = null
 
    /**
-    * Returns the timeout to be used by each test case. This value is overriden by a timeout
+    * Returns the timeout to be used by each test case. This value is overridden by a timeout
     * specified on a [TestCase] itself.
     *
     * If this value returns null, and the test case does not define a timeout, then the project
@@ -119,7 +129,7 @@ abstract class Spec : TestConfiguration() {
    open fun timeout(): Long? = null
 
    /**
-    * Returns the invocation timeout to be used by each test case. This value is overriden by a
+    * Returns the invocation timeout to be used by each test case. This value is overridden by a
     * value specified on a [TestCase] itself.
     *
     * If this value returns null, and the test case does not define an invocation timeout, then
@@ -138,7 +148,7 @@ abstract class Spec : TestConfiguration() {
    open fun tags(): Set<Tag> = emptySet()
 
    /**
-    * Sets the [AssertionMode] to be used by test cases in this spec. This value is overriden
+    * Sets the [AssertionMode] to be used by test cases in this spec. This value is overridden
     * by a value specified on a [TestCase] itself.
     *
     * If this value returns null, and the test case does not define a value, then the project
@@ -231,14 +241,14 @@ abstract class Spec : TestConfiguration() {
     * When this value is false, the framework is free to assign different dispatchers to different
     * root tests (nested tests always run in the same thread as their parent test).
     *
-    * Note: This setting has no effect unless the number of threads is increasd; see [ProjectConfiguration.parallelism].
+    * Note: This setting has no effect unless the number of threads is increased; see [ProjectConfiguration.parallelism].
     */
    @ExperimentalKotest
    @JsName("dispatcherAffinity_js")
    var dispatcherAffinity: Boolean? = null
 
    /**
-    * Sets a millisecond timeout for each test case in this spec unless overriden in the test config itself.
+    * Sets a millisecond timeout for each test case in this spec unless overridden in the test config itself.
     *
     * If this value is null, and the [SpecFunctionConfiguration.timeout] is also null, the project default will be used.
     */
@@ -246,7 +256,7 @@ abstract class Spec : TestConfiguration() {
    var timeout: Long? = null
 
    /**
-    * Sets a millisecond invocation timeout for each test case in this spec unless overriden in the test config itself.
+    * Sets a millisecond invocation timeout for each test case in this spec unless overridden in the test config itself.
     * If this value is null, and the [SpecFunctionConfiguration.invocationTimeout] is also null,
     * the project default will be used.
     *
@@ -265,7 +275,7 @@ abstract class Spec : TestConfiguration() {
    /**
     * When set to true, execution will switch to a dedicated thread for each test
     * case in this spec, therefore allowing the test engine to safely interrupt
-    * tests via Thread.interrupt when they time out.
+    * tests via `Thread.interrupt` when they time out.
     *
     * This is useful if you are testing blocking code and want to use timeouts
     * because coroutine timeouts are cooperative by nature.
@@ -282,9 +292,11 @@ abstract class Spec : TestConfiguration() {
    var coroutineDispatcherFactory: CoroutineDispatcherFactory? = null
 
    /**
-    * If set to true then the test engine will install a [TestDispatcher].
+    * If set to true then the test engine will install a
+    * [`TestDispatcher`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/).
     * This can be retrieved via `delayController` in your tests.
-    * @see https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
+    *
+    * See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
     */
    @ExperimentalKotest
    @Deprecated("Replaced with coroutineTestScope. Deprecated since 5.3")

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/SpecRef.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/SpecRef.kt
@@ -6,8 +6,8 @@ import kotlin.reflect.KClass
  * A [SpecRef] is a reference to a spec that was detected during classpath
  * scanning or during compilation.
  *
- * On platforms that lack reflective capability, such as nodeJS, web or kotlin/native,
- * specs are preconstructed or constructed through a simple function. On the JVM, the
+ * On platforms that lack reflective capability, such as nodeJS, web or Kotlin/Native,
+ * specs are pre-constructed or constructed through a simple function. On JVM, the
  * powerful reflection support means instances can be created via the [KClass] reference.
  */
 sealed interface SpecRef {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope.kt
@@ -13,18 +13,21 @@ typealias BehaviorSpecGivenContainerContext = BehaviorSpecGivenContainerScope
 /**
  * A context that allows tests to be registered using the syntax:
  *
+ * ```
  * when("some test")
  * when("some test").config(...)
  * xwhen("some disabled test")
  * xwhen("some disabled test").config(...)
+ * ```
  *
  * and
  *
+ * ```
  * then("some test")
  * then("some test").config(...)
  * xthen("some disabled test").config(...)
  * xthen("some disabled test").config(...)
- *
+ * ```
  */
 @Suppress("FunctionName")
 @KotestTestScope

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
@@ -8,8 +8,10 @@ typealias BehaviorSpecRootContext = BehaviorSpecRootScope
 /**
  * A context that allows tests to be registered using the syntax:
  *
+ * ```
  * given("some test")
  * xgiven("some disabled test")
+ * ```
  */
 interface BehaviorSpecRootScope : RootScope {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope.kt
@@ -13,14 +13,17 @@ typealias BehaviorSpecWhenContainerContext = BehaviorSpecWhenContainerScope
 /**
  * A context that allows tests to be registered using the syntax:
  *
+ * ```
  * then("some test")
  * then("some test").config(...)
+ * ```
  *
  * or disabled tests via:
  *
+ * ```
  * xthen("some disabled test")
  * xthen("some disabled test").config(...)
- *
+ * ```
  */
 @Suppress("FunctionName")
 @KotestTestScope

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
@@ -15,18 +15,24 @@ typealias DescribeSpecContainerContext = DescribeSpecContainerScope
 /**
  * A scope that allows tests to be registered using the syntax:
  *
+ * ```
  * describe("some test")
+ * ```
  *
  * or
  *
+ * ```
  * xdescribe("some disabled test")
+ * ```
  *
  * and
  *
+ * ```
  * it("some test")
  * it("some test").config(...)
  * xit("some test")
  * xit("some test").config(...)
+ * ```
  */
 @KotestTestScope
 class DescribeSpecContainerScope(

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
@@ -10,11 +10,15 @@ typealias DescribeSpecRootContext = DescribeSpecRootScope
 /**
  * A context that allows root tests to be registered using the syntax:
  *
+ * ```
  * describe("some test")
+ * ```
  *
  * or
  *
+ * ```
  * xdescribe("some disabled test")
+ * ```
  */
 interface DescribeSpecRootScope : RootScope {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerScope.kt
@@ -14,16 +14,19 @@ typealias ExpectSpecContainerContext = ExpectSpecContainerScope
 /**
  * A context that allows tests to be registered using the syntax:
  *
+ * ```
  * context("some test")
  * xcontext("some disabled test")
+ * ```
  *
  * and
  *
+ * ```
  * expect("some test")
  * expect("some test").config(...)
  * xexpect("some test")
  * xexpect("some test").config(...)
- *
+ * ```
  */
 @KotestTestScope
 class ExpectSpecContainerScope(

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
@@ -14,16 +14,19 @@ typealias FeatureSpecContainerContext = FeatureSpecContainerScope
 /**
  * A scope that allows tests to be registered using the syntax:
  *
+ * ```
  * feature("some context")
  * xfeature("some disabled context")
+ * ```
  *
  * and
  *
+ * ```
  * scenario("some test")
  * scenario("some test").config(...)
  * xscenario("some test")
  * xscenario("some test").config(...)
- *
+ * ```
  */
 class FeatureSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(testScope) {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecRootScope.kt
@@ -9,10 +9,12 @@ typealias FeatureSpecRootContext = FeatureSpecRootScope
 /**
  * Extends [RootScope] with dsl-methods for the 'fun spec' style.
  *
- * Eg:
- *   feature("some context") { }
- *   xfeature("some test") { }
+ * E.g.:
  *
+ * ```
+ * feature("some context") { }
+ * xfeature("some test") { }
+ * ```
  */
 interface FeatureSpecRootScope : RootScope {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
@@ -36,7 +36,10 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
    /**
     * Adds a configured test to this scope as a leaf test.
     *
-    * eg, "this test".config(...) { }
+    * E.g.
+    * ```
+    * "this test".config(...) { }
+    * ```
     */
    suspend fun String.config(
       enabled: Boolean? = null,
@@ -76,7 +79,10 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
    /**
     * Adds the contained config and test to this scope as a container test.
     *
-    * eg, "this test".config(...) - { }
+    * E.g.
+    * ```
+    * "this test".config(...) - { }
+    * ```
     */
    suspend infix operator fun FreeSpecContextConfigBuilder.minus(test: suspend FreeSpecContainerScope.() -> Unit) {
       registerContainer(TestName(name), false, config) { FreeSpecContainerScope(this).test() }
@@ -85,8 +91,10 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
    /**
     * Starts a config builder, which can be added to the scope by invoking [minus] on the returned value.
     *
-    * eg, "this test".config(...) - { }
-    *
+    * E.g.
+    * ```
+    * "this test".config(...) - { }
+    * ```
     */
    fun String.config(
       enabled: Boolean? = null,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecRootScope.kt
@@ -29,7 +29,11 @@ interface FreeSpecRootScope : RootScope {
    /**
     * Starts a config builder, which can be added to the scope by invoking [minus] on the returned value.
     *
-    * eg, "this test".config(...) - { }
+    * E.g.
+    *
+    * ```
+    * "this test".config(...) - { }
+    * ```
     */
    fun String.config(
       enabled: Boolean? = null,
@@ -65,7 +69,10 @@ interface FreeSpecRootScope : RootScope {
    /**
     * Adds the contained config and test to this scope as a container test.
     *
-    * eg, "this test".config(...) - { }
+    * E.g.
+    * ```
+    * "this test".config(...) - { }
+    * ```
     */
    infix operator fun FreeSpecContextConfigBuilder.minus(test: suspend FreeSpecContainerScope.() -> Unit) {
       addContainer(TestName(name), false, config) { FreeSpecContainerScope(this).test() }
@@ -74,7 +81,10 @@ interface FreeSpecRootScope : RootScope {
    /**
     * Adds a configured test to this scope as a leaf test.
     *
-    * eg, "this test".config(...) { }
+    * E.g.
+    * ```
+    * "this test".config(...) { }
+    * ```
     */
    fun String.config(
       enabled: Boolean? = null,
@@ -108,4 +118,3 @@ interface FreeSpecRootScope : RootScope {
       addTest(TestName(this), false, config, test)
    }
 }
-

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerScope.kt
@@ -15,10 +15,11 @@ typealias ShouldSpecContainerContext = ShouldSpecContainerScope
 /**
  * A scope that allows tests to be registered using the syntax:
  *
+ * ```
  * context("some context")
  * should("some test")
  * should("some test").config(...)
- *
+ * ```
  */
 @KotestTestScope
 class ShouldSpecContainerScope(

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecRootScope.kt
@@ -10,17 +10,21 @@ typealias ShouldSpecRootContext = ShouldSpecRootScope
 /**
  * Allows tests to be registered in the 'ShouldSpec' fashion.
  *
- *  context("with context") {
- *    should("do something") {
- *      // test here
- *    }
- *  }
+ * ```
+ * context("with context") {
+ *   should("do something") {
+ *     // test here
+ *   }
+ * }
+ * ```
  *
  *  or
  *
- *  should("do something") {
- *    // test here
- *  }
+ * ```
+ * should("do something") {
+ *   // test here
+ * }
+ * ```
  */
 interface ShouldSpecRootScope : RootScope {
 
@@ -56,7 +60,7 @@ interface ShouldSpecRootScope : RootScope {
 
    /**
     * Adds a top level test, with the given name and test function, with test config supplied
-    * by invoking .config on the return of this function.
+    * by invoking [`.config()`][RootContainerWithConfigBuilder.config] on the return of this function.
     */
    fun should(name: String): RootTestWithConfigBuilder =
       RootTestWithConfigBuilder(this, TestName("should ", name, true), false)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecRootScope.kt
@@ -60,7 +60,7 @@ interface ShouldSpecRootScope : RootScope {
 
    /**
     * Adds a top level test, with the given name and test function, with test config supplied
-    * by invoking [`.config()`][RootContainerWithConfigBuilder.config] on the return of this function.
+    * by invoking [.config()][RootContainerWithConfigBuilder.config] on the return of this function.
     */
    fun should(name: String): RootTestWithConfigBuilder =
       RootTestWithConfigBuilder(this, TestName("should ", name, true), false)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/StringSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/StringSpecRootScope.kt
@@ -19,11 +19,11 @@ typealias StringSpecRootContext = StringSpecRootScope
  * Defines the DSL for creating tests in the 'StringSpec' style.
  *
  * Example:
- *
+ * ```
  * "my test" {
  *   1 + 1 shouldBe 2
  * }
- *
+ * ```
  */
 interface StringSpecRootScope : RootScope {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerScope.kt
@@ -18,11 +18,15 @@ typealias WordSpecShouldContainerContext = WordSpecShouldContainerScope
 /**
  * A scope that allows tests to be registered using the syntax:
  *
+ * ```
  * "some context" { }
+ * ```
  *
  * or
  *
+ * ```
  * "some context".config(...) { }
+ * ```
  *
  */
 @KotestTestScope

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
@@ -19,7 +19,7 @@ object TestDslState {
 
    /**
     * Will throw an exception if we had a test that was not constructed properly (looks
-    * for any test where we invoked .config but did not pass in a test lambda aftewards).
+    * for any test where we invoked .config but did not pass in a test lambda afterwards).
     */
    fun checkState() {
       val unfinished = started.map { "Test was not fully defined: $it" }
@@ -33,5 +33,3 @@ object TestDslState {
       }
    }
 }
-
-

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/AssertionMode.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/AssertionMode.kt
@@ -15,8 +15,11 @@ package io.kotest.core.test
  * Note: There are valid use cases for not having an assertion. For example, testing that some code will
  * compile is a valid use case, and the successful return of the compiler is sufficient test.
  *
- * Warning: This mode will only work with kotest-assertions. If you are using another
- * assertion library, such as `kotlin.test` or AssertJ, then this setting will have no effect.
+ * Warning: This mode will only work with
+ * [`kotest-assertions`](https://kotest.io/docs/assertions/assertions.html).
+ * If you are using another assertion library, such as
+ * [`kotlin.test`](https://kotlinlang.org/api/latest/kotlin.test/) or
+ * [AssertJ](https://assertj.github.io/doc/), then this setting will have no effect.
  */
 enum class AssertionMode {
    Error, Warn, None

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/AssertionMode.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/AssertionMode.kt
@@ -7,16 +7,16 @@ package io.kotest.core.test
  * is probably erroneous (see note). It is common to see junior developers write a test that does not actually test
  * anything.
  *
- * Therefore by setting [AssertionMode] to [Error] or [Warn], the lack of assertions in a test will cause
+ * Therefore, by setting [AssertionMode] to [Error] or [Warn], the lack of assertions in a test will cause
  * the test to fail, or a warning to be outputted respectively.
  *
- * The default value of [None] is the status quo - absense of assertions will cause no issues.
+ * The default value of [None] is the status quo - absence of assertions will cause no issues.
  *
  * Note: There are valid use cases for not having an assertion. For example, testing that some code will
  * compile is a valid use case, and the successful return of the compiler is sufficient test.
  *
  * Warning: This mode will only work with kotest-assertions. If you are using another
- * assertions library, such as kotlin.test or assertJ, then this setting will have no effect.
+ * assertion library, such as `kotlin.test` or AssertJ, then this setting will have no effect.
  */
 enum class AssertionMode {
    Error, Warn, None

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/AssertionMode.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/AssertionMode.kt
@@ -1,7 +1,7 @@
 package io.kotest.core.test
 
 /**
- * AssertionMode is used to detect and warn a developer that a test does not execute any assertions.
+ * [AssertionMode] is used to detect and warn a developer that a test does not execute any assertions.
  *
  * It is usually the case that if a test function does not execute some kind of assertion then the test
  * is probably erroneous (see note). It is common to see junior developers write a test that does not actually test

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/Identifiers.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/Identifiers.kt
@@ -12,9 +12,9 @@ object Identifiers {
     * Each test name must be unique. We can use the toString if we determine the instance is stable.
     *
     * An instance is considered stable if it is a data class where each parameter is either a data class itself,
-    * or one of the [primitiveTypes]. Or if the type of instance is annotated with [IsStableType].
+    * or one of the [io.kotest.mpp.primitiveTypes]. Or if the type of instance is annotated with [io.kotest.datatest.IsStableType].
     *
-    * Note: If the user has overridden toString() and the returned value is not stable, tests may not appear.
+    * Note: If the user has overridden `toString()` and the returned value is not stable, tests may not appear.
     */
    fun stableIdentifier(t: Any): String {
       return if (isStable(t::class)) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCase.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCase.kt
@@ -64,14 +64,14 @@ data class TestCase(
 }
 
 /**
- * Returns true if this test is focused.
+ * Returns `true` if this test is focused.
  *
- * A focused test case is one which is defined at the top level and has a f: prefix
+ * A focused test case is one which is defined at the top level and has a `f:` prefix
  */
 fun TestCase.isFocused() = this.parent == null && name.focus
 
 /**
- * Returns true if this descriptor represents a root test case.
+ * Returns `true` if this descriptor represents a root test case.
  *
  * A root test case is one which is defined at the top level in a spec.
  */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCase.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCase.kt
@@ -25,18 +25,21 @@ import io.kotest.core.test.config.ResolvedTestConfig
  *
  * For example, in the FunSpec we only allow top level tests.
  *
+ * ```
  * test("this is a test") { }
+ * ```
  *
  * And in WordSpec we allow two levels of tests.
  *
+ * ```
  * "a string" should {
  *   "return the length" {
  *   }
  * }
- *
+ * ```
  */
 data class TestCase(
-   // parseable, stable, consistent identifer for this test element
+   // parseable, stable, consistent identifier for this test element
    val descriptor: Descriptor.TestDescriptor,
    // the name of the test as entered by the user
    val name: TestName,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCaseOrder.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCaseOrder.kt
@@ -1,7 +1,7 @@
 package io.kotest.core.test
 
 /**
- * This enum is used to configure the order of root test execution in a [Spec].
+ * This enum is used to configure the order of root test execution in a [io.kotest.core.spec.Spec].
  */
 enum class TestCaseOrder {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestType.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestType.kt
@@ -3,24 +3,25 @@ package io.kotest.core.test
 import io.kotest.common.ExperimentalKotest
 
 /**
- * Test's in Kotest are arranged in a tree with the "Engine" sitting at the root, and each
- * Spec sitting directly under the Engine.
+ * Tests in Kotest are arranged in a tree with the "Engine" sitting at the root, and each
+ * [`Spec`][io.kotest.core.spec.Spec] sitting directly under the Engine.
  *
- * Tests then sit under each Spec. If a test is a leaf node and is not permitted to contain
- * other tests, then we say it has type "Test". If a test is a parent node and is permitted
- * to contain other nodes, then we say it is a "Container". If a test is
+ * Tests then sit under each [`Spec`][io.kotest.core.spec.Spec].
+ *
+ * * If a test is a leaf node and is not permitted to contain other tests, then we say it has type "Test".
+ * * If a test is a parent node and is permitted to contain other nodes, then we say it is a "Container".
  */
 enum class TestType {
 
    /**
     * A container that can contain other tests.
-    * Used when a test has been defined programatically via the DSL.
+    * Used when a test has been defined programmatically via the DSL.
     */
    Container,
 
    /**
     * A leaf test that cannot contain nested tests.
-    * Used when a test has been defined programatically via the DSL.
+    * Used when a test has been defined programmatically via the DSL.
     */
    Test,
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestType.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestType.kt
@@ -4,9 +4,9 @@ import io.kotest.common.ExperimentalKotest
 
 /**
  * Tests in Kotest are arranged in a tree with the "Engine" sitting at the root, and each
- * [`Spec`][io.kotest.core.spec.Spec] sitting directly under the Engine.
+ * [Spec][io.kotest.core.spec.Spec] sitting directly under the Engine.
  *
- * Tests then sit under each [`Spec`][io.kotest.core.spec.Spec].
+ * Tests then sit under each [Spec][io.kotest.core.spec.Spec].
  *
  * * If a test is a leaf node and is not permitted to contain other tests, then we say it has type "Test".
  * * If a test is a parent node and is permitted to contain other nodes, then we say it is a "Container".

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/ResolvedTestConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/ResolvedTestConfig.kt
@@ -9,7 +9,7 @@ import io.kotest.core.test.TestCaseSeverityLevel
 import kotlin.time.Duration
 
 /**
- * Runtime resolved config attached to a [TestCase].
+ * Runtime resolved config attached to a [io.kotest.core.test.TestCase].
  *
  * Settings specified here have been resolved against spec level and project level defaults
  * and are the final definitive settings to be used by a test case.
@@ -69,10 +69,11 @@ data class ResolvedTestConfig(
    val coroutineDebugProbes: Boolean,
 
    /**
-    * If set to true then the test engine will install a [TestDispatcher].
+    * If set to true then the test engine will install a
+    * [`TestDispatcher`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/).
     * This can be retrieved via `delayController` in your tests.
     *
-    * @see https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
+    * See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
     */
    @Deprecated("Replaced with coroutineTestScope. Deprecated since 5.3")
    val testCoroutineDispatcher: Boolean,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/UnresolvedTestConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/UnresolvedTestConfig.kt
@@ -64,10 +64,11 @@ data class UnresolvedTestConfig(
    val coroutineDebugProbes: Boolean? = null,
 
    /**
-    * If set to true then the test engine will install a [TestCoroutineDispatcher].
+    * If set to true then the test engine will install a
+    * [`TestDispatcher`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-test/kotlinx.coroutines.test/-test-dispatcher/).
     * This can be retrieved via `delayController` in your tests.
     *
-    * @see https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
+    * See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-test/index.html
     */
    @Deprecated("Replaced with coroutineTestScope. Deprecated since 5.3")
    val testCoroutineDispatcher: Boolean? = null,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/namecase.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/namecase.kt
@@ -2,5 +2,5 @@ package io.kotest.core.test
 
 import io.kotest.core.names.TestNameCase
 
-@Deprecated("Relocated to io.kotest.core.names.TestNameCase. This typelias will be removed in 6.0")
+@Deprecated("Relocated to io.kotest.core.names.TestNameCase. This typealias will be removed in 6.0")
 typealias TestNameCase = TestNameCase

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/status.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/status.kt
@@ -1,15 +1,15 @@
 package io.kotest.core.test
 
 enum class TestStatus {
-   // the test was skipped completely
+   /** The test was skipped completely */
    Ignored,
 
-   // the test was successful
+   /** The test was successful */
    Success,
 
-   // the test failed because of some exception that was not an assertion error
+   /** The test failed because of some exception that was not an assertion error */
    Error,
 
-   // the test ran but an assertion failed
+   /** The test ran but an assertion failed */
    Failure
 }

--- a/kotest-framework/kotest-framework-engine/src/jsMain/kotlin/io/kotest/engine/externalTestMethods.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsMain/kotlin/io/kotest/engine/externalTestMethods.kt
@@ -1,12 +1,35 @@
 package io.kotest.engine
 
-/**
- * Defines the jasmine/mocha/karma style test function names as external functions.
- * Then we can invoke them from the test engine.
- *
- * Note: At runtime, one of the supported JS test frameworks must make these functions available.
- */
-external fun describe(name: String, fn: () -> Unit)
-external fun xdescribe(name: String, fn: () -> Unit)
-external fun it(name: String, fn: (dynamic) -> Any?): dynamic
-external fun xit(name: String, fn: () -> Any?)
+///**
+// * Defines the jasmine/mocha/karma style test function names as external functions.
+// * Then we can invoke them from the test engine.
+// *
+// * Note: At runtime, one of the supported JS test frameworks must make these functions available.
+// */
+//external fun describe(name: String, fn: () -> Unit)
+//external fun xdescribe(name: String, fn: () -> Unit)
+//external fun it(name: String, fn: (dynamic) -> Any?): dynamic
+//external fun xit(name: String, fn: () -> Any?)
+
+@JsModule("kotlin-test")
+@JsNonModule
+private external val kotlinTestJsModule: dynamic
+
+
+internal fun suite(name: String, ignored: Boolean, suiteFn: () -> Unit) {
+   kotlinTestJsModule.kotlin.test.suite(name, ignored) {
+      suiteFn()
+   }
+}
+
+internal fun test(name: String, ignored: Boolean, testFn: () -> Any?) {
+   kotlinTestJsModule.kotlin.test.test(name, ignored) {
+      testFn()
+   }
+}
+
+internal fun suite(name: String, suiteFn: () -> Unit) = suite(name, ignored = false, suiteFn)
+internal fun xsuite(name: String, suiteFn: () -> Unit) = suite(name, ignored = true, suiteFn)
+
+internal fun test(name: String, testFn: () -> Any?) = test(name, ignored = false, testFn)
+internal fun xtest(name: String, testFn: () -> Any?) = test(name, ignored = true, testFn)

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/createSpecExecutorDelegate.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/createSpecExecutorDelegate.kt
@@ -75,13 +75,18 @@ class JvmSpecExecutorDelegate(
 /**
  * Returns the concurrent tests count to use for tests in this spec.
  *
- * If threads is specified on the spec, then that will implicitly raise the concurrentTests
- * count to the same value if concurrentTests is not specified.
+ * If threads is specified on the spec, then that will implicitly raise the
+ * [concurrentTests][io.kotest.core.config.AbstractProjectConfig.concurrentTests]
+ * count to the same value if
+ * [concurrentTests][io.kotest.core.config.AbstractProjectConfig.concurrentTests]
+ * is not specified.
  *
- * Note that if this spec is annotated with @Isolate then the value
- * will be 1 regardless of the config setting.
+ * Note that if this spec is annotated with [@Isolate][io.kotest.core.annotation.Isolate] then
+ * the value will be 1 regardless of the config setting.
  *
+ * ```
  * spec.concurrency ?: configuration.concurrentTests
+ * ```
  */
 @OptIn(ExperimentalKotest::class)
 internal fun Spec.resolvedConcurrentTests(defaultConcurrentTests: Int): Int {

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerLeafSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerLeafSpecRunner.kt
@@ -39,26 +39,26 @@ internal class InstancePerLeafSpecRunner(
    private val extensions = SpecExtensions(configuration.registry)
    private val results = mutableMapOf<TestCase, TestResult>()
 
-   // keeps track of tests we've already discovered
+   /** keeps track of tests we've already discovered */
    private val seen = mutableSetOf<Descriptor>()
 
-   // keeps track of tests we've already notified the listener about
+   /** keeps track of tests we've already notified the listener about */
    private val ignored = mutableSetOf<Descriptor>()
    private val started = mutableSetOf<Descriptor>()
 
-   // we keep a count to break ties (first discovered)
+   /** we keep a count to break ties (first discovered) */
    data class Enqueued(val testCase: TestCase, val count: Int)
 
    private val counter = AtomicInteger(0)
 
-   // the queue contains tests discovered to run next. We always run the tests with the "furthest" path first.
+   /** the queue contains tests discovered to run next. We always run the tests with the "furthest" path first. */
    private val queue = PriorityQueue(Comparator<Enqueued> { o1, o2 ->
       val o1s = o1.testCase.descriptor.depth()
       val o2s = o2.testCase.descriptor.depth()
       if (o1s == o2s) o1.count.compareTo(o2.count) else o2s.compareTo(o1s)
    })
 
-   // enqueues a test case that will execute in it's own spec instance
+   /** enqueues a test case that will execute in its own spec instance */
    private fun enqueue(testCase: TestCase) {
       queue.add(Enqueued(testCase, counter.incrementAndGet()))
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerTestSpecRunner.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/runners/InstancePerTestSpecRunner.kt
@@ -34,17 +34,20 @@ import kotlin.coroutines.CoroutineContext
  *
  * So, given the following structure:
  *
- *  outerTest {
- *    innerTestA {
- *      // test
- *    }
- *    innerTestB {
- *      // test
- *    }
- *  }
+ * ```
+ * outerTest {
+ *   innerTestA {
+ *     // test
+ *   }
+ *   innerTestB {
+ *     // test
+ *   }
+ * }
+ * ```
  *
  * Three spec instances will be created. The execution process will be:
  *
+ * ```
  * spec1 = instantiate spec
  * spec1.outerTest
  * spec2 = instantiate spec
@@ -53,6 +56,7 @@ import kotlin.coroutines.CoroutineContext
  * spec3 = instantiate spec
  * spec3.outerTest
  * spec3.innerTestB
+ * ```
  */
 @ExperimentalKotest
 internal class InstancePerTestSpecRunner(


### PR DESCRIPTION
Docs only changes

* Fixed code links to work when the class isn't imported
* Added code fence backticks to multiline code blocks
* minor spelling fixes