### PR TITLE
add exhaustive enumsExcept

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/enum.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/enum.kt
@@ -6,3 +6,8 @@ inline fun <reified T : Enum<T>> Exhaustive.Companion.enum(): Exhaustive<T> {
    val constants = enumValues<T>().asList()
    return exhaustive(constants)
 }
+
+inline fun <reified T : Enum<T>> Exhaustive.Companion.enumsExcept(vararg elements: T): Exhaustive<T> {
+   val constants = enumValues<T>().toMutableList().apply { removeAll(elements.toSet()) }
+   return exhaustive(constants)
+}


### PR DESCRIPTION
`Exhaustive.Companion.enum()` helps to get an Exhaustive of all enums of a enum class.

However, sometimes we need to test that some predicate is `true` for exact enums of a enum class and `false` for remaining enums. Here `enumsExcept` function may help

P.S: is it okay that `./gradlew apiDump` didn't add anything?