### PR TITLE
Remove unnecessary delay when retry and fix error message

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -85,7 +85,7 @@ suspend fun <T> retry(
          // else ignore and continue
       }
       retrySoFar++
-      if (retrySoFar >= config.maxRetry) break
+      if (retrySoFar >= config.maxRetry || end.hasPassedNow()) break
       delay(nextAwaitDuration)
       nextAwaitDuration *= config.multiplier
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -85,6 +85,7 @@ suspend fun <T> retry(
          // else ignore and continue
       }
       retrySoFar++
+      if (retrySoFar >= config.maxRetry) break
       delay(nextAwaitDuration)
       nextAwaitDuration *= config.multiplier
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -67,7 +67,8 @@ suspend fun <T> retry(
    val mark = MonotonicTimeSourceCompat.markNow()
    val end = mark.plus(config.timeout)
    var retrySoFar = 0
-   var nextAwaitDuration = config.delay.inWholeMilliseconds
+   var nextAwaitDuration = config.delay
+   var delayedTime = 0.seconds
    var lastError: Throwable? = null
 
    while (end.hasNotPassedNow() && retrySoFar < config.maxRetry) {
@@ -87,11 +88,12 @@ suspend fun <T> retry(
       retrySoFar++
       if (retrySoFar >= config.maxRetry || end.hasPassedNow()) break
       delay(nextAwaitDuration)
+      delayedTime += nextAwaitDuration
       nextAwaitDuration *= config.multiplier
    }
    val underlyingCause = if (lastError == null) "" else "; underlying cause was ${lastError.message}"
    throw failure(
-      "Test failed after ${config.delay.toLong(DurationUnit.SECONDS)} seconds; attempted $retrySoFar times$underlyingCause",
+      "Test failed after ${delayedTime.toLong(DurationUnit.SECONDS)} seconds; attempted $retrySoFar times$underlyingCause",
       lastError
    )
 }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

resolve #3890

Pre-check the number of retries to eliminate additional delays