### PR TITLE
Improve Sequence.shouldHaveSingleElement(...)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -276,14 +276,22 @@ infix fun <T> Sequence<T>.shouldNotBeSortedWith(cmp: (T, T) -> Int) = this shoul
 infix fun <T> Sequence<T>.shouldHaveSingleElement(t: T) = this should singleElement(t)
 infix fun <T> Sequence<T>.shouldNotHaveSingleElement(t: T) = this shouldNot singleElement(t)
 
-fun <T> singleElement(t: T) = object : Matcher<Sequence<T>> {
+fun <T> singleElement(expectedElement: T) = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
-      val valueAsList = value.toList()
-      val actualCount = valueAsList.count()
+      var failureMessage: String? = null
+      val iterator = value.iterator()
+      var actualElement: T?
+      if (!iterator.hasNext()) {
+         failureMessage = "Sequence should have a single element of $expectedElement but is empty."
+      } else if (eq(iterator.next().also { actualElement = it }, expectedElement) != null) {
+         failureMessage = "Sequence should have a single element of $expectedElement but has $actualElement as first element."
+      } else if (iterator.hasNext()) {
+         failureMessage = "Sequence should have a single element of $expectedElement but has more than one element."
+      }
       return MatcherResult(
-         actualCount == 1 && valueAsList.first() == t,
-         { "Sequence should be a single element of $t but has $actualCount elements" },
-         { "Sequence should not be a single element of $t" }
+         failureMessage == null,
+         { failureMessage ?: "" },
+         { "Sequence should not have a single element of $expectedElement." }
       )
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/sequences/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/sequences/SequenceMatchersTest.kt
@@ -3,7 +3,9 @@ package com.sksamuel.kotest.matchers.sequences
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.sequences.shouldContainExactly
+import io.kotest.matchers.sequences.shouldHaveSingleElement
 import io.kotest.matchers.sequences.shouldNotContainExactly
+import io.kotest.matchers.sequences.shouldNotHaveSingleElement
 import io.kotest.matchers.shouldBe
 
 class SequenceMatchersTest : StringSpec({
@@ -40,5 +42,29 @@ class SequenceMatchersTest : StringSpec({
       shouldThrow<AssertionError> {
          sequenceOf(1, 2, 3).shouldNotContainExactly(1, 2, 3)
       }.message shouldBe "Sequence should not contain exactly 1, 2, 3"
+   }
+
+   "single element" {
+      sequenceOf(1).shouldHaveSingleElement(1)
+
+      shouldThrow<AssertionError> {
+         emptySequence<Int>().shouldHaveSingleElement(1)
+      }.message shouldBe "Sequence should have a single element of 1 but is empty."
+
+      shouldThrow<AssertionError> {
+         sequenceOf(2).shouldHaveSingleElement(1)
+      }.message shouldBe "Sequence should have a single element of 1 but has 2 as first element."
+
+      shouldThrow<AssertionError> {
+         sequenceOf(1, 2).shouldHaveSingleElement(1)
+      }.message shouldBe "Sequence should have a single element of 1 but has more than one element."
+
+      shouldThrow<AssertionError> {
+         generateSequence(1) { it + 1 }.shouldHaveSingleElement(1)
+      }.message shouldBe "Sequence should have a single element of 1 but has more than one element."
+
+      shouldThrow<AssertionError> {
+         sequenceOf(1).shouldNotHaveSingleElement(1)
+      }.message shouldBe "Sequence should not have a single element of 1."
    }
 })


### PR DESCRIPTION
When the asserted sequence contains a different single element than expected, then the failure message was misleading. Now the three cases: empty sequence, different element, and sequence with more than one element have specific failure messages. Also, this assertion now works on infinite sequences and is much faster on long sequences since it no longer converts the sequence into a list.

Fixes https://github.com/kotest/kotest/issues/3744

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
