### PR TITLE
Feature/improve arrow documentation

### DIFF
--- a/documentation/docs/assertions/arrow.md
+++ b/documentation/docs/assertions/arrow.md
@@ -10,7 +10,7 @@ sidebar_label: Arrow
 This page lists all current matchers in the Kotest arrow matchers extension library.
 
 :::note
-The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently from the main Kotest project.
+The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently of the main Kotest project.
 Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
 :::
 

--- a/documentation/docs/assertions/arrow.md
+++ b/documentation/docs/assertions/arrow.md
@@ -18,33 +18,33 @@ Search maven central for latest version [here](https://central.sonatype.com/sear
 In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, please add it. To prevent Unresolved Reference errors.
 :::
 
-| Option | |
-| -------- | ---- |
-| `option.shouldBeSome()` | Asserts that the option is of type Some and returns value |
-| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v |
-| `option.shouldBeNone()` | Asserts that the option is of type None |
+| Option                   |                                                           |
+|--------------------------|-----------------------------------------------------------|
+| `option.shouldBeSome()`  | Asserts that the option is of type Some and returns value |
+| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v      |
+| `option.shouldBeNone()`  | Asserts that the option is of type None                   |
 
-| Either | |
-| -------- | ---- |
-| `either.shouldBeRight()` | Asserts that the either is of type Right and returns the Right value |
-| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
-| `either.shouldBeLeft()` | Asserts that the either is of type Left and returns the Left value |
-| `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| Either                    |                                                                      |
+|---------------------------|----------------------------------------------------------------------|
+| `either.shouldBeRight()`  | Asserts that the either is of type Right and returns the Right value |
+| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v      |
+| `either.shouldBeLeft()`   | Asserts that the either is of type Left and returns the Left value   |
+| `either.shouldBeLeft(v)`  | Asserts that the either is of type Left with specific value v        |
 
-| NonEmptyList | |
-| -------- | ---- |
-| `nel.shouldContain(e)` | Asserts that the NonEmptyList contains the given element e |
+| NonEmptyList                         |                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------|
+| `nel.shouldContain(e)`               | Asserts that the NonEmptyList contains the given element e                 |
 | `nel.shouldContainAll(e1,e2,...,en)` | Asserts that the NonEmptyList contains all the given elements e1,e2,...,en |
-| `nel.shouldContainNull()` | Asserts that the NonEmptyList contains at least one null |
-| `nel.shouldContainNoNulls()` | Asserts that the NonEmptyList contains no nulls |
-| `nel.shouldContainOnlyNulls()` | Asserts that the NonEmptyList contains only nulls or is empty |
-| `nel.shouldHaveDuplicates()` | Asserts that the NonEmptyList has at least one duplicate |
-| `nel.shouldBeSingleElement(e)` | Asserts that the NonEmptyList has a single element which is e |
-| `nel.shouldBeSorted()` | Asserts that the NonEmptyList is sorted |
+| `nel.shouldContainNull()`            | Asserts that the NonEmptyList contains at least one null                   |
+| `nel.shouldContainNoNulls()`         | Asserts that the NonEmptyList contains no nulls                            |
+| `nel.shouldContainOnlyNulls()`       | Asserts that the NonEmptyList contains only nulls or is empty              |
+| `nel.shouldHaveDuplicates()`         | Asserts that the NonEmptyList has at least one duplicate                   |
+| `nel.shouldBeSingleElement(e)`       | Asserts that the NonEmptyList has a single element which is e              |
+| `nel.shouldBeSorted()`               | Asserts that the NonEmptyList is sorted                                    |
 
-| Validated | |
-| -------- | ---- |
-| `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
-| `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
-| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
-| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v |
+| Validated                      |                                                                             |
+|--------------------------------|-----------------------------------------------------------------------------|
+| `validated.shouldBeValid()`    | Asserts that the validated is of type Valid and returns the Valid value     |
+| `validated.shouldBeValid(v)`   | Asserts that the validated is of type Valid with specific value v           |
+| `validated.shouldBeInvalid()`  | Asserts that the validated is of type Invalid and returns the Invalid value |
+| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v         |

--- a/documentation/docs/assertions/arrow.md
+++ b/documentation/docs/assertions/arrow.md
@@ -11,7 +11,7 @@ This page lists all current matchers in the Kotest arrow matchers extension libr
 
 :::note
 The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently from the main Kotest project.
-Search maven central for latest version [here](https://search.maven.org/search?q=kotest-assertions-arrow).
+Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
 :::
 
 :::note

--- a/documentation/versioned_docs/version-5.2/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.2/assertions/arrow.md
@@ -5,7 +5,7 @@ sidebar_label: Arrow
 ---
 
 
-This page lists all current matchers in the Kotest arrow matchers extension library. 
+This page lists all current matchers in the Kotest arrow matchers extension library.
 
 To use this library you need to add `io.kotest.extensions:kotest-assertions-arrow` to your build.
 
@@ -13,32 +13,32 @@ To use this library you need to add `io.kotest.extensions:kotest-assertions-arro
 In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, please add it. To prevent Unresolved Reference errors.
 :::
 
-| Option | |
-| -------- | ---- |
-| `option.shouldBeSome()` | Asserts that the option is of type Some and returns value |
-| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v |
-| `option.shouldBeNone()` | Asserts that the option is of type None |
+| Option                   |                                                           |
+|--------------------------|-----------------------------------------------------------|
+| `option.shouldBeSome()`  | Asserts that the option is of type Some and returns value |
+| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v      |
+| `option.shouldBeNone()`  | Asserts that the option is of type None                   |
 
-| Either | |
-| -------- | ---- |
-| `either.shouldBeRight()` | Asserts that the either is of type Right and returns the Right value |
-| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
-| `either.shouldBeLeft()` | Asserts that the either is of type Left and returns the Left value |
-| `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| Either                    |                                                                      |
+|---------------------------|----------------------------------------------------------------------|
+| `either.shouldBeRight()`  | Asserts that the either is of type Right and returns the Right value |
+| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v      |
+| `either.shouldBeLeft()`   | Asserts that the either is of type Left and returns the Left value   |
+| `either.shouldBeLeft(v)`  | Asserts that the either is of type Left with specific value v        |
 
-| NonEmptyList | |
-| -------- | ---- |
-| `nel.shouldContain(e)` | Asserts that the NonEmptyList contains the given element e |
+| NonEmptyList                         |                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------|
+| `nel.shouldContain(e)`               | Asserts that the NonEmptyList contains the given element e                 |
 | `nel.shouldContainAll(e1,e2,...,en)` | Asserts that the NonEmptyList contains all the given elements e1,e2,...,en |
-| `nel.shouldContainNull()` | Asserts that the NonEmptyList contains at least one null |
-| `nel.shouldContainNoNulls()` | Asserts that the NonEmptyList contains no nulls |
-| `nel.shouldContainOnlyNulls()` | Asserts that the NonEmptyList contains only nulls or is empty |
-| `nel.shouldHaveDuplicates()` | Asserts that the NonEmptyList has at least one duplicate |
-| `nel.shouldBeSingleElement(e)` | Asserts that the NonEmptyList has a single element which is e |
-| `nel.shouldBeSorted()` | Asserts that the NonEmptyList is sorted |
+| `nel.shouldContainNull()`            | Asserts that the NonEmptyList contains at least one null                   |
+| `nel.shouldContainNoNulls()`         | Asserts that the NonEmptyList contains no nulls                            |
+| `nel.shouldContainOnlyNulls()`       | Asserts that the NonEmptyList contains only nulls or is empty              |
+| `nel.shouldHaveDuplicates()`         | Asserts that the NonEmptyList has at least one duplicate                   |
+| `nel.shouldBeSingleElement(e)`       | Asserts that the NonEmptyList has a single element which is e              |
+| `nel.shouldBeSorted()`               | Asserts that the NonEmptyList is sorted                                    |
 
-| Validated | |
-| -------- | ---- |
-| `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
-| `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
-| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
+| Validated                     |                                                                             |
+|-------------------------------|-----------------------------------------------------------------------------|
+| `validated.shouldBeValid()`   | Asserts that the validated is of type Valid and returns the Valid value     |
+| `validated.shouldBeValid(v)`  | Asserts that the validated is of type Valid with specific value v           |
+| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value |

--- a/documentation/versioned_docs/version-5.3/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.3/assertions/arrow.md
@@ -5,7 +5,7 @@ sidebar_label: Arrow
 ---
 
 
-This page lists all current matchers in the Kotest arrow matchers extension library. 
+This page lists all current matchers in the Kotest arrow matchers extension library.
 
 To use this library you need to add `io.kotest.extensions:kotest-assertions-arrow` to your build.
 
@@ -13,32 +13,32 @@ To use this library you need to add `io.kotest.extensions:kotest-assertions-arro
 In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, please add it. To prevent Unresolved Reference errors.
 :::
 
-| Option | |
-| -------- | ---- |
-| `option.shouldBeSome()` | Asserts that the option is of type Some and returns value |
-| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v |
-| `option.shouldBeNone()` | Asserts that the option is of type None |
+| Option                   |                                                           |
+|--------------------------|-----------------------------------------------------------|
+| `option.shouldBeSome()`  | Asserts that the option is of type Some and returns value |
+| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v      |
+| `option.shouldBeNone()`  | Asserts that the option is of type None                   |
 
-| Either | |
-| -------- | ---- |
-| `either.shouldBeRight()` | Asserts that the either is of type Right and returns the Right value |
-| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
-| `either.shouldBeLeft()` | Asserts that the either is of type Left and returns the Left value |
-| `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| Either                    |                                                                      |
+|---------------------------|----------------------------------------------------------------------|
+| `either.shouldBeRight()`  | Asserts that the either is of type Right and returns the Right value |
+| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v      |
+| `either.shouldBeLeft()`   | Asserts that the either is of type Left and returns the Left value   |
+| `either.shouldBeLeft(v)`  | Asserts that the either is of type Left with specific value v        |
 
-| NonEmptyList | |
-| -------- | ---- |
-| `nel.shouldContain(e)` | Asserts that the NonEmptyList contains the given element e |
+| NonEmptyList                         |                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------|
+| `nel.shouldContain(e)`               | Asserts that the NonEmptyList contains the given element e                 |
 | `nel.shouldContainAll(e1,e2,...,en)` | Asserts that the NonEmptyList contains all the given elements e1,e2,...,en |
-| `nel.shouldContainNull()` | Asserts that the NonEmptyList contains at least one null |
-| `nel.shouldContainNoNulls()` | Asserts that the NonEmptyList contains no nulls |
-| `nel.shouldContainOnlyNulls()` | Asserts that the NonEmptyList contains only nulls or is empty |
-| `nel.shouldHaveDuplicates()` | Asserts that the NonEmptyList has at least one duplicate |
-| `nel.shouldBeSingleElement(e)` | Asserts that the NonEmptyList has a single element which is e |
-| `nel.shouldBeSorted()` | Asserts that the NonEmptyList is sorted |
+| `nel.shouldContainNull()`            | Asserts that the NonEmptyList contains at least one null                   |
+| `nel.shouldContainNoNulls()`         | Asserts that the NonEmptyList contains no nulls                            |
+| `nel.shouldContainOnlyNulls()`       | Asserts that the NonEmptyList contains only nulls or is empty              |
+| `nel.shouldHaveDuplicates()`         | Asserts that the NonEmptyList has at least one duplicate                   |
+| `nel.shouldBeSingleElement(e)`       | Asserts that the NonEmptyList has a single element which is e              |
+| `nel.shouldBeSorted()`               | Asserts that the NonEmptyList is sorted                                    |
 
-| Validated | |
-| -------- | ---- |
-| `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
-| `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
-| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
+| Validated                     |                                                                             |
+|-------------------------------|-----------------------------------------------------------------------------|
+| `validated.shouldBeValid()`   | Asserts that the validated is of type Valid and returns the Valid value     |
+| `validated.shouldBeValid(v)`  | Asserts that the validated is of type Valid with specific value v           |
+| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value |

--- a/documentation/versioned_docs/version-5.4/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.4/assertions/arrow.md
@@ -5,7 +5,7 @@ sidebar_label: Arrow
 ---
 
 
-This page lists all current matchers in the Kotest arrow matchers extension library. 
+This page lists all current matchers in the Kotest arrow matchers extension library.
 
 To use this library you need to add `io.kotest.extensions:kotest-assertions-arrow` to your build.
 
@@ -13,32 +13,32 @@ To use this library you need to add `io.kotest.extensions:kotest-assertions-arro
 In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, please add it. To prevent Unresolved Reference errors.
 :::
 
-| Option | |
-| -------- | ---- |
-| `option.shouldBeSome()` | Asserts that the option is of type Some and returns value |
-| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v |
-| `option.shouldBeNone()` | Asserts that the option is of type None |
+| Option                   |                                                           |
+|--------------------------|-----------------------------------------------------------|
+| `option.shouldBeSome()`  | Asserts that the option is of type Some and returns value |
+| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v      |
+| `option.shouldBeNone()`  | Asserts that the option is of type None                   |
 
-| Either | |
-| -------- | ---- |
-| `either.shouldBeRight()` | Asserts that the either is of type Right and returns the Right value |
-| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
-| `either.shouldBeLeft()` | Asserts that the either is of type Left and returns the Left value |
-| `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| Either                    |                                                                      |
+|---------------------------|----------------------------------------------------------------------|
+| `either.shouldBeRight()`  | Asserts that the either is of type Right and returns the Right value |
+| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v      |
+| `either.shouldBeLeft()`   | Asserts that the either is of type Left and returns the Left value   |
+| `either.shouldBeLeft(v)`  | Asserts that the either is of type Left with specific value v        |
 
-| NonEmptyList | |
-| -------- | ---- |
-| `nel.shouldContain(e)` | Asserts that the NonEmptyList contains the given element e |
+| NonEmptyList                         |                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------|
+| `nel.shouldContain(e)`               | Asserts that the NonEmptyList contains the given element e                 |
 | `nel.shouldContainAll(e1,e2,...,en)` | Asserts that the NonEmptyList contains all the given elements e1,e2,...,en |
-| `nel.shouldContainNull()` | Asserts that the NonEmptyList contains at least one null |
-| `nel.shouldContainNoNulls()` | Asserts that the NonEmptyList contains no nulls |
-| `nel.shouldContainOnlyNulls()` | Asserts that the NonEmptyList contains only nulls or is empty |
-| `nel.shouldHaveDuplicates()` | Asserts that the NonEmptyList has at least one duplicate |
-| `nel.shouldBeSingleElement(e)` | Asserts that the NonEmptyList has a single element which is e |
-| `nel.shouldBeSorted()` | Asserts that the NonEmptyList is sorted |
+| `nel.shouldContainNull()`            | Asserts that the NonEmptyList contains at least one null                   |
+| `nel.shouldContainNoNulls()`         | Asserts that the NonEmptyList contains no nulls                            |
+| `nel.shouldContainOnlyNulls()`       | Asserts that the NonEmptyList contains only nulls or is empty              |
+| `nel.shouldHaveDuplicates()`         | Asserts that the NonEmptyList has at least one duplicate                   |
+| `nel.shouldBeSingleElement(e)`       | Asserts that the NonEmptyList has a single element which is e              |
+| `nel.shouldBeSorted()`               | Asserts that the NonEmptyList is sorted                                    |
 
-| Validated | |
-| -------- | ---- |
-| `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
-| `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
-| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
+| Validated                     |                                                                             |
+|-------------------------------|-----------------------------------------------------------------------------|
+| `validated.shouldBeValid()`   | Asserts that the validated is of type Valid and returns the Valid value     |
+| `validated.shouldBeValid(v)`  | Asserts that the validated is of type Valid with specific value v           |
+| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value |

--- a/documentation/versioned_docs/version-5.5/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.5/assertions/arrow.md
@@ -10,7 +10,7 @@ sidebar_label: Arrow
 This page lists all current matchers in the Kotest arrow matchers extension library.
 
 :::note
-The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently from the main Kotest project.
+The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently of the main Kotest project.
 Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
 :::
 

--- a/documentation/versioned_docs/version-5.5/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.5/assertions/arrow.md
@@ -18,33 +18,33 @@ Search maven central for latest version [here](https://central.sonatype.com/sear
 In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, please add it. To prevent Unresolved Reference errors.
 :::
 
-| Option | |
-| -------- | ---- |
-| `option.shouldBeSome()` | Asserts that the option is of type Some and returns value |
-| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v |
-| `option.shouldBeNone()` | Asserts that the option is of type None |
+| Option                   |                                                           |
+|--------------------------|-----------------------------------------------------------|
+| `option.shouldBeSome()`  | Asserts that the option is of type Some and returns value |
+| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v      |
+| `option.shouldBeNone()`  | Asserts that the option is of type None                   |
 
-| Either | |
-| -------- | ---- |
-| `either.shouldBeRight()` | Asserts that the either is of type Right and returns the Right value |
-| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
-| `either.shouldBeLeft()` | Asserts that the either is of type Left and returns the Left value |
-| `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| Either                    |                                                                      |
+|---------------------------|----------------------------------------------------------------------|
+| `either.shouldBeRight()`  | Asserts that the either is of type Right and returns the Right value |
+| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v      |
+| `either.shouldBeLeft()`   | Asserts that the either is of type Left and returns the Left value   |
+| `either.shouldBeLeft(v)`  | Asserts that the either is of type Left with specific value v        |
 
-| NonEmptyList | |
-| -------- | ---- |
-| `nel.shouldContain(e)` | Asserts that the NonEmptyList contains the given element e |
+| NonEmptyList                         |                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------|
+| `nel.shouldContain(e)`               | Asserts that the NonEmptyList contains the given element e                 |
 | `nel.shouldContainAll(e1,e2,...,en)` | Asserts that the NonEmptyList contains all the given elements e1,e2,...,en |
-| `nel.shouldContainNull()` | Asserts that the NonEmptyList contains at least one null |
-| `nel.shouldContainNoNulls()` | Asserts that the NonEmptyList contains no nulls |
-| `nel.shouldContainOnlyNulls()` | Asserts that the NonEmptyList contains only nulls or is empty |
-| `nel.shouldHaveDuplicates()` | Asserts that the NonEmptyList has at least one duplicate |
-| `nel.shouldBeSingleElement(e)` | Asserts that the NonEmptyList has a single element which is e |
-| `nel.shouldBeSorted()` | Asserts that the NonEmptyList is sorted |
+| `nel.shouldContainNull()`            | Asserts that the NonEmptyList contains at least one null                   |
+| `nel.shouldContainNoNulls()`         | Asserts that the NonEmptyList contains no nulls                            |
+| `nel.shouldContainOnlyNulls()`       | Asserts that the NonEmptyList contains only nulls or is empty              |
+| `nel.shouldHaveDuplicates()`         | Asserts that the NonEmptyList has at least one duplicate                   |
+| `nel.shouldBeSingleElement(e)`       | Asserts that the NonEmptyList has a single element which is e              |
+| `nel.shouldBeSorted()`               | Asserts that the NonEmptyList is sorted                                    |
 
-| Validated | |
-| -------- | ---- |
-| `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
-| `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
-| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
-| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v |
+| Validated                      |                                                                             |
+|--------------------------------|-----------------------------------------------------------------------------|
+| `validated.shouldBeValid()`    | Asserts that the validated is of type Valid and returns the Valid value     |
+| `validated.shouldBeValid(v)`   | Asserts that the validated is of type Valid with specific value v           |
+| `validated.shouldBeInvalid()`  | Asserts that the validated is of type Invalid and returns the Invalid value |
+| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v         |

--- a/documentation/versioned_docs/version-5.5/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.5/assertions/arrow.md
@@ -11,7 +11,7 @@ This page lists all current matchers in the Kotest arrow matchers extension libr
 
 :::note
 The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently from the main Kotest project.
-Search maven central for latest version [here](https://search.maven.org/search?q=kotest-assertions-arrow).
+Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
 :::
 
 :::note

--- a/documentation/versioned_docs/version-5.6/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.6/assertions/arrow.md
@@ -10,7 +10,7 @@ sidebar_label: Arrow
 This page lists all current matchers in the Kotest arrow matchers extension library.
 
 :::note
-The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently from the main Kotest project.
+The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently of the main Kotest project.
 Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
 :::
 

--- a/documentation/versioned_docs/version-5.6/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.6/assertions/arrow.md
@@ -18,33 +18,33 @@ Search maven central for latest version [here](https://central.sonatype.com/sear
 In the case `io.arrow-kt:arrow-core:arrow-version` is not in your classpath, please add it. To prevent Unresolved Reference errors.
 :::
 
-| Option | |
-| -------- | ---- |
-| `option.shouldBeSome()` | Asserts that the option is of type Some and returns value |
-| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v |
-| `option.shouldBeNone()` | Asserts that the option is of type None |
+| Option                   |                                                           |
+|--------------------------|-----------------------------------------------------------|
+| `option.shouldBeSome()`  | Asserts that the option is of type Some and returns value |
+| `option.shouldBeSome(v)` | Asserts that the option is of type Some with value v      |
+| `option.shouldBeNone()`  | Asserts that the option is of type None                   |
 
-| Either | |
-| -------- | ---- |
-| `either.shouldBeRight()` | Asserts that the either is of type Right and returns the Right value |
-| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v |
-| `either.shouldBeLeft()` | Asserts that the either is of type Left and returns the Left value |
-| `either.shouldBeLeft(v)` | Asserts that the either is of type Left with specific value v |
+| Either                    |                                                                      |
+|---------------------------|----------------------------------------------------------------------|
+| `either.shouldBeRight()`  | Asserts that the either is of type Right and returns the Right value |
+| `either.shouldBeRight(v)` | Asserts that the either is of type Right with specified value v      |
+| `either.shouldBeLeft()`   | Asserts that the either is of type Left and returns the Left value   |
+| `either.shouldBeLeft(v)`  | Asserts that the either is of type Left with specific value v        |
 
-| NonEmptyList | |
-| -------- | ---- |
-| `nel.shouldContain(e)` | Asserts that the NonEmptyList contains the given element e |
+| NonEmptyList                         |                                                                            |
+|--------------------------------------|----------------------------------------------------------------------------|
+| `nel.shouldContain(e)`               | Asserts that the NonEmptyList contains the given element e                 |
 | `nel.shouldContainAll(e1,e2,...,en)` | Asserts that the NonEmptyList contains all the given elements e1,e2,...,en |
-| `nel.shouldContainNull()` | Asserts that the NonEmptyList contains at least one null |
-| `nel.shouldContainNoNulls()` | Asserts that the NonEmptyList contains no nulls |
-| `nel.shouldContainOnlyNulls()` | Asserts that the NonEmptyList contains only nulls or is empty |
-| `nel.shouldHaveDuplicates()` | Asserts that the NonEmptyList has at least one duplicate |
-| `nel.shouldBeSingleElement(e)` | Asserts that the NonEmptyList has a single element which is e |
-| `nel.shouldBeSorted()` | Asserts that the NonEmptyList is sorted |
+| `nel.shouldContainNull()`            | Asserts that the NonEmptyList contains at least one null                   |
+| `nel.shouldContainNoNulls()`         | Asserts that the NonEmptyList contains no nulls                            |
+| `nel.shouldContainOnlyNulls()`       | Asserts that the NonEmptyList contains only nulls or is empty              |
+| `nel.shouldHaveDuplicates()`         | Asserts that the NonEmptyList has at least one duplicate                   |
+| `nel.shouldBeSingleElement(e)`       | Asserts that the NonEmptyList has a single element which is e              |
+| `nel.shouldBeSorted()`               | Asserts that the NonEmptyList is sorted                                    |
 
-| Validated | |
-| -------- | ---- |
-| `validated.shouldBeValid()` | Asserts that the validated is of type Valid and returns the Valid value |
-| `validated.shouldBeValid(v)` | Asserts that the validated is of type Valid with specific value v |
-| `validated.shouldBeInvalid()` | Asserts that the validated is of type Invalid and returns the Invalid value|
-| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v |
+| Validated                      |                                                                             |
+|--------------------------------|-----------------------------------------------------------------------------|
+| `validated.shouldBeValid()`    | Asserts that the validated is of type Valid and returns the Valid value     |
+| `validated.shouldBeValid(v)`   | Asserts that the validated is of type Valid with specific value v           |
+| `validated.shouldBeInvalid()`  | Asserts that the validated is of type Invalid and returns the Invalid value |
+| `validated.shouldBeInvalid(v)` | Asserts that the validated is of type Invalid with specific value v         |

--- a/documentation/versioned_docs/version-5.6/assertions/arrow.md
+++ b/documentation/versioned_docs/version-5.6/assertions/arrow.md
@@ -11,7 +11,7 @@ This page lists all current matchers in the Kotest arrow matchers extension libr
 
 :::note
 The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently from the main Kotest project.
-Search maven central for latest version [here](https://search.maven.org/search?q=kotest-assertions-arrow).
+Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
 :::
 
 :::note


### PR DESCRIPTION
Few change in documentation in arrow assertions documentation :

1. Changed link to maven central that you can use to search for kotest-assertions-arrow. Current one lists old version first, and if you use it with kotest version > 5.0 you get nasty exception at runtime. Took me a while to figure out that I actually need to use second library from the top in maven central, so I changed the link, and now only one (correct) library is listed - it's less confusing.

2. Changed tables formatting and corrected one preposition - mostly to get rid of warnings in intellij  