### PR TITLE
Added IPAddressV6 arb

### DIFF
--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -1148,6 +1148,7 @@ public final class io/kotest/property/arbitrary/MultiplesShrinker : io/kotest/pr
 
 public final class io/kotest/property/arbitrary/NetworkKt {
 	public static final fun ipAddressV4 (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
+	public static final fun ipAddressV6 (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
 }
 
 public final class io/kotest/property/arbitrary/NextKt {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/network.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/network.kt
@@ -14,3 +14,20 @@ fun Arb.Companion.ipAddressV4(): Arb<String> = arbitrary {
       it.random.nextInt(0, 255)
    ).joinToString(".")
 }
+
+/**
+ * Returns an [Arb] where each generated value is an IP Address in V6 format represented as a String.
+ * Each part is a number between 0 and 65535 represented as a hexadecimal number.
+ */
+fun Arb.Companion.ipAddressV6(): Arb<String> = arbitrary {
+   listOf(
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase(),
+      it.random.nextInt(0x10000).toString(16).uppercase()
+   ).joinToString(":")
+}

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/IpAddressTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/IpAddressTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.ints.shouldBeBetween
 import io.kotest.matchers.string.shouldMatch
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.ipAddressV4
+import io.kotest.property.arbitrary.ipAddressV6
 import io.kotest.property.checkAll
 
 class IpAddressTest : FunSpec() {
@@ -23,6 +24,26 @@ class IpAddressTest : FunSpec() {
             result.groupValues[2].toInt().shouldBeBetween(0, 255)
             result.groupValues[3].toInt().shouldBeBetween(0, 255)
             result.groupValues[4].toInt().shouldBeBetween(0, 255)
+         }
+      }
+
+      test("Arb.ipAddressV6 should generate in a:b:c:d:e:f:g:h format") {
+         checkAll(100, Arb.ipAddressV6()) { ip ->
+            ip.shouldMatch("([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}".toRegex())
+         }
+      }
+
+      test("Arb.ipAddressV6 should generate each component in the range 0-65535") {
+         checkAll(100, Arb.ipAddressV6()) { ip ->
+            val result = "([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}:([0-9,A-F]){1,4}".toRegex().matchEntire(ip)!!
+            result.groupValues[1].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[2].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[3].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[4].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[5].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[6].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[7].toInt(16).shouldBeBetween(0, 65535)
+            result.groupValues[8].toInt(16).shouldBeBetween(0, 65535)
          }
       }
    }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->


# Summary

There is a function that creates IPV4-formatted strings, but IPV6 does not exist, so I added this function.

# How Has This Been Tested
- Added a test to check if it produces a String that is ipv6-formatted




