### PR TITLE
Quote expected and actual exception messages in assertions

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/CovariantThrowableHandlingTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/CovariantThrowableHandlingTest.kt
@@ -229,7 +229,8 @@ class CovariantThrowableHandlingTest : FreeSpec() {
       val throwable = catchThrowable(block)
 
       throwable.shouldBeInstanceOf<AssertionError>()
-      throwable.message shouldBe "Expected exception message '$expectedMessage' but was '$actualMessage' instead."
+      throwable.message shouldBe "Unexpected exception message: " +
+         "expected:<\"$expectedMessage\"> but was:<\"$actualMessage\">"
    }
 
    private fun verifyReturnsExactly(thrownException: Throwable, block: () -> Any?) {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/CovariantThrowableHandlingTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/CovariantThrowableHandlingTest.kt
@@ -229,7 +229,7 @@ class CovariantThrowableHandlingTest : FreeSpec() {
       val throwable = catchThrowable(block)
 
       throwable.shouldBeInstanceOf<AssertionError>()
-      throwable.message shouldBe "Expected exception message $expectedMessage but was $actualMessage instead."
+      throwable.message shouldBe "Expected exception message '$expectedMessage' but was '$actualMessage' instead."
    }
 
    private fun verifyReturnsExactly(thrownException: Throwable, block: () -> Any?) {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
@@ -63,7 +63,7 @@ inline fun <reified T : Throwable> shouldThrowUnitWithMessage(message: String, b
    shouldThrowUnit<T>(block).let {
       when (it.message) {
          message -> it
-         else -> throw failure("Expected exception message $message but was ${it.message} instead.", it)
+         else -> throw failure("Expected exception message '$message' but was '${it.message}' instead.", it)
       }
    }
 
@@ -212,7 +212,7 @@ inline fun <reified T : Throwable> shouldThrowWithMessage(message: String, block
    shouldThrow<T>(block).let {
       when (it.message) {
          message -> it
-         else -> throw failure("Expected exception message $message but was ${it.message} instead.", it)
+         else -> throw failure("Expected exception message '$message' but was '${it.message}' instead.", it)
       }
    }
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
@@ -1,10 +1,13 @@
 package io.kotest.assertions.throwables
 
+import io.kotest.assertions.Actual
 import io.kotest.assertions.ErrorCollectionMode
+import io.kotest.assertions.Expected
 import io.kotest.assertions.assertionCounter
 import io.kotest.assertions.collectOrThrow
 import io.kotest.assertions.errorCollector
 import io.kotest.assertions.failure
+import io.kotest.assertions.print.print
 import io.kotest.mpp.bestName
 
 /**
@@ -63,7 +66,7 @@ inline fun <reified T : Throwable> shouldThrowUnitWithMessage(message: String, b
    shouldThrowUnit<T>(block).let {
       when (it.message) {
          message -> it
-         else -> throw failure("Expected exception message '$message' but was '${it.message}' instead.", it)
+         else -> throw failure( Expected(message.print()), Actual(it.message.print()),"Unexpected exception message: ")
       }
    }
 
@@ -212,7 +215,7 @@ inline fun <reified T : Throwable> shouldThrowWithMessage(message: String, block
    shouldThrow<T>(block).let {
       when (it.message) {
          message -> it
-         else -> throw failure("Expected exception message '$message' but was '${it.message}' instead.", it)
+         else -> throw failure(Expected(message.print()), Actual(it.message.print()), "Unexpected exception message: ")
       }
    }
 


### PR DESCRIPTION
This makes the output more readable if the exception messages are full sentences.