### PR TITLE
Adding test executions for JVM 8 and 11.

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-jvm-conventions.gradle.kts
@@ -18,3 +18,22 @@ kotlin {
       }
    }
 }
+
+// Normal test task runs on compile JDK.
+listOf(8, 11, 17).forEach { ltsVersion ->
+   val jdkTest = tasks.register<Test>("jvmTestWithJdk$ltsVersion") {
+      javaLauncher.set(javaToolchains.launcherFor {
+         languageVersion.set(JavaLanguageVersion.of(ltsVersion))
+      })
+
+      description = "Runs the JVM test suite on JDK $ltsVersion"
+      group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+      // Copy inputs from normal Test task.
+      val testTask = tasks.named("jvmTest", Test::class.java).get()
+      classpath = testTask.classpath
+      testClassesDirs = testTask.testClassesDirs
+   }
+
+   tasks.named("jvmTest").configure { dependsOn(jdkTest) }
+}

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -32,9 +32,9 @@ tasks.withType<KotlinCompile>().configureEach {
          "-opt-in=io.kotest.common.KotestInternal",
          "-opt-in=io.kotest.common.ExperimentalKotest",
       )
-      apiVersion = "1.8"
-      languageVersion = "1.8"
-      compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
+//      apiVersion = "1.8"
+//      languageVersion = "1.8"
+//      compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
    }
 }
 


### PR DESCRIPTION
Disabling setting of jvmTarget, which should hopefully trigger a test failure on those JVMs

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
