### PR TITLE
Add an Arbitrary to generate whitespace.

### DIFF
--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -830,6 +830,7 @@ public final class io/kotest/property/arbitrary/CodepointsKt {
 	public static final fun katakana (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
 	public static final fun katakana (Lio/kotest/property/arbitrary/Codepoint$Companion;)Lio/kotest/property/Arb;
 	public static final fun printableAscii (Lio/kotest/property/arbitrary/Codepoint$Companion;)Lio/kotest/property/Arb;
+	public static final fun whitespace (Lio/kotest/property/arbitrary/Codepoint$Companion;)Lio/kotest/property/Arb;
 }
 
 public final class io/kotest/property/arbitrary/CollectionsKt {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/codepoints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/codepoints.kt
@@ -177,6 +177,16 @@ fun Codepoint.Companion.egyptianHieroglyphs(): Arb<Codepoint> =
    Arb.of((0x13000..0x1342E).map(::Codepoint))
       .withEdgecases(Codepoint(0x13000))
 
+fun Codepoint.Companion.whitespace(): Arb<Codepoint> =
+   Arb.of(listOf(
+      9,  // TAB
+      10, // LINE FEED
+      11, // LINE TABULATION
+      12, // FORM FEED
+      13, // CARRIAGE RETURN
+      32, // SPACE
+   ).map(::Codepoint))
+
 data class Codepoint(val value: Int) {
    companion object
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/StringArbTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/StringArbTest.kt
@@ -18,6 +18,7 @@ import io.kotest.property.arbitrary.katakana
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.printableAscii
 import io.kotest.property.arbitrary.string
+import io.kotest.property.arbitrary.whitespace
 import io.kotest.property.checkAll
 import io.kotest.property.forAll
 import kotlin.streams.toList
@@ -147,6 +148,22 @@ class StringArbTest : FunSpec() {
          checkAll(Arb.string(10..20, Codepoint.cyrillic())) { a ->
             a.codepoints().forEach {
                Character.isValidCodePoint(it)
+            }
+         }
+      }
+
+      test("all strings generated with whitespace codepoints should be valid code codepoints") {
+         checkAll(Arb.string(10..20, Codepoint.whitespace())) { a ->
+            a.codepoints().forEach {
+               Character.isValidCodePoint(it)
+            }
+         }
+      }
+
+      test("all strings generated with whitespace codepoints should be whitespace only") {
+         checkAll(Arb.string(10..20, Codepoint.whitespace())) { a ->
+            a.codepoints().forEach {
+               Character.isWhitespace(it)
             }
          }
       }


### PR DESCRIPTION
This pull request adds a `whitespace` function to the Codepoints in order to generate strings with only whitespace characters (and compose more complex generators). I happened to need one for a project and thought I might share it.

Since this is my first contribution, I'm not sure of which docs I should update where (and also, I've never multiplatform'd in kotlin before, so I'm not sure if I need to do anything else than the code I've written for this to work everwhere).

Cheers :)