### PR TITLE
Fixed containAll Matchers with varargs

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -8,14 +8,14 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 fun <T> Iterable<T>.shouldContainAll(vararg ts: T) = toList().shouldContainAll(*ts)
-fun <T> Array<T>.shouldContainAll(vararg ts: T) = asList().shouldContainAll(ts)
+fun <T> Array<T>.shouldContainAll(vararg ts: T) = asList().shouldContainAll(*ts)
 fun <T> Collection<T>.shouldContainAll(vararg ts: T) = this should containAll(*ts)
 infix fun <T> Iterable<T>.shouldContainAll(ts: Collection<T>) = toList().shouldContainAll(ts)
 infix fun <T> Array<T>.shouldContainAll(ts: Collection<T>) = asList().shouldContainAll(ts)
 infix fun <T> Collection<T>.shouldContainAll(ts: Collection<T>) = this should containAll(ts)
 
 fun <T> Iterable<T>.shouldNotContainAll(vararg ts: T) = toList().shouldNotContainAll(*ts)
-fun <T> Array<T>.shouldNotContainAll(vararg ts: T) = asList().shouldNotContainAll(ts)
+fun <T> Array<T>.shouldNotContainAll(vararg ts: T) = asList().shouldNotContainAll(*ts)
 fun <T> Collection<T>.shouldNotContainAll(vararg ts: T) = this shouldNot containAll(*ts)
 infix fun <T> Iterable<T>.shouldNotContainAll(ts: Collection<T>) = toList().shouldNotContainAll(ts)
 infix fun <T> Array<T>.shouldNotContainAll(ts: Collection<T>) = asList().shouldNotContainAll(ts)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -14,7 +14,7 @@ infix fun <T> Iterable<T>.shouldContainAll(ts: Collection<T>) = toList().shouldC
 infix fun <T> Array<T>.shouldContainAll(ts: Collection<T>) = asList().shouldContainAll(ts)
 infix fun <T> Collection<T>.shouldContainAll(ts: Collection<T>) = this should containAll(ts)
 
-fun <T> Iterable<T>.shouldNotContainAll(vararg ts: T) = toList().shouldNotContainAll(ts)
+fun <T> Iterable<T>.shouldNotContainAll(vararg ts: T) = toList().shouldNotContainAll(*ts)
 fun <T> Array<T>.shouldNotContainAll(vararg ts: T) = asList().shouldNotContainAll(ts)
 fun <T> Collection<T>.shouldNotContainAll(vararg ts: T) = this shouldNot containAll(*ts)
 infix fun <T> Iterable<T>.shouldNotContainAll(ts: Collection<T>) = toList().shouldNotContainAll(ts)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
-fun <T> Iterable<T>.shouldContainAll(vararg ts: T) = toList().shouldContainAll(ts)
+fun <T> Iterable<T>.shouldContainAll(vararg ts: T) = toList().shouldContainAll(*ts)
 fun <T> Array<T>.shouldContainAll(vararg ts: T) = asList().shouldContainAll(ts)
 fun <T> Collection<T>.shouldContainAll(vararg ts: T) = this should containAll(*ts)
 infix fun <T> Iterable<T>.shouldContainAll(ts: Collection<T>) = toList().shouldContainAll(ts)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
@@ -49,66 +49,66 @@ class ShouldContainAllTest : WordSpec() {
          }
 
          "test that a iterable contains all the elements but in any order" {
-            val col = listOf(1, 2, 3, 4, 5).asIterable()
+            val iter = listOf(1, 2, 3, 4, 5).asIterable()
 
-            col.shouldContainAll(1, 2, 3)
-            col.shouldContainAll(3, 1)
-            col.shouldContainAll(3)
+            iter.shouldContainAll(1, 2, 3)
+            iter.shouldContainAll(3, 1)
+            iter.shouldContainAll(3)
 
-            col.shouldNotContainAll(6)
-            col.shouldNotContainAll(1, 6)
-            col.shouldNotContainAll(6, 1)
+            iter.shouldNotContainAll(6)
+            iter.shouldNotContainAll(1, 6)
+            iter.shouldNotContainAll(6, 1)
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(1, 2, 6)
+               iter.shouldContainAll(1, 2, 6)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(6)
+               iter.shouldContainAll(6)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(0, 1, 2)
+               iter.shouldContainAll(0, 1, 2)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(3, 2, 0)
+               iter.shouldContainAll(3, 2, 0)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldNotContainAll(1, 2)
+               iter.shouldNotContainAll(1, 2)
             }
          }
 
          "test that a array contains all the elements but in any order" {
-            val col = arrayOf(1, 2, 3, 4, 5)
+            val arr = arrayOf(1, 2, 3, 4, 5)
 
-            col.shouldContainAll(1, 2, 3)
-            col.shouldContainAll(3, 1)
-            col.shouldContainAll(3)
+            arr.shouldContainAll(1, 2, 3)
+            arr.shouldContainAll(3, 1)
+            arr.shouldContainAll(3)
 
-            col.shouldNotContainAll(6)
-            col.shouldNotContainAll(1, 6)
-            col.shouldNotContainAll(6, 1)
+            arr.shouldNotContainAll(6)
+            arr.shouldNotContainAll(1, 6)
+            arr.shouldNotContainAll(6, 1)
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(1, 2, 6)
+               arr.shouldContainAll(1, 2, 6)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(6)
+               arr.shouldContainAll(6)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(0, 1, 2)
+               arr.shouldContainAll(0, 1, 2)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldContainAll(3, 2, 0)
+               arr.shouldContainAll(3, 2, 0)
             }
 
             shouldThrow<AssertionError> {
-               col.shouldNotContainAll(1, 2)
+               arr.shouldNotContainAll(1, 2)
             }
          }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
@@ -74,6 +74,42 @@ class ShouldContainAllTest : WordSpec() {
             shouldThrow<AssertionError> {
                col.shouldContainAll(3, 2, 0)
             }
+
+            shouldThrow<AssertionError> {
+               col.shouldNotContainAll(1, 2)
+            }
+         }
+
+         "test that a array contains all the elements but in any order" {
+            val col = arrayOf(1, 2, 3, 4, 5)
+
+            col.shouldContainAll(1, 2, 3)
+            col.shouldContainAll(3, 1)
+            col.shouldContainAll(3)
+
+            col.shouldNotContainAll(6)
+            col.shouldNotContainAll(1, 6)
+            col.shouldNotContainAll(6, 1)
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(1, 2, 6)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(6)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(0, 1, 2)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(3, 2, 0)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldNotContainAll(1, 2)
+            }
          }
 
          "print missing elements" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
@@ -47,6 +47,35 @@ class ShouldContainAllTest : WordSpec() {
                col should containAll(3, 2, 0)
             }
          }
+
+         "test that a iterable contains all the elements but in any order" {
+            val col = listOf(1, 2, 3, 4, 5).asIterable()
+
+            col.shouldContainAll(1, 2, 3)
+            col.shouldContainAll(3, 1)
+            col.shouldContainAll(3)
+
+            col.shouldNotContainAll(6)
+            col.shouldNotContainAll(1, 6)
+            col.shouldNotContainAll(6, 1)
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(1, 2, 6)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(6)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(0, 1, 2)
+            }
+
+            shouldThrow<AssertionError> {
+               col.shouldContainAll(3, 2, 0)
+            }
+         }
+
          "print missing elements" {
             shouldThrow<AssertionError> {
                listOf<Number>(1, 2).shouldContainAll(listOf<Number>(1L, 2L))


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolves #3730 

- Fixed `Iterable.shouldContainAll`  and `Iterable.shouldNotContainAll`
- Fixed `Array.shouldContainAll`  and `Array.shouldNotContainAll`
- Added tests for `Iterable` and `Array`