### PR TITLE
Fixing Arb.localDate when minDate == maxDate

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
@@ -56,6 +56,7 @@ fun Arb.Companion.localDate(
    minDate: LocalDate = LocalDate.of(1970, 1, 1),
    maxDate: LocalDate = LocalDate.of(2030, 12, 31)
 ): Arb<LocalDate> {
+   if (minDate == maxDate) return Arb.constant(minDate)
 
    val leapYears = (minDate.year..maxDate.year).filter { isLeap(it.toLong()) }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -82,6 +82,13 @@ class DateTest : WordSpec({
       }
    }
 
+   "Arb.localDate(minDate, maxDate)" should {
+      "Work when min date == max date" {
+         val date = of(2021, 1, 1)
+         Arb.localDate(date, date).take(10).toList() shouldBe List(10) { date }
+      }
+   }
+
    "Arb.localTime()" should {
       "generate N valid LocalTimes(no exceptions)" {
          Arb.localTime().generate(RandomSource.default()).take(10_000).toList()

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.property.arbitrary
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContain
@@ -86,6 +87,13 @@ class DateTest : WordSpec({
       "Work when min date == max date" {
          val date = of(2021, 1, 1)
          Arb.localDate(date, date).take(10).toList() shouldBe List(10) { date }
+      }
+
+      "Throw when min date > max date" {
+         shouldThrow<IllegalArgumentException> {
+            val minDate = of(2021, 1, 1)
+            Arb.localDate(minDate, minDate.minusDays(1))
+         }.message shouldBe "minDate must be before maxDate"
       }
    }
 


### PR DESCRIPTION
Now simply returns a constant Arb for the given date.

Fixes #3829

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
