### PR TITLE
docs: Fix example of nested clues

### DIFF
--- a/documentation/docs/assertions/clues.md
+++ b/documentation/docs/assertions/clues.md
@@ -123,10 +123,10 @@ Clues can be nested, and they all will be visible in the failed assertion messag
 
 ```kotlin
 { "Verifying user_id=${user.name}" }.asClue {
-  "email_confirmed should be false since we've just created the user" {
+  "email_confirmed should be false since we've just created the user".asClue {
     user.emailConfirmed shouldBe false
   }
-  "login" {
+  "login".asClue {
     user.login shouldBe "sksamuel"
   }
 }

--- a/documentation/versioned_docs/version-5.5/assertions/clues.md
+++ b/documentation/versioned_docs/version-5.5/assertions/clues.md
@@ -123,10 +123,10 @@ Clues can be nested, and they all will be visible in the failed assertion messag
 
 ```kotlin
 { "Verifying user_id=${user.name}" }.asClue {
-  "email_confirmed should be false since we've just created the user" {
+  "email_confirmed should be false since we've just created the user".asClue {
     user.emailConfirmed shouldBe false
   }
-  "login" {
+  "login".asClue {
     user.login shouldBe "sksamuel"
   }
 }


### PR DESCRIPTION
It looks like `.asClue` is missed in example of nested clues usage