### PR TITLE
Add selfie snapshot testing to the versioned docs pages

### DIFF
--- a/documentation/versioned_docs/version-5.4/extensions/index.md
+++ b/documentation/versioned_docs/version-5.4/extensions/index.md
@@ -29,12 +29,12 @@ maintained and hosted by third parties.
 
 | Project | Description |
 | ------- | ----------- |
+| [Fluentlenium](https://fluentlenium.io/docs/test-runners/#kotest) | FluentLenium integration with Kotest |
 | [Http4k](https://www.http4k.org/guide/reference/kotest/) | Functional toolkit for Kotlin HTTP applications |
+| [Kotless](https://github.com/LeoColman/kotest-kotless) | Utilties for kotless and kotest |
+| [KotlinFixture](https://github.com/appmattus/kotlinfixture/blob/main/fixture-kotest/README.adoc) | generate well-defined, but essentially random, input |
+| [LogCapture](https://github.com/jsalinaspolo/logcapture) | LogCapture is a testing library for asserting logging messages |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test) | JVM-based, full-stack framework for building modular, easily testable microservice |
+| [Result4s](https://github.com/MrBergin/result4k-kotest-matchers) | Result4s matchers|
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest) | Network connectivity testing |
 | [TestFiles](https://github.com/jGleitz/testfiles) | Creates organized files and directories for testing |
-| [Result4s](https://github.com/MrBergin/result4k-kotest-matchers) | Result4s matchers|
-| [Kotless](https://github.com/LeoColman/kotest-kotless) | Utilties for kotless and kotest |
-| [LogCapture](https://github.com/jsalinaspolo/logcapture) | LogCapture is a testing library for asserting logging messages |
-| [KotlinFixture](https://github.com/appmattus/kotlinfixture/blob/main/fixture-kotest/README.adoc) | generate well-defined, but essentially random, input |
-| [Fluentlenium](https://fluentlenium.io/docs/test-runners/#kotest) | FluentLenium integration with Kotest |

--- a/documentation/versioned_docs/version-5.4/extensions/index.md
+++ b/documentation/versioned_docs/version-5.4/extensions/index.md
@@ -36,5 +36,6 @@ maintained and hosted by third parties.
 | [LogCapture](https://github.com/jsalinaspolo/logcapture) | LogCapture is a testing library for asserting logging messages |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test) | JVM-based, full-stack framework for building modular, easily testable microservice |
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers) | Result4s matchers|
+| [Selfie](https://www.github.com/diffplug/selfie) | Snapshot testing (inline, disk, and memoization) |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest) | Network connectivity testing |
 | [TestFiles](https://github.com/jGleitz/testfiles) | Creates organized files and directories for testing |

--- a/documentation/versioned_docs/version-5.5/extensions/index.md
+++ b/documentation/versioned_docs/version-5.5/extensions/index.md
@@ -28,12 +28,12 @@ maintained and hosted by third parties.
 
 | Project | Description |
 | ------- | ----------- |
+| [Fluentlenium](https://fluentlenium.io/docs/test-runners/#kotest) | FluentLenium integration with Kotest |
 | [Http4k](https://www.http4k.org/guide/reference/kotest/) | Functional toolkit for Kotlin HTTP applications |
+| [Kotless](https://github.com/LeoColman/kotest-kotless) | Utilties for kotless and kotest |
+| [KotlinFixture](https://github.com/appmattus/kotlinfixture/blob/main/fixture-kotest/README.adoc) | generate well-defined, but essentially random, input |
+| [LogCapture](https://github.com/jsalinaspolo/logcapture) | LogCapture is a testing library for asserting logging messages |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test) | JVM-based, full-stack framework for building modular, easily testable microservice |
+| [Result4s](https://github.com/MrBergin/result4k-kotest-matchers) | Result4s matchers|
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest) | Network connectivity testing |
 | [TestFiles](https://github.com/jGleitz/testfiles) | Creates organized files and directories for testing |
-| [Result4s](https://github.com/MrBergin/result4k-kotest-matchers) | Result4s matchers|
-| [Kotless](https://github.com/LeoColman/kotest-kotless) | Utilties for kotless and kotest |
-| [LogCapture](https://github.com/jsalinaspolo/logcapture) | LogCapture is a testing library for asserting logging messages |
-| [KotlinFixture](https://github.com/appmattus/kotlinfixture/blob/main/fixture-kotest/README.adoc) | generate well-defined, but essentially random, input |
-| [Fluentlenium](https://fluentlenium.io/docs/test-runners/#kotest) | FluentLenium integration with Kotest |

--- a/documentation/versioned_docs/version-5.5/extensions/index.md
+++ b/documentation/versioned_docs/version-5.5/extensions/index.md
@@ -35,5 +35,6 @@ maintained and hosted by third parties.
 | [LogCapture](https://github.com/jsalinaspolo/logcapture) | LogCapture is a testing library for asserting logging messages |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test) | JVM-based, full-stack framework for building modular, easily testable microservice |
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers) | Result4s matchers|
+| [Selfie](https://www.github.com/diffplug/selfie) | Snapshot testing (inline, disk, and memoization) |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest) | Network connectivity testing |
 | [TestFiles](https://github.com/jGleitz/testfiles) | Creates organized files and directories for testing |

--- a/documentation/versioned_docs/version-5.6/extensions/index.md
+++ b/documentation/versioned_docs/version-5.6/extensions/index.md
@@ -37,5 +37,6 @@ maintained and hosted by third parties.
 | [LogCapture](https://github.com/jsalinaspolo/logcapture)                                         | LogCapture is a testing library for asserting logging messages                     |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test)                                | JVM-based, full-stack framework for building modular, easily testable microservice |
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers)                                 | Result4s matchers                                                                  |
+| [Selfie](https://www.github.com/diffplug/selfie)                                                 | Snapshot testing (inline, disk, and memoization)                                   |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest)                            | Network connectivity testing                                                       |
 | [TestFiles](https://github.com/jGleitz/testfiles)                                                | Creates organized files and directories for testing                                |

--- a/documentation/versioned_docs/version-5.7/extensions/index.md
+++ b/documentation/versioned_docs/version-5.7/extensions/index.md
@@ -37,5 +37,6 @@ maintained and hosted by third parties.
 | [LogCapture](https://github.com/jsalinaspolo/logcapture)                                         | LogCapture is a testing library for asserting logging messages                     |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test)                                | JVM-based, full-stack framework for building modular, easily testable microservice |
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers)                                 | Result4s matchers                                                                  |
+| [Selfie](https://www.github.com/diffplug/selfie)                                                 | Snapshot testing (inline, disk, and memoization)                                   |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest)                            | Network connectivity testing                                                       |
 | [TestFiles](https://github.com/jGleitz/testfiles)                                                | Creates organized files and directories for testing                                |

--- a/documentation/versioned_docs/version-5.8/extensions/index.md
+++ b/documentation/versioned_docs/version-5.8/extensions/index.md
@@ -37,5 +37,6 @@ maintained and hosted by third parties.
 | [LogCapture](https://github.com/jsalinaspolo/logcapture)                                         | LogCapture is a testing library for asserting logging messages                     |
 | [Micronaut](https://github.com/micronaut-projects/micronaut-test)                                | JVM-based, full-stack framework for building modular, easily testable microservice |
 | [Result4s](https://github.com/MrBergin/result4k-kotest-matchers)                                 | Result4s matchers                                                                  |
+| [Selfie](https://www.github.com/diffplug/selfie)                                                 | Snapshot testing (inline, disk, and memoization)                                   |
 | [Sniffy](https://www.sniffy.io/docs/latest/#_integration_with_kotest)                            | Network connectivity testing                                                       |
 | [TestFiles](https://github.com/jGleitz/testfiles)                                                | Creates organized files and directories for testing                                |


### PR DESCRIPTION
- This is a followup to #3870
- I tested Selfie on old versions of Kotest, it works back through Kotest 5.4.0
  - https://github.com/diffplug/selfie/pull/239
- So I added Selfie to the 3rd party extensions for 5.8 -> 5.4
  - The extensions were not sorted in 5.5 and 5.4, so I sorted first before adding selfie