### PR TITLE
Update build to use Gradle toolchains and modern JDK

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -26,7 +26,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'temurin'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 
@@ -57,7 +57,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'temurin'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 
@@ -105,7 +105,7 @@ jobs:
          -  name: Setup JDK
             uses: actions/setup-java@v3
             with:
-               java-version: '8'
+               java-version: '17'
                distribution: 'temurin'
 
          -  uses: gradle/gradle-build-action@v2
@@ -142,7 +142,7 @@ jobs:
          -  name: Setup JDK
             uses: actions/setup-java@v3
             with:
-               java-version: '8'
+               java-version: '17'
                distribution: 'temurin'
 
          -  uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release_base.yml
+++ b/.github/workflows/release_base.yml
@@ -46,7 +46,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release_ios.yml
+++ b/.github/workflows/release_ios.yml
@@ -44,7 +44,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -42,7 +42,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release_multiplatform_plugin_gradle.yml
+++ b/.github/workflows/release_multiplatform_plugin_gradle.yml
@@ -29,7 +29,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release_tvos.yml
+++ b/.github/workflows/release_tvos.yml
@@ -43,7 +43,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release_watchos.yml
+++ b/.github/workflows/release_watchos.yml
@@ -45,7 +45,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -36,7 +36,7 @@ jobs:
             uses: actions/setup-java@v3
             with:
                distribution: 'adopt'
-               java-version: '8'
+               java-version: '17'
 
          -  uses: gradle/gradle-build-action@v2
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,6 +7,10 @@ repositories {
    gradlePluginPortal()
 }
 
+kotlin {
+   jvmToolchain(17)
+}
+
 dependencies {
    implementation(libs.testlogger.gradle.plugin)
    implementation(libs.kotlin.gradle.plugin)

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
    kotlin("multiplatform")
@@ -33,10 +34,13 @@ tasks.withType<KotlinCompile>().configureEach {
       )
       apiVersion = "1.8"
       languageVersion = "1.8"
+      compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
    }
 }
 
 kotlin {
+   jvmToolchain(17)
+
    sourceSets.configureEach {
       languageSettings {
          optIn("kotlin.time.ExperimentalTime")
@@ -44,4 +48,8 @@ kotlin {
          optIn("kotlin.contracts.ExperimentalContracts")
       }
    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+   options.release.set(8)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,8 @@ kotlin.native.ignoreDisabledTargets=true
 systemProp.kotlin.native.disableCompilerDaemon=true
 org.gradle.configureondemand=false
 kotlin.mpp.stability.nowarn=true
+# https://youtrack.jetbrains.com/issue/KT-58063 (should be fixed in Kotlin 1.9)
+org.gradle.configuration-cache=false
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/kotest-extensions/build.gradle.kts
+++ b/kotest-extensions/build.gradle.kts
@@ -25,3 +25,7 @@ kotlin {
       }
    }
 }
+
+tasks.withType<Test>().configureEach {
+   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+}

--- a/kotest-extensions/kotest-extensions-blockhound/build.gradle.kts
+++ b/kotest-extensions/kotest-extensions-blockhound/build.gradle.kts
@@ -17,3 +17,7 @@ kotlin {
       }
    }
 }
+
+tasks.withType<Test>().configureEach {
+   jvmArgs("-XX:+AllowRedefinitionToAddDeleteMethods") // https://github.com/reactor/BlockHound/issues/33
+}

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -52,3 +52,7 @@ kotlin {
       }
    }
 }
+
+tasks.withType<Test>().configureEach {
+   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+}

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
-import org.gradle.internal.impldep.io.opencensus.tags.Tags
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
    kotlin("jvm")
@@ -92,6 +93,19 @@ gradlePlugin {
    }
 }
 
+kotlin {
+   jvmToolchain(17)
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+   kotlinOptions {
+      compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+   }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+   options.release.set(8)
+}
 
 val updateKotestPluginConstants by tasks.registering(Sync::class) {
 

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/test-project/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/test-project/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
    id("org.jetbrains.kotlin.multiplatform")
@@ -15,6 +17,8 @@ val kotestVersion: String by project
 val useNewNativeMemoryModel: String by project
 
 kotlin {
+   jvmToolchain(17)
+
    jvm()
 
    js(IR) {

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/test-project/gradle.properties
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/test-project/gradle.properties
@@ -1,0 +1,2 @@
+# https://youtrack.jetbrains.com/issue/KT-58063 (should be fixed in Kotlin 1.9)
+org.gradle.configuration-cache=false


### PR DESCRIPTION
I've checked out Kotest repository and couldn't build it because I'm using JDK20. This PR is a suggestion on how this could be fixed: now contributors can run the build using any JDK they want, and Gradle will download JDK used for the build itself. This ensures all developers and CI will use the same JDK to build the project, and the resulting artifacts will always target the same bytecode