### PR TITLE
Fix duration shrinker so it shrinks

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/duration/DurationClassifier.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/duration/DurationClassifier.kt
@@ -2,12 +2,13 @@ package io.kotest.property.arbitrary.duration
 
 import io.kotest.property.Classifier
 import kotlin.time.Duration
+import kotlin.time.DurationUnit
 
 class DurationClassifier(
    private val range: ClosedRange<Duration>
-) : Classifier<Duration> {
-   override fun classify(value: Duration): String? =
-      when (value) {
+) : Classifier<Pair<Duration, DurationUnit>> {
+   override fun classify(value: Pair<Duration, DurationUnit>): String? =
+      when (value.first) {
           range.start -> "MIN"
           range.endInclusive -> "MAX"
           Duration.ZERO -> "ZERO"

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/durations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/durations.kt
@@ -5,14 +5,8 @@ import io.kotest.property.Shrinker
 import io.kotest.property.arbitrary.duration.DurationClassifier
 import kotlin.random.nextLong
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
-import kotlin.time.DurationUnit.MILLISECONDS
-import kotlin.time.DurationUnit.values
 import kotlin.time.toDuration
 
 /**
@@ -24,71 +18,49 @@ import kotlin.time.toDuration
 fun Arb.Companion.duration(
    range: ClosedRange<Duration> = (-Int.MAX_VALUE.seconds)..Int.MAX_VALUE.seconds,
    unit: DurationUnit? = null
-): Arb<Duration> =
-   ArbitraryBuilder.create { rs ->
-      val durationUnit: DurationUnit = unit ?: values().random(rs.random)
+): Arb<Duration> = durationWithUnit(range, unit?.let { Arb.constant(it) } ?: Arb.enum()).map { it.first }
 
-      rs.random
-         .nextLong(range.start.toLong(durationUnit)..range.endInclusive.toLong(durationUnit))
-         .toDuration(durationUnit)
-         .coerceIn(range)
-   }.withEdgecases(
-      setOfNotNull(
-         range.start,
-         Duration.ZERO,
-         range.endInclusive,
-      ).map { it.coerceIn(range) }
-   )
+/**
+ * Arbitrary [Duration] with associated [DurationUnit].
+ *
+ * @param[range] constrains the generated durations to be within this range.
+ * @param[unit] constraints the associated units
+ */
+fun Arb.Companion.durationWithUnit(
+   range: ClosedRange<Duration> = (-Int.MAX_VALUE.seconds)..Int.MAX_VALUE.seconds,
+   unit: Arb<DurationUnit> = Arb.enum(),
+): Arb<Pair<Duration, DurationUnit>> {
+   return ArbitraryBuilder.create { rs ->
+      val durationUnit = unit.next(rs)
+
+      Pair(
+         rs.random
+            .nextLong(range.start.toLong(durationUnit)..range.endInclusive.toLong(durationUnit))
+            .toDuration(durationUnit)
+            .coerceIn(range),
+         durationUnit,
+      )
+   }.withEdgecaseFn { rs ->
+      Pair(
+         listOf(range.start, Duration.ZERO, range.endInclusive).random(rs.random),
+         unit.next(rs),
+      )
+   }
       .withShrinker(DurationShrinker(range))
       .withClassifier(DurationClassifier(range))
       .build()
+}
 
 class DurationShrinker(
-   private val range: ClosedRange<Duration>
-) : Shrinker<Duration> {
+   private val range: ClosedRange<Duration>,
+) : Shrinker<Pair<Duration, DurationUnit>> {
 
-   override fun shrink(value: Duration): List<Duration> {
-      val unsafeShrinks = unsafeShrinks.mapNotNull { op ->
-         try {
-            op(value)
-         } catch (_: IllegalArgumentException) {
-            null
-         }
-      }
-
-      val componentShrinks = componentsShrinker.shrink(value)
-
-      return (unsafeShrinks + componentShrinks)
-         .map { it.coerceIn(range) }
-         .takeIf { shrinks -> shrinks.all { it != Duration.ZERO } }
-         ?.distinct()
-         ?: emptyList()
-   }
-
-   /** Tries to shrink, but might through an [IllegalArgumentException] if the resulting duration is invalid */
-   private val unsafeShrinks: List<(Duration) -> Duration> =
-      listOf(
-         { d -> (d / 10).truncate(MILLISECONDS) },
-         { d -> (d / 100).truncate(MILLISECONDS) },
-         { d -> d * 10 },
-         { d -> d * 100 },
-      )
-
-   private val componentsShrinker = Shrinker<Duration> { d ->
-      d.toComponents { days, hours, minutes, seconds, nanoseconds ->
-         listOf(
-            days.days,
-            hours.hours,
-            minutes.minutes,
-            seconds.seconds,
-            nanoseconds.nanoseconds,
-         )
-      }
-   }
-
-   companion object {
-      /** truncate the duration, removing any time units smaller than [unit] */
-      private fun Duration.truncate(unit: DurationUnit): Duration =
-         toLong(unit).toDuration(unit)
+   override fun shrink(value: Pair<Duration, DurationUnit>): List<Pair<Duration, DurationUnit>> {
+      return LongShrinker(range.start.toLong(value.second)..range.endInclusive.toLong(value.second))
+         .shrink(value.first.toLong(value.second))
+         .map { it.toDuration(value.second) to value.second }
+         .distinctBy { it.first }
+         .filterNot { it.first == value.first }
+         .filter { it.first in range }
    }
 }


### PR DESCRIPTION
The duration shrinker was producing values greater than the value provided to the shrinker. This is not only a violation of the shrinking constract (it's not shrinking), it can result in infinite loops when a test fails and shrinks are generated.