### PR TITLE
Have upper bound print violations 

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.collections
 
+import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -20,10 +21,13 @@ infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveUpperBound(t: T): C
 }
 
 fun <T : Comparable<T>, C : Collection<T>> haveUpperBound(t: T) = object : Matcher<C> {
-   override fun test(value: C) = MatcherResult(
-      value.all { it <= t },
-      { "Collection should have upper bound $t" },
-      { "Collection should not have upper bound $t" })
+   override fun test(value: C): MatcherResult {
+      val violatingElements = value.filter { it > t }
+      return MatcherResult(
+         violatingElements.isEmpty(),
+         { "Collection should have upper bound $t, but the following elements are above it: ${violatingElements.print().value}" },
+         { "Collection should not have upper bound $t" })
+   }
 }
 
 infix fun <T : Comparable<T>> Iterable<T>.shouldHaveLowerBound(t: T): Iterable<T> {
@@ -42,8 +46,11 @@ infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveLowerBound(t: T): C
 }
 
 fun <T : Comparable<T>, C : Collection<T>> haveLowerBound(t: T) = object : Matcher<C> {
-   override fun test(value: C) = MatcherResult(
-      value.all { t <= it },
-      { "Collection should have lower bound $t" },
-      { "Collection should not have lower bound $t" })
+   override fun test(value: C): MatcherResult {
+      val violatingElements = value.filter { it < t }
+      return MatcherResult(
+         violatingElements.isEmpty(),
+         { "Collection should have lower bound $t, but the following elements are below it: ${violatingElements.print().value}" },
+         { "Collection should not have lower bound $t" })
+   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.kotest.matchers.collections
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldHaveLowerBound
+import io.kotest.matchers.collections.shouldHaveUpperBound
+import io.kotest.matchers.throwable.shouldHaveMessage
+
+class BoundsTest: WordSpec() {
+   init {
+      "haveUpperBound" should {
+         "pass" {
+            listOf(1, 2, 3) shouldHaveUpperBound 3
+        }
+
+         "fail" {
+            shouldThrowAny {
+               listOf(1, 2, 3) shouldHaveUpperBound 2
+            }.shouldHaveMessage("Collection should have upper bound 2, but the following elements are above it: [3]")
+         }
+      }
+
+      "haveLowerBound" should {
+         "pass" {
+            listOf(1, 2, 3) shouldHaveLowerBound 1
+         }
+         "fail" {
+            shouldThrowAny {
+               listOf(1, 2, 3) shouldHaveLowerBound 2
+            }.shouldHaveMessage("Collection should have lower bound 2, but the following elements are below it: [1]")
+         }
+      }
+   }
+}


### PR DESCRIPTION
`shouldHaveUpperBound` should output elements that violate the assumption, such as:
```
            shouldThrowAny {
               listOf(1, 2, 3) shouldHaveUpperBound 2
            }.shouldHaveMessage("Collection should have upper bound 2, but the following elements are above it: [3]")
```
likewise, add same output for `shouldHaveLowerBound`:
```
            shouldThrowAny {
               listOf(1, 2, 3) shouldHaveLowerBound 2
            }.shouldHaveMessage("Collection should have lower bound 2, but the following elements are below it: [1]")
```
