### PR TITLE
Do not allow TestConfiguration::tags after spec is initialized

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -88,7 +88,7 @@ public abstract class io/kotest/core/TestConfiguration {
 	public final fun setAssertions (Lio/kotest/core/test/AssertionMode;)V
 	public final fun setDefaultTestConfig (Lio/kotest/core/test/config/TestCaseConfig;)V
 	public final fun setParentConfiguration (Lio/kotest/core/TestConfiguration;)V
-	public final fun tags ([Lio/kotest/core/Tag;)V
+	public fun tags ([Lio/kotest/core/Tag;)V
 }
 
 public final class io/kotest/core/Tuple10 {
@@ -1943,6 +1943,7 @@ public abstract class io/kotest/core/spec/DslDrivenSpec : io/kotest/core/spec/Sp
 	public final fun include (Ljava/lang/String;Lio/kotest/core/factory/TestFactory;)V
 	public fun rootTests ()Ljava/util/List;
 	public final fun seal ()V
+	public fun tags ([Lio/kotest/core/Tag;)V
 }
 
 public final class io/kotest/core/spec/InvalidDslException : java/lang/Exception {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -150,7 +150,7 @@ abstract class TestConfiguration {
     * When applied in a factory, only tests generated from that factory will have the tags applied.
     * When applied to a spec, all tests will have the tags applied.
     */
-   fun tags(vararg tags: Tag) {
+   open fun tags(vararg tags: Tag) {
       _tags = _tags + tags.toSet()
    }
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/DslDrivenSpec.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/DslDrivenSpec.kt
@@ -1,5 +1,6 @@
 package io.kotest.core.spec
 
+import io.kotest.core.Tag
 import io.kotest.core.Tuple2
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.SpecExtension
@@ -44,6 +45,11 @@ abstract class DslDrivenSpec : Spec(), RootScope {
    override fun add(test: RootTest) {
       if (sealed) throw InvalidDslException("Cannot add a root test after the spec has been instantiated: ${test.name.testName}")
       rootTests = rootTests + test
+   }
+
+   override fun tags(vararg tags: Tag) {
+      if (sealed) throw InvalidDslException("Cannot add a tag after the spec has been instantiated")
+      super.tags(*tags)
    }
 
    /**

--- a/kotest-tests/kotest-tests-tagextension/src/jvmTest/kotlin/com/sksamuel/kotest/tag/ExcludedTestBySpecTagTest.kt
+++ b/kotest-tests/kotest-tests-tagextension/src/jvmTest/kotlin/com/sksamuel/kotest/tag/ExcludedTestBySpecTagTest.kt
@@ -45,5 +45,5 @@ class ExcludedTestByOverrideTagTest : StringSpec() {
          fail("Shouldn't get here")
       }
    }
-
 }
+

--- a/kotest-tests/kotest-tests-tagextension/src/jvmTest/kotlin/com/sksamuel/kotest/tag/SealedTagsTest.kt
+++ b/kotest-tests/kotest-tests-tagextension/src/jvmTest/kotlin/com/sksamuel/kotest/tag/SealedTagsTest.kt
@@ -1,0 +1,15 @@
+package com.sksamuel.kotest.tag
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.InvalidDslException
+import io.kotest.core.spec.style.FunSpec
+
+class SealedTagsTest : FunSpec() {
+   init {
+      test("do not allow tags after spec is initialized") {
+         shouldThrow<InvalidDslException> {
+            tags(Exclude)
+         }
+      }
+   }
+}


### PR DESCRIPTION
Fixes #3793