### PR TITLE
Fix json assertions artifact coordinate in docs

### DIFF
--- a/documentation/docs/assertions/json/overview.md
+++ b/documentation/docs/assertions/json/overview.md
@@ -4,7 +4,7 @@ slug: json-overview.html
 sidebar_label: Overview
 ---
 
-To use these matchers add `testImplementation("io.kotest.extensions:kotest-assertions-json:<version>")` to your build.
+To use these matchers add `testImplementation("io.kotest:kotest-assertions-json:<version>")` to your build.
 
 ## Basic matchers
 

--- a/documentation/versioned_docs/version-5.8/assertions/json/overview.md
+++ b/documentation/versioned_docs/version-5.8/assertions/json/overview.md
@@ -4,7 +4,7 @@ slug: json-overview.html
 sidebar_label: Overview
 ---
 
-To use these matchers add `testImplementation("io.kotest.extensions:kotest-assertions-json:<version>")` to your build. 
+To use these matchers add `testImplementation("io.kotest:kotest-assertions-json:<version>")` to your build.
 
 ## Basic matchers
 


### PR DESCRIPTION
Affecting: https://kotest.io/docs/assertions/json/json-overview.html

https://mvnrepository.com/artifact/io.kotest/kotest-assertions-json, the other one apparently never existed (according to mvnrepository).

Fix https://github.com/kotest/kotest/pull/3898 cc @jlous