### PR TITLE
docs(tags.md) -  update code snippet to pass env vars to jvm

### DIFF
--- a/documentation/docs/framework/tags.md
+++ b/documentation/docs/framework/tags.md
@@ -190,7 +190,7 @@ Kotlin Gradle DSL:
 ```kotlin
 val test by tasks.getting(Test::class) {
     // ... Other configurations ...
-    systemProperties = System.getProperties().associate { it.key.toString() to it.value }
+    systemProperties = System.getProperties().asIterable().associate { it.key.toString() to it.value }
 }
 ```
 


### PR DESCRIPTION
Hello! Proposing this update to save others some troubleshooting time.

The code snippet to "inject" the env vars within the JVM wouldn't compile for me using Kotlin 1.9-RC. Adding `.asIterable()` corrected the issue. 

That being said, let me know whether I've missed something.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
