### PR TITLE
Local time plus or minus take2

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -962,6 +962,7 @@ public final class io/kotest/matchers/date/LocaltimeKt {
 	public static final fun haveSameMinutes (Ljava/time/LocalTime;)Lio/kotest/matchers/Matcher;
 	public static final fun haveSameNanos (Ljava/time/LocalTime;)Lio/kotest/matchers/Matcher;
 	public static final fun haveSameSeconds (Ljava/time/LocalTime;)Lio/kotest/matchers/Matcher;
+	public static final fun plusOrMinus-HG0u8IE (Ljava/time/LocalTime;J)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeAfter (Ljava/time/LocalTime;Ljava/time/LocalTime;)V
 	public static final fun shouldBeBefore (Ljava/time/LocalTime;Ljava/time/LocalTime;)V
 	public static final fun shouldBeBetween (Ljava/time/LocalTime;Ljava/time/LocalTime;Ljava/time/LocalTime;)Ljava/lang/Object;

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localtime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localtime.kt
@@ -588,10 +588,10 @@ fun between(a: LocalTime, b: LocalTime): Matcher<LocalTime> = object : Matcher<L
  * @see LocalTime.shouldBeBetween
  * @see LocalTime.shouldNotBeBetween
  */
-infix fun LocalTime.plusOrMinus(tolerance: Duration): LocalTimeToleranceMatcher =
+infix fun LocalTime.plusOrMinus(tolerance: Duration): Matcher<LocalTime> =
    LocalTimeToleranceMatcher(this, tolerance)
 
-class LocalTimeToleranceMatcher(
+internal class LocalTimeToleranceMatcher(
    private val expected: LocalTime,
    private val tolerance: Duration
 ): Matcher<LocalTime> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localtime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localtime.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import java.time.LocalTime
+import kotlin.time.Duration
 
 /**
  * Asserts that hours in this time are the same as [time]'s hours
@@ -562,3 +563,72 @@ fun between(a: LocalTime, b: LocalTime): Matcher<LocalTime> = object : Matcher<L
     )
   }
 }
+
+/**
+ * Matcher that checks if LocalTime is within tolerance of another LocalTime
+ *
+ * Verifies that LocalTime is after the first LocalTime and before the second LocalTime
+ * For example, 12:30:00 is within 5 minutes of 12:34:59, and the matcher will have a positive result for this comparison.
+ * It handles cases when one of these times is before midnight and another after midnight
+ *
+ * ```
+ *    val time = LocalTime.of(12, 30, 0)
+ *    val anotherTime = LocalTime.of(12, 34, 59)
+ *
+ *    time shouldBe (anotherTime plusOrMinus 5.minutes) // Assertion passes
+ *    time shouldNotBe (anotherTime plusOrMinus 3.minutes) // Assertion fails
+ *
+ *    val beforeMidnight = LocalTime.of(23, 59, 0)
+ *    val afterMidnight = LocalTime.of(0, 1, 0)
+ *
+ *    beforeMidnight shouldBe (afterMidnight plusOrMinus 3.minutes)   // Assertion passes
+ *    afterMidnight shouldBe (beforeMidnight plusOrMinus 3.minutes)   // Assertion passes
+ * ```
+ *
+ * @see LocalTime.shouldBeBetween
+ * @see LocalTime.shouldNotBeBetween
+ */
+infix fun LocalTime.plusOrMinus(tolerance: Duration): LocalTimeToleranceMatcher =
+   LocalTimeToleranceMatcher(this, tolerance)
+
+class LocalTimeToleranceMatcher(
+   private val expected: LocalTime,
+   private val tolerance: Duration
+): Matcher<LocalTime> {
+   init {
+      validateTolerance(tolerance)
+   }
+
+   override fun test(value: LocalTime): MatcherResult {
+      val positiveTolerance = tolerance.absoluteValue
+      val lowerBound = expected.minusNanos(positiveTolerance.inWholeNanoseconds)
+      val upperBound = expected.plusNanos(positiveTolerance.inWholeNanoseconds)
+      val spansTwoDays = upperBound < lowerBound
+      val insideToleranceInterval = if(spansTwoDays) (lowerBound <= value) || (value <= upperBound)
+         else (lowerBound <= value) && (value <= upperBound)
+      return MatcherResult(
+         insideToleranceInterval,
+         { "$value should be equal to $expected with tolerance $tolerance (${rangeDescription(lowerBound, upperBound)})" },
+         { "$value should not be equal to $expected with tolerance $tolerance (not ${rangeDescription(lowerBound, upperBound)})" }
+      )
+   }
+
+   infix fun plusOrMinus(tolerance: Duration): LocalTimeToleranceMatcher =
+      LocalTimeToleranceMatcher(expected, tolerance)
+
+   companion object {
+      const val NANOS_IN_SECOND = 1_000_000_000L
+      const val SECONDS_IN_HOUR = 3_600L
+      const val MAX_TOLERANCE = 12 * SECONDS_IN_HOUR * NANOS_IN_SECOND - 1
+
+      internal fun rangeDescription(lowerBound: LocalTime, upperBound: LocalTime) =
+         "between $lowerBound and $upperBound${if (upperBound < lowerBound) " next day" else ""}"
+
+      internal fun validateTolerance(tolerance: Duration) {
+         require(tolerance.absoluteValue.inWholeNanoseconds <= MAX_TOLERANCE) {
+            "Tolerance cannot be 12 hours or more, was: $tolerance"
+         }
+      }
+   }
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/LocalTimeToleranceMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/LocalTimeToleranceMatcherTest.kt
@@ -1,0 +1,112 @@
+package com.sksamuel.kotest.matchers.date
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.date.LocalTimeToleranceMatcher
+import io.kotest.matchers.date.and
+import io.kotest.matchers.date.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.LocalTime
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+class LocalTimeToleranceMatcherTest: WordSpec() {
+   private val oneAm = LocalTime.of(1, 0, 0)
+   private val onePm = LocalTime.of(13, 0, 0)
+   private val sixPm = LocalTime.of(18, 0, 0)
+   init {
+      "should" should {
+         "pass when the whole range is inside one calendar day" {
+             onePm shouldBe (LocalTime.of(13, 1, 0) plusOrMinus 2.minutes)
+             onePm shouldBe (LocalTime.of(12, 59, 0) plusOrMinus 2.minutes)
+         }
+
+         "fail when the whole range is inside one calendar day" {
+            shouldThrowAny {
+               onePm shouldBe (LocalTime.of(13, 3, 0) plusOrMinus 2.minutes)
+            }.message shouldBe "13:00 should be equal to 13:03 with tolerance 2m (between 13:01 and 13:05)"
+            shouldThrowAny {
+               onePm shouldBe (LocalTime.of(12, 57, 0) plusOrMinus 2.minutes)
+            }.message shouldBe "13:00 should be equal to 12:57 with tolerance 2m (between 12:55 and 12:59)"
+         }
+
+         "pass when the range includes midnight" {
+            val oneMinuteAfterMidnight = LocalTime.of(0, 1, 0)
+            LocalTime.of(23, 59) shouldBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            LocalTime.of(0, 0) shouldBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            LocalTime.of(0, 2) shouldBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+         }
+
+         "fail when the range includes midnight" {
+            val oneMinuteAfterMidnight = LocalTime.of(0, 1, 0)
+            shouldThrowAny {
+               LocalTime.of(23, 58) shouldBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            }.message shouldBe "23:58 should be equal to 00:01 with tolerance 2m (between 23:59 and 00:03 next day)"
+            shouldThrowAny {
+               LocalTime.of(0, 4) shouldBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            }.message shouldBe "00:04 should be equal to 00:01 with tolerance 2m (between 23:59 and 00:03 next day)"
+         }
+      }
+
+      "shouldNot" should {
+         "fail when the whole range is inside one calendar day" {
+            shouldThrowAny {
+               onePm shouldNotBe (LocalTime.of(13, 1, 0) plusOrMinus 2.minutes)
+            }.message shouldBe "13:00 should not be equal to 13:01 with tolerance 2m (not between 12:59 and 13:03)"
+            shouldThrowAny {
+               onePm shouldNotBe (LocalTime.of(12, 59, 0) plusOrMinus 2.minutes)
+            }.message shouldBe "13:00 should not be equal to 12:59 with tolerance 2m (not between 12:57 and 13:01)"
+         }
+
+         "pass when the whole range is inside one calendar day" {
+            onePm shouldNotBe (LocalTime.of(13, 3, 0) plusOrMinus 2.minutes)
+            onePm shouldNotBe (LocalTime.of(12, 57, 0) plusOrMinus 2.minutes)
+         }
+
+         "fail when the range includes midnight" {
+            val oneMinuteAfterMidnight = LocalTime.of(0, 1, 0)
+            shouldThrowAny {
+               LocalTime.of(23, 59) shouldNotBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            }.message shouldBe "23:59 should not be equal to 00:01 with tolerance 2m (not between 23:59 and 00:03 next day)"
+            shouldThrowAny {
+               LocalTime.of(0, 0) shouldNotBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            }.message shouldBe "00:00 should not be equal to 00:01 with tolerance 2m (not between 23:59 and 00:03 next day)"
+            shouldThrowAny {
+               LocalTime.of(0, 2) shouldNotBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            }.message shouldBe "00:02 should not be equal to 00:01 with tolerance 2m (not between 23:59 and 00:03 next day)"
+         }
+
+         "pass when the range includes midnight" {
+            val oneMinuteAfterMidnight = LocalTime.of(0, 1, 0)
+            LocalTime.of(23, 58) shouldNotBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+            LocalTime.of(0, 4) shouldNotBe (oneMinuteAfterMidnight plusOrMinus 2.minutes)
+         }
+      }
+
+      "rangeDescription" should {
+          "works when interval is within day" {
+             LocalTimeToleranceMatcher.rangeDescription(oneAm, sixPm) shouldBe "between 01:00 and 18:00"
+          }
+
+         "works when interval is spans two days" {
+            LocalTimeToleranceMatcher.rangeDescription(sixPm, oneAm) shouldBe "between 18:00 and 01:00 next day"
+         }
+      }
+
+      "validateTolerance" should {
+          "pass when less than 12 hours" {
+             shouldNotThrowAny {
+                LocalTimeToleranceMatcher.validateTolerance(11.hours and 59.minutes)
+             }
+          }
+
+         "fail when 12 hours" {
+            shouldThrowAny {
+               LocalTimeToleranceMatcher.validateTolerance(12.hours)
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
support `plusOrMinus` for `LocalTime`. For instance:
` LocalTime.of(13, 0, 0) shouldBe (LocalTime.of(13, 1, 0) plusOrMinus 2.minutes)`
` LocalTime.of(13, 5, 0) shouldNotBe (LocalTime.of(13, 1, 0) plusOrMinus 2.minutes)`

also support ranges that span two calendar days, including a midnight:

```
LocalTime.of(23, 59) shouldBe (LocalTime.of(0, 1, 0) plusOrMinus 2.minutes)
LocalTime.of(0, 0) shouldBe (LocalTime.of(0, 1, 0) plusOrMinus 2.minutes)
LocalTime.of(0, 2) shouldBe (LocalTime.of(0, 1, 0) plusOrMinus 2.minutes)
```
