### PR TITLE
add language annotation to json matchers

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -63,7 +63,7 @@ private fun equalJsonTree(
 
 data class JsonTree(val root: JsonNode, val raw: String)
 
-infix fun String.shouldEqualJson(expected: String): String {
+infix fun String.shouldEqualJson(@KotestLanguage("json", "", "") expected: String): String {
    this should equalJson(expected, CompareJsonOptions())
    return this
 }
@@ -79,7 +79,7 @@ infix fun String.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions
    return this
 }
 
-infix fun String.shouldNotEqualJson(expected: String): String {
+infix fun String.shouldNotEqualJson(@KotestLanguage("json", "", "") expected: String): String {
    this shouldNot equalJson(expected, CompareJsonOptions())
    return this
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -15,11 +15,29 @@ import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.az
 import io.kotest.property.arbitrary.numericDouble
 import io.kotest.property.arbitrary.string
+import io.kotest.property.assume
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.boolean
 
 class EqualTest : FunSpec() {
    init {
+      test("compare non equal objects") {
+         val arb = Arb.string(1 .. 10, Codepoint.az())
+         checkAll(arb, arb) {a,b ->
+            assume( a != b)
+
+            val left = """{ "a": "$a" }"""
+            val right = """{ "a": "$b" }"""
+
+            left shouldNotEqualJson right
+         }
+
+         val a = """ { "a" : "foo", "b" : "bar" } """
+
+         shouldFail {
+            a shouldNotEqualJson a
+         }.shouldHaveMessage("Expected values to not match")
+      }
 
       test("comparing strings in objects") {
 


### PR DESCRIPTION
this is a follow-up to https://github.com/kotest/kotest/pull/3438

this adds the `@KotestLanguage` annotation to the `expected` param of the matchers `shouldEqualJson` and `shouldNotEqualJson`. This is to enable proper syntax hightlighting in IntelliJ.

* also add a test for shouldNotEqualJson matcher as apparently there was none

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
