### PR TITLE
Update documentation to fix typographical error

### DIFF
--- a/documentation/versioned_docs/version-5.6/framework/extensions/advanced.md
+++ b/documentation/versioned_docs/version-5.6/framework/extensions/advanced.md
@@ -8,7 +8,7 @@ sidebar_label: Advanced Extensions
 This table lists more advanced extensions that can be used to hook into the Engine itself to:
 
   * intercept tests, skipping them, and modify test results
-  * intercept specs specs skipping them if required
+  * intercept specs, skipping them if required
   * post process spec instances after instantiation
   * modify the coroutine context used by specs and tests
   * apply custom instantiation logic


### PR DESCRIPTION
Fix typographical error on the "Advanced Extensions" page in the documentation.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
