### PR TITLE
fix map edgecases

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
@@ -24,38 +24,41 @@ import io.kotest.property.Shrinker
  */
 fun <K, V> Arb.Companion.map(
    arb: Arb<Pair<K, V>>,
-   minSize: Int = 1,
+   minSize: Int = 0,
    maxSize: Int = 100,
-   slippage: Int = 10,
-   includeEmpty: Boolean = true
-): Arb<Map<K, V>> = arbitrary(mapEdgeCases(includeEmpty), MapShrinker(minSize)) { random ->
-   val targetSize = random.random.nextInt(minSize, maxSize)
-   val maxMisses = targetSize * slippage
-   val map = mutableMapOf<K, V>()
-   var iterations = 0
-   while (iterations < maxMisses && map.size < targetSize) {
-      val initialSize = map.size
-      val (key, value) = arb.single(random)
-      map[key] = value
-      if (map.size == initialSize) iterations++
-   }
+   slippage: Int = 10
+): Arb<Map<K, V>> {
 
-   require(map.size >= minSize) {
-      "the minimum size requirement of $minSize could not be satisfied after $iterations consecutive samples"
-   }
+   require(minSize >= 0) { "minSize must be positive" }
+   require(maxSize >= 0) { "maxSize must be positive" }
+   val edgecase = if (minSize == 0) listOf(emptyMap<K, V>()) else emptyList()
 
-   map
+   return arbitrary(edgecase, MapShrinker(minSize)) { random ->
+      val targetSize = random.random.nextInt(minSize, maxSize)
+      val maxMisses = targetSize * slippage
+      val map = mutableMapOf<K, V>()
+      var iterations = 0
+      while (iterations < maxMisses && map.size < targetSize) {
+         val initialSize = map.size
+         val (key, value) = arb.single(random)
+         map[key] = value
+         if (map.size == initialSize) iterations++
+      }
+
+      require(map.size >= minSize) {
+         "the minimum size requirement of $minSize could not be satisfied after $iterations consecutive samples"
+      }
+
+      map
+   }
 }
-
-private fun <K,V> mapEdgeCases(includeEmpty: Boolean): List<Map<K,V>> =
-   if (includeEmpty) listOf(emptyMap()) else emptyList()
 
 /**
  * Returns an [Arb] where each generated value is a map, with the entries of the map
  * drawn by combining values from the key gen and value gen. The size of each
  * generated map is a random value between the specified min and max bounds.
  *
- * There are no edge cases.
+ * The edgecase of this map is an empty map which is only specified when minSize = 0.
  *
  * This arbitrary uses a [Shrinker] which will reduce the size of a failing map by
  * removing elements until they map is empty.
@@ -75,32 +78,10 @@ private fun <K,V> mapEdgeCases(includeEmpty: Boolean): List<Map<K,V>> =
 fun <K, V> Arb.Companion.map(
    keyArb: Arb<K>,
    valueArb: Arb<V>,
-   minSize: Int = 1,
+   minSize: Int = 0,
    maxSize: Int = 100,
-   slippage: Int = 10,
-   includeEmpty: Boolean = true
-): Arb<Map<K, V>> {
-   require(minSize >= 0) { "minSize must be positive" }
-   require(maxSize >= 0) { "maxSize must be positive" }
-
-   return arbitrary(mapEdgeCases(includeEmpty), MapShrinker(minSize)) { random ->
-      val targetSize = random.random.nextInt(minSize, maxSize)
-      val maxMisses = targetSize * slippage
-      val map = mutableMapOf<K, V>()
-      var iterations = 0
-      while (iterations < maxMisses && map.size < targetSize) {
-         val initialSize = map.size
-         map[keyArb.single(random)] = valueArb.single(random)
-         if (map.size == initialSize) iterations++
-      }
-
-      require(map.size >= minSize) {
-         "the minimum size requirement of $minSize could not be satisfied after $iterations consecutive samples"
-      }
-
-      map
-   }
-}
+   slippage: Int = 10
+): Arb<Map<K, V>> = Arb.map(Arb.pair(keyArb, valueArb), minSize, maxSize, slippage)
 
 class MapShrinker<K, V>(private val minSize: Int) : Shrinker<Map<K, V>> {
    override fun shrink(value: Map<K, V>): List<Map<K, V>> {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
@@ -108,12 +108,12 @@ class MapsTest : FunSpec({
    }
 
    context("Arb.map(arb,arb) edgecases") {
-      test("should be empty if disabled") {
-         Arb.map(keyArb = Arb.string(), valueArb = Arb.int(), includeEmpty = false).edgecase(RandomSource.seeded(1234L)).shouldBeNull()
+      test("should be empty if minSize is larger than 0") {
+         Arb.map(keyArb = Arb.string(), valueArb = Arb.int(), minSize = 1).edgecase(RandomSource.seeded(1234L)).shouldBeNull()
       }
 
-      test("should contain empty map if enabled") {
-         Arb.map(keyArb = Arb.string(), valueArb = Arb.int(), includeEmpty = true).edgecase(RandomSource.seeded(1234L))
+      test("should contain empty map if minSize is 0 (default)") {
+         Arb.map(keyArb = Arb.string(), valueArb = Arb.int()).edgecase(RandomSource.seeded(1234L))
             .shouldNotBeNull()
             .shouldBeEmpty()
       }
@@ -121,11 +121,11 @@ class MapsTest : FunSpec({
 
    context("Arb.map(arb) edgecases") {
       test("should be empty if disabled") {
-         Arb.map(arb = Arb.pair(Arb.string(), Arb.int()), includeEmpty = false).edgecase(RandomSource.seeded(1234L)).shouldBeNull()
+         Arb.map(arb = Arb.pair(Arb.string(), Arb.int()), minSize = 1).edgecase(RandomSource.seeded(1234L)).shouldBeNull()
       }
 
       test("should contain empty map if enabled") {
-         Arb.map(arb = Arb.pair(Arb.string(), Arb.int()), includeEmpty = true).edgecase(RandomSource.seeded(1234L))
+         Arb.map(arb = Arb.pair(Arb.string(), Arb.int())).edgecase(RandomSource.seeded(1234L))
             .shouldNotBeNull()
             .shouldBeEmpty()
       }


### PR DESCRIPTION
# in this PR
- remove recently added includeEmpty arg in favour of edgecase derived from minSize. 
- modify edgecase generation logic to be determined by minSize instead
- This ensures sane generation of edgecases based on the parameter provided in the map

# Context

The recently added includeEmpty arg was introduced in 5.6.0 and was causing the regression