### PR TITLE
Added java.time.Year arbitrary support

### DIFF
--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -891,6 +891,8 @@ public final class io/kotest/property/arbitrary/DatesKt {
 	public static final fun period (Lio/kotest/property/Arb$Companion;I)Lio/kotest/property/Arb;
 	public static synthetic fun period$default (Lio/kotest/property/Arb$Companion;IILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static final fun random (Lkotlin/ranges/ClosedRange;Lkotlin/random/Random;)Ljava/time/Instant;
+	public static final fun year (Lio/kotest/property/Arb$Companion;Ljava/time/Year;Ljava/time/Year;)Lio/kotest/property/Arb;
+	public static synthetic fun year$default (Lio/kotest/property/Arb$Companion;Ljava/time/Year;Ljava/time/Year;ILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static final fun yearMonth (Lio/kotest/property/Arb$Companion;Ljava/time/YearMonth;Ljava/time/YearMonth;)Lio/kotest/property/Arb;
 	public static synthetic fun yearMonth$default (Lio/kotest/property/Arb$Companion;Ljava/time/YearMonth;Ljava/time/YearMonth;ILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static final fun zonedDateTime (Lio/kotest/property/Arb$Companion;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lio/kotest/property/Arb;)Lio/kotest/property/Arb;

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.Year
 import java.time.Year.isLeap
 import java.time.YearMonth
 import java.time.ZoneId
@@ -18,6 +19,7 @@ import java.time.temporal.TemporalQueries.localDate
 import java.time.temporal.TemporalQueries.localTime
 import java.util.*
 import kotlin.random.Random
+import kotlin.random.nextInt
 
 /**
  * Arberates a random [Period]s.
@@ -167,6 +169,20 @@ fun Arb.Companion.localDateTime(
          }.first { !it.isBefore(minLocalDateTime) && !it.isAfter(maxLocalDateTime) }
       }
    )
+}
+
+/**
+ * Arberates a stream of random Year
+ *
+ * This generator creates randomly generated Year, in the range [[minYear, maxYear]].
+ */
+fun Arb.Companion.year(
+   minYear: Year = Year.of(1970),
+   maxYear: Year = Year.of(2030)
+): Arb<Year> {
+   return arbitrary(listOf(minYear, maxYear)) {
+      Year.of(it.random.nextInt(minYear.value..maxYear.value))
+   }
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -20,6 +20,7 @@ import io.kotest.property.arbitrary.of
 import io.kotest.property.arbitrary.offsetDateTime
 import io.kotest.property.arbitrary.period
 import io.kotest.property.arbitrary.take
+import io.kotest.property.arbitrary.year
 import io.kotest.property.arbitrary.yearMonth
 import io.kotest.property.arbitrary.zonedDateTime
 import io.kotest.property.checkAll
@@ -30,6 +31,7 @@ import java.time.LocalDate.of
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.Period
+import java.time.Year
 import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZoneOffset
@@ -226,6 +228,24 @@ class DateTest : WordSpec({
 
       "Be the default generator for Duration" {
          checkAll(10) { _: Period -> /* No use. Won't reach here if unsupported */ }
+      }
+   }
+
+   "Arb.year(minYear, maxYear)" should {
+      "generate valid years (no exceptions)" {
+         shouldNotThrowAny {
+            Arb.year().take(10_000).toList()
+         }
+      }
+
+      "generate years between minYear and maxYear" {
+         val years = mutableSetOf<Year>()
+
+         checkAll(10_000, Arb.year(Year.of(1998), Year.of(1999))) {
+            years += it
+         }
+
+         years shouldBe setOf(Year.of(1998), Year.of(1999))
       }
    }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolve #3838