### PR TITLE
Support `Iterable` in `withData` on root level

### DIFF
--- a/kotest-framework/kotest-framework-datatest/api/kotest-framework-datatest.api
+++ b/kotest-framework/kotest-framework-datatest/api/kotest-framework-datatest.api
@@ -16,10 +16,10 @@ public abstract interface annotation class io/kotest/datatest/IsStableType : jav
 }
 
 public final class io/kotest/datatest/RootKt {
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)V
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V
-	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Ljava/util/Collection;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Lkotlin/jvm/functions/Function1;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)V
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V
-	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Lkotlin/jvm/functions/Function1;Ljava/util/Collection;Lkotlin/jvm/functions/Function3;)V
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Lkotlin/jvm/functions/Function1;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)V
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/RootScope;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)V
 	public static final fun withDataMap (Lio/kotest/core/spec/style/scopes/RootScope;Ljava/util/Map;Lkotlin/jvm/functions/Function3;)V

--- a/kotest-framework/kotest-framework-datatest/src/commonMain/kotlin/io/kotest/datatest/root.kt
+++ b/kotest-framework/kotest-framework-datatest/src/commonMain/kotlin/io/kotest/datatest/root.kt
@@ -47,7 +47,7 @@ fun <T> RootScope.withData(nameFn: (T) -> String, ts: Sequence<T>, test: suspend
  *
  * The test name will be generated from the stable properties of the elements. See [StableIdentifiers].
  */
-fun <T> RootScope.withData(ts: Collection<T>, test: suspend ContainerScope.(T) -> Unit) {
+fun <T> RootScope.withData(ts: Iterable<T>, test: suspend ContainerScope.(T) -> Unit) {
    withData({ getStableIdentifier(it) }, ts, test)
 }
 
@@ -58,7 +58,7 @@ fun <T> RootScope.withData(ts: Collection<T>, test: suspend ContainerScope.(T) -
  */
 fun <T> RootScope.withData(
    nameFn: (T) -> String,
-   ts: Collection<T>,
+   ts: Iterable<T>,
    test: suspend ContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->

--- a/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/ContainerDataTestNameFunctionTest.kt
+++ b/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/ContainerDataTestNameFunctionTest.kt
@@ -6,7 +6,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.delay
 
 @ExperimentalKotest
 class ContainerDataTestNameFunctionTest : FunSpec({
@@ -20,8 +19,8 @@ class ContainerDataTestNameFunctionTest : FunSpec({
 
    context("Data test with triple") {
       withData(
-         Triple(1,2,3),
-         Triple(3,2,1),
+         Triple(1, 2, 3),
+         Triple(3, 2, 1),
       ) {}
    }
 
@@ -67,6 +66,17 @@ class ContainerDataTestNameFunctionTest : FunSpec({
       ) {}
    }
 
+   context("data test with name function and range") {
+      withData<Int>(
+         { i: Int -> "Test $i" },
+         1..3
+      ) {}
+   }
+
+   context("data test with progression") {
+      withData(4 downTo 0 step 2) {}
+   }
+
 }) {
    override suspend fun afterAny(testCase: TestCase, result: TestResult) {
       DataTestNamesStore.names.add(testCase.descriptor.id.value)
@@ -95,6 +105,14 @@ class ContainerDataTestNameFunctionTest : FunSpec({
          "simplea1b1",
          "simplea2b2",
          "data test with name function and collection",
+         "Test 1",
+         "Test 2",
+         "Test 3",
+         "data test with name function and range",
+         "4",
+         "2",
+         "0",
+         "data test with progression",
       )
    }
 

--- a/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/RootDataTestNameFunctionTest.kt
+++ b/kotest-framework/kotest-framework-datatest/src/jvmTest/kotlin/io/kotest/datatest/RootDataTestNameFunctionTest.kt
@@ -52,6 +52,12 @@ class RootDataTestNameFunctionTest : FunSpec({
       )
    ) {}
 
+   withData<Int>(
+      { i: Int -> "Test $i" },
+      1..3
+   ) {}
+
+   withData(4 downTo 0 step 2) {}
 }) {
    override suspend fun afterAny(testCase: TestCase, result: TestResult) {
       DataTestNamesStore.names.add(testCase.descriptor.id.value)
@@ -73,6 +79,12 @@ class RootDataTestNameFunctionTest : FunSpec({
          "(1) simplea2b2",
          "(2) simplea1b1",
          "(2) simplea2b2",
+         "Test 1",
+         "Test 2",
+         "Test 3",
+         "4",
+         "2",
+         "0",
       )
    }
 


### PR DESCRIPTION
Fixes #3830

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
