### PR TITLE
Changing the Kotlin Gradle plugin dependncy to compileOnly

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -20,8 +20,9 @@ repositories {
 }
 
 dependencies {
-   implementation(libs.kotlin.gradle.plugin)
+   compileOnly(libs.kotlin.gradle.plugin)
 
+   testImplementation(libs.kotlin.gradle.plugin)
    testImplementation(projects.kotestAssertions.kotestAssertionsCore)
    testImplementation(projects.kotestFramework.kotestFrameworkApi)
    testImplementation(projects.kotestFramework.kotestFrameworkEngine)


### PR DESCRIPTION
Using it as an implementation dependency seems to add a possibly stale version of the Kotlin plugin to the build path. Normally a user would already have a possibly different version of Kotlin pulled in, and these could clash (as seen in issue #3850)

Could this cause regressions that I'm not thinking of?