### PR TITLE
Making NamedTag a data class, so it gets equals()

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -1,6 +1,12 @@
 public final class io/kotest/core/NamedTag : io/kotest/core/Tag {
 	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/kotest/core/NamedTag;
+	public static synthetic fun copy$default (Lio/kotest/core/NamedTag;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/core/NamedTag;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/kotest/core/StringTag : io/kotest/core/Tag {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/Tag.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/Tag.kt
@@ -39,7 +39,10 @@ abstract class Tag {
 /**
  * Creates a tag using the given parameter as the name.
  */
-class NamedTag(override val name: String) : Tag()
+data class NamedTag(override val name: String) : Tag() {
+   // Don't use toString from `data class`
+   override fun toString() = super.toString()
+}
 
 @Deprecated("Use NamedTag. This Will be removed in 6.0")
 class StringTag(override val name: String) : Tag()


### PR DESCRIPTION
Fixes set of tags including NamedTags multiple times. Fixes #3566

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
