### PR TITLE
print-duplicates (#33)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -5,6 +5,7 @@ package io.kotest.matchers.sequences
 import io.kotest.assertions.eq.eq
 import io.kotest.assertions.print.print
 import io.kotest.matchers.*
+import io.kotest.matchers.collections.duplicates
 
 /*
 How should infinite sequences be detected, and how should they be dealt with?
@@ -199,10 +200,10 @@ fun <T> Sequence<T>.shouldBeUnique() = this should beUnique()
 fun <T> Sequence<T>.shouldNotBeUnique() = this shouldNot beUnique()
 fun <T> beUnique() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
-      val valueAsList = value.toList()
+      val duplicates = value.toList().duplicates()
       return MatcherResult(
-         valueAsList.toSet().size == valueAsList.size,
-         { "Sequence should be Unique" },
+         duplicates.isEmpty(),
+         { "Sequence should be Unique, but has duplicates: ${duplicates.print().value}" },
          { "Sequence should contain at least one duplicate element" }
       )
    }
@@ -212,11 +213,11 @@ fun <T> Sequence<T>.shouldContainDuplicates() = this should containDuplicates()
 fun <T> Sequence<T>.shouldNotContainDuplicates() = this shouldNot containDuplicates()
 fun <T> containDuplicates() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
-      val valueAsList = value.toList()
+      val duplicates = value.toList().duplicates()
       return MatcherResult(
-         valueAsList.toSet().size < valueAsList.size,
+         duplicates.isNotEmpty(),
          { "Sequence should contain duplicates" },
-         { "Sequence should not contain duplicates" }
+         { "Sequence should not contain duplicates, but has some: ${duplicates.print().value}" }
       )
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -34,6 +34,7 @@ import io.kotest.matchers.sequences.shouldNotBeSortedWith
 import io.kotest.matchers.sequences.shouldNotBeUnique
 import io.kotest.matchers.sequences.shouldNotContain
 import io.kotest.matchers.sequences.shouldNotContainAllInAnyOrder
+import io.kotest.matchers.sequences.shouldNotContainDuplicates
 import io.kotest.matchers.sequences.shouldNotContainExactly
 import io.kotest.matchers.sequences.shouldNotContainNoNulls
 import io.kotest.matchers.sequences.shouldNotContainNull
@@ -42,6 +43,7 @@ import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.throwable.shouldHaveMessage
 
 class SequenceMatchersTest : WordSpec() {
 
@@ -844,12 +846,16 @@ class SequenceMatchersTest : WordSpec() {
             sampleData.single.shouldBeUnique()
          }
 
-         fail("with repeated nulls") {
-            sampleData.sparse.shouldBeUnique()
+         "fail with repeated nulls" {
+            shouldThrowAny {
+               sampleData.sparse.shouldBeUnique()
+            }.shouldHaveMessage("Sequence should be Unique, but has duplicates: [<null>]")
          }
 
-         fail("with repeats") {
-            sampleData.repeating.shouldBeUnique()
+         "fail with repeats" {
+            shouldThrowAny {
+               sampleData.repeating.shouldBeUnique()
+            }.shouldHaveMessage("Sequence should be Unique, but has duplicates: [1, 2, 3]")
          }
 
          succeed("for multiple unique") {
@@ -898,6 +904,12 @@ class SequenceMatchersTest : WordSpec() {
 
          fail("for multiple unique") {
             sampleData.countup.shouldContainDuplicates()
+         }
+
+         "fail with repeats" {
+            shouldThrowAny {
+               sampleData.repeating.shouldNotContainDuplicates()
+            }.shouldHaveMessage("Sequence should not contain duplicates, but has some: [1, 2, 3]")
          }
       }
 


### PR DESCRIPTION
for both `shouldBeUnique` and `shouldNotContainDuplicates` for failures, print duplicates, such as:
instead of "Sequence should be Unique", print "Sequence should be Unique, __but has duplicates: [1, 2, 3]__"
