### PR TITLE
fix(docs): indentation in System Extensions

### DIFF
--- a/documentation/docs/extensions/system.md
+++ b/documentation/docs/extensions/system.md
@@ -53,39 +53,32 @@ You can also use multiple values in this extension, through a map or list of pai
 
 ```kotlin
 withEnvironment(mapOf("FooKey" to "BarValue", "BarKey" to "FooValue")) {
-  // Use FooKey and BarKey
+    // Use FooKey and BarKey
 }
-
 ```
 
 These functions will add the keys and values if they're not currently present in the environment, and will override them if they are. Any keys untouched by the function will remain in the environment, and won't be messed with.
 
-Instead of extensions functions, you can also use the provided Listeners to apply these functionalities in a bigger scope. There's an alternative for the Spec/Per test level, and an alternative for the Project Level.
+Instead of extension functions, you can also use the provided Listeners to apply these functionalities in a bigger scope. There's an alternative for the Spec/Per test level, and an alternative for the Project Level.
 
 ```kotlin
-
 class MyTest : FreeSpec() {
 
-      override fun listeners() = listOf(SystemEnvironmentTestListener("foo", "bar"))
+    override fun listeners() = listOf(SystemEnvironmentTestListener("foo", "bar"))
 
     init {
-      "MyTest" {
-        System.getenv("foo") shouldBe "bar"
-      }
+        "MyTest" {
+            System.getenv("foo") shouldBe "bar"
+          }
     }
 
 }
-
 ```
 
 ```kotlin
-
 class ProjectConfig : AbstractProjectConfig() {
-
     override fun listeners(): List<TestListener> = listOf(SystemEnvironmentProjectListener("foo", "bar"))
-
 }
-
 ```
 
 
@@ -96,24 +89,23 @@ In the same fashion as the Environment Extensions, you can override the System P
 
 ```kotlin
 withSystemProperty("foo", "bar") {
-  System.getProperty("foo") shouldBe "bar"
+    System.getProperty("foo") shouldBe "bar"
 }
 ```
 
 And with similar Listeners:
 
 ```kotlin
-    class MyTest : FreeSpec() {
+class MyTest : FreeSpec() {
 
-          override fun listeners() = listOf(SystemPropertyListener("foo", "bar"))
+    override fun listeners() = listOf(SystemPropertyListener("foo", "bar"))
 
-        init {
-          "MyTest" {
+    init {
+        "MyTest" {
             System.getProperty("foo") shouldBe "bar"
-          }
         }
-
     }
+}
 ```
 
 
@@ -123,25 +115,22 @@ And with similar Listeners:
 Similarly, with System Security Manager you can override the System Security Manager (`System.getSecurityManager()`)
 
 ```kotlin
-
-    withSecurityManager(myManager) {
-      // Usage of security manager
-    }
-
+withSecurityManager(myManager) {
+    // Usage of security manager
+}
 ```
 
 And the Listeners:
 
 ```kotlin
-    class MyTest : FreeSpec() {
+class MyTest : FreeSpec() {
 
-              override fun listeners() = listOf(SecurityManagerListener(myManager))
+    override fun listeners() = listOf(SecurityManagerListener(myManager))
 
-            init {
-              // Use my security manager
-            }
-
-        }
+    init {
+        // Use my security manager
+    }
+}
 ```
 
 ### System Exit Extensions
@@ -149,22 +138,20 @@ And the Listeners:
 Sometimes you want to test that your code calls `System.exit`. For that you can use the `System Exit Listeners`. The Listener will throw an exception when the `System.exit` is called, allowing you to catch it and verify:
 
 ```kotlin
-
 class MyTest : FreeSpec() {
 
-  override fun listeners() = listOf(SpecSystemExitListener)
+    override fun listeners() = listOf(SpecSystemExitListener)
 
-  init {
-    "Catch exception" {
-      val thrown: SystemExitException = shouldThrow<SystemExitException> {
-        System.exit(22)
-      }
+    init {
+        "Catch exception" {
+            val thrown: SystemExitException = shouldThrow<SystemExitException> {
+                System.exit(22)
+            }
 
-      thrown.exitCode shouldBe 22
+            thrown.exitCode shouldBe 22
+        }
     }
-  }
 }
-
 ```
 
 ### No-stdout / no-stderr listeners
@@ -174,8 +161,8 @@ Maybe you want to guarantee that you didn't leave any debug messages around, or 
 For that, Kotest provides you with `NoSystemOutListener` and `NoSystemErrListener`. These listeners won't allow any messages to be printed straight to `System.out` or `System.err`, respectively:
 
 ```kotlin
-    // In Project or in Spec
-    override fun listeners() = listOf(NoSystemOutListener, NoSystemErrListener)
+// In Project or in Spec
+override fun listeners() = listOf(NoSystemOutListener, NoSystemErrListener)
 ```
 
 ### Locale/Timezone listeners
@@ -185,22 +172,20 @@ let Kotest do it for you!
 
 ```kotlin
 withDefaultLocale(Locale.FRANCE) {
-  println("My locale is now France! Très bien!")
+    println("My locale is now France! Très bien!")
 }
 
 withDefaultTimeZone(TimeZone.getTimeZone(ZoneId.of("America/Sao_Paulo"))) {
-  println("My timezone is now America/Sao_Paulo! Muito bem!")
+    println("My timezone is now America/Sao_Paulo! Muito bem!")
 }
-
 ```
 
 And with the listeners
 
 ```kotlin
-  // In Project or in Spec
-  override fun listeners() = listOf(
+// In Project or in Spec
+override fun listeners() = listOf(
     LocaleTestListener(Locale.FRANCE),
     TimeZoneTestListener(TimeZone.getTimeZone(ZoneId.of("America/Sao_Paulo")))
-  )
-
+)
 ```


### PR DESCRIPTION
This PR updates some of the indentations in the system extensions files in the docs. There is a mix of two space and four space indentations in the docs, but as Kotlin seems to recommend four spaces this is what I went for here.

No content has changed. I also didn't update all relevant versions. At least it will look nice for the next release.


<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
