### PR TITLE
Fix compiler plugin for K2 compiler

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/entry.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/entry.kt
@@ -11,7 +11,11 @@ object EntryPoint {
    // in JS we use promise() which ultimately calls into GlobalScope.promise on JS platforms
    const val PromiseMethodName = "promise"
 
-   // the FQN for the class used to launch the MPP engine
+   /**
+    * the FQN for the class used to launch the MPP engine.
+    *
+    * This must be a string where packages are delimited by '/' and classes by '.', e.g. "kotlin/Map.Entry".
+    */
    const val TestEngineClassName = "io/kotest/engine/TestEngineLauncher"
 
    // the method invoked to add specs to the launcher, must exist on TestEngineLauncher

--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/entry.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/entry.kt
@@ -12,7 +12,7 @@ object EntryPoint {
    const val PromiseMethodName = "promise"
 
    // the FQN for the class used to launch the MPP engine
-   const val TestEngineClassName = "io.kotest.engine.TestEngineLauncher"
+   const val TestEngineClassName = "io/kotest/engine/TestEngineLauncher"
 
    // the method invoked to add specs to the launcher, must exist on TestEngineLauncher
    const val WithSpecsMethodName = "withSpecs"


### PR DESCRIPTION
Enable Kotest to be used with K2 compilation in Kotlin versions 1.8.10 up to at least 2.0.0-Beta1.

This avoids compilation errors
"java.lang.IllegalStateException: Cannot find io.kotest.engine.TestEngineLauncher class reference".