### PR TITLE
Fix continually does not work with null values

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/ContinuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/ContinuallyTest.kt
@@ -19,6 +19,12 @@ class ContinuallyTest : FunSpec() {
          }
       }
 
+      test("pass tests with null values") {
+         val test = continually(500.milliseconds) {
+            null shouldBe null
+         }
+      }
+
       test("use interval function") {
          val config = continuallyConfig<Unit> {
             duration = 700.milliseconds


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolve #3780

Instead of checking if result is null, I changed to checking using the `Result` class.
