### PR TITLE
Add `shouldNotBePositive` and `shouldNotBeNegative` matchers for BigDecimal

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -127,6 +127,8 @@ Matchers provided by the `kotest-assertions-core` module.
 | `bigDecimal.shouldHaveScale(n)`             | Asserts that the bigDecimal scale is equals than the given value n |
 | `bigDecimal.shouldBePositive()`             | Asserts that the bigDecimal is positive |
 | `bigDecimal.shouldBeNegative()`             | Asserts that the bigDecimal is negative |
+| `bigDecimal.shouldNotBePositive()`          | Asserts that the bigDecimal is not positive |
+| `bigDecimal.shouldNotBeNegative()`          | Asserts that the bigDecimal is not negative |
 | `bigDecimal.shouldBeZero()`                 | Asserts that the bigDecimal is zero |
 | `bigDecimal.shouldBeLessThan(n)`            | Asserts that the bigDecimal is less than the given value n |
 | `bigDecimal.shouldBeLessThanOrEquals(n)`    | Asserts that the bigDecimal is less than or equ|

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -259,6 +259,8 @@ public final class io/kotest/matchers/bigdecimal/MatchersKt {
 	public static final fun shouldNotBeInRange (Ljava/math/BigDecimal;Lkotlin/ranges/ClosedRange;)V
 	public static final fun shouldNotBeLessThan (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBeLessThanOrEquals (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
+	public static final fun shouldNotBeNegative (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
+	public static final fun shouldNotBePositive (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotHaveScale (Ljava/math/BigDecimal;I)I
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/matchers.kt
@@ -15,6 +15,8 @@ import java.math.BigDecimal
 fun BigDecimal.shouldBeZero() = this shouldBe BigDecimal.ZERO
 fun BigDecimal.shouldBePositive() = this shouldBe gt(BigDecimal.ZERO)
 fun BigDecimal.shouldBeNegative() = this shouldBe lt(BigDecimal.ZERO)
+fun BigDecimal.shouldNotBePositive() = this shouldNotBe gt(BigDecimal.ZERO)
+fun BigDecimal.shouldNotBeNegative() = this shouldNotBe lt(BigDecimal.ZERO)
 
 infix fun BigDecimal.shouldHavePrecision(precision: Int) = this.precision() shouldBe precision
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/bigdecimal/BigDecimalMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/bigdecimal/BigDecimalMatchersTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.matchers.bigdecimal
 
 import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.bigdecimal.shouldBeGreaterThan
 import io.kotest.matchers.bigdecimal.shouldBeGreaterThanOrEquals
 import io.kotest.matchers.bigdecimal.shouldBeInRange
@@ -16,8 +17,9 @@ import io.kotest.matchers.bigdecimal.shouldNotBeGreaterThanOrEquals
 import io.kotest.matchers.bigdecimal.shouldNotBeInRange
 import io.kotest.matchers.bigdecimal.shouldNotBeLessThan
 import io.kotest.matchers.bigdecimal.shouldNotBeLessThanOrEquals
+import io.kotest.matchers.bigdecimal.shouldNotBeNegative
+import io.kotest.matchers.bigdecimal.shouldNotBePositive
 import io.kotest.matchers.bigdecimal.shouldNotHaveScale
-import io.kotest.core.spec.style.StringSpec
 import java.math.BigDecimal
 
 class BigDecimalMatchersTest : StringSpec() {
@@ -63,6 +65,18 @@ class BigDecimalMatchersTest : StringSpec() {
 
       shouldThrowAny { BigDecimal(1).shouldBeNegative() }
       shouldThrowAny { BigDecimal.ZERO.shouldBeNegative() }
+    }
+    "shouldNotBePositive" {
+       BigDecimal(-1).shouldNotBePositive()
+       BigDecimal.ZERO.shouldNotBePositive()
+
+       shouldThrowAny { BigDecimal(1).shouldNotBePositive() }
+    }
+    "shouldNotBeNegative" {
+       BigDecimal(1).shouldNotBeNegative()
+       BigDecimal.ZERO.shouldNotBeNegative()
+
+       shouldThrowAny { BigDecimal(-1).shouldNotBeNegative() }
     }
     "shouldBeGreaterThan" {
       BigDecimal.ONE shouldBeGreaterThan BigDecimal.ZERO


### PR DESCRIPTION
> Anyone relying on the old behaviour (zero being considered positive) could switch assertion to `bd.shouldNotBeNegative()`

_Originally posted by @Kantis in https://github.com/kotest/kotest/pull/3814#pullrequestreview-1798445484_

--

Okay, I got the hint 😂.