### PR TITLE
Adding shouldHaveSameInstantAs matcher for OffsetDateTime. Fixes #3488

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -209,6 +209,11 @@ Matchers provided by the `kotest-assertions-core` module.
 | `zonedDateTime.shouldBeToday()`                               | Asserts that the ZonedDateTime has the same day as the today. |
 | `zonedDateTime.shouldHaveSameInstantAs(other: ZonedDateTime)` | Asserts that the ZonedDateTime is equal to other ZonedDateTime using ```ChronoZonedDateTime.isEqual```. |
 
+| OffsetDateTime                                                  |                                                                                                      |
+|-----------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `offsetDateTime.shouldBeToday()`                                | Asserts that the OffsetDateTime has the same day as today.                                           |
+| `offsetDateTime.shouldHaveSameInstantAs(other: OffsetDateTime)` | Asserts that the OffsetDateTime is equal to other OffsetDateTime using ```OffsetDateTime.isEqual```. |
+
 | Times                                         ||
 |-----------------------------------------------| ---- |
 | `time.shouldHaveSameHoursAs(otherTime)`       | Asserts that the time has the same hours as the given time. |

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/offsetdatetime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/offsetdatetime.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 fun beInTodayODT() = object : Matcher<OffsetDateTime> {
    override fun test(value: OffsetDateTime): MatcherResult {
@@ -37,3 +38,77 @@ fun OffsetDateTime.shouldBeToday() = this should beInTodayODT()
  */
 fun OffsetDateTime.shouldNotBeToday() = this shouldNot beInTodayODT()
 
+/**
+ * Asserts that this is equal to [other] using the [OffsetDateTime.isEqual]
+ *
+ * Opposite of [OffsetDateTime.shouldNotHaveSameInstantAs]
+ *
+ * ```
+ *    val date = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldHaveSameInstantAs(other)  // Assertion passes
+ *
+ *
+ *    val date = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldHaveSameInstantAs(other)  // Assertion fails, date is NOT equal to the other date
+ * ```
+ *
+ * @see OffsetDateTime.shouldNotHaveSameInstantAs
+ */
+infix fun OffsetDateTime.shouldHaveSameInstantAs(other: OffsetDateTime) = this should haveSameInstantAs(other)
+
+/**
+ * Asserts that this is NOT equal to [other] using the [OffsetDateTime.isEqual]
+ *
+ * Opposite of [OffsetDateTime.shouldHaveSameInstantAs]
+ *
+ * ```
+ *    val date = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldNotHaveSameInstantAs(other)  // Assertion passes
+ *
+ *
+ *    val date = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.shouldNotHaveSameInstantAs(other)  // Assertion fails, date is equal to the other date
+ * ```
+ *
+ * @see OffsetDateTime.shouldHaveSameInstantAs
+ */
+infix fun OffsetDateTime.shouldNotHaveSameInstantAs(other: OffsetDateTime) = this shouldNot haveSameInstantAs(other)
+
+/**
+ * Matcher that checks if OffsetDateTime is equal to another OffsetDateTime using the
+ * [OffsetDateTime.isEqual]
+ *
+ *
+ * ```
+ *    val date = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.haveSameInstantAs(other)  // Assertion passes
+ *
+ *
+ *    val date = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *    val other = OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-3))
+ *
+ *    date.haveSameInstantAs(other)  // Assertion fails, date is NOT equal to the other date
+ * ```
+ *
+ * @see OffsetDateTime.shouldHaveSameInstantAs
+ * @see OffsetDateTime.shouldNotHaveSameInstantAs
+ */
+fun haveSameInstantAs(other: OffsetDateTime) = object : Matcher<OffsetDateTime> {
+   override fun test(value: OffsetDateTime): MatcherResult =
+      MatcherResult(
+         passed = value.isEqual(other),
+         failureMessageFn = { "$value should be equal to $other" },
+         negatedFailureMessageFn = {
+            "$value should not be equal to $other"
+         })
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
@@ -419,5 +419,12 @@ class DateMatchersTest : StringSpec() {
        ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNot haveSameInstantAs(ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2)))
        ZonedDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotHaveSameInstantAs ZonedDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2))
     }
+
+     "OffsetDateTime should be have same instant of the given OffsetDateTime irrespective of their timezone" {
+        OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) should haveSameInstantAs(OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3)))
+        OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldHaveSameInstantAs OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-3))
+        OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNot haveSameInstantAs(OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2)))
+        OffsetDateTime.of(2019, 2, 16, 11, 0, 0, 0, ZoneOffset.ofHours(-1)) shouldNotHaveSameInstantAs OffsetDateTime.of(2019, 2, 16, 9, 0, 0, 0, ZoneOffset.ofHours(-2))
+     }
   }
 }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
