### PR TITLE
Fix using IrFactory's deprecated api

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/NativeTransformer.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/NativeTransformer.kt
@@ -43,15 +43,16 @@ class NativeTransformer(messageCollector: MessageCollector, pluginContext: IrPlu
             name = Name.identifier(EntryPoint.LauncherValName)
          }.also { field ->
             field.correspondingPropertySymbol = this@apply.symbol
-            field.initializer = pluginContext.irFactory.createExpressionBody(startOffset, endOffset) {
-               this.expression = DeclarationIrBuilder(pluginContext, field.symbol).irBlock {
+            field.initializer = pluginContext.irFactory.createExpressionBody(
+               startOffset,
+               endOffset,
+               DeclarationIrBuilder(pluginContext, field.symbol).irBlock {
                   +callLauncher(launchFn, specs, configs) {
                      irCall(withTeamCityListenerMethodNameFn).also { withTeamCity ->
                         withTeamCity.dispatchReceiver = irCall(launcherConstructor)
                      }
                   }
-               }
-            }
+               })
          }
 
          addGetter {

--- a/kotest-framework/kotest-framework-multiplatform-plugin-legacy-native/src/jvmMain/kotlin/io/kotest/framework/multiplatform/native/SpecIrGenerationExtension.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-legacy-native/src/jvmMain/kotlin/io/kotest/framework/multiplatform/native/SpecIrGenerationExtension.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.backend.common.IrElementTransformerVoidWithContext
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
+import org.jetbrains.kotlin.backend.common.serialization.proto.IrExpression
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.toLogger
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
@@ -82,8 +83,10 @@ class SpecIrGenerationExtension(private val messageCollector: MessageCollector) 
                   name = Name.identifier(EntryPoint.LauncherValName)
                }.also { field ->
                   field.correspondingPropertySymbol = this@apply.symbol
-                  field.initializer = pluginContext.irFactory.createExpressionBody(startOffset, endOffset) {
-                     this.expression = DeclarationIrBuilder(pluginContext, field.symbol).irBlock {
+                  field.initializer = pluginContext.irFactory.createExpressionBody(
+                     startOffset,
+                     endOffset,
+                     DeclarationIrBuilder(pluginContext, field.symbol).irBlock {
                         +irCall(launchFn).also { launch ->
                            launch.dispatchReceiver = irCall(withTeamCityListenerMethodNameFn).also { withTeamCity ->
                               withTeamCity.dispatchReceiver = irCall(withSpecsFn).also { withSpecs ->
@@ -99,7 +102,7 @@ class SpecIrGenerationExtension(private val messageCollector: MessageCollector) 
                            }
                         }
                      }
-                  }
+                  )
                }
 
                addGetter {


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolve #3749

Because below function removed at Kotlin's latest version, change to other function.

**AS-IS**

```kotlin
fun createExpressionBody(
        startOffset: Int,
        endOffset: Int,
        initializer: IrExpressionBody.() -> Unit,
): IrExpressionBody
```
- this function name changed to `createBlockBody` and deprecated.
- https://github.com/JetBrains/kotlin/blob/1.9.20/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/declarations/IrFactory.kt#L235-L248

**TO-BE**

```kotlin
fun createExpressionBody(
        startOffset: Int,
        endOffset: Int,
        expression: IrExpression,
): IrExpressionBody
```
- https://github.com/JetBrains/kotlin/blob/eaa46a80684e0980e5b70759718640b9feb3b8d3/compiler/ir/ir.tree/gen/org/jetbrains/kotlin/ir/declarations/IrFactory.kt#L229-L233
