### PR TITLE
Should contain exactly in any order count mismatch draft (#19)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactlyInAnyOrder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactlyInAnyOrder.kt
@@ -129,13 +129,19 @@ fun <T, C : Collection<T>> containExactlyInAnyOrder(
    val extra = actual.filterNot { t ->
       expected.any { verifier?.verify(it, t)?.areEqual() ?: (t == it) }
    }
+   val countMismatch = countMismatch(expectedGroupedCounts, valueGroupedCounts)
 
    val failureMessage = {
       buildString {
          append("Collection should contain ${expected.print().value} in any order, but was ${actual.print().value}")
          appendLine()
          appendMissingAndExtra(missing, extra)
-         appendLine()
+         if(missing.isNotEmpty() || extra.isNotEmpty()) {
+            appendLine()
+         }
+         if(countMismatch.isNotEmpty()) {
+            append("CountMismatches: ${countMismatch.joinToString(", ")}")
+         }
       }
    }
 
@@ -146,4 +152,23 @@ fun <T, C : Collection<T>> containExactlyInAnyOrder(
       failureMessage,
       negatedFailureMessage
    )
+}
+
+internal fun<T> countMismatch(expectedCounts: Map<T, Int>, actualCounts: Map<T, Int>) =
+   actualCounts.entries.mapNotNull { actualEntry ->
+      expectedCounts[actualEntry.key]?.let { expectedValue ->
+         if(actualEntry.value != expectedValue)
+            CountMismatch(actualEntry.key, expectedValue, actualEntry.value)
+         else null
+      }
+   }
+
+internal data class CountMismatch<T>(val key: T, val expectedCount: Int, val actualCount: Int) {
+   init {
+       require(expectedCount >= 0 && actualCount >= 0) {
+          "Both expected and actual count should be non-negative, but expected was: $expectedCount and actual: was: $actualCount"
+       }
+   }
+
+   override fun toString(): String = "Key=\"${key}\", expected count: $expectedCount, but was: $actualCount"
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -295,13 +295,24 @@ class ShouldContainExactlyTest : WordSpec() {
             )
          }
 
-         "print count mismatches" {
+         "print count mismatches for not null keys" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 2, 3).shouldContainExactlyInAnyOrder(listOf(1, 2, 3, 3))
             }.shouldHaveMessage(
                """
                   Collection should contain [1, 2, 3, 3] in any order, but was [1, 2, 2, 3]
                   CountMismatches: Key="2", expected count: 1, but was: 2, Key="3", expected count: 2, but was: 1
+               """.trimIndent()
+            )
+         }
+
+         "print count mismatches for nullable keys" {
+            shouldThrow<AssertionError> {
+               listOf(1, null, null, 3).shouldContainExactlyInAnyOrder(listOf(1, null, 3, 3))
+            }.shouldHaveMessage(
+               """
+                  Collection should contain [1, <null>, 3, 3] in any order, but was [1, <null>, <null>, 3]
+                  CountMismatches: Key="null", expected count: 1, but was: 2, Key="3", expected count: 2, but was: 1
                """.trimIndent()
             )
          }
@@ -324,12 +335,20 @@ class ShouldContainExactlyTest : WordSpec() {
             val counts = mapOf("apple" to 1, "orange" to 2)
             countMismatch(counts, counts).shouldBeEmpty()
          }
-         "return differences" {
+         "return differences for not null key" {
             countMismatch(
                mapOf("apple" to 1, "orange" to 2, "banana" to 3),
                mapOf("apple" to 2, "orange" to 2, "peach" to 1)
             ) shouldBe listOf(
                CountMismatch("apple", 1, 2)
+            )
+         }
+         "return differences for null key" {
+            countMismatch(
+               mapOf(null to 1, "orange" to 2, "banana" to 3),
+               mapOf(null to 2, "orange" to 2, "peach" to 1)
+            ) shouldBe listOf(
+               CountMismatch(null, 1, 2)
             )
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -3,8 +3,11 @@ package com.sksamuel.kotest.matchers.collections
 import io.kotest.assertions.shouldFailWithMessage
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.CountMismatch
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.countMismatch
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContainExactly
@@ -292,6 +295,17 @@ class ShouldContainExactlyTest : WordSpec() {
             )
          }
 
+         "print count mismatches" {
+            shouldThrow<AssertionError> {
+               listOf(1, 2, 2, 3).shouldContainExactlyInAnyOrder(listOf(1, 2, 3, 3))
+            }.shouldHaveMessage(
+               """
+                  Collection should contain [1, 2, 3, 3] in any order, but was [1, 2, 2, 3]
+                  CountMismatches: Key="2", expected count: 1, but was: 2, Key="3", expected count: 2, but was: 1
+               """.trimIndent()
+            )
+         }
+
          "disambiguate when using optional expected value" {
             val actual: List<String> = listOf("A", "B", "C")
             val expected: List<String>? = listOf("A", "B", "C")
@@ -302,6 +316,21 @@ class ShouldContainExactlyTest : WordSpec() {
             checkAll(1000, Arb.shuffle(listOf("1", "2", "3", "4", "5", "6", "7"))) {
                it shouldContainExactlyInAnyOrder listOf("1", "2", "3", "4", "5", "6", "7")
             }
+         }
+      }
+
+      "countMismatch" should {
+         "return empty list for a complete match" {
+            val counts = mapOf("apple" to 1, "orange" to 2)
+            countMismatch(counts, counts).shouldBeEmpty()
+         }
+         "return differences" {
+            countMismatch(
+               mapOf("apple" to 1, "orange" to 2, "banana" to 3),
+               mapOf("apple" to 2, "orange" to 2, "peach" to 1)
+            ) shouldBe listOf(
+               CountMismatch("apple", 1, 2)
+            )
          }
       }
    }

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -1,6 +1,5 @@
 package io.kotest.property.arbitrary
 
-import io.kotest.mpp.bestName
 import io.kotest.property.Arb
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -12,16 +11,14 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.Year
 import java.time.YearMonth
 import java.time.ZonedDateTime
 import java.util.Date
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.javaType
-import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
 @Suppress("UNCHECKED_CAST")
@@ -40,6 +37,7 @@ fun targetDefaultForType(
       typeOf<LocalDateTime>(), typeOf<LocalDateTime?>() -> Arb.localDateTime()
       typeOf<LocalTime>(), typeOf<LocalTime?>() -> Arb.localTime()
       typeOf<Period>(), typeOf<Period?>() -> Arb.period()
+      typeOf<Year>(), typeOf<Year?>() -> Arb.year()
       typeOf<YearMonth>(), typeOf<YearMonth?>() -> Arb.yearMonth()
       typeOf<ZonedDateTime>(), typeOf<ZonedDateTime?>() -> Arb.zonedDateTime()
       typeOf<OffsetDateTime>(), typeOf<OffsetDateTime?>() -> Arb.offsetDateTime()

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -23,6 +23,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.Year
 import java.time.YearMonth
 import java.time.ZonedDateTime
 import kotlin.reflect.KClass
@@ -100,9 +101,10 @@ class ReflectiveBindTest : StringSpec(
             val b: LocalDateTime,
             val c: LocalTime,
             val d: Period,
-            val e: YearMonth,
-            val f: OffsetDateTime,
-            val g: ZonedDateTime
+            val e: Year,
+            val f: YearMonth,
+            val g: OffsetDateTime,
+            val h: ZonedDateTime
          )
 
          val arb = Arb.bind<DateContainer>()
@@ -115,9 +117,10 @@ class ReflectiveBindTest : StringSpec(
             val b: LocalDateTime?,
             val c: LocalTime?,
             val d: Period?,
-            val e: YearMonth?,
-            val f: OffsetDateTime?,
-            val g: ZonedDateTime?
+            val e: Year?,
+            val f: YearMonth?,
+            val g: OffsetDateTime?,
+            val h: ZonedDateTime?
          )
 
          val arb = Arb.bind<DateNullableContainer>()


### PR DESCRIPTION
modify `containExactlyInAnyOrder` so that it explicitly prints out when count of duplicates is different, such as:
```
            shouldThrow<AssertionError> {
               listOf(1, 2, 2, 3).shouldContainExactlyInAnyOrder(listOf(1, 2, 3, 3))
            }.shouldHaveMessage(
               """
                  Collection should contain [1, 2, 3, 3] in any order, but was [1, 2, 2, 3]
                  CountMismatches: Key="2", expected count: 1, but was: 2, Key="3", expected count: 2, but was: 1
               """.trimIndent()
```
