### PR TITLE
Fix matchJsonResource should check file existence

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
@@ -22,9 +22,9 @@ fun matchJsonResource(resource: String) = object : Matcher<String?> {
 
    override fun test(value: String?): MatcherResult {
       val actualJson = value?.let(pretty::parseToJsonElement)
-      val expectedJson = this.javaClass.getResourceAsStream(resource).bufferedReader().use {
+      val expectedJson = this.javaClass.getResourceAsStream(resource)?.bufferedReader()?.use {
          pretty.parseToJsonElement(it.readText())
-      }
+      } ?: throw AssertionError("File should exist in resources: $resource")
 
       return ComparableMatcherResult(
          actualJson == expectedJson,


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->


resolve #3633 

When I call shouldMatchJsonResource with a non-existent resource will throw an NPE.

Change it to proceed with a null check and throw an AssertionError for a safe assertion.