### PR TITLE
fix(docs): fix annotation typo and add link to Spring docs

### DIFF
--- a/doc/reference_3.1.md
+++ b/doc/reference_3.1.md
@@ -1023,7 +1023,8 @@ KotlinTest offers a Spring extension that allows you to test code that wires dep
 To use this extension add the `kotlintest-extensions-spring` module to your test compile path.
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use
+[`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 There are two ways to enable spring wiring depending on if you want to use constructor injection, or field injection.

--- a/documentation/docs/extensions/spring.md
+++ b/documentation/docs/extensions/spring.md
@@ -37,11 +37,12 @@ class MyTestSpec : FunSpec() {
 ```
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use
+[`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 :::note
-In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality. 
+In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality.
 :::
 
 ### Constructor Injection

--- a/documentation/versioned_docs/version-5.2/extensions/spring.md
+++ b/documentation/versioned_docs/version-5.2/extensions/spring.md
@@ -37,11 +37,12 @@ class MyTestSpec : FunSpec() {
 ```
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use
+[`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 :::note
-In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality. 
+In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality.
 :::
 
 ### Constructor Injection

--- a/documentation/versioned_docs/version-5.3/extensions/spring.md
+++ b/documentation/versioned_docs/version-5.3/extensions/spring.md
@@ -37,11 +37,12 @@ class MyTestSpec : FunSpec() {
 ```
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use
+[`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 :::note
-In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality. 
+In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality.
 :::
 
 ### Constructor Injection

--- a/documentation/versioned_docs/version-5.4/extensions/spring.md
+++ b/documentation/versioned_docs/version-5.4/extensions/spring.md
@@ -37,11 +37,12 @@ class MyTestSpec : FunSpec() {
 ```
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use
+[`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 :::note
-In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality. 
+In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality.
 :::
 
 ### Constructor Injection

--- a/documentation/versioned_docs/version-5.5/extensions/spring.md
+++ b/documentation/versioned_docs/version-5.5/extensions/spring.md
@@ -37,11 +37,12 @@ class MyTestSpec : FunSpec() {
 ```
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use
+[`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 :::note
-In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality. 
+In Kotest 4.3 and earlier, the Spring extension was called `SpringListener`. This extension has now been deprecated in favour of `SpringExtension`. The usage is the same, but the SpringExtension has more functionality.
 :::
 
 ### Constructor Injection

--- a/documentation/versioned_docs/version-5.6/extensions/spring.md
+++ b/documentation/versioned_docs/version-5.6/extensions/spring.md
@@ -37,7 +37,7 @@ class MyTestSpec : FunSpec() {
 ```
 
 In order to let Spring know which configuration class to use, you must annotate your Spec classes with `@ContextConfiguration`.
-This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use `@ActiveProfile` to
+This should point to a class annotated with the Spring `@Configuration` annotation. Alternatively, you can use [`@ActiveProfiles`](https://docs.spring.io/spring-framework/reference/testing/annotations/integration-spring/annotation-activeprofiles.html) to
 point to a [specific application context file](https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html).
 
 :::note


### PR DESCRIPTION
Spring Framework uses `@ActiveProfiles` annotation in integration tests.

This PR fixes the typo and adds a link to the Spring Framework documentation on the `@ActiveProfiles` annotation.
