### PR TITLE
Fix duration shrinker so it shrinks

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/durations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/durations.kt
@@ -70,8 +70,6 @@ class DurationShrinker(
       listOf(
          { d -> (d / 10).truncate(MILLISECONDS) },
          { d -> (d / 100).truncate(MILLISECONDS) },
-         { d -> d * 10 },
-         { d -> d * 100 },
       )
 
    private val componentsShrinker = Shrinker<Duration> { d ->


### PR DESCRIPTION
The duration shrinker was producing values greater than the value provided to the shrinker. This is not only a violation of the shrinking contract (it's not shrinking), it can result in infinite loops when a test fails and shrinks are generated.
