### PR TITLE
Fix the snapshot version badge in index markdowns

### DIFF
--- a/documentation/docs/assertions/index.md
+++ b/documentation/docs/assertions/index.md
@@ -16,7 +16,7 @@ or with another test framework like JUnit or Spock.
 
 
 [![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-core-jvm.svg?label=release)](https://search.maven.org/search?q=g:io.kotest)
-[![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-assertions-core-jvm.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
+[![version badge](https://img.shields.io/nexus/s/https/s01.oss.sonatype.org/io.kotest/kotest-assertions-core-jvm.svg?label=snapshot)](https://s01.oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 The core functionality of the assertion modules are functions that test state. Kotest calls these types of state
 assertion functions _matchers_. There are [core](matchers.md) matchers and matchers for third party libraries.

--- a/documentation/docs/framework/index.md
+++ b/documentation/docs/framework/index.md
@@ -7,7 +7,7 @@ slug: framework.html
 ![intro_gif](/img/intro_gif.gif)
 
 [![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-framework-engine.svg?label=release)](https://search.maven.org/search?q=g:io.kotest%20OR%20g:io.kotest.extensions)
-[![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-framework-engine.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
+[![version badge](https://img.shields.io/nexus/s/https/s01.oss.sonatype.org/io.kotest/kotest-framework-engine.svg?label=snapshot)](https://s01.oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 Test with Style
 ---------------

--- a/documentation/versioned_docs/version-5.8/assertions/index.md
+++ b/documentation/versioned_docs/version-5.8/assertions/index.md
@@ -16,7 +16,7 @@ or with another test framework like JUnit or Spock.
 
 
 [![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-core-jvm.svg?label=release)](https://search.maven.org/search?q=g:io.kotest)
-[![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-assertions-core-jvm.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
+[![version badge](https://img.shields.io/nexus/s/https/s01.oss.sonatype.org/io.kotest/kotest-assertions-core-jvm.svg?label=snapshot)](https://s01.oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 The core functionality of the assertion modules are functions that test state. Kotest calls these types of state
 assertion functions _matchers_. There are [core](matchers.md) matchers and matchers for third party libraries.

--- a/documentation/versioned_docs/version-5.8/framework/index.md
+++ b/documentation/versioned_docs/version-5.8/framework/index.md
@@ -7,7 +7,7 @@ slug: framework.html
 ![intro_gif](/img/intro_gif.gif)
 
 [![version badge](https://img.shields.io/maven-central/v/io.kotest/kotest-framework-engine.svg?label=release)](https://search.maven.org/search?q=g:io.kotest%20OR%20g:io.kotest.extensions)
-[![version badge](https://img.shields.io/nexus/s/https/oss.sonatype.org/io.kotest/kotest-framework-engine.svg?label=snapshot)](https://oss.sonatype.org/content/repositories/snapshots/io/kotest/)
+[![version badge](https://img.shields.io/nexus/s/https/s01.oss.sonatype.org/io.kotest/kotest-framework-engine.svg?label=snapshot)](https://s01.oss.sonatype.org/content/repositories/snapshots/io/kotest/)
 
 Test with Style
 ---------------


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

#3857 
Started from this issue.

Kotest migrated to a new Sonatype repository a while back which caused the badges to break. 
it changed to s01.oss.sonatype.org now.