### PR TITLE
Have upper bound failure with more detail (#32)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -178,21 +178,33 @@ fun <T, C : Sequence<T>> containAllInAnyOrder(expected: C): Matcher<C?> = neverN
 infix fun <T : Comparable<T>, C : Sequence<T>> C.shouldHaveUpperBound(t: T) = this should haveUpperBound(t)
 
 fun <T : Comparable<T>, C : Sequence<T>> haveUpperBound(t: T) = object : Matcher<C> {
-   override fun test(value: C) = MatcherResult(
-      (value.maxOrNull() ?: t) <= t,
-      { "Sequence should have upper bound $t" },
-      { "Sequence should not have upper bound $t" }
-   )
+   override fun test(value: C): MatcherResult {
+      val elementAboveUpperBound = value.withIndex().firstOrNull { it.value > t }
+      val elementAboveUpperBoundStr = elementAboveUpperBound?.let {
+         ", but element at index ${it.index} was: ${it.value.print().value}"
+      } ?: ""
+      return MatcherResult(
+         elementAboveUpperBound == null,
+         { "Sequence should have upper bound $t$elementAboveUpperBoundStr" },
+         { "Sequence should not have upper bound $t" }
+      )
+   }
 }
 
 infix fun <T : Comparable<T>, C : Sequence<T>> C.shouldHaveLowerBound(t: T) = this should haveLowerBound(t)
 
 fun <T : Comparable<T>, C : Sequence<T>> haveLowerBound(t: T) = object : Matcher<C> {
-   override fun test(value: C) = MatcherResult(
-      (value.minOrNull() ?: t) >= t,
-      { "Sequence should have lower bound $t" },
-      { "Sequence should not have lower bound $t" }
-   )
+   override fun test(value: C): MatcherResult {
+      val elementBelowLowerBound = value.withIndex().firstOrNull { it.value < t }
+      val elementBelowLowerBoundStr = elementBelowLowerBound?.let {
+         ", but element at index ${it.index} was: ${it.value.print().value}"
+      } ?: ""
+      return MatcherResult(
+         elementBelowLowerBound == null,
+         { "Sequence should have lower bound $t$elementBelowLowerBoundStr" },
+         { "Sequence should not have lower bound $t" }
+      )
+   }
 }
 
 fun <T> Sequence<T>.shouldBeUnique() = this should beUnique()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -42,6 +42,7 @@ import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.throwable.shouldHaveMessage
 
 class SequenceMatchersTest : WordSpec() {
 
@@ -912,16 +913,20 @@ class SequenceMatchersTest : WordSpec() {
             sampleData.single.shouldHaveUpperBound(0)
          }
 
-         fail("for single with wrong bound") {
-            sampleData.single.shouldHaveUpperBound(-1)
+         "fail for single with wrong bound" {
+            shouldThrowAny {
+               sampleData.single.shouldHaveUpperBound(-1)
+            }.shouldHaveMessage("Sequence should have upper bound -1, but element at index 0 was: 0")
          }
 
          succeed("for multiple") {
             sampleData.countup.shouldHaveUpperBound(sampleData.countup.maxOrNull() ?: Int.MAX_VALUE)
          }
 
-         fail("for multiple with wrong bound") {
-            sampleData.countup.shouldHaveUpperBound((sampleData.countup.maxOrNull() ?: Int.MAX_VALUE) - 1)
+         "fail for multiple with wrong bound" {
+            shouldThrowAny {
+               sampleData.countup.shouldHaveUpperBound((sampleData.countup.maxOrNull() ?: Int.MAX_VALUE) - 1)
+            }.shouldHaveMessage("Sequence should have upper bound 9, but element at index 10 was: 10")
          }
       }
 
@@ -934,16 +939,20 @@ class SequenceMatchersTest : WordSpec() {
             sampleData.single.shouldHaveLowerBound(0)
          }
 
-         fail("for single with wrong bound") {
-            sampleData.single.shouldHaveLowerBound(1)
+         "fail for single with wrong bound" {
+            shouldThrowAny {
+               sampleData.single.shouldHaveLowerBound(1)
+            }.shouldHaveMessage("Sequence should have lower bound 1, but element at index 0 was: 0")
          }
 
          succeed("for multiple") {
             sampleData.countup.shouldHaveLowerBound(sampleData.countup.minOrNull() ?: Int.MIN_VALUE)
          }
 
-         fail("for multiple with wrong bound") {
-            sampleData.countup.shouldHaveLowerBound((sampleData.countup.minOrNull() ?: Int.MIN_VALUE) + 1)
+         "fail for multiple with wrong bound" {
+            shouldThrowAny {
+               sampleData.countup.shouldHaveLowerBound((sampleData.countup.minOrNull() ?: Int.MIN_VALUE) + 1)
+            }.shouldHaveMessage("Sequence should have lower bound 1, but element at index 0 was: 0")
          }
       }
 


### PR DESCRIPTION
whenever `haveUpperBound` and/or `haveLowerBound` fail, provide in more detail what exactly failed. For instance, instead of "Sequence should have upper bound 9"
output the following:
"Sequence should have upper bound 9, **but element at index 10 was: 10**"