### PR TITLE
ContainDuplicates should print them (#20)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.collections
 
+import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -35,10 +36,20 @@ fun <T> Collection<T>.shouldNotContainDuplicates(): Collection<T> {
 }
 
 fun <T> containDuplicates() = object : Matcher<Collection<T>> {
-   override fun test(value: Collection<T>) = MatcherResult(
-      value.toSet().size < value.size,
-      { "Collection should contain duplicates" },
-      {
-         "Collection should not contain duplicates"
-      })
+   override fun test(value: Collection<T>): MatcherResult {
+      val duplicates = value.duplicates()
+      return MatcherResult(
+         duplicates.isNotEmpty(),
+         { "Collection should contain duplicates" },
+         {
+            "Collection should not contain duplicates, but has some: ${duplicates.print().value}"
+         })
+   }
 }
+
+internal fun<T> Collection<T>.duplicates(): Collection<T> = this.groupingBy { it }
+   .eachCount().entries
+   .mapNotNull { when(it.value) {
+      1 -> null
+      else -> it.key
+   } }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
@@ -49,7 +49,5 @@ fun <T> containDuplicates() = object : Matcher<Collection<T>> {
 
 internal fun<T> Collection<T>.duplicates(): Collection<T> = this.groupingBy { it }
    .eachCount().entries
-   .mapNotNull { when(it.value) {
-      1 -> null
-      else -> it.key
-   } }
+   .filter { it.value > 1 }
+   .map { it.key }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.matchers.collections
 import io.kotest.assertions.shouldFail
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.equals.Equality
@@ -229,6 +230,12 @@ class CollectionMatchersTest : WordSpec() {
             listOf(1, 2, 3, 4) shouldNot containDuplicates()
             listOf(1, 2, 3, 3).shouldContainDuplicates()
             listOf(1, 2, 3, 4).shouldNotContainDuplicates()
+         }
+
+         "print duplicates in message" {
+            shouldThrowAny {
+               listOf(1, 2, 3, 4, 2, 1) shouldNot containDuplicates()
+            }.shouldHaveMessage("Collection should not contain duplicates, but has some: [1, 2]")
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/DuplicatesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/DuplicatesTest.kt
@@ -1,0 +1,17 @@
+package com.sksamuel.kotest.matchers.collections
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.duplicates
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+
+class DuplicatesTest : StringSpec(){
+   init {
+       "return empty list" {
+          listOf(1, 2, 3, 4).duplicates().shouldBeEmpty()
+       }
+      "return duplicates" {
+         listOf(1, 2, 3, 4, 3, 2).duplicates() shouldContainExactlyInAnyOrder listOf(2, 3)
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/DuplicatesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/DuplicatesTest.kt
@@ -8,10 +8,15 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 class DuplicatesTest : StringSpec(){
    init {
        "return empty list" {
-          listOf(1, 2, 3, 4).duplicates().shouldBeEmpty()
+          listOf(1, 2, 3, 4, null).duplicates().shouldBeEmpty()
        }
-      "return duplicates" {
+
+      "return not null duplicates" {
          listOf(1, 2, 3, 4, 3, 2).duplicates() shouldContainExactlyInAnyOrder listOf(2, 3)
+      }
+
+      "return null duplicates" {
+         listOf(1, 2, 3, null, 4, 3, null, 2).duplicates() shouldContainExactlyInAnyOrder listOf(2, 3, null)
       }
    }
 }

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/targetDefaultForClassName.kt
@@ -1,6 +1,5 @@
 package io.kotest.property.arbitrary
 
-import io.kotest.mpp.bestName
 import io.kotest.property.Arb
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
@@ -12,16 +11,14 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.Year
 import java.time.YearMonth
 import java.time.ZonedDateTime
 import java.util.Date
 import kotlin.reflect.KClass
-import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.javaType
-import kotlin.reflect.jvm.jvmErasure
 import kotlin.reflect.typeOf
 
 @Suppress("UNCHECKED_CAST")
@@ -40,6 +37,7 @@ fun targetDefaultForType(
       typeOf<LocalDateTime>(), typeOf<LocalDateTime?>() -> Arb.localDateTime()
       typeOf<LocalTime>(), typeOf<LocalTime?>() -> Arb.localTime()
       typeOf<Period>(), typeOf<Period?>() -> Arb.period()
+      typeOf<Year>(), typeOf<Year?>() -> Arb.year()
       typeOf<YearMonth>(), typeOf<YearMonth?>() -> Arb.yearMonth()
       typeOf<ZonedDateTime>(), typeOf<ZonedDateTime?>() -> Arb.zonedDateTime()
       typeOf<OffsetDateTime>(), typeOf<OffsetDateTime?>() -> Arb.offsetDateTime()

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -23,6 +23,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.OffsetDateTime
 import java.time.Period
+import java.time.Year
 import java.time.YearMonth
 import java.time.ZonedDateTime
 import kotlin.reflect.KClass
@@ -100,9 +101,10 @@ class ReflectiveBindTest : StringSpec(
             val b: LocalDateTime,
             val c: LocalTime,
             val d: Period,
-            val e: YearMonth,
-            val f: OffsetDateTime,
-            val g: ZonedDateTime
+            val e: Year,
+            val f: YearMonth,
+            val g: OffsetDateTime,
+            val h: ZonedDateTime
          )
 
          val arb = Arb.bind<DateContainer>()
@@ -115,9 +117,10 @@ class ReflectiveBindTest : StringSpec(
             val b: LocalDateTime?,
             val c: LocalTime?,
             val d: Period?,
-            val e: YearMonth?,
-            val f: OffsetDateTime?,
-            val g: ZonedDateTime?
+            val e: Year?,
+            val f: YearMonth?,
+            val g: OffsetDateTime?,
+            val h: ZonedDateTime?
          )
 
          val arb = Arb.bind<DateNullableContainer>()


### PR DESCRIPTION
`containDuplicates` should list duplicates that violate the assumption, for instance:
```
           shouldThrowAny {
               listOf(1, 2, 3, 4, 2, 1) shouldNot containDuplicates()
            }.shouldHaveMessage("Collection should not contain duplicates, but has some: [1, 2]")
```
