### PR TITLE
BlockHound extension: Fix handling of nested tests (#3454)

### DIFF
--- a/kotest-extensions/kotest-extensions-blockhound/src/jvmMain/kotlin/io/kotest/extensions/blockhound/BlockHound.kt
+++ b/kotest-extensions/kotest-extensions-blockhound/src/jvmMain/kotlin/io/kotest/extensions/blockhound/BlockHound.kt
@@ -12,6 +12,9 @@ enum class BlockHoundMode {
 
 data class BlockHound(private val mode: BlockHoundMode = BlockHoundMode.ERROR) : TestCaseExtension {
    override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
+      // Skip intercepting lower level tests in case of nesting.
+      if (testCase.parent != null) return execute(testCase)
+
       initialize()
 
       require (activeExtension == null) {

--- a/kotest-extensions/kotest-extensions-blockhound/src/jvmTest/kotlin/io/kotest/extensions/blockhound/BlockHoundTest.kt
+++ b/kotest-extensions/kotest-extensions-blockhound/src/jvmTest/kotlin/io/kotest/extensions/blockhound/BlockHoundTest.kt
@@ -49,6 +49,12 @@ class BlockHoundSpecTest : FunSpec({
       }
    }
 
+   context("nested test") {
+      test("child test") {
+         shouldThrow<BlockingOperationError> { blockInNonBlockingContext() }
+      }
+   }
+
    /*
       test("configuration failure").config(extensions = listOf(BlockHound(BlockHoundMode.PRINT))) {
          // Cannot register a BlockHound extension twice (spec plus test case).


### PR DESCRIPTION
Skip intercepting lower level tests in case of nesting as described in #3454.