### PR TITLE
add support for SortedSet and add test accordingly

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -17,8 +17,10 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.kotest.property.Arb
+import io.kotest.property.Exhaustive
 import io.kotest.property.arbitrary.shuffle
 import io.kotest.property.checkAll
+import io.kotest.property.exhaustive.of
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -83,69 +85,35 @@ class ShouldContainExactlyTest : WordSpec() {
             }
          }
 
-         "test that it supports LinkedHashSet" {
-            val actual = linkedSetOf(1, 2, 3)
 
-            actual should containExactly(1, 2, 3)
-            actual.shouldContainExactly(1, 2, 3)
+         "Supports all sorted set types" {
+            /**
+             * Generates an [Exhaustive] for all (supported) sorted set implementations of the given elements.
+             */
+            fun <T> Exhaustive.Companion.sortedSetOf(vararg elements: T): Exhaustive<Set<T>> = Exhaustive.of(
+               TreeSet(elements.asList()),
+               ConcurrentSkipListSet(elements.asList()),
+               linkedSetOf(*elements),
+            )
 
-            actual shouldNot containExactly(1, 2)
-            actual.shouldNotContainExactly(1, 2)
+            checkAll(Exhaustive.sortedSetOf(1,2,3)) { actual ->
+               actual should containExactly(1, 2, 3)
+               actual.shouldContainExactly(1, 2, 3)
 
-            actual shouldNot containExactly(3, 2, 1)
-            actual.shouldNotContainExactly(3, 2, 1)
-            actual.shouldContainExactly(linkedSetOf(3, 2, 1))
+               actual shouldNot containExactly(1, 2)
+               actual.shouldNotContainExactly(1, 2)
 
-            shouldThrow<AssertionError> {
-               actual should containExactly(1, 2)
-            }
+               actual shouldNot containExactly(3, 2, 1)
+               actual.shouldNotContainExactly(3, 2, 1)
+               actual.shouldContainExactly(linkedSetOf(3, 2, 1))
 
-            shouldThrow<AssertionError> {
-               actual should containExactly(3, 2, 1)
-            }
-         }
+               shouldThrow<AssertionError> {
+                  actual should containExactly(1, 2)
+               }
 
-         "test that is supports TreeSet" {
-            val actual = TreeSet(listOf(3, 2, 1))
-
-            actual should containExactly(1, 2, 3)
-            actual.shouldContainExactly(1, 2, 3)
-            actual.shouldContainExactly(TreeSet(listOf(3, 2, 1)))
-
-            actual shouldNot containExactly(1, 2)
-            actual.shouldNotContainExactly(1, 2)
-
-            actual shouldNot containExactly(3, 2, 1)
-            actual.shouldNotContainExactly(3, 2, 1)
-
-            shouldThrow<AssertionError> {
-               actual should containExactly(1, 2)
-            }
-
-            shouldThrow<AssertionError> {
-               actual should containExactly(3, 2, 1)
-            }
-         }
-
-         "test that is supports ConcurrentSkipListSet" {
-            val actual = ConcurrentSkipListSet(listOf(3, 2, 1))
-
-            actual should containExactly(1, 2, 3)
-            actual.shouldContainExactly(1, 2, 3)
-            actual.shouldContainExactly(ConcurrentSkipListSet(listOf(3, 2, 1)))
-
-            actual shouldNot containExactly(1, 2)
-            actual.shouldNotContainExactly(1, 2)
-
-            actual shouldNot containExactly(3, 2, 1)
-            actual.shouldNotContainExactly(3, 2, 1)
-
-            shouldThrow<AssertionError> {
-               actual should containExactly(1, 2)
-            }
-
-            shouldThrow<AssertionError> {
-               actual should containExactly(3, 2, 1)
+               shouldThrow<AssertionError> {
+                  actual should containExactly(3, 2, 1)
+               }
             }
          }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -22,6 +22,8 @@ import io.kotest.property.checkAll
 import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.*
+import java.util.concurrent.ConcurrentSkipListSet
 import kotlin.time.Duration.Companion.seconds
 
 
@@ -104,11 +106,47 @@ class ShouldContainExactlyTest : WordSpec() {
          }
 
          "test that is supports TreeSet" {
+            val actual = TreeSet(listOf(3, 2, 1))
 
+            actual should containExactly(1, 2, 3)
+            actual.shouldContainExactly(1, 2, 3)
+            actual.shouldContainExactly(TreeSet(listOf(3, 2, 1)))
+
+            actual shouldNot containExactly(1, 2)
+            actual.shouldNotContainExactly(1, 2)
+
+            actual shouldNot containExactly(3, 2, 1)
+            actual.shouldNotContainExactly(3, 2, 1)
+
+            shouldThrow<AssertionError> {
+               actual should containExactly(1, 2)
+            }
+
+            shouldThrow<AssertionError> {
+               actual should containExactly(3, 2, 1)
+            }
          }
 
          "test that is supports ConcurrentSkipListSet" {
+            val actual = ConcurrentSkipListSet(listOf(3, 2, 1))
 
+            actual should containExactly(1, 2, 3)
+            actual.shouldContainExactly(1, 2, 3)
+            actual.shouldContainExactly(ConcurrentSkipListSet(listOf(3, 2, 1)))
+
+            actual shouldNot containExactly(1, 2)
+            actual.shouldNotContainExactly(1, 2)
+
+            actual shouldNot containExactly(3, 2, 1)
+            actual.shouldNotContainExactly(3, 2, 1)
+
+            shouldThrow<AssertionError> {
+               actual should containExactly(1, 2)
+            }
+
+            shouldThrow<AssertionError> {
+               actual should containExactly(3, 2, 1)
+            }
          }
 
          "Iterable with non-stable iteration order gives an informative message" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -81,6 +81,36 @@ class ShouldContainExactlyTest : WordSpec() {
             }
          }
 
+         "test that it supports LinkedHashSet" {
+            val actual = linkedSetOf(1, 2, 3)
+
+            actual should containExactly(1, 2, 3)
+            actual.shouldContainExactly(1, 2, 3)
+
+            actual shouldNot containExactly(1, 2)
+            actual.shouldNotContainExactly(1, 2)
+
+            actual shouldNot containExactly(3, 2, 1)
+            actual.shouldNotContainExactly(3, 2, 1)
+            actual.shouldContainExactly(linkedSetOf(3, 2, 1))
+
+            shouldThrow<AssertionError> {
+               actual should containExactly(1, 2)
+            }
+
+            shouldThrow<AssertionError> {
+               actual should containExactly(3, 2, 1)
+            }
+         }
+
+         "test that is supports TreeSet" {
+
+         }
+
+         "test that is supports ConcurrentSkipListSet" {
+
+         }
+
          "Iterable with non-stable iteration order gives an informative message" {
 
             // Ideally the last two newlines shouldn't be there, IMO.
@@ -242,6 +272,7 @@ class ShouldContainExactlyTest : WordSpec() {
                   |(set the 'kotest.assertions.collection.enumerate.size' JVM property to see full output)
                """.trimMargin()
          }
+
       }
 
       "containExactlyInAnyOrder" should {

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/eq/isOrderedSet.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/eq/isOrderedSet.kt
@@ -1,11 +1,11 @@
 package io.kotest.assertions.eq
 
-import java.util.TreeSet
+import java.util.SortedSet
 
 /**
  * JVM-specific: Allows TreeSet to be considered ordered for iterable comparisons
  */
 actual fun isOrderedSet(item: Iterable<*>) =
    item is LinkedHashSet ||
-      item is TreeSet ||
+      item is SortedSet ||
       (item is Set && item.size == 1)


### PR DESCRIPTION
while working on this issue
#3848 

I found out adding support for JAVA 21 is impossible since gradle version which is 8.2.1 we are using does not support JAVA 21 
However, I found out implementation now is only working on `TreeSet` which is not appropriate for function name `isOrderedSet` so I fixed function to check if item belongs to `SortedSet`

And I added test case if it supports all implemantation of `SortedSet`

before
```kotlin
actual fun isOrderedSet(item: Iterable<*>) =
   item is LinkedHashSet ||
      item is TreeSet ||
      (item is Set && item.size == 1)
```

after
```kotlin
actual fun isOrderedSet(item: Iterable<*>) =
   item is LinkedHashSet ||
      item is SortedSet ||
      (item is Set && item.size == 1)
```