### PR TITLE
Fix test name comparison in docs

### DIFF
--- a/documentation/docs/framework/conditional/config_enabled.md
+++ b/documentation/docs/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.2/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.2/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.3/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.3/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.4/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.4/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.5/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.5/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.6/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.6/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.7/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.7/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.8/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.8/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled

--- a/documentation/versioned_docs/version-5.9/framework/conditional/config_enabled.md
+++ b/documentation/versioned_docs/version-5.9/framework/conditional/config_enabled.md
@@ -39,7 +39,7 @@ For example, if we wanted to disable all tests that begin with the word "danger"
 then we could do this:
 
 ```kotlin
-val disableDangerOnFridays: EnabledIf = { !(it.name.startsWith("danger") && isFriday()) }
+val disableDangerOnFridays: EnabledIf = { !(it.name.testName.startsWith("danger") && isFriday()) }
 
 "danger Will Robinson".config(enabledIf = disableDangerOnFridays) {
   // test here
@@ -60,7 +60,7 @@ For example, we can re-write the earlier 'danger' example like this:
 
 ```kotlin
 val disableDangerOnFridays: (TestCase) -> Enabled = {
-   if (it.name.startsWith("danger") && isFriday())
+   if (it.name.testName.startsWith("danger") && isFriday())
       Enabled.disabled("It's a friday, and we don't like danger!")
    else
       Enabled.enabled


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

**Thanks for creating a great testing tool called kotest🙂**

While reading the documentation, I found something wrong and fixed it.

![image](https://github.com/kotest/kotest/assets/78959175/f9a59820-adfa-4f7e-93f7-baa745be9468)

In the Conditional tests with enabled flags example code, I'm using `it.name.startsWith(...)`, whereas in the current specification I can access it as `it.name.testName.startsWith(...)`.

I've seen the error appear in versions 5.2 to 5.9, and I've fixed them all.
(Please excuse the awkwardness of the PR due to translation)

I always support kotest👍
