### PR TITLE
Adding changelog for v5.6.2

### DIFF
--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -6,9 +6,42 @@ slug: changelog.html
 
 ## 5.6.2 May 2023
 
+#### Assertions
+* Adding shouldHaveSameInstantAs matcher for OffsetDateTime. Fixes #3488 by @Kantis in https://github.com/kotest/kotest/pull/3501
+
+#### Property testing
 * Fixes a problem with property testing on Apple platforms [#3506](https://github.com/kotest/kotest/issues/3506)
-* Reverts behaviour of `Arb.string()` to only generate Strings of printable ascii characters.
+* Reverts behaviour of `Arb.string()` to only generate Strings of printable ascii characters
   * 5.6.0 changed it to include some control characters, see [#3513](https://github.com/kotest/kotest/issues/3513) for details
+* Fix huge allocation for OffsetDateTime Arb without arguments by @rescribet in https://github.com/kotest/kotest/pull/3491
+* Fix Arb.map edgecases by @myuwono in https://github.com/kotest/kotest/pull/3496
+
+
+#### Documentation
+* Update writing_tests.md by @erikhuizinga in https://github.com/kotest/kotest/pull/3497
+* Update shouldBeEqualToComparingFields doc by @ktrueda in https://github.com/kotest/kotest/pull/3416
+
+#### Other
+* Build Kotlin/Native library for ARM64 on Linux by @charleskorn in https://github.com/kotest/kotest/pull/3521
+
+### ⚠️ Reverted behavior of `Arb.string()`
+
+With Kotest 5.6.0, `Codepoint.ascii()` was changed to include a wider range of ascii chararacters, and `Codepoint.printableAscii()` was introduced with the historic range used by `Codepoint.ascii()`.
+
+`Arb.string()` has been using `Codepoint.ascii()` as it's default for generating chars for the string. This caused issues for some users, and we decided to revert `Arb.string()` to the historic behavior by changing the default to the new `Codepoint.printableAscii()`.
+
+Hopefully this doesn't cause any issues for you. If it does, you can revert to the 5.6.0 ~ 5.6.1 behavior by using  `Codepoint.ascii()` explicitly.
+
+If you added explicit usage of `Codepoint.printableAscii()` to circumvent the issue, you can safely remove the explicit parameter starting with Kotest 5.6.2.
+
+
+### New Contributors
+* @rescribet made their first contribution in https://github.com/kotest/kotest/pull/3491
+* @ktrueda made their first contribution in https://github.com/kotest/kotest/pull/3416
+* @erikhuizinga made their first contribution in https://github.com/kotest/kotest/pull/3497
+
+**Full Changelog**: https://github.com/kotest/kotest/compare/v5.6.1...v5.6.2
+
 
 ## 5.6.1 April 2023
 

--- a/documentation/docs/changelog.md
+++ b/documentation/docs/changelog.md
@@ -4,6 +4,12 @@ sidebar_label: Changelog
 slug: changelog.html
 ---
 
+## 5.6.2 May 2023
+
+* Fixes a problem with property testing on Apple platforms [#3506](https://github.com/kotest/kotest/issues/3506)
+* Reverts behaviour of `Arb.string()` to only generate Strings of printable ascii characters.
+  * 5.6.0 changed it to include some control characters, see [#3513](https://github.com/kotest/kotest/issues/3513) for details
+
 ## 5.6.1 April 2023
 
 ** This release is mainly to add some missing klib dependencies for ios **

--- a/documentation/versioned_docs/version-5.6/changelog.md
+++ b/documentation/versioned_docs/version-5.6/changelog.md
@@ -4,6 +4,12 @@ sidebar_label: Changelog
 slug: changelog.html
 ---
 
+## 5.6.2 May 2023
+
+* Fixes a problem with property testing on Apple platforms [#3506](https://github.com/kotest/kotest/issues/3506)
+* Reverts behaviour of `Arb.string()` to only generate Strings of printable ascii characters.
+  * 5.6.0 changed it to include some control characters, see [#3513](https://github.com/kotest/kotest/issues/3513) for details
+
 ## 5.6.1 April 2023
 
 ** This release is mainly to add some missing klib dependencies for ios **

--- a/documentation/versioned_docs/version-5.6/changelog.md
+++ b/documentation/versioned_docs/version-5.6/changelog.md
@@ -6,9 +6,41 @@ slug: changelog.html
 
 ## 5.6.2 May 2023
 
+#### Assertions
+* Adding shouldHaveSameInstantAs matcher for OffsetDateTime. Fixes #3488 by @Kantis in https://github.com/kotest/kotest/pull/3501
+
+#### Property testing
 * Fixes a problem with property testing on Apple platforms [#3506](https://github.com/kotest/kotest/issues/3506)
-* Reverts behaviour of `Arb.string()` to only generate Strings of printable ascii characters.
+* Reverts behaviour of `Arb.string()` to only generate Strings of printable ascii characters
   * 5.6.0 changed it to include some control characters, see [#3513](https://github.com/kotest/kotest/issues/3513) for details
+* Fix huge allocation for OffsetDateTime Arb without arguments by @rescribet in https://github.com/kotest/kotest/pull/3491
+* Fix Arb.map edgecases by @myuwono in https://github.com/kotest/kotest/pull/3496
+
+
+#### Documentation
+* Update writing_tests.md by @erikhuizinga in https://github.com/kotest/kotest/pull/3497
+* Update shouldBeEqualToComparingFields doc by @ktrueda in https://github.com/kotest/kotest/pull/3416
+
+#### Other
+* Build Kotlin/Native library for ARM64 on Linux by @charleskorn in https://github.com/kotest/kotest/pull/3521
+
+### ⚠️ Reverted behavior of `Arb.string()`
+
+With Kotest 5.6.0, `Codepoint.ascii()` was changed to include a wider range of ascii chararacters, and `Codepoint.printableAscii()` was introduced with the historic range used by `Codepoint.ascii()`.
+
+`Arb.string()` has been using `Codepoint.ascii()` as it's default for generating chars for the string. This caused issues for some users, and we decided to revert `Arb.string()` to the historic behavior by changing the default to the new `Codepoint.printableAscii()`.
+
+Hopefully this doesn't cause any issues for you. If it does, you can revert to the 5.6.0 ~ 5.6.1 behavior by using  `Codepoint.ascii()` explicitly.
+
+If you added explicit usage of `Codepoint.printableAscii()` to circumvent the issue, you can safely remove the explicit parameter starting with Kotest 5.6.2.
+
+
+### New Contributors
+* @rescribet made their first contribution in https://github.com/kotest/kotest/pull/3491
+* @ktrueda made their first contribution in https://github.com/kotest/kotest/pull/3416
+* @erikhuizinga made their first contribution in https://github.com/kotest/kotest/pull/3497
+
+**Full Changelog**: https://github.com/kotest/kotest/compare/v5.6.1...v5.6.2
 
 ## 5.6.1 April 2023
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
