### PR TITLE
cutting docs for 5.8 (right this time)

### DIFF
--- a/documentation/versioned_docs/version-5.8/assertions/core.md
+++ b/documentation/versioned_docs/version-5.8/assertions/core.md
@@ -185,25 +185,24 @@ Matchers provided by the `kotest-assertions-core` module.
 | `file.shouldHaveParent(name)`                      |  Assert that the file has a parent with the given name |
 
 | Dates                                         ||
-|-----------------------------------------------|--------------------------------------------------------- Asserts that the date has the same year as the given date.                                                                           -----------------|
-| `date.shouldHaveSameYearAs(otherDate)`        | Asserts that the date has the same year as the given date.                                                                           |
-| `date.shouldHaveSameMonthAs(otherDate)`       | Asserts that the date has the same month as the given date.                                                                          |
-| `date.shouldHaveSameDayAs(otherDate)`         | Asserts that the date has the same day of the month as the given date.                                                               |
-| `date.shouldBeBefore(otherDate)`              | Asserts that the date is before the given date.                                                                                      |
-| `date.shouldBeAfter(otherDate)`               | Asserts that the date is after the given date.                                                                                       |
-| `date.shouldBeWithin(period, otherDate)`      | Asserts that the date is within the period of the given date.                                                                        |
-| `date.shouldBeWithin(duration, otherDate)`    | Asserts that the date is within the duration of the given date.                                                                      |
-| `date.shouldBeBetween(firstDate, secondDate)` | Asserts that the date is between firstdate and seconddate.                                                                           |
-| `date.shouldHaveYear(year)`                   | Asserts that the date have correct year.                                                                                             |
-| `date.shouldHaveMonth(month)`                 | Asserts that the date have correct month.                                                                                            |
-| `date.shouldHaveDayOfYear(day)`               | Asserts that the date have correct day of year.                                                                                      |
-| `date.shouldHaveDayOfMonth(day)`              | Asserts that the date have correct day of month.                                                                                     |
-| `date.shouldHaveDayOfWeek(day)`               | Asserts that the date have correct day of week.                                                                                      |
-| `date.shouldHaveHour(hour)`                   | Asserts that the date have correct hour.                                                                                             |
-| `date.shouldHaveMinute(Minute)`               | Asserts that the date have correct minute.                                                                                           |
-| `date.shouldHaveSecond(second)`               | Asserts that the date have correct second.                                                                                           |
-| `date.shouldHaveNano(nao)`                    | Asserts that the date have correct nano second.                                                                                      |
-| `date.shouldBe(value plusOrMinus(tolerance))` | Asserts that the date is equal to the given value within a tolerance range of duration.                                              |
+|-----------------------------------------------| ---- |
+| `date.shouldHaveSameYearAs(otherDate)`        | Asserts that the date has the same year as the given date. |
+| `date.shouldHaveSameMonthAs(otherDate)`       | Asserts that the date has the same month as the given date. |
+| `date.shouldHaveSameDayAs(otherDate)`         | Asserts that the date has the same day of the month as the given date. |
+| `date.shouldBeBefore(otherDate)`              | Asserts that the date is before the given date. |
+| `date.shouldBeAfter(otherDate)`               | Asserts that the date is after the given date. |
+| `date.shouldBeWithin(period, otherDate)`      | Asserts that the date is within the period of the given date. |
+| `date.shouldBeWithin(duration, otherDate)`    | Asserts that the date is within the duration of the given date. |
+| `date.shouldBeBetween(firstDate, secondDate)` | Asserts that the date is between firstdate and seconddate. |
+| `date.shouldHaveYear(year)`                   | Asserts that the date have correct year. |
+| `date.shouldHaveMonth(month)`                 | Asserts that the date have correct month. |
+| `date.shouldHaveDayOfYear(day)`               | Asserts that the date have correct day of year. |
+| `date.shouldHaveDayOfMonth(day)`              | Asserts that the date have correct day of month. |
+| `date.shouldHaveDayOfWeek(day)`               | Asserts that the date have correct day of week. |
+| `date.shouldHaveHour(hour)`                   | Asserts that the date have correct hour. |
+| `date.shouldHaveMinute(Minute)`               | Asserts that the date have correct minute. |
+| `date.shouldHaveSecond(second)`               | Asserts that the date have correct second. |
+| `date.shouldHaveNano(nao)`                    | Asserts that the date have correct nano second. |
 
 | ZonedDateTime                                                 ||
 |---------------------------------------------------------------| ---- |

--- a/documentation/versioned_docs/version-5.8/extensions/index.md
+++ b/documentation/versioned_docs/version-5.8/extensions/index.md
@@ -39,5 +39,3 @@ maintained and hosted by third parties.
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers)                                 | Result4s matchers                                                                  |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest)                            | Network connectivity testing                                                       |
 | [TestFiles](https://github.com/jGleitz/testfiles)                                                | Creates organized files and directories for testing                                |
-| [FixtureMonkey](https://github.com/naver/fixture-monkey)                                         | generate a complex type and customize it within Kotest                             |
-

--- a/documentation/versioned_docs/version-5.8/framework/styles.md
+++ b/documentation/versioned_docs/version-5.8/framework/styles.md
@@ -199,21 +199,19 @@ class MyTests : DescribeSpec({
 
 ## Behavior Spec
 
-Popular with people who like to write tests in the _BDD_ style, `BehaviorSpec` allows you to use `context`, `given`, `when`, `then`.
+Popular with people who like to write tests in the _BDD_ style, `BehaviorSpec` allows you to use `given`, `when`, `then`.
 
 ```kotlin
 class MyTests : BehaviorSpec({
-    context("a broomstick should be able to be fly and come back on it's own") {
-        given("a broomstick") {
-            `when`("I sit on it") {
-                then("I should be able to fly") {
-                    // test code
-                }
+    given("a broomstick") {
+        `when`("I sit on it") {
+            then("I should be able to fly") {
+                // test code
             }
-            `when`("I throw it away") {
-                then("it should come back") {
-                    // test code
-                }
+        }
+        `when`("I throw it away") {
+            then("it should come back") {
+                // test code
             }
         }
     }
@@ -221,7 +219,7 @@ class MyTests : BehaviorSpec({
 ```
 
 :::note
-Because `when` is a keyword in Kotlin, we must enclose it with backticks. Alternatively, there are title case versions available if you don't like the use of backticks, eg, `Context`, `Given`, `When`, `Then`.
+Because `when` is a keyword in Kotlin, we must enclose it with backticks. Alternatively, there are title case versions available if you don't like the use of backticks, eg, `Given`, `When`, `Then`.
 :::
 
 
@@ -248,7 +246,7 @@ Note: `Then` scope doesn't have an `and` scope due to a Gradle bug. For more inf
 
 
 
-Tests can be disabled using the `xcontext`, `xgiven`, `xwhen`, and `xthen` variants (in addition to the [usual ways](conditional_evaluation.md))
+Tests can be disabled using the `xgiven`, `xwhen`, and `xthen` variants (in addition to the [usual ways](conditional_evaluation.md))
 
 ```kotlin
 class MyTests : BehaviorSpec({


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

5.8 docs were cut from master 2 weeks after 5.8.0 release went out, so some changes made it into the docs that are not actually present in 5.8.

Fixes #3790 