### PR TITLE
Add more java.time supports for reflective bind

### DIFF
--- a/documentation/versioned_docs/version-5.6/proptest/reflective_arbs.md
+++ b/documentation/versioned_docs/version-5.6/proptest/reflective_arbs.md
@@ -44,8 +44,7 @@ Reflective binding is supported for:
 * Primitives
 * Enums
 * Sealed classes, subtypes and their primary constructor must not be private
-* `LocalDate`, `LocalDateTime`, `LocalTime`, `Period`, `Instant` from `java.time`
+* `LocalDate`, `LocalDateTime`, `LocalTime`, `Period`, `Instant`, `YearMonth`, `ZonedDateTime`, `OffsetDateTime` from `java.time`
 * `BigDecimal`, `BigInteger`
 * Collections (`Set`, `List`, `Map`)
 * Classes for which an Arb has been provided through `providedArbs`
-

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -9,7 +9,10 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.OffsetDateTime
 import java.time.Period
+import java.time.YearMonth
+import java.time.ZonedDateTime
 import java.util.Date
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
@@ -28,6 +31,9 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
       typeOf<LocalDateTime>(), typeOf<LocalDateTime?>() -> Arb.localDateTime()
       typeOf<LocalTime>(), typeOf<LocalTime?>() -> Arb.localTime()
       typeOf<Period>(), typeOf<Period?>() -> Arb.period()
+      typeOf<YearMonth>(), typeOf<YearMonth?>() -> Arb.yearMonth()
+      typeOf<ZonedDateTime>(), typeOf<ZonedDateTime?>() -> Arb.zonedDateTime()
+      typeOf<OffsetDateTime>(), typeOf<OffsetDateTime?>() -> Arb.offsetDateTime()
       typeOf<BigDecimal>(), typeOf<BigDecimal?>() -> Arb.bigDecimal()
       typeOf<BigInteger>(), typeOf<BigInteger?>() -> Arb.bigInt(maxNumBits = 256)
       else -> null

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -21,7 +21,10 @@ import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.OffsetDateTime
 import java.time.Period
+import java.time.YearMonth
+import java.time.ZonedDateTime
 import kotlin.reflect.KClass
 
 class ReflectiveBindTest : StringSpec(
@@ -96,7 +99,10 @@ class ReflectiveBindTest : StringSpec(
             val a: LocalDate,
             val b: LocalDateTime,
             val c: LocalTime,
-            val d: Period
+            val d: Period,
+            val e: YearMonth,
+            val f: OffsetDateTime,
+            val g: ZonedDateTime
          )
 
          val arb = Arb.bind<DateContainer>()
@@ -108,7 +114,10 @@ class ReflectiveBindTest : StringSpec(
             val a: LocalDate?,
             val b: LocalDateTime?,
             val c: LocalTime?,
-            val d: Period?
+            val d: Period?,
+            val e: YearMonth?,
+            val f: OffsetDateTime?,
+            val g: ZonedDateTime?
          )
 
          val arb = Arb.bind<DateNullableContainer>()


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Add more java.time supports for reflective bind.