### PR TITLE
Update Sonatype snapshot URL

### DIFF
--- a/documentation/versioned_docs/version-5.8/quick_start.mdx
+++ b/documentation/versioned_docs/version-5.8/quick_start.mdx
@@ -400,6 +400,11 @@ kotlin {
 Snapshot are automatically published on each commit to master.
 If you want to test the latest snapshot build, setup the same way described above, change the version to the current snapshot version and add the following repository to your `repositories` block:
 
-```
-https://oss.sonatype.org/content/repositories/snapshots
+```kotlin
+repositories {
+    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+        name = "MavenCentralSnapshots"
+        mavenContent { snapshotsOnly() }
+    }
+}
 ```


### PR DESCRIPTION
I couldn't resolve the latest Kotest snapshot release from https://oss.sonatype.org/content/repositories/snapshots. However, https://s01.oss.sonatype.org/content/repositories/snapshots worked.

This is a quick edit via the GitHub web gui. Do other parts of the docs need to be updated too?
