### PR TITLE
fix: Path.shouldBeAFile should fail on non-existant files

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
@@ -12,6 +12,8 @@ import io.kotest.matchers.shouldNotBe
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.isRegularFile
 import kotlin.streams.toList
 
 infix fun Path.shouldStartWithPath(file: File) = this should startWithPath(file)
@@ -66,9 +68,9 @@ fun Path.shouldBeAFile() = this should aFile()
 fun Path.shouldNotBeAFile() = this shouldNot aFile()
 fun aFile(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult = MatcherResult(
-      !Files.isDirectory(value),
-      { "File $value should be a directory" },
-      { "File $value should not be a directory" })
+      value.isRegularFile(),
+      { "Path $value should be a regular file" },
+      { "Path $value should not be a regular file" })
 }
 
 fun Path.shouldBeAbsolute() = this should beAbsolute()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
@@ -1,27 +1,34 @@
 package com.sksamuel.kotest.matchers.paths
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.paths.shouldBeAFile
 import io.kotest.matchers.paths.shouldBeEmptyDirectory
 import io.kotest.matchers.paths.shouldNotBeEmptyDirectory
 import java.nio.file.Files
+import kotlin.io.path.Path
 
-@Suppress("BlockingMethodInNonBlockingContext")
-class PathMatchersTest : FunSpec() {
+class PathMatchersTest : FunSpec({
 
-  init {
 
-    test("directory should be empty (deprecated)") {
-       val path = Files.createTempDirectory("testdir")
-       path.shouldBeEmptyDirectory()
-       Files.write(path.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
-       path.shouldNotBeEmptyDirectory()
-    }
+   context("Be a file") {
+      test("Should fail for files that don't exist") {
+         shouldThrow<AssertionError> { Path("abc").shouldBeAFile() }
+      }
+   }
 
-    test("directory should be empty") {
+
+   test("directory should be empty (deprecated)") {
       val path = Files.createTempDirectory("testdir")
       path.shouldBeEmptyDirectory()
       Files.write(path.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
       path.shouldNotBeEmptyDirectory()
-    }
-  }
-}
+   }
+
+   test("directory should be empty") {
+      val path = Files.createTempDirectory("testdir")
+      path.shouldBeEmptyDirectory()
+      Files.write(path.resolve("testfile.txt"), byteArrayOf(1, 2, 3))
+      path.shouldNotBeEmptyDirectory()
+   }
+})


### PR DESCRIPTION
Fixes #3825

