### PR TITLE
Creating a PR base workflow that shall be mandatory

### DIFF
--- a/.github/workflows/PR-base.yml
+++ b/.github/workflows/PR-base.yml
@@ -1,0 +1,57 @@
+name: PR-base
+# Triggers Docs PR workflow on changes to documentation
+# Triggers tests on non-docs PRs
+
+on:
+   merge_group:
+   pull_request:
+
+jobs:
+   determine-workflows-to-run:
+      runs-on: ubuntu-latest
+      outputs:
+         run_docs: ${{ steps.check_files.outputs.run_docs }}
+         run_tests: ${{ steps.check_files.outputs.run_tests }}
+      steps:
+         -  name: Checkout code
+            uses: actions/checkout@v2
+            with:
+               fetch-depth: 2
+
+         -  name: check modified files
+            id: check_files
+            run: |
+               echo "::set-output name=run_docs::false"
+               echo "::set-output name=run_tests::false"
+
+               echo "=============== list modified files ==============="
+               git diff --name-only HEAD^ HEAD
+
+               echo "========== check paths of modified files =========="
+               git diff --name-only HEAD^ HEAD &gt; files.txt
+               while IFS= read -r file
+               do
+                 echo $file
+                 if [[ $file != documentation/* ]]; then
+                   echo "This modified file is not under the 'documentation' folder. Will run tests."
+                   echo "::set-output name=run_tests::true"
+                 else
+                   echo "This modified file is under the 'documentation' folder. Will run docs workflow."
+                   echo "::set-output name=run_docs::true"
+                 fi
+               done &lt; files.txt
+   run-tests:
+      name: Run tests
+      needs: determine-workflows-to-run
+      if: ${{ needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
+      uses: ./.github/workflows/PR.yml
+      with:
+         ref: ${{ github.event.inputs.ref }}
+   run-docs:
+      name: Run docs
+      needs: determine-workflows-to-run
+      if: ${{ needs.determine-workflows-to-run.outputs.run_docs == 'true' }}
+      uses: ./.github/workflows/docs_pr.yml
+      with:
+         ref: ${{ github.event.inputs.ref }}
+

--- a/.github/workflows/PR-base.yml
+++ b/.github/workflows/PR-base.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
    determine-workflows-to-run:
+      name: Determine workflows to run
       runs-on: ubuntu-latest
       outputs:
          run_docs: ${{ steps.check_files.outputs.run_docs }}
@@ -24,8 +25,8 @@ jobs:
          -  name: check modified files
             id: check_files
             run: |
-               echo "::set-output name=run_docs::false"
-               echo "::set-output name=run_tests::false"
+               echo "run_docs=false" >> $GITHUB_OUTPUT
+               echo "run_tests=false" >> $GITHUB_OUTPUT
 
                echo "=============== list modified files ==============="
                git diff --name-only HEAD^ HEAD
@@ -37,10 +38,10 @@ jobs:
                  echo $file
                  if [[ $file != documentation/* ]]; then
                    echo "This modified file is not under the 'documentation' folder. Will run tests."
-                   echo "::set-output name=run_tests::true"
+                   echo "run_tests=true" >> $GITHUB_OUTPUT
                  else
                    echo "This modified file is under the 'documentation' folder. Will run docs workflow."
-                   echo "::set-output name=run_docs::true"
+                   echo "run_docs=true" >> $GITHUB_OUTPUT
                  fi
                done < files.txt
    run-tests:

--- a/.github/workflows/PR-base.yml
+++ b/.github/workflows/PR-base.yml
@@ -31,7 +31,7 @@ jobs:
                git diff --name-only HEAD^ HEAD
 
                echo "========== check paths of modified files =========="
-               git diff --name-only HEAD^ HEAD &gt; files.txt
+               git diff --name-only HEAD^ HEAD > files.txt
                while IFS= read -r file
                do
                  echo $file
@@ -42,7 +42,7 @@ jobs:
                    echo "This modified file is under the 'documentation' folder. Will run docs workflow."
                    echo "::set-output name=run_docs::true"
                  fi
-               done &lt; files.txt
+               done < files.txt
    run-tests:
       name: Run tests
       needs: determine-workflows-to-run

--- a/.github/workflows/PR-base.yml
+++ b/.github/workflows/PR-base.yml
@@ -6,6 +6,9 @@ on:
    merge_group:
    pull_request:
 
+permissions:
+   contents: read
+
 jobs:
    determine-workflows-to-run:
       runs-on: ubuntu-latest

--- a/.github/workflows/PR-base.yml
+++ b/.github/workflows/PR-base.yml
@@ -44,13 +44,6 @@ jobs:
                    echo "run_docs=true" >> $GITHUB_OUTPUT
                  fi
                done < files.txt
-   run-tests:
-      name: Run tests
-      needs: determine-workflows-to-run
-      if: ${{ needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
-      uses: ./.github/workflows/PR.yml
-      with:
-         ref: ${{ github.event.inputs.ref }}
    run-docs:
       name: Run docs
       needs: determine-workflows-to-run
@@ -58,4 +51,10 @@ jobs:
       uses: ./.github/workflows/docs_pr.yml
       with:
          ref: ${{ github.event.inputs.ref }}
-
+   run-tests:
+      name: Run tests
+      needs: determine-workflows-to-run
+      if: ${{ needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
+      uses: ./.github/workflows/PR.yml
+      with:
+         ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,18 +1,12 @@
 name: PR-Test
 
 on:
-   merge_group:
-      paths-ignore:
-         - 'doc/**'
-         - 'documentation/**'
-         - '*.md'
-         - '*.yml'
-   pull_request:
-      paths-ignore:
-         - 'doc/**'
-         - 'documentation/**'
-         - '*.md'
-         - '*.yml'
+   workflow_call:
+      inputs:
+         ref:
+            description: "The git branch, tag or SHA to checkout"
+            required: false
+            type: string
 
 permissions:
   contents: read
@@ -26,7 +20,7 @@ jobs:
             uses: actions/checkout@v3
             with:
                fetch-depth: 0
-               ref: ${{ github.event.inputs.branch }}
+               ref: ${{ inputs.ref }}
 
          -  name: Setup JDK
             uses: actions/setup-java@v3

--- a/.github/workflows/docs_pr.yml
+++ b/.github/workflows/docs_pr.yml
@@ -13,8 +13,6 @@ permissions:
 
 jobs:
    build:
-      permissions:
-         contents: write  # for Git to git push
       runs-on: ubuntu-latest
       steps:
          -  uses: actions/checkout@v3

--- a/.github/workflows/docs_pr.yml
+++ b/.github/workflows/docs_pr.yml
@@ -1,12 +1,12 @@
 name: docs-test
 
 on:
-   merge_group:
-      paths:
-         - 'documentation/**'
-   pull_request:
-      paths:
-         - 'documentation/**'
+   workflow_call:
+      inputs:
+         ref:
+            description: "The git branch, tag or SHA to checkout"
+            required: false
+            type: string
 
 permissions:
    contents: read
@@ -18,6 +18,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
          -  uses: actions/checkout@v3
+            with:
+               fetch-depth: 0
+               ref: ${{ inputs.ref }}
          -  uses: actions/setup-node@v3
             with:
                node-version: '18.4.0'


### PR DESCRIPTION
We tried enabling a merge queue to Kotest. The merge queue solves the issue of merging non-updated PRs by letting us add them to the merge queue. GitHub will merge once the PR is still up-to-date with master and passing required status checks. Which is where we ran into issues, since we had no _required_ status checks, we merely had status checks which ran.

This PR adds a base PR workflow which detects what workflows should be run for any given PR. The new base workflow can be added as a required status check, since it'll always be able to run and will figure out what needs to be run subsequently.

