### PR TITLE
ShouldExistInOrderTest.kt (#30)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -26,7 +26,7 @@ fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> 
 
    MatcherResult(
       subsequenceIndex == predicates.size,
-      { "${actual.print().value} did not match the predicates ${predicates.print().value} in order. Predicate number $subsequenceIndex did not match." },
+      { "${actual.print().value} did not match the predicates ${predicates.print().value} in order. Predicate at index $subsequenceIndex did not match." },
       { "${actual.print().value} should not match the predicates ${predicates.print().value} in order" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -26,7 +26,7 @@ fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> 
 
    MatcherResult(
       subsequenceIndex == predicates.size,
-      { "${actual.print().value} did not match the predicates ${predicates.print().value} in order" },
+      { "${actual.print().value} did not match the predicates ${predicates.print().value} in order. Predicate number $subsequenceIndex did not match." },
       { "${actual.print().value} should not match the predicates ${predicates.print().value} in order" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
@@ -11,7 +11,7 @@ class ShouldExistInOrderTest: WordSpec() {
           "pass" {
               listOf(1, 2).shouldExistInOrder(
                  { i: Int -> i < 2 },
-             { i: Int -> i < 3 }
+                 { i: Int -> i < 3 }
               )
           }
           "fail with clear message" {
@@ -20,7 +20,7 @@ class ShouldExistInOrderTest: WordSpec() {
                    { i: Int -> i < 2 },
                    { i: Int -> i < 2 }
                 )
-             }.message shouldBe "[1, 2] did not match the predicates [(kotlin.Int) -> kotlin.Boolean, (kotlin.Int) -> kotlin.Boolean] in order. Predicate number 1 did not match."
+             }.message shouldBe "[1, 2] did not match the predicates [(kotlin.Int) -> kotlin.Boolean, (kotlin.Int) -> kotlin.Boolean] in order. Predicate at index 1 did not match."
           }
        }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
@@ -1,0 +1,27 @@
+package com.sksamuel.kotest.matchers.collections
+
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldExistInOrder
+import io.kotest.matchers.shouldBe
+
+class ShouldExistInOrderTest: WordSpec() {
+   init {
+       "shouldExistInOrder" should {
+          "pass" {
+              listOf(1, 2).shouldExistInOrder(
+                 { i: Int -> i < 2 },
+             { i: Int -> i < 3 }
+              )
+          }
+          "fail with clear message" {
+             shouldThrowAny {
+                listOf(1, 2).shouldExistInOrder(
+                   { i: Int -> i < 2 },
+                   { i: Int -> i < 2 }
+                )
+             }.message shouldBe "[1, 2] did not match the predicates [(kotlin.Int) -> kotlin.Boolean, (kotlin.Int) -> kotlin.Boolean] in order. Predicate number 1 did not match."
+          }
+       }
+   }
+}


### PR DESCRIPTION
provide more details when `shouldExistInOrder` fails. For instance, print out "Predicate number 1 did not match", as shown in the following example:
```
        "fail with clear message" {
             shouldThrowAny {
                listOf(1, 2).shouldExistInOrder(
                   { i: Int -> i < 2 },
                   { i: Int -> i < 2 }
                )
             }.message shouldBe "[1, 2] did not match the predicates [(kotlin.Int) -> kotlin.Boolean, (kotlin.Int) -> kotlin.Boolean] in order. Predicate at index 1 did not match."
          }
```