### PR TITLE
fix : extra properties are not tolerated with different array ordering

### DIFF
--- a/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
+++ b/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
@@ -373,6 +373,7 @@ public final class io/kotest/assertions/json/MatchersKt {
 	public static final fun shouldEqualJson (Ljava/lang/String;Ljava/lang/String;Lio/kotest/assertions/json/CompareOrder;)V
 	public static final fun shouldEqualJson (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
 	public static final fun shouldEqualSpecifiedJson (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun shouldEqualSpecifiedJsonIgnoringOrder (Ljava/lang/String;Ljava/lang/String;)V
 	public static final fun shouldNotEqualJson (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 	public static final fun shouldNotEqualJson (Ljava/lang/String;Ljava/lang/String;Lio/kotest/assertions/json/CompareMode;)V
 	public static final fun shouldNotEqualJson (Ljava/lang/String;Ljava/lang/String;Lio/kotest/assertions/json/CompareOrder;)V

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
@@ -270,7 +270,7 @@ internal fun compareArrays(
          fun findMatchingIndex(element: JsonNode): Int? {
             for (i in availableIndexes()) {
                // Comparison with no error -> matching element
-               val isMatch = compare(path + "[$i]", element, expected.elements[i], options) == null
+               val isMatch = compare(path + "[$i]", expected.elements[i], element, options) == null
 
                if (isMatch) {
                   return i

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -116,6 +116,14 @@ infix fun String.shouldEqualSpecifiedJson(expected: String) {
    }
 }
 
+infix fun String.shouldEqualSpecifiedJsonIgnoringOrder(expected: String) {
+   shouldEqualJson {
+      fieldComparison = FieldComparison.Lenient
+      arrayOrder = ArrayOrder.Lenient
+      expected
+   }
+}
+
 infix fun String.shouldNotEqualSpecifiedJson(expected: String) {
    shouldNotEqualJson {
       fieldComparison = FieldComparison.Lenient

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/EqualIgnoringUnknownTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/EqualIgnoringUnknownTest.kt
@@ -183,6 +183,13 @@ expected:<{
 }>"""
             )
          }
+
+         test("extra fields ok with different order array") {
+            val a = """ { "wrapper": [{ "c" : "baz" }, { "a" : "foo", "b": "bar" } ] }"""
+            val b = """ { "wrapper": [{ "a" : "foo" }, { "c" : "baz" } ] }"""
+
+            a shouldEqualSpecifiedJsonIgnoringOrder b
+         }
       }
    }
 )


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolve #3571 

fix `Extra properties are not tolerated IFF the array ordering is also different from the expected JSON`

This bug was caused by reversing the order of the actual and expected parameters.
