### PR TITLE
Rewrite System Extensions docs intro for more clarity

### DIFF
--- a/documentation/docs/extensions/system.md
+++ b/documentation/docs/extensions/system.md
@@ -10,10 +10,19 @@ slug: system_extensions.html
 
 ## System Extensions
 
-Sometimes your code might use some functionalities straight from the JVM, which are very hard to simulate. With Kotest System Extensions, these difficulties are made easy to mock and simulate, and your code can be tested correctly. After changing the system and using the extensions, the previous state will be restored.
+If you need to test code that uses `java.lang.System`, Kotest provides extensions that can alter the system and restore it after each test. This extension is only available on the JVM.
+
+To use this extension, add the dependency to your project:
+
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-jvm.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest/kotest-extensions-jvm)
+[<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-extensions-jvm.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest-extensions-jvm/)
+
+```kotlin
+io.kotest:kotest-extensions-jvm:${version}
+```
 
 :::caution
-This code is sensitive to concurrency. Due to the JVM specification there can only be one instance of these extensions running (For example: Only one Environment map must exist). If you try to run more than one instance at a time, the result is unknown.
+This extension does not support concurrent test execution. Due to the JVM specification there can only be one instance of these extensions running (For example: Only one Environment map must exist). If you try to run more than one instance at a time, the result is undefined.
 :::
 
 ### System Environment

--- a/documentation/versioned_docs/version-5.6/extensions/system.md
+++ b/documentation/versioned_docs/version-5.6/extensions/system.md
@@ -10,10 +10,19 @@ slug: system_extensions.html
 
 ## System Extensions
 
-Sometimes your code might use some functionalities straight from the JVM, which are very hard to simulate. With Kotest System Extensions, these difficulties are made easy to mock and simulate, and your code can be tested correctly. After changing the system and using the extensions, the previous state will be restored.
+If you need to test code that uses `java.lang.System`, Kotest provides extensions that can alter the system and restore it after each test. This extension is only available on the JVM.
+
+To use this extension, add the dependency to your project:
+
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-jvm.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest/kotest-extensions-jvm)
+[<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-extensions-jvm.svg?label=latest%20snapshot"/>](https://oss.sonatype.org/content/repositories/snapshots/io/kotest-extensions-jvm/)
+
+```kotlin
+io.kotest:kotest-extensions-jvm:${version}
+```
 
 :::caution
-This code is sensitive to concurrency. Due to the JVM specification there can only be one instance of these extensions running (For example: Only one Environment map must exist). If you try to run more than one instance at a time, the result is unknown.
+This extension does not support concurrent test execution. Due to the JVM specification there can only be one instance of these extensions running (For example: Only one Environment map must exist). If you try to run more than one instance at a time, the result is undefined.
 :::
 
 ### System Environment


### PR DESCRIPTION
I recently tried to add the System Extensions to a project and found their docs a little confusing.

- It doesn't list the maven artifact, so I had to dig through maven central to find its name
- It doesn't explicitly mention that the extension is JVM-only. It makes sense why it is, but functions like `withEnvironment` could theoretically be multi-platform, so I think it's worth calling out.
- The scope of the extension were a little unclear from the intro, so I changed to wording to hopefully be more clear.