### PR TITLE
Change Arb.filterIsInstance() signature to use single type parameter

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/filter.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/filter.kt
@@ -6,7 +6,6 @@ import io.kotest.property.RTree
 import io.kotest.property.RandomSource
 import io.kotest.property.Sample
 import io.kotest.property.filter
-import kotlin.jvm.JvmName
 
 /**
  * Returns a new [Arb] which takes its elements from the receiver and filters them using the supplied

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/filter.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/filter.kt
@@ -6,6 +6,7 @@ import io.kotest.property.RTree
 import io.kotest.property.RandomSource
 import io.kotest.property.Sample
 import io.kotest.property.filter
+import kotlin.jvm.JvmName
 
 /**
  * Returns a new [Arb] which takes its elements from the receiver and filters them using the supplied
@@ -39,4 +40,4 @@ fun <A> Arb<A>.filterNot(f: (A) -> Boolean): Arb<A> = filter { !f(it) }
  * a particular subtype.
  */
 @Suppress("UNCHECKED_CAST")
-inline fun <A, reified B : A> Arb<A>.filterIsInstance(): Arb<B> = filter { it is B }.map { it as B }
+inline fun <reified B> Arb<*>.filterIsInstance(): Arb<B> = filter { it is B } as Arb<B>

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FilterTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FilterTest.kt
@@ -6,12 +6,15 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldNotBeIn
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
 import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.Sample
 import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.filterIsInstance
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.of
@@ -67,5 +70,12 @@ class FilterTest : FunSpec({
       }
       val result = shouldNotThrowAny { arb.single(RandomSource.seeded(1234L)) }
       result shouldBe 0
+   }
+
+   test("Arb.filterIsInstance should only keep instances of the given type") {
+      val arb: Arb<Any> = Arb.of(1, "2", 3.0, "4", 5)
+      val filtered = arb.filterIsInstance<String>()
+      val result = filtered.samples().take(100).map { it.value }
+      result.forAll { it should beInstanceOf(String::class) }
    }
 })


### PR DESCRIPTION
resolve #3942 

Change Arb.filterIsInstance() signature to use single type parameter.

This change is **breaking change.** But there's no way to add a new function, so I change the existing signature.