### PR TITLE
docs: fix EnabledCondition example (interface, not class)

### DIFF
--- a/documentation/docs/framework/conditional/annotations.md
+++ b/documentation/docs/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run

--- a/documentation/versioned_docs/version-5.2/framework/conditional/annotations.md
+++ b/documentation/versioned_docs/version-5.2/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run

--- a/documentation/versioned_docs/version-5.3/framework/conditional/annotations.md
+++ b/documentation/versioned_docs/version-5.3/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run

--- a/documentation/versioned_docs/version-5.4/framework/conditional/annotations.md
+++ b/documentation/versioned_docs/version-5.4/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run

--- a/documentation/versioned_docs/version-5.6/framework/conditional/annotations.md
+++ b/documentation/versioned_docs/version-5.6/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run

--- a/documentation/versioned_docs/version-5.7/framework/conditional/annotations.md
+++ b/documentation/versioned_docs/version-5.7/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run

--- a/documentation/versioned_docs/version-5.8/framework/conditional/annotations.md
+++ b/documentation/versioned_docs/version-5.8/framework/conditional/annotations.md
@@ -40,7 +40,7 @@ to determine if a spec is enabled. Note that implementations must have a zero ar
 For example, we may wish to only execute tests containing the name "Linux" when run on a Linux machine.
 
 ```kotlin
-class LinuxOnlyCondition : EnabledCondition() {
+class LinuxOnlyCondition : EnabledCondition {
   override fun enabled(kclass: KClass<out Spec>): Boolean = when {
     kclass.simpleName?.contains("Linux") == true -> IS_OS_LINUX
     else -> true // non Linux tests always run


### PR DESCRIPTION
Relates to #3259 but applied to all doc versions

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
