### PR TITLE
Fix nullable reflective binds not working some supported types

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -22,14 +22,14 @@ actual inline fun <reified A> targetDefaultForClass(): Arb<A>? = targetDefaultFo
 
 fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type: KType): Arb<*>? {
    when (type) {
-      typeOf<Instant>() -> Arb.instant()
-      typeOf<Date>() -> Arb.javaDate()
-      typeOf<LocalDate>() -> Arb.localDate()
-      typeOf<LocalDateTime>() -> Arb.localDateTime()
-      typeOf<LocalTime>() -> Arb.localTime()
-      typeOf<Period>() -> Arb.period()
-      typeOf<BigDecimal>() -> Arb.bigDecimal()
-      typeOf<BigInteger>() -> Arb.bigInt(maxNumBits = 256)
+      typeOf<Instant>(), typeOf<Instant?>() -> Arb.instant()
+      typeOf<Date>(), typeOf<Date?>() -> Arb.javaDate()
+      typeOf<LocalDate>(), typeOf<LocalDate?>() -> Arb.localDate()
+      typeOf<LocalDateTime>(), typeOf<LocalDateTime?>() -> Arb.localDateTime()
+      typeOf<LocalTime>(), typeOf<LocalTime?>() -> Arb.localTime()
+      typeOf<Period>(), typeOf<Period?>() -> Arb.period()
+      typeOf<BigDecimal>(), typeOf<BigDecimal?>() -> Arb.bigDecimal()
+      typeOf<BigInteger>(), typeOf<BigInteger?>() -> Arb.bigInt(maxNumBits = 256)
       else -> null
    }?.let { return it }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -17,6 +17,7 @@ import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.next
 import io.kotest.property.arbitrary.take
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -29,7 +30,7 @@ class ReflectiveBindTest : StringSpec(
 
       data class Wobble(val a: String, val b: Boolean, val c: Int, val d: Pair<Double, Float>)
       class WobbleWobble(val a: Wobble)
-      data class BubbleBobble(val a: String?, val b: Boolean?)
+      data class BubbleBobble(val a: String?, val b: Boolean?, val c: BigInteger?, val d: BigDecimal?)
 
       "binds enum parameters" {
          data class Hobble(val shape: Shape)
@@ -99,6 +100,18 @@ class ReflectiveBindTest : StringSpec(
          )
 
          val arb = Arb.bind<DateContainer>()
+         arb.take(10).toList().size shouldBe 10
+      }
+
+      "java.time types with nullable" {
+         data class DateNullableContainer(
+            val a: LocalDate?,
+            val b: LocalDateTime?,
+            val c: LocalTime?,
+            val d: Period?
+         )
+
+         val arb = Arb.bind<DateNullableContainer>()
          arb.take(10).toList().size shouldBe 10
       }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolves #3627 

Fix Arb.bind not working with some supported types which are nullable.
