### PR TITLE
Non-negative/positive `Long` assertions and property testers

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/long.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/long.kt
@@ -24,6 +24,19 @@ fun positiveL() = object : Matcher<Long> {
          { "$value should not be > 0" })
 }
 
+fun Long.shouldBeNonNegative(): Long {
+   this shouldBe nonNegativeL()
+   return this
+}
+
+fun nonNegativeL() = object : Matcher<Long> {
+   override fun test(value: Long) =
+      MatcherResult(
+         value >= 0,
+         { "$value should be >= 0" },
+         { "$value should not be >= 0" })
+}
+
 fun Long.shouldBeNegative(): Long {
    this shouldBe negativeL()
    return this
@@ -35,6 +48,19 @@ fun negativeL() = object : Matcher<Long> {
          value < 0,
          { "$value should be < 0" },
          { "$value should not be < 0" })
+}
+
+fun Long.shouldBeNonPositive(): Long {
+   this shouldBe nonPositiveL()
+   return this
+}
+
+fun nonPositiveL() = object : Matcher<Long> {
+   override fun test(value: Long) =
+      MatcherResult(
+         value <= 0,
+         { "$value should be <= 0" },
+         { "$value should not be <= 0" })
 }
 
 fun Long.shouldBeEven(): Long {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/longs.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/longs.kt
@@ -49,10 +49,24 @@ fun Arb.Companion.long(range: LongRange = Long.MIN_VALUE..Long.MAX_VALUE): Arb<L
 fun Arb.Companion.positiveLong(max: Long = Long.MAX_VALUE): Arb<Long> = long(1L, max)
 
 /**
+ * Returns an [Arb] that produces non-negative [Long]s from 0 to [max] (inclusive).
+ * The edge cases are 0, 1 and [max].
+ *
+ * Max defaults to [Long.MAX_VALUE]
+ */
+fun Arb.Companion.nonNegativeLong(max: Long = Long.MAX_VALUE) = long(0, max)
+
+/**
  * Returns an [Arb] that produces negative [Long]s from [min] to -1 (inclusive).
  * The edge cases are [min] and -1.
  */
 fun Arb.Companion.negativeLong(min: Long = Long.MIN_VALUE): Arb<Long> = long(min, -1L)
+
+/**
+ * Returns an [Arb] that produces non-positive [Long]s from [min] to 0 (inclusive).
+ * The edge cases are [min], -1 and 0.
+ */
+fun Arb.Companion.nonPositiveLong(min: Long = Long.MIN_VALUE) = long(min, 0)
 
 /**
  * Returns an [Arb] that produces [LongArray]s where [generateArrayLength] produces the length of the arrays and

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/LongTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/LongTest.kt
@@ -5,11 +5,20 @@ import io.kotest.data.blocking.forAll
 import io.kotest.data.row
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.longs.shouldBeBetween
+import io.kotest.matchers.longs.shouldBeNegative
+import io.kotest.matchers.longs.shouldBeNonNegative
+import io.kotest.matchers.longs.shouldBeNonPositive
+import io.kotest.matchers.longs.shouldBePositive
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.edgecases
 import io.kotest.property.arbitrary.long
+import io.kotest.property.arbitrary.negativeLong
+import io.kotest.property.arbitrary.nonNegativeLong
+import io.kotest.property.arbitrary.nonPositiveLong
+import io.kotest.property.arbitrary.positiveLong
 import io.kotest.property.arbitrary.single
+import io.kotest.property.arbitrary.take
 import io.kotest.property.arbitrary.uLong
 import io.kotest.property.checkAll
 import io.kotest.property.checkCoverage
@@ -49,6 +58,26 @@ class LongTest : FunSpec({
       checkAll(100_000, Arb.long(min, max)) { value ->
          value.shouldBeBetween(min, max)
       }
+   }
+
+   test("Arb.positiveLongs should return positive longs only") {
+      val numbers = Arb.positiveLong().take(1000).toSet()
+      numbers.forAll { it.shouldBePositive() }
+   }
+
+   test("Arb.nonNegativeLongs should return non negative longs only") {
+      val numbers = Arb.nonNegativeLong().take(1000).toSet()
+      numbers.forAll { it.shouldBeNonNegative() }
+   }
+
+   test("Arb.negativeLongs should return negative longs only") {
+      val numbers = Arb.negativeLong().take(1000).toSet()
+      numbers.forAll { it.shouldBeNegative() }
+   }
+
+   test("Arb.nonPositiveLongs should return non positive longs only") {
+      val numbers = Arb.nonPositiveLong().take(1000).toSet()
+      numbers.forAll { it.shouldBeNonPositive() }
    }
 })
 


### PR DESCRIPTION
These all exist for `Int` (which these `Long` versions are based on)

Are there any docs that need updating for this?
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
