### PR TITLE
Fix memory leak in CollectingTestEngineListener

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -323,6 +323,22 @@ public final class io/kotest/engine/listener/CollectingTestEngineListener : io/k
 	public fun specFinished (Lkotlin/reflect/KClass;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun testFinished (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun testIgnored (Lio/kotest/core/test/TestCase;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun toKey (Lio/kotest/core/test/TestCase;)Lio/kotest/engine/listener/CollectingTestEngineListener$TestCaseKey;
+}
+
+public final class io/kotest/engine/listener/CollectingTestEngineListener$TestCaseKey {
+	public fun <init> (Lio/kotest/core/descriptors/Descriptor$TestDescriptor;Lio/kotest/core/names/TestName;Lkotlin/reflect/KClass;)V
+	public final fun component1 ()Lio/kotest/core/descriptors/Descriptor$TestDescriptor;
+	public final fun component2 ()Lio/kotest/core/names/TestName;
+	public final fun component3 ()Lkotlin/reflect/KClass;
+	public final fun copy (Lio/kotest/core/descriptors/Descriptor$TestDescriptor;Lio/kotest/core/names/TestName;Lkotlin/reflect/KClass;)Lio/kotest/engine/listener/CollectingTestEngineListener$TestCaseKey;
+	public static synthetic fun copy$default (Lio/kotest/engine/listener/CollectingTestEngineListener$TestCaseKey;Lio/kotest/core/descriptors/Descriptor$TestDescriptor;Lio/kotest/core/names/TestName;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/kotest/engine/listener/CollectingTestEngineListener$TestCaseKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescriptor ()Lio/kotest/core/descriptors/Descriptor$TestDescriptor;
+	public final fun getName ()Lio/kotest/core/names/TestName;
+	public final fun getSpecClass ()Lkotlin/reflect/KClass;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/kotest/engine/listener/CompositeTestEngineListener : io/kotest/engine/listener/TestEngineListener {

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/WriteFailuresInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/WriteFailuresInterceptor.kt
@@ -28,7 +28,7 @@ internal object WriteFailuresInterceptor : EngineInterceptor {
          val result = execute(context.mergeListener(collector))
          val failedSpecs = collector.tests
             .filterValues { it.isErrorOrFailure }
-            .map { it.key.spec::class }
+            .map { it.key.specClass }
             .toSet()
          writeSpecFailures(failedSpecs, context.configuration.specFailureFilePath)
          result


### PR DESCRIPTION
This PR removes unnecessary retention of all the Spec instances by the `CollectingTestEngineListener` that leads to a memory leak and increased GC activity / OOM with more executed tests.
This is a proposed fix and potentially Closes #3572
