### PR TITLE
Update test-coroutine-dispatcher docs

### DIFF
--- a/documentation/docs/framework/coroutines/test_coroutine_dispatcher.md
+++ b/documentation/docs/framework/coroutines/test_coroutine_dispatcher.md
@@ -72,6 +72,6 @@ Finally, you can enable test dispatchers for all tests in a module by using [Pro
 
 ```kotlin
 class ProjectConfig : AbstractProjectConfig() {
-  override var testCoroutineDispatcher = true
+  override var coroutineTestScope = true
 }
 ```

--- a/documentation/versioned_docs/version-5.5/framework/coroutines/test_coroutine_dispatcher.md
+++ b/documentation/versioned_docs/version-5.5/framework/coroutines/test_coroutine_dispatcher.md
@@ -72,6 +72,6 @@ Finally, you can enable test dispatchers for all tests in a module by using [Pro
 
 ```kotlin
 class ProjectConfig : AbstractProjectConfig() {
-  override var testCoroutineDispatcher = true
+  override var coroutineTestScope = true
 }
 ```


### PR DESCRIPTION
`coroutineTestScope` was added to `AbstractProjectConfig` in v5.5.5, so I've updated docs according to #3383.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
