### PR TITLE
Rename unresolved test config and allow passing into test methods

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -982,6 +982,7 @@ public final class io/kotest/core/config/Defaults {
 	public static final field projectWideFailFast Z
 	public static final field specFailureFilePath Ljava/lang/String;
 	public static final field testCoroutineDispatcher Z
+	public static final field threads I
 	public static final field writeSpecFailureFile Z
 	public final fun getAssertionMode ()Lio/kotest/core/test/AssertionMode;
 	public final fun getDefaultIncludeTestScopeAffixes ()Ljava/lang/Boolean;
@@ -1085,6 +1086,7 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun getGlobalAssertSoftly ()Z
 	public final fun getIncludeTestScopeAffixes ()Ljava/lang/Boolean;
 	public final fun getInvocationTimeout ()Ljava/lang/Long;
+	public final fun getInvocations ()I
 	public final fun getIsolationMode ()Lio/kotest/core/spec/IsolationMode;
 	public final fun getLogLevel ()Lio/kotest/core/config/LogLevel;
 	public final fun getParallelism ()I
@@ -1101,6 +1103,7 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun getTestCoroutineDispatcher ()Z
 	public final fun getTestNameAppendTags ()Z
 	public final fun getTestNameCase ()Lio/kotest/core/names/TestNameCase;
+	public final fun getThreads ()I
 	public final fun getTimeout ()Ljava/lang/Long;
 	public final fun getWriteSpecFailureFile ()Z
 	public final fun listeners ()Ljava/lang/Void;
@@ -1123,6 +1126,7 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun setGlobalAssertSoftly (Z)V
 	public final fun setIncludeTestScopeAffixes (Ljava/lang/Boolean;)V
 	public final fun setInvocationTimeout (Ljava/lang/Long;)V
+	public final fun setInvocations (I)V
 	public final fun setIsolationMode (Lio/kotest/core/spec/IsolationMode;)V
 	public final fun setLogLevel (Lio/kotest/core/config/LogLevel;)V
 	public final fun setParallelism (I)V
@@ -1138,6 +1142,7 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun setTestCoroutineDispatcher (Z)V
 	public final fun setTestNameAppendTags (Z)V
 	public final fun setTestNameCase (Lio/kotest/core/names/TestNameCase;)V
+	public final fun setThreads (I)V
 	public final fun setTimeout (Ljava/lang/Long;)V
 	public final fun setWriteSpecFailureFile (Z)V
 }
@@ -1969,18 +1974,18 @@ public abstract interface annotation class io/kotest/core/spec/Order : java/lang
 }
 
 public final class io/kotest/core/spec/RootTest {
-	public fun <init> (Lio/kotest/core/names/TestName;Lkotlin/jvm/functions/Function2;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Ljava/lang/Boolean;Lio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/factory/FactoryId;)V
+	public fun <init> (Lio/kotest/core/names/TestName;Lkotlin/jvm/functions/Function2;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Ljava/lang/Boolean;Lio/kotest/core/test/config/TestConfig;Lio/kotest/core/factory/FactoryId;)V
 	public final fun component1 ()Lio/kotest/core/names/TestName;
 	public final fun component2 ()Lkotlin/jvm/functions/Function2;
 	public final fun component3 ()Lio/kotest/core/test/TestType;
 	public final fun component4 ()Lio/kotest/core/source/SourceRef;
 	public final fun component5 ()Ljava/lang/Boolean;
-	public final fun component6 ()Lio/kotest/core/test/config/UnresolvedTestConfig;
+	public final fun component6 ()Lio/kotest/core/test/config/TestConfig;
 	public final fun component7 ()Lio/kotest/core/factory/FactoryId;
-	public final fun copy (Lio/kotest/core/names/TestName;Lkotlin/jvm/functions/Function2;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Ljava/lang/Boolean;Lio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/factory/FactoryId;)Lio/kotest/core/spec/RootTest;
-	public static synthetic fun copy$default (Lio/kotest/core/spec/RootTest;Lio/kotest/core/names/TestName;Lkotlin/jvm/functions/Function2;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Ljava/lang/Boolean;Lio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/factory/FactoryId;ILjava/lang/Object;)Lio/kotest/core/spec/RootTest;
+	public final fun copy (Lio/kotest/core/names/TestName;Lkotlin/jvm/functions/Function2;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Ljava/lang/Boolean;Lio/kotest/core/test/config/TestConfig;Lio/kotest/core/factory/FactoryId;)Lio/kotest/core/spec/RootTest;
+	public static synthetic fun copy$default (Lio/kotest/core/spec/RootTest;Lio/kotest/core/names/TestName;Lkotlin/jvm/functions/Function2;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Ljava/lang/Boolean;Lio/kotest/core/test/config/TestConfig;Lio/kotest/core/factory/FactoryId;ILjava/lang/Object;)Lio/kotest/core/spec/RootTest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getConfig ()Lio/kotest/core/test/config/UnresolvedTestConfig;
+	public final fun getConfig ()Lio/kotest/core/test/config/TestConfig;
 	public final fun getDisabled ()Ljava/lang/Boolean;
 	public final fun getFactoryId ()Lio/kotest/core/factory/FactoryId;
 	public final fun getName ()Lio/kotest/core/names/TestName;
@@ -2281,6 +2286,8 @@ public abstract class io/kotest/core/spec/style/FreeSpec : io/kotest/core/spec/D
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public fun config-rDtbm-Q (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public fun config-s0vPEsQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -2294,6 +2301,8 @@ public final class io/kotest/core/spec/style/FreeSpecKt {
 
 public final class io/kotest/core/spec/style/FreeSpecTestFactoryConfiguration : io/kotest/core/factory/TestFactoryConfiguration, io/kotest/core/spec/style/scopes/FreeSpecRootScope {
 	public fun <init> ()V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public fun config-rDtbm-Q (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public fun config-s0vPEsQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -2415,9 +2424,9 @@ public class io/kotest/core/spec/style/scopes/AbstractContainerScope : io/kotest
 	public fun getCoroutineContext ()Lkotlin/coroutines/CoroutineContext;
 	public fun getTestCase ()Lio/kotest/core/test/TestCase;
 	public fun hasChildren ()Z
-	public fun registerContainer (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun registerContainer (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun registerTestCase (Lio/kotest/core/test/NestedTest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -2504,9 +2513,9 @@ public abstract interface class io/kotest/core/spec/style/scopes/ContainerScope 
 	public abstract fun beforeEach (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun beforeTest (Lkotlin/jvm/functions/Function2;)V
 	public abstract fun hasChildren ()Z
-	public abstract fun registerContainer (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun registerContainer (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun registerTest (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/core/spec/style/scopes/ContainerScope$DefaultImpls {
@@ -2518,9 +2527,9 @@ public final class io/kotest/core/spec/style/scopes/ContainerScope$DefaultImpls 
 	public static fun beforeContainer (Lio/kotest/core/spec/style/scopes/ContainerScope;Lkotlin/jvm/functions/Function2;)V
 	public static fun beforeEach (Lio/kotest/core/spec/style/scopes/ContainerScope;Lkotlin/jvm/functions/Function2;)V
 	public static fun beforeTest (Lio/kotest/core/spec/style/scopes/ContainerScope;Lkotlin/jvm/functions/Function2;)V
-	public static fun registerContainer (Lio/kotest/core/spec/style/scopes/ContainerScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun registerTest (Lio/kotest/core/spec/style/scopes/ContainerScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun registerTest (Lio/kotest/core/spec/style/scopes/ContainerScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun registerContainer (Lio/kotest/core/spec/style/scopes/ContainerScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun registerTest (Lio/kotest/core/spec/style/scopes/ContainerScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun registerTest (Lio/kotest/core/spec/style/scopes/ContainerScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/core/spec/style/scopes/ContainerWithConfigBuilder {
@@ -2633,6 +2642,7 @@ public final class io/kotest/core/spec/style/scopes/FeatureSpecRootScope$Default
 
 public final class io/kotest/core/spec/style/scopes/FreeSpecContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
+	public final fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun config-rDtbm-Q (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun config-rDtbm-Q$default (Lio/kotest/core/spec/style/scopes/FreeSpecContainerScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun config-xwBXJq0 (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
@@ -2644,19 +2654,21 @@ public final class io/kotest/core/spec/style/scopes/FreeSpecContainerScope : io/
 }
 
 public final class io/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder {
-	public fun <init> (Ljava/lang/String;Lio/kotest/core/test/config/UnresolvedTestConfig;)V
+	public fun <init> (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Lio/kotest/core/test/config/UnresolvedTestConfig;
-	public final fun copy (Ljava/lang/String;Lio/kotest/core/test/config/UnresolvedTestConfig;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
-	public static synthetic fun copy$default (Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;Ljava/lang/String;Lio/kotest/core/test/config/UnresolvedTestConfig;ILjava/lang/Object;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
+	public final fun component2 ()Lio/kotest/core/test/config/TestConfig;
+	public final fun copy (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
+	public static synthetic fun copy$default (Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;ILjava/lang/Object;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getConfig ()Lio/kotest/core/test/config/UnresolvedTestConfig;
+	public final fun getConfig ()Lio/kotest/core/test/config/TestConfig;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/kotest/core/spec/style/scopes/FreeSpecRootScope : io/kotest/core/spec/style/scopes/RootScope {
+	public abstract fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
+	public abstract fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public abstract fun config-rDtbm-Q (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public abstract fun config-s0vPEsQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public abstract fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -2665,6 +2677,8 @@ public abstract interface class io/kotest/core/spec/style/scopes/FreeSpecRootSco
 }
 
 public final class io/kotest/core/spec/style/scopes/FreeSpecRootScope$DefaultImpls {
+	public static fun config (Lio/kotest/core/spec/style/scopes/FreeSpecRootScope;Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
+	public static fun config (Lio/kotest/core/spec/style/scopes/FreeSpecRootScope;Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public static fun config-rDtbm-Q (Lio/kotest/core/spec/style/scopes/FreeSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun config-rDtbm-Q$default (Lio/kotest/core/spec/style/scopes/FreeSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static fun config-s0vPEsQ (Lio/kotest/core/spec/style/scopes/FreeSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
@@ -2718,6 +2732,7 @@ public final class io/kotest/core/spec/style/scopes/FunSpecRootScope$DefaultImpl
 
 public final class io/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder {
 	public fun <init> (Lio/kotest/core/names/TestName;ZLio/kotest/core/spec/style/scopes/RootScope;Lkotlin/jvm/functions/Function1;)V
+	public final fun config (Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 	public final fun config-Q9yt8Vw (Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/Set;Lkotlin/time/Duration;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun config-Q9yt8Vw$default (Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/util/Set;Lkotlin/time/Duration;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public final fun getContextFn ()Lkotlin/jvm/functions/Function1;
@@ -2728,9 +2743,9 @@ public abstract interface class io/kotest/core/spec/style/scopes/RootScope {
 }
 
 public final class io/kotest/core/spec/style/scopes/RootScopeKt {
-	public static final fun addContainer (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;)V
-	public static final fun addTest (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;)V
-	public static final fun addTest (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lkotlin/jvm/functions/Function2;)V
+	public static final fun addContainer (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
+	public static final fun addTest (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lkotlin/jvm/functions/Function2;)V
+	public static final fun addTest (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/kotest/core/spec/style/scopes/RootTestWithConfigBuilder {
@@ -2806,6 +2821,7 @@ public final class io/kotest/core/spec/style/scopes/TestDslState {
 
 public final class io/kotest/core/spec/style/scopes/TestWithConfigBuilder {
 	public fun <init> (Lio/kotest/core/names/TestName;Lio/kotest/core/spec/style/scopes/ContainerScope;Z)V
+	public final fun config (Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun config--XidU4I (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun config--XidU4I$default (Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
@@ -2899,17 +2915,17 @@ public final class io/kotest/core/test/NamesKt {
 }
 
 public final class io/kotest/core/test/NestedTest {
-	public fun <init> (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Lkotlin/jvm/functions/Function2;)V
+	public fun <init> (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Lkotlin/jvm/functions/Function2;)V
 	public final fun component1 ()Lio/kotest/core/names/TestName;
 	public final fun component2 ()Z
-	public final fun component3 ()Lio/kotest/core/test/config/UnresolvedTestConfig;
+	public final fun component3 ()Lio/kotest/core/test/config/TestConfig;
 	public final fun component4 ()Lio/kotest/core/test/TestType;
 	public final fun component5 ()Lio/kotest/core/source/SourceRef;
 	public final fun component6 ()Lkotlin/jvm/functions/Function2;
-	public final fun copy (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Lkotlin/jvm/functions/Function2;)Lio/kotest/core/test/NestedTest;
-	public static synthetic fun copy$default (Lio/kotest/core/test/NestedTest;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/UnresolvedTestConfig;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/kotest/core/test/NestedTest;
+	public final fun copy (Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Lkotlin/jvm/functions/Function2;)Lio/kotest/core/test/NestedTest;
+	public static synthetic fun copy$default (Lio/kotest/core/test/NestedTest;Lio/kotest/core/names/TestName;ZLio/kotest/core/test/config/TestConfig;Lio/kotest/core/test/TestType;Lio/kotest/core/source/SourceRef;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/kotest/core/test/NestedTest;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getConfig ()Lio/kotest/core/test/config/UnresolvedTestConfig;
+	public final fun getConfig ()Lio/kotest/core/test/config/TestConfig;
 	public final fun getDisabled ()Z
 	public final fun getName ()Lio/kotest/core/names/TestName;
 	public final fun getSource ()Lio/kotest/core/source/SourceRef;
@@ -3200,7 +3216,7 @@ public final class io/kotest/core/test/config/TestCaseConfig {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/kotest/core/test/config/UnresolvedTestConfig {
+public final class io/kotest/core/test/config/TestConfig {
 	public synthetic fun <init> (Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Lio/kotest/core/test/AssertionMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Lio/kotest/core/test/AssertionMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Boolean;
@@ -3221,8 +3237,8 @@ public final class io/kotest/core/test/config/UnresolvedTestConfig {
 	public final fun component7-FghU774 ()Lkotlin/time/Duration;
 	public final fun component8 ()Ljava/util/Set;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy-7XgAYuk (Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Lio/kotest/core/test/AssertionMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/test/config/UnresolvedTestConfig;
-	public static synthetic fun copy-7XgAYuk$default (Lio/kotest/core/test/config/UnresolvedTestConfig;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Lio/kotest/core/test/AssertionMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/kotest/core/test/config/UnresolvedTestConfig;
+	public final fun copy-7XgAYuk (Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Lio/kotest/core/test/AssertionMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/test/config/TestConfig;
+	public static synthetic fun copy-7XgAYuk$default (Lio/kotest/core/test/config/TestConfig;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Lio/kotest/core/test/AssertionMode;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/kotest/core/test/config/TestConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAssertSoftly ()Ljava/lang/Boolean;
 	public final fun getAssertionMode ()Lio/kotest/core/test/AssertionMode;

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -12,7 +12,6 @@ import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.test.AssertionMode
 import io.kotest.core.test.TestCaseOrder
-import io.kotest.core.test.config.ResolvedTestConfig
 import io.kotest.core.test.config.TestCaseConfig
 import kotlin.reflect.KClass
 import kotlin.time.Duration
@@ -200,9 +199,10 @@ abstract class AbstractProjectConfig {
    open val assertionMode: AssertionMode? = null
 
    /**
-    * Any [ResolvedTestConfig] set here is used as the default for tests, unless overridden in a spec,
+    * Any [TestCaseConfig] set here is used as the default for tests, unless overridden in a spec,
     * or in a test itself. In other words the order is test -> spec -> project config default -> kotest default
     */
+   @Deprecated("use the individual settings instead of the test case config class. Deprecated since 5.8.1")
    open val defaultTestCaseConfig: TestCaseConfig? = null
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
@@ -11,6 +11,7 @@ import io.kotest.core.test.config.TestCaseConfig
 
 object Defaults {
 
+   const val threads = 1
    const val disableTestNestedJarScanning: Boolean = true
 
    val assertionMode: AssertionMode = AssertionMode.None
@@ -36,7 +37,7 @@ object Defaults {
    const val parallelism: Int = 1
 
    const val defaultTimeoutMillis = 10 * 60 * 1000L
-   const val defaultInvocationTimeoutMillis =  10 * 60 * 1000L
+   const val defaultInvocationTimeoutMillis = 10 * 60 * 1000L
 
    const val failOnIgnoredTests: Boolean = false
    const val failfast: Boolean = false

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -352,6 +352,10 @@ class ProjectConfiguration {
 
    var allowOutOfOrderCallbacks: Boolean = Defaults.allowOutOfOrderCallbacks
 
+   var threads: Int = defaultTestConfig.threads
+
+   var invocations: Int = defaultTestConfig.invocations
+
    /**
     * Returns all globally registered [Listener]s.
     */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -26,7 +26,7 @@ import io.kotest.core.test.TestScope
 import io.kotest.core.test.TestType
 import io.kotest.core.test.config.ResolvedTestConfig
 import io.kotest.core.test.config.TestCaseConfig
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.js.JsName
 
 /**
@@ -438,6 +438,6 @@ data class RootTest(
    val type: TestType,
    val source: SourceRef,
    val disabled: Boolean?, // if the test is explicitly disabled, say through an annotation or method name
-   val config: UnresolvedTestConfig?, // if specified by the test, may be null
+   val config: TestConfig?, // if specified by the test, may be null
    val factoryId: FactoryId?, // if this root test was added from a factory
 )

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
@@ -20,7 +20,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
 import io.kotest.core.test.TestType
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.coroutines.CoroutineContext
 
 @Deprecated("Renamed to ContainerScope in 5.0")
@@ -41,11 +41,11 @@ interface ContainerScope : TestScope {
    fun hasChildren(): Boolean
 
    suspend fun registerTest(
-      name: TestName,
-      disabled: Boolean,
-      config: UnresolvedTestConfig?,
-      type: TestType,
-      test: suspend TestScope.() -> Unit,
+     name: TestName,
+     disabled: Boolean,
+     config: TestConfig?,
+     type: TestType,
+     test: suspend TestScope.() -> Unit,
    ) {
       registerTestCase(
          NestedTest(
@@ -60,19 +60,19 @@ interface ContainerScope : TestScope {
    }
 
    suspend fun registerContainer(
-      name: TestName,
-      disabled: Boolean,
-      config: UnresolvedTestConfig?,
-      test: suspend TestScope.() -> Unit,
+     name: TestName,
+     disabled: Boolean,
+     config: TestConfig?,
+     test: suspend TestScope.() -> Unit,
    ) {
       registerTest(name, disabled, config, TestType.Container, test)
    }
 
    suspend fun registerTest(
-      name: TestName,
-      disabled: Boolean,
-      config: UnresolvedTestConfig?,
-      test: suspend TestScope.() -> Unit,
+     name: TestName,
+     disabled: Boolean,
+     config: TestConfig?,
+     test: suspend TestScope.() -> Unit,
    ) {
       registerTest(name, disabled, config, TestType.Test, test)
    }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerWithConfigBuilder.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerWithConfigBuilder.kt
@@ -6,7 +6,7 @@ import io.kotest.core.names.TestName
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
 @ExperimentalKotest
@@ -27,7 +27,7 @@ class ContainerWithConfigBuilder<T>(
       blockingTest: Boolean? = null,
       test: suspend T.() -> Unit
    ) {
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          enabledIf = enabledIf,
          enabledOrReasonIf = enabledOrReasonIf,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
@@ -7,7 +7,7 @@ import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
 @Deprecated("Renamed to FreeSpecContainerScope. Deprecated since 4.5")
@@ -75,6 +75,20 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
       )
    }
 
+   suspend fun String.config(
+      config: TestConfig,
+      test: suspend TestScope.() -> Unit,
+   ) {
+      TestWithConfigBuilder(
+         name = TestName(this),
+         context = this@FreeSpecContainerScope,
+         xdisabled = false,
+      ).config(
+         config = config,
+         test = test,
+      )
+   }
+
 
    /**
     * Adds the contained config and test to this scope as a container test.
@@ -108,7 +122,7 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
       severity: TestCaseSeverityLevel? = null,
       failfast: Boolean? = null,
    ): FreeSpecContextConfigBuilder {
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          tags = tags,
          extensions = extensions,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecRootScope.kt
@@ -6,13 +6,13 @@ import io.kotest.core.names.TestName
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
 @Deprecated("Renamed to FreeSpecRootContext. Deprecated since 5.0")
 typealias FreeSpecRootContext = FreeSpecRootScope
 
-data class FreeSpecContextConfigBuilder(val name: String, val config: UnresolvedTestConfig)
+data class FreeSpecContextConfigBuilder(val name: String, val config: TestConfig)
 
 interface FreeSpecRootScope : RootScope {
 
@@ -49,7 +49,7 @@ interface FreeSpecRootScope : RootScope {
       blockingTest: Boolean? = null,
       coroutineTestScope: Boolean? = null,
    ): FreeSpecContextConfigBuilder {
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          tags = tags,
          extensions = extensions,
@@ -63,6 +63,21 @@ interface FreeSpecRootScope : RootScope {
          blockingTest = blockingTest,
          coroutineTestScope = coroutineTestScope,
       )
+      return config(config)
+   }
+
+   /**
+    * Starts a config builder, which can be added to the scope by invoking [minus] on the returned value.
+    *
+    * E.g.
+    *
+    * ```
+    * "this test".config(...) - { }
+    * ```
+    */
+   fun String.config(
+      config: TestConfig,
+   ): FreeSpecContextConfigBuilder {
       return FreeSpecContextConfigBuilder(this, config)
    }
 
@@ -101,7 +116,7 @@ interface FreeSpecRootScope : RootScope {
       coroutineTestScope: Boolean? = null,
       test: suspend TestScope.() -> Unit,
    ) {
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          tags = tags,
          extensions = extensions,
@@ -116,5 +131,9 @@ interface FreeSpecRootScope : RootScope {
          coroutineTestScope = coroutineTestScope,
       )
       addTest(TestName(this), false, config, test)
+   }
+
+   fun String.config(config: TestConfig, test: suspend TestScope.() -> Unit): FreeSpecContextConfigBuilder {
+      return FreeSpecContextConfigBuilder(this, config)
    }
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder.kt
@@ -6,7 +6,7 @@ import io.kotest.core.names.TestName
 import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
 @ExperimentalKotest
@@ -16,6 +16,14 @@ class RootContainerWithConfigBuilder<T>(
    private val context: RootScope,
    val contextFn: (TestScope) -> T
 ) {
+
+   @ExperimentalKotest
+   fun config(
+      config: TestConfig,
+      test: suspend T.() -> Unit,
+   ) {
+      context.addContainer(name, xdisabled, config) { contextFn(this).test() }
+   }
 
    @ExperimentalKotest
    fun config(
@@ -29,7 +37,7 @@ class RootContainerWithConfigBuilder<T>(
       coroutineTestScope: Boolean? = null,
       test: suspend T.() -> Unit
    ) {
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          enabledIf = enabledIf,
          enabledOrReasonIf = enabledOrReasonIf,
@@ -39,6 +47,6 @@ class RootContainerWithConfigBuilder<T>(
          blockingTest = blockingTest,
          coroutineTestScope = coroutineTestScope,
       )
-      context.addContainer(name, xdisabled, config) { contextFn(this).test() }
+      config(config, test)
    }
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootScope.kt
@@ -5,7 +5,7 @@ import io.kotest.core.source.sourceRef
 import io.kotest.core.spec.RootTest
 import io.kotest.core.test.TestScope
 import io.kotest.core.test.TestType
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 
 @Deprecated("Renamed to RootContext. Deprecated since 5.0")
 typealias RootContext = RootScope
@@ -24,11 +24,11 @@ interface RootScope {
  * Convenience method to add a test of type [type] to this [RootScope].
  */
 fun RootScope.addTest(
-   testName: TestName,
-   disabled: Boolean,
-   config: UnresolvedTestConfig?,
-   type: TestType,
-   test: suspend ContainerScope.() -> Unit
+  testName: TestName,
+  disabled: Boolean,
+  config: TestConfig?,
+  type: TestType,
+  test: suspend ContainerScope.() -> Unit
 ) {
    add(
       RootTest(
@@ -47,10 +47,10 @@ fun RootScope.addTest(
  * Convenience method to add a [TestType.Test] test to this [RootScope].
  */
 fun RootScope.addTest(
-   testName: TestName,
-   disabled: Boolean,
-   config: UnresolvedTestConfig?,
-   test: suspend TestScope.() -> Unit
+  testName: TestName,
+  disabled: Boolean,
+  config: TestConfig?,
+  test: suspend TestScope.() -> Unit
 ) {
    addTest(testName, disabled, config, TestType.Test, test)
 }
@@ -59,10 +59,10 @@ fun RootScope.addTest(
  * Convenience method to add a [TestType.Container] test to this [RootScope].
  */
 fun RootScope.addContainer(
-   testName: TestName,
-   disabled: Boolean,
-   config: UnresolvedTestConfig?,
-   test: suspend ContainerScope.() -> Unit
+  testName: TestName,
+  disabled: Boolean,
+  config: TestConfig?,
+  test: suspend ContainerScope.() -> Unit
 ) {
    addTest(testName, disabled, config, TestType.Container, test)
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootTestWithConfigBuilder.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootTestWithConfigBuilder.kt
@@ -7,7 +7,7 @@ import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
 class RootTestWithConfigBuilder(
@@ -33,7 +33,7 @@ class RootTestWithConfigBuilder(
       coroutineTestScope: Boolean? = null,
       test: suspend TestScope.() -> Unit,
    ) {
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          tags = tags,
          extensions = extensions,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/TestWithConfigBuilder.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/TestWithConfigBuilder.kt
@@ -8,7 +8,7 @@ import io.kotest.core.test.EnabledIf
 import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
 class TestWithConfigBuilder(
@@ -16,6 +16,11 @@ class TestWithConfigBuilder(
    private val context: ContainerScope,
    private val xdisabled: Boolean,
 ) {
+
+   suspend fun config(config: TestConfig, test: suspend TestScope.() -> Unit) {
+      TestDslState.clear(context.testCase.descriptor.append(name))
+      context.registerTest(name, xdisabled, config, test)
+   }
 
    suspend fun config(
       enabled: Boolean? = null,
@@ -32,10 +37,7 @@ class TestWithConfigBuilder(
       coroutineTestScope: Boolean? = null,
       test: suspend TestScope.() -> Unit
    ) {
-
-      TestDslState.clear(context.testCase.descriptor.append(name))
-
-      val config = UnresolvedTestConfig(
+      val config = TestConfig(
          enabled = enabled,
          enabledIf = enabledIf,
          enabledOrReasonIf = enabledOrReasonIf,
@@ -49,7 +51,6 @@ class TestWithConfigBuilder(
          blockingTest = blockingTest,
          coroutineTestScope = coroutineTestScope,
       )
-
-      context.registerTest(name, xdisabled, config, test)
+      config(config, test)
    }
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/NestedTest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/NestedTest.kt
@@ -2,17 +2,17 @@ package io.kotest.core.test
 
 import io.kotest.core.source.SourceRef
 import io.kotest.core.names.TestName
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 
 /**
  * Describes a test that has been discovered at runtime but has not yet been
  * attached to a parent [TestCase].
  */
 data class NestedTest(
-   val name: TestName,
-   val disabled: Boolean,
-   val config: UnresolvedTestConfig?, // can be null if the test does not specify config
-   val type: TestType,
-   val source: SourceRef,
-   val test: suspend TestScope.() -> Unit,
+  val name: TestName,
+  val disabled: Boolean,
+  val config: TestConfig?, // can be null if the test does not specify config
+  val type: TestType,
+  val source: SourceRef,
+  val test: suspend TestScope.() -> Unit,
 )

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/TestCaseConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/TestCaseConfig.kt
@@ -10,6 +10,7 @@ import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import kotlin.time.Duration
 
+@Deprecated("Deprecated in favor of ResolvedTestConfig")
 data class TestCaseConfig(
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
@@ -9,13 +9,16 @@ import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import kotlin.time.Duration
 
+@Deprecated("Renamed to TestConfig. Type alias will be removed in 6.0")
+typealias UnresolvedTestConfig = TestConfig
+
 /**
  * Test config that is attached to a [RootTest] or [NestedTest] during compile time.
  *
  * This config is not resolved, and will be converted to a [ResolvedTestConfig] once
  * resolved at runtime.
  */
-data class UnresolvedTestConfig(
+data class TestConfig(
 
    val enabled: Boolean? = null,
    val enabledIf: EnabledIf? = null,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/Materializer.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/Materializer.kt
@@ -50,7 +50,7 @@ class Materializer(private val configuration: ProjectConfiguration) {
                xdisabled = rootTest.disabled,
                parent = null,
                spec = spec,
-               configuration = configuration,
+               projectConfiguration = configuration,
             ),
             factoryId = rootTest.factoryId,
          )
@@ -79,7 +79,7 @@ class Materializer(private val configuration: ProjectConfiguration) {
             xdisabled = nested.disabled,
             parent = parent,
             spec = parent.spec,
-            configuration = configuration
+            projectConfiguration = configuration
          ),
          factoryId = parent.factoryId,
          parent = parent,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/resolveConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/resolveConfig.kt
@@ -6,26 +6,26 @@ import io.kotest.core.test.Enabled
 import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.config.ResolvedTestConfig
-import io.kotest.core.test.config.UnresolvedTestConfig
+import io.kotest.core.test.config.TestConfig
 import io.kotest.engine.tags.tags
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Accepts an [UnresolvedTestConfig] and returns a [ResolvedTestConfig] by completing
+ * Accepts an [TestConfig] and returns a [ResolvedTestConfig] by completing
  * any nulls in the unresolved config with defaults from the [spec] or [ProjectConfiguration].
  */
 internal fun resolveConfig(
-   config: UnresolvedTestConfig?,
+   config: TestConfig?,
    xdisabled: Boolean?,
    parent: TestCase?,
    spec:Spec,
-   configuration: ProjectConfiguration
+   projectConfiguration: ProjectConfiguration
 ): ResolvedTestConfig {
 
    val defaultTestConfig = spec.defaultTestConfig
       ?: spec.defaultTestCaseConfig()
-      ?: configuration.defaultTestConfig
+      ?: projectConfiguration.defaultTestConfig
 
    val enabled: EnabledOrReasonIf = { testCase ->
       when {
@@ -45,27 +45,28 @@ internal fun resolveConfig(
       ?: spec.timeout?.toMillis()
       ?: spec.timeout()?.toMillis()
       ?: defaultTestConfig.timeout
-      ?: configuration.timeout?.toMillis()
+      ?: projectConfiguration.timeout?.toMillis()
 
-   val threads = config?.threads
+   val threads: Int = config?.threads
       ?: spec.threads
       ?: spec.threads()
-      ?: defaultTestConfig.threads
+      ?: projectConfiguration.threads
 
    val invocations = config?.invocations
-      ?: defaultTestConfig.invocations
+      ?: projectConfiguration.invocations
 
    val invocationTimeout: Duration? = config?.invocationTimeout
       ?: parent?.config?.invocationTimeout
       ?: spec.invocationTimeout?.toMillis()
       ?: spec.invocationTimeout()?.toMillis()
       ?: defaultTestConfig.invocationTimeout
-      ?: configuration.invocationTimeout?.toMillis()
+      ?: projectConfiguration.invocationTimeout?.toMillis()
 
    val extensions = (config?.listeners ?: emptyList()) +
       (config?.extensions ?: emptyList()) +
       defaultTestConfig.extensions +
-      defaultTestConfig.listeners
+      defaultTestConfig.listeners +
+      projectConfiguration.registry.all()
 
    return ResolvedTestConfig(
       enabled = enabled,
@@ -73,16 +74,16 @@ internal fun resolveConfig(
       invocations = invocations,
       timeout = timeout,
       invocationTimeout = invocationTimeout,
-      tags = (config?.tags ?: emptySet()) + (defaultTestConfig.tags) + (parent?.config?.tags ?: emptySet()) + spec.tags() + spec.appliedTags() + spec::class.tags(configuration.tagInheritance),
+      tags = (config?.tags ?: emptySet()) + (defaultTestConfig.tags) + (parent?.config?.tags ?: emptySet()) + spec.tags() + spec.appliedTags() + spec::class.tags(projectConfiguration.tagInheritance),
       extensions = extensions,
-      failfast = config?.failfast ?: parent?.config?.failfast ?: spec.failfast ?: configuration.failfast,
-      severity = config?.severity ?: parent?.config?.severity ?: spec.severity ?: configuration.severity,
-      assertSoftly = config?.assertSoftly ?: parent?.config?.assertSoftly ?:spec.assertSoftly ?: configuration.globalAssertSoftly,
-      assertionMode = config?.assertionMode ?: parent?.config?.assertionMode ?: spec.assertions ?: spec.assertionMode() ?: configuration.assertionMode,
-      coroutineDebugProbes = config?.coroutineDebugProbes ?: parent?.config?.coroutineDebugProbes ?:spec.coroutineDebugProbes ?: configuration.coroutineDebugProbes,
-      testCoroutineDispatcher = config?.testCoroutineDispatcher ?: parent?.config?.testCoroutineDispatcher ?: spec.testCoroutineDispatcher ?: configuration.testCoroutineDispatcher,
-      coroutineTestScope = config?.coroutineTestScope ?: parent?.config?.coroutineTestScope ?: spec.coroutineTestScope ?: configuration.coroutineTestScope,
-      blockingTest = config?.blockingTest ?: parent?.config?.blockingTest ?: spec.blockingTest ?: configuration.blockingTest,
+      failfast = config?.failfast ?: parent?.config?.failfast ?: spec.failfast ?: projectConfiguration.failfast,
+      severity = config?.severity ?: parent?.config?.severity ?: spec.severity ?: projectConfiguration.severity,
+      assertSoftly = config?.assertSoftly ?: parent?.config?.assertSoftly ?:spec.assertSoftly ?: projectConfiguration.globalAssertSoftly,
+      assertionMode = config?.assertionMode ?: parent?.config?.assertionMode ?: spec.assertions ?: spec.assertionMode() ?: projectConfiguration.assertionMode,
+      coroutineDebugProbes = config?.coroutineDebugProbes ?: parent?.config?.coroutineDebugProbes ?:spec.coroutineDebugProbes ?: projectConfiguration.coroutineDebugProbes,
+      testCoroutineDispatcher = config?.testCoroutineDispatcher ?: parent?.config?.testCoroutineDispatcher ?: spec.testCoroutineDispatcher ?: projectConfiguration.testCoroutineDispatcher,
+      coroutineTestScope = config?.coroutineTestScope ?: parent?.config?.coroutineTestScope ?: spec.coroutineTestScope ?: projectConfiguration.coroutineTestScope,
+      blockingTest = config?.blockingTest ?: parent?.config?.blockingTest ?: spec.blockingTest ?: projectConfiguration.blockingTest,
    )
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/resolveConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/resolveConfig.kt
@@ -65,8 +65,7 @@ internal fun resolveConfig(
    val extensions = (config?.listeners ?: emptyList()) +
       (config?.extensions ?: emptyList()) +
       defaultTestConfig.extensions +
-      defaultTestConfig.listeners +
-      projectConfiguration.registry.all()
+      defaultTestConfig.listeners
 
    return ResolvedTestConfig(
       enabled = enabled,

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/DescribeSpecConfigSyntaxTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/DescribeSpecConfigSyntaxTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.spec.config
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.test.Enabled
+import io.kotest.core.test.config.TestConfig
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
@@ -39,6 +40,13 @@ class DescribeSpecConfigSyntaxTest : DescribeSpec() {
       describe("a describe with multiple tags").config(tags = setOf(Tag1, Tag2)) {
          counter.incrementAndGet()
          it("an inner test") {}
+      }
+
+      describe("a describe with overloaded config") {
+         val config = TestConfig(enabled = false)
+         it("disabled from config object").config(config) {
+            error("boom")
+         }
       }
 
       describe("a describe disabled by an enabled flag").config(enabled = false) {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/FreeSpecConfigSyntaxTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/FreeSpecConfigSyntaxTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.spec.config
 
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.test.config.TestConfig
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
@@ -46,6 +47,17 @@ class FreeSpecConfigSyntaxTest : FreeSpec() {
 
       "a test with multiple tags".config(tags = setOf(Tag1, Tag2)) {
          counter.incrementAndGet()
+      }
+
+      val config = TestConfig(enabled = false)
+      "a test with overloaded config".config(config) {
+         error("boom")
+      }
+
+      "a context with overloaded config" - {
+         "disabled from config object".config(config) {
+            error("boom")
+         }
       }
 
       "an outer context with timeout".config(timeout = 2.seconds) - {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/FunSpecConfigSyntaxTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/FunSpecConfigSyntaxTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.spec.config
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.Tag
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.config.TestConfig
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
@@ -81,6 +82,13 @@ class FunSpecConfigSyntaxTest : FunSpec() {
       context("an outer context disabled by an enabled function").config(enabledIf = { System.currentTimeMillis() == 0L }) {
          error("boom")
          test("an inner test") { error("boom") }
+      }
+
+      context("a context with overloaded config") {
+         val config = TestConfig(enabled = false)
+         test("disabled from config object").config(config) {
+            error("boom")
+         }
       }
 
       context("an outer context") {


### PR DESCRIPTION
Fixes #3801