### PR TITLE
Allow comparison between empty set and other iterables

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/eq/isOrderedSet.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/eq/isOrderedSet.kt
@@ -8,4 +8,4 @@ import java.util.SortedSet
 actual fun isOrderedSet(item: Iterable<*>) =
    item is LinkedHashSet ||
       item is SortedSet ||
-      (item is Set && item.size == 1)
+      (item is Set && item.size <= 1)

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/IterableEqTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/eq/IterableEqTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.kotest.eq
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.eq.IterableEq
+import io.kotest.assertions.shouldFail
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.nulls.shouldBeNull
@@ -41,6 +43,20 @@ private val expectedPath = if (System.getProperty("os.name").lowercase().contain
 }
 
 class IterableEqTest : FunSpec({
+   test("Comparing empty set with other iterable should be ok") {
+      shouldNotThrowAny {
+         emptySet<Int>() shouldBe listOf()
+      }
+   }
+
+   test("Comparing empty set with other iterable should provide meaningful assertion error") {
+      shouldFail {
+         emptySet<Int>() shouldBe listOf(1)
+      }.message shouldBe """
+         Missing elements from index 0
+         expected:<[1]> but was:<[]>
+      """.trimIndent()
+   }
 
    test("should give null for two equal sets") {
       IterableEq.equals(setOf(1, 2, 3), setOf(2, 3, 1)).shouldBeNull()


### PR DESCRIPTION
We disallow comparison between sets and other iterables when the iteration order is not clear. For an empty set, there is nothing to iterate so there is no such ambiguity.

Fixes #4004

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
