### PR TITLE
Mention that one might want a platform-specific module

### DIFF
--- a/documentation/docs/framework/datatesting/data_driven_testing.md
+++ b/documentation/docs/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.2/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.2/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.3/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.3/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.4/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.4/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.5/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.5/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.6/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.6/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.7/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.7/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 

--- a/documentation/versioned_docs/version-5.8/framework/datatesting/data_driven_testing.md
+++ b/documentation/versioned_docs/version-5.8/framework/datatesting/data_driven_testing.md
@@ -5,7 +5,8 @@ slug: data-driven-testing.html
 ---
 
 :::tip Required Module
-Before data-driven-testing can be used, you need to add the module `kotest-framework-datatest` to your build.
+Before data-driven-testing can be used, you need to add the `kotest-framework-datatest` module for your platform,
+e.g. `kotest-framework-datatest-jvm`, to your build.
 :::
 
 


### PR DESCRIPTION
Being new to kotest (and Kotlin), we misinterpreted the tip about adding `kotest-framework-datatest` to mean we should have `io.kotest:kotest-framework-datatest:5.8.0` as a Maven dependency. Took an inordinate amount of head-scratching before we figured out the reason `withData` didn´t get resolved was that we should have used `io.kotest:kotest-framework-datatest-jvm:5.8.0` instead. I´m guessing other beginners might make the same mistake, so I think the tip should mention platform modules.