### PR TITLE
Fixed shouldContainAnyOf matchers with varargs

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -93,11 +93,11 @@ infix fun <T> List<T>.shouldNotExistInOrder(expected: List<(T) -> Boolean>) = th
 
 
 
-fun <T> Iterable<T>.shouldContainAnyOf(vararg ts: T) = toList().shouldContainAnyOf(ts)
-fun <T> Array<T>.shouldContainAnyOf(vararg ts: T) = asList().shouldContainAnyOf(ts)
+fun <T> Iterable<T>.shouldContainAnyOf(vararg ts: T) = toList().shouldContainAnyOf(*ts)
+fun <T> Array<T>.shouldContainAnyOf(vararg ts: T) = asList().shouldContainAnyOf(*ts)
 fun <T> Collection<T>.shouldContainAnyOf(vararg ts: T) = this should containAnyOf(ts.asList())
-fun <T> Iterable<T>.shouldNotContainAnyOf(vararg ts: T) = toList().shouldNotContainAnyOf(ts)
-fun <T> Array<T>.shouldNotContainAnyOf(vararg ts: T) = asList().shouldNotContainAnyOf(ts)
+fun <T> Iterable<T>.shouldNotContainAnyOf(vararg ts: T) = toList().shouldNotContainAnyOf(*ts)
+fun <T> Array<T>.shouldNotContainAnyOf(vararg ts: T) = asList().shouldNotContainAnyOf(*ts)
 fun <T> Collection<T>.shouldNotContainAnyOf(vararg ts: T) = this shouldNot containAnyOf(ts.asList())
 infix fun <T> Iterable<T>.shouldContainAnyOf(ts: Collection<T>) = toList().shouldContainAnyOf(ts)
 infix fun <T> Array<T>.shouldContainAnyOf(ts: Collection<T>) = asList().shouldContainAnyOf(ts)
@@ -122,4 +122,3 @@ fun <T> containAnyOf(ts: Collection<T>) = object : Matcher<Collection<T>> {
 internal fun throwEmptyCollectionError(): Nothing {
    throw AssertionError("Asserting content on empty collection. Use Collection.shouldBeEmpty() instead.")
 }
-

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -857,6 +857,14 @@ class CollectionMatchersTest : WordSpec() {
             listOf(1, 2, 3).shouldContainAnyOf(1)
          }
 
+         "Pass when one element is in the iterable" {
+            listOf(1, 2, 3).asIterable().shouldContainAnyOf(1)
+         }
+
+         "Pass when one element is in the array" {
+            arrayOf(1, 2, 3).shouldContainAnyOf(1)
+         }
+
          "Pass when all elements are in the list" {
             listOf(1, 2, 3).shouldContainAnyOf(1, 2, 3)
          }
@@ -864,6 +872,18 @@ class CollectionMatchersTest : WordSpec() {
          "Fail when no element is in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldContainAnyOf(4)
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain any of [4]")
+         }
+
+         "Fail when no element is in the iterable" {
+            shouldThrow<AssertionError> {
+               listOf(1, 2, 3).asIterable().shouldContainAnyOf(4)
+            }.shouldHaveMessage("Collection [1, 2, 3] should contain any of [4]")
+         }
+
+         "Fail when no element is in the array" {
+            shouldThrow<AssertionError> {
+               arrayOf(1, 2, 3).shouldContainAnyOf(4)
             }.shouldHaveMessage("Collection [1, 2, 3] should contain any of [4]")
          }
       }
@@ -882,6 +902,18 @@ class CollectionMatchersTest : WordSpec() {
          "Fail when one element is in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldNotContainAnyOf(1)
+            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
+         }
+
+         "Fail when one element is in the iterable" {
+            shouldThrow<AssertionError> {
+               listOf(1, 2, 3).asIterable().shouldNotContainAnyOf(1)
+            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
+         }
+
+         "Fail when one element is in the array" {
+            shouldThrow<AssertionError> {
+               arrayOf(1, 2, 3).shouldNotContainAnyOf(1)
             }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
          }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolves #3732 

- Fixed `shouldContainAnyOf`, `shouldNotContainAnyOf` matchers with varargs bug.
- Added tests