### PR TITLE
Add range to reflective Set of Enum values

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -51,6 +51,9 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
          if (upperBoundKClass.isSubclassOf(Enum::class)) {
             val maxElements = Class.forName(upperBoundKClass.java.name).enumConstants.size
             Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
+         } else if(upperBoundKClass.isSealed) {
+            val maxElements = upperBoundKClass.sealedSubclasses.size
+            Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
          } else {
             Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>)
          }

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -47,7 +47,13 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
       }
       clazz.isSubclassOf(Set::class) -> {
          val upperBound = type.arguments.first().type ?: error("No bound for Set")
-         Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>)
+         val upperBoundKClass = (upperBound.classifier as KClass<*>)
+         if (upperBoundKClass.isSubclassOf(Enum::class)) {
+            val maxElements = Class.forName(upperBoundKClass.java.name).enumConstants.size
+            Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
+         } else {
+            Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>)
+         }
       }
       clazz.isSubclassOf(Pair::class) -> {
          val first = type.arguments[0].type ?: error("No bound for first type parameter of Pair")

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -47,11 +47,11 @@ fun targetDefaultForType(providedArbs: Map<KClass<*>, Arb<*>> = emptyMap(), type
       }
       clazz.isSubclassOf(Set::class) -> {
          val upperBound = type.arguments.first().type ?: error("No bound for Set")
-         val upperBoundKClass = (upperBound.classifier as KClass<*>)
-         if (upperBoundKClass.isSubclassOf(Enum::class)) {
+         val upperBoundKClass = (upperBound.classifier as? KClass<*>)
+         if (upperBoundKClass != null && upperBoundKClass.isSubclassOf(Enum::class)) {
             val maxElements = Class.forName(upperBoundKClass.java.name).enumConstants.size
             Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
-         } else if(upperBoundKClass.isSealed) {
+         } else if(upperBoundKClass != null && upperBoundKClass.isSealed) {
             val maxElements = upperBoundKClass.sealedSubclasses.size
             Arb.set(Arb.forType(providedArbs, upperBound) as Arb<*>, 0..maxElements)
          } else {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -218,6 +218,11 @@ class ReflectiveBindTest : StringSpec(
          val arb = Arb.bind<Set<Shape>>()
          arb.take(100).toList()
       }
+
+      "Arb.bind for set of sealed type should not fail target size requirement" {
+         val arb = Arb.bind<Set<Shape3d>>()
+         arb.take(100).toList()
+      }
    }
 ) {
    companion object {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -214,6 +214,10 @@ class ReflectiveBindTest : StringSpec(
 
       }
 
+      "Arb.bind for set of enum should not fail target size requirement" {
+         val arb = Arb.bind<Set<Shape>>()
+         arb.take(100).toList()
+      }
    }
 ) {
    companion object {


### PR DESCRIPTION
Creating a reflective Arb for a `Set<EnumType>` should not fail with 
`java.lang.IllegalStateException: the target size requirement of 60 could not be satisfied after 600 consecutive samples
`.

This change restricts the expected size of the Arb.set to match the number of enum values.
