### PR TITLE
Simple POC to check if #3482 would be doable

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
@@ -1,6 +1,7 @@
 package io.kotest.core.spec.style.scopes
 
 import io.kotest.core.Tuple2
+import io.kotest.core.factory.TestFactory
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.names.TestName
 import io.kotest.core.source.sourceRef
@@ -198,6 +199,18 @@ interface ContainerScope : TestScope {
             if (thisTestCase.descriptor.isAncestorOf(testCase.descriptor)) f(Tuple2(testCase, result))
          }
       })
+   }
+
+   suspend fun include(factory: TestFactory) {
+      factory.tests.forEach { test ->
+         registerTest(
+            test.name,
+            test.disabled ?: false,
+            test.config,
+            test.type,
+            test.test,
+         )
+      }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/nestedFactoryOrderingTests.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/nestedFactoryOrderingTests.kt
@@ -36,6 +36,16 @@ class NestedFactoriesShouldInlineTest : FunSpec() {
    }
 }
 
+class FactoryInContainerTest : FunSpec({
+   context("foo") {
+      include(factory1(StringBuilder()))
+
+      test("bar") {
+         1 shouldBe 2
+      }
+   }
+})
+
 class NestedFactoriesShouldRespectTestOrderFunctionOverrideTest : FunSpec() {
 
    override fun testCaseOrder() = TestCaseOrder.Lexicographic


### PR DESCRIPTION
Initially it seems promising. 

Test factories create `RootTest`s however, and I'm not sure if there could be any implications from passing the data from them to register new tests within a container. 

Need to check how this affects:
- [ ] Tags
- [ ] Extensions
- [ ] AssertionMode

