### PR TITLE
Add selfie snapshot testing to the extensions listing

### DIFF
--- a/documentation/docs/extensions/index.md
+++ b/documentation/docs/extensions/index.md
@@ -37,6 +37,7 @@ maintained and hosted by third parties.
 | [LogCapture](https://github.com/jsalinaspolo/logcapture)                                         | LogCapture is a testing library for asserting logging messages                     |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test)                                | JVM-based, full-stack framework for building modular, easily testable microservice |
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers)                                 | Result4s matchers                                                                  |
+| [Selfie](https://www.github.com/diffplug/selfie)                                                 | Snapshot testing (inline, disk, and memoization)                                   |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest)                            | Network connectivity testing                                                       |
 | [TestFiles](https://github.com/jGleitz/testfiles)                                                | Creates organized files and directories for testing                                |
 | [FixtureMonkey](https://github.com/naver/fixture-monkey)                                         | generate a complex type and customize it within Kotest                             |


### PR DESCRIPTION
Selfie just released its `1.2.0` version which added support for Kotest.

- add `testImplementation("com.diffplug.selfie:selfie-runner-junit5:1.2.0")`
- add `override fun extensions() = listOf(SelfieExtension(this))` to your `AbstractProjectConfig`
- do snapshot testing! https://github.com/diffplug/selfie

It's written in KMP, but there are some stubs which have only been implemented for JVM so far. If anyone is interested in helping with other platforms:

- https://github.com/diffplug/selfie/issues/186

Also perhaps of interest to Kotest folks:

- https://github.com/diffplug/selfie/issues/214