### PR TITLE
Better timeouts handling

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -2952,6 +2952,7 @@ public final class io/kotest/core/test/TestCase {
 }
 
 public final class io/kotest/core/test/TestCaseKt {
+	public static final fun getTimeout (Lio/kotest/core/test/TestCase;)J
 	public static final fun isFocused (Lio/kotest/core/test/TestCase;)Z
 	public static final fun isRootTest (Lio/kotest/core/test/TestCase;)Z
 	public static final fun parents (Lio/kotest/core/test/TestCase;)Ljava/util/List;
@@ -3182,7 +3183,6 @@ public final class io/kotest/core/test/config/ResolvedTestConfig {
 	public final fun getFailfast ()Z
 	public final fun getInvocationTimeout-UwyO8pc ()J
 	public final fun getInvocations ()I
-	public final fun getResolvedInvocationTimeout-UwyO8pc ()J
 	public final fun getSeverity ()Lio/kotest/core/test/TestCaseSeverityLevel;
 	public final fun getTags ()Ljava/util/Set;
 	public final fun getThreads ()I

--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -3154,7 +3154,7 @@ public final class io/kotest/core/test/config/EnabledKt {
 
 public final class io/kotest/core/test/config/ResolvedTestConfig {
 	public static final field Companion Lio/kotest/core/test/config/ResolvedTestConfig$Companion;
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;IILkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;ZLio/kotest/core/test/AssertionMode;ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;IIJJLjava/util/Set;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;ZLio/kotest/core/test/AssertionMode;ZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lkotlin/jvm/functions/Function1;
 	public final fun component10 ()Lio/kotest/core/test/AssertionMode;
 	public final fun component11 ()Z
@@ -3163,14 +3163,14 @@ public final class io/kotest/core/test/config/ResolvedTestConfig {
 	public final fun component14 ()Z
 	public final fun component2 ()I
 	public final fun component3 ()I
-	public final fun component4-FghU774 ()Lkotlin/time/Duration;
-	public final fun component5-FghU774 ()Lkotlin/time/Duration;
+	public final fun component4-UwyO8pc ()J
+	public final fun component5-UwyO8pc ()J
 	public final fun component6 ()Ljava/util/Set;
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Lio/kotest/core/test/TestCaseSeverityLevel;
 	public final fun component9 ()Z
-	public final fun copy-DHtx3qU (Lkotlin/jvm/functions/Function1;IILkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;ZLio/kotest/core/test/AssertionMode;ZZZZ)Lio/kotest/core/test/config/ResolvedTestConfig;
-	public static synthetic fun copy-DHtx3qU$default (Lio/kotest/core/test/config/ResolvedTestConfig;Lkotlin/jvm/functions/Function1;IILkotlin/time/Duration;Lkotlin/time/Duration;Ljava/util/Set;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;ZLio/kotest/core/test/AssertionMode;ZZZZILjava/lang/Object;)Lio/kotest/core/test/config/ResolvedTestConfig;
+	public final fun copy-hLKUlo8 (Lkotlin/jvm/functions/Function1;IIJJLjava/util/Set;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;ZLio/kotest/core/test/AssertionMode;ZZZZ)Lio/kotest/core/test/config/ResolvedTestConfig;
+	public static synthetic fun copy-hLKUlo8$default (Lio/kotest/core/test/config/ResolvedTestConfig;Lkotlin/jvm/functions/Function1;IIJJLjava/util/Set;Ljava/util/List;Lio/kotest/core/test/TestCaseSeverityLevel;ZLio/kotest/core/test/AssertionMode;ZZZZILjava/lang/Object;)Lio/kotest/core/test/config/ResolvedTestConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAssertSoftly ()Z
 	public final fun getAssertionMode ()Lio/kotest/core/test/AssertionMode;
@@ -3180,12 +3180,13 @@ public final class io/kotest/core/test/config/ResolvedTestConfig {
 	public final fun getEnabled ()Lkotlin/jvm/functions/Function1;
 	public final fun getExtensions ()Ljava/util/List;
 	public final fun getFailfast ()Z
-	public final fun getInvocationTimeout-FghU774 ()Lkotlin/time/Duration;
+	public final fun getInvocationTimeout-UwyO8pc ()J
 	public final fun getInvocations ()I
+	public final fun getResolvedInvocationTimeout-UwyO8pc ()J
 	public final fun getSeverity ()Lio/kotest/core/test/TestCaseSeverityLevel;
 	public final fun getTags ()Ljava/util/Set;
 	public final fun getThreads ()I
-	public final fun getTimeout-FghU774 ()Lkotlin/time/Duration;
+	public final fun getTimeout-UwyO8pc ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCase.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestCase.kt
@@ -1,12 +1,13 @@
 package io.kotest.core.test
 
-import io.kotest.core.source.SourceRef
 import io.kotest.core.descriptors.Descriptor
 import io.kotest.core.factory.FactoryId
 import io.kotest.core.names.TestName
+import io.kotest.core.source.SourceRef
 import io.kotest.core.source.sourceRef
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.config.ResolvedTestConfig
+import kotlin.time.Duration
 
 /**
  * A [TestCase] describes a test lambda at runtime.
@@ -76,3 +77,10 @@ fun TestCase.isRootTest() = this.parent == null
 fun TestCase.parents(): List<TestCase> {
    return if (parent == null) emptyList() else parent.parents() + parent
 }
+
+/** Returns timeout to be used depending on the [TestType]. */
+val TestCase.timeout: Duration
+   get() = when (type) {
+      TestType.Container -> config.timeout
+      else -> minOf(config.invocationTimeout, config.timeout)
+   }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/ResolvedTestConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/ResolvedTestConfig.kt
@@ -1,12 +1,14 @@
 package io.kotest.core.test.config
 
 import io.kotest.core.Tag
+import io.kotest.core.config.Defaults
 import io.kotest.core.extensions.Extension
 import io.kotest.core.test.AssertionMode
 import io.kotest.core.test.Enabled
 import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCaseSeverityLevel
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Runtime resolved config attached to a [io.kotest.core.test.TestCase].
@@ -30,13 +32,13 @@ data class ResolvedTestConfig(
     *
     * To set a timeout per invocation see [invocationTimeout].
     */
-   val timeout: Duration?,
+   val timeout: Duration,
 
    /**
     * This timeout applies to individual invocations of a test case. If invocations is 1, then this
     * has the same effect as timeout. To set a timeout across all invocations then see [timeout].
     */
-   val invocationTimeout: Duration?,
+   val invocationTimeout: Duration,
 
    /**
     * [Tag]s that are applied to this test case, in addition to any tags declared on
@@ -81,6 +83,9 @@ data class ResolvedTestConfig(
       require(threads > 0) { "Number of threads must be greater than 0" }
    }
 
+   // note: the invocation timeout can't be larger than the test case timeout
+   val resolvedInvocationTimeout: Duration = minOf(timeout, invocationTimeout)
+
    companion object {
       val default = ResolvedTestConfig(
          { Enabled.enabled },
@@ -92,8 +97,8 @@ data class ResolvedTestConfig(
          assertSoftly = false,
          blockingTest = false,
          extensions = emptyList(),
-         timeout = null,
-         invocationTimeout = null,
+         timeout = Defaults.defaultTimeoutMillis.milliseconds,
+         invocationTimeout = Defaults.defaultInvocationTimeoutMillis.milliseconds,
          tags = emptySet(),
          severity = TestCaseSeverityLevel.TRIVIAL,
          failfast = false,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/ResolvedTestConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/ResolvedTestConfig.kt
@@ -83,9 +83,6 @@ data class ResolvedTestConfig(
       require(threads > 0) { "Number of threads must be greater than 0" }
    }
 
-   // note: the invocation timeout can't be larger than the test case timeout
-   val resolvedInvocationTimeout: Duration = minOf(timeout, invocationTimeout)
-
    companion object {
       val default = ResolvedTestConfig(
          { Enabled.enabled },

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
@@ -74,5 +74,9 @@ data class TestConfig(
       require((threads ?: 0) <= (invocations ?: 1)) { "Number of threads must be <= number of invocations" }
       require(timeout?.isPositive() ?: true) { "Timeout must be positive" }
       require(invocationTimeout?.isPositive() ?: true) { "Invocation timeout must be positive" }
+      require(timeout == null || invocationTimeout == null || invocationTimeout <= timeout) {
+         "Invocation timeout must not exceed the test case timeout: " +
+            "$invocationTimeout (invocationTimeout) > $timeout (timeout)"
+      }
    }
 }

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -781,6 +781,8 @@ public abstract interface class io/kotest/engine/test/TestCaseExecutionListener 
 }
 
 public final class io/kotest/engine/test/interceptors/BlockedThreadTestTimeoutException : io/kotest/engine/test/interceptors/TestTimeoutException {
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
@@ -795,6 +797,8 @@ public final class io/kotest/engine/test/interceptors/TestDispatcherInterceptor 
 }
 
 public class io/kotest/engine/test/interceptors/TestTimeoutException : java/lang/Exception {
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getTestName ()Ljava/lang/String;
 	public final fun getTimeout-UwyO8pc ()J

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -86,7 +86,8 @@ internal class TestCaseExecutor(
             context.configuration.registry,
             timeMark,
             listOfNotNull(
-               InvocationTimeoutInterceptor,
+               // Timeout is handled inside TestCoroutineInterceptor if it is enabled
+               if (!useCoroutineTestScope) InvocationTimeoutInterceptor else null,
                if (useCoroutineTestScope) TestCoroutineInterceptor() else null,
             )
          ),

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
@@ -5,6 +5,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
 import io.kotest.core.test.TestType
+import io.kotest.core.test.timeout
 import io.kotest.engine.test.scopes.withCoroutineContext
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeoutOrNull
@@ -26,7 +27,7 @@ internal object InvocationTimeoutInterceptor : TestExecutionInterceptor {
          test(testCase, scope)
       } else {
 
-         val timeout = testCase.config.resolvedInvocationTimeout
+         val timeout = testCase.timeout
          logger.log { Pair(testCase.name.testName, "Switching context to add invocationTimeout $timeout") }
 
          try {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
@@ -1,15 +1,13 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.core.Logger
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
 import io.kotest.core.test.TestType
 import io.kotest.engine.test.scopes.withCoroutineContext
-import io.kotest.core.Logger
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlin.math.min
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Installs an invocation timeout.
@@ -28,20 +26,15 @@ internal object InvocationTimeoutInterceptor : TestExecutionInterceptor {
          test(testCase, scope)
       } else {
 
-         // note: the invocation timeout cannot be larger than the test case timeout
-         val timeout = min(
-            testCase.config.timeout?.inWholeMilliseconds ?: 10000000,
-            testCase.config.invocationTimeout?.inWholeMilliseconds ?: 10000000
-         )
-
+         val timeout = testCase.config.resolvedInvocationTimeout
          logger.log { Pair(testCase.name.testName, "Switching context to add invocationTimeout $timeout") }
 
-         return try {
+         try {
             // we use orNull because we want to disambiguate between our timeouts and user level timeouts
             // user level timeouts will throw an exception, ours will return null
             withTimeoutOrNull(timeout) {
                test(testCase, scope.withCoroutineContext(coroutineContext))
-            } ?: throw TestTimeoutException(timeout.milliseconds, testCase.name.testName)
+            } ?: throw TestTimeoutException(timeout, testCase.name.testName)
          } catch (t: TimeoutCancellationException) {
             logger.log { Pair(testCase.name.testName, "Caught user timeout $t") }
             throw t

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
@@ -6,7 +6,7 @@ import io.kotest.core.coroutines.TestScopeElement
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
-import io.kotest.core.test.TestType
+import io.kotest.core.test.timeout
 import io.kotest.engine.test.scopes.withCoroutineContext
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
@@ -31,13 +31,7 @@ class TestCoroutineInterceptor : TestExecutionInterceptor {
       logger.log { Pair(testCase.name.testName, "Switching context to coroutines runTest") }
 
       // Handle timeouts here to avoid the influence of the default timeout set inside runTest
-      val timeout = if (testCase.type == TestType.Container) {
-         testCase.config.timeout
-      } else {
-         testCase.config.resolvedInvocationTimeout
-      }
-
-      runTest(timeout = timeout) {
+      runTest(timeout = testCase.timeout) {
          var additionalContext: CoroutineContext = TestScopeElement(this)
          if (testCase.spec.nonDeterministicTestVirtualTimeEnabled) {
             additionalContext += NonDeterministicTestVirtualTimeEnabled

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
@@ -52,7 +52,7 @@ internal class TimeoutInterceptor(
       } catch (t: CancellationException) {
          if (t is WallclockTimeoutCancellationException || t is TimeoutCancellationException) {
             logger.log { Pair(testCase.name.testName, "Caught timeout $t") }
-            TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName))
+            TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName, t))
          } else {
             throw t
          }
@@ -107,5 +107,10 @@ private class WallclockTimeoutCancellationException(message: String) : Cancellat
 /**
  * Exception used for when a test exceeds its timeout.
  */
-open class TestTimeoutException(val timeout: Duration, val testName: String) :
-   Exception("Test '${testName}' did not complete within $timeout")
+open class TestTimeoutException(val timeout: Duration, val testName: String, cause: Throwable? = null) :
+   Exception("Test '${testName}' did not complete within $timeout", cause) {
+
+   @Suppress("unused")
+   @Deprecated("Maintained for binary compatibility", level = DeprecationLevel.HIDDEN)
+   constructor(timeout: Duration, testName: String) : this(timeout, testName, cause = null)
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
@@ -1,10 +1,10 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.core.Logger
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
 import io.kotest.engine.test.scopes.withCoroutineContext
-import io.kotest.core.Logger
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration
 import kotlin.time.TimeMark
@@ -23,22 +23,20 @@ internal class TimeoutInterceptor(
       scope: TestScope,
       test: suspend (TestCase, TestScope) -> TestResult
    ): TestResult {
+      val timeout = testCase.config.timeout
 
-      // this timeout applies to the test itself. If the test has multiple invocations then
+      // This timeout applies to the test itself. If the test has multiple invocations, then
       // this timeout applies across all invocations. In other words, if a test has invocations = 3,
-      // each test takes 300ms, and a timeout of 800ms, this would fail, becauase 3 x 300 > 800.
-      logger.log { Pair(testCase.name.testName, "Switching context to add timeout ${testCase.config.timeout}") }
+      // each test takes 300ms, and a timeout of 800ms, this would fail, because 3 x 300 > 800.
+      logger.log { Pair(testCase.name.testName, "Switching context to add timeout $timeout") }
 
-      return when (val timeout = testCase.config.timeout) {
-         null -> test(testCase, scope)
-         else -> try {
-            withTimeout(timeout) {
-               test(testCase, scope.withCoroutineContext(coroutineContext))
-            }
-         } catch (t: Throwable) {
-            logger.log { Pair(testCase.name.testName, "Caught timeout $t") }
-            TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName))
+      return try {
+         withTimeout(timeout) {
+            test(testCase, scope.withCoroutineContext(coroutineContext))
          }
+      } catch (t: Throwable) {
+         logger.log { Pair(testCase.name.testName, "Caught timeout $t") }
+         TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName))
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
@@ -5,7 +5,22 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
 import io.kotest.engine.test.scopes.withCoroutineContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.select
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
+import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration
 import kotlin.time.TimeMark
 
@@ -31,15 +46,63 @@ internal class TimeoutInterceptor(
       logger.log { Pair(testCase.name.testName, "Switching context to add timeout $timeout") }
 
       return try {
-         withTimeout(timeout) {
+         withAppropriateTimeout(timeout) {
             test(testCase, scope.withCoroutineContext(coroutineContext))
          }
-      } catch (t: Throwable) {
-         logger.log { Pair(testCase.name.testName, "Caught timeout $t") }
-         TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName))
+      } catch (t: CancellationException) {
+         if (t is WallclockTimeoutCancellationException || t is TimeoutCancellationException) {
+            logger.log { Pair(testCase.name.testName, "Caught timeout $t") }
+            TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName))
+         } else {
+            throw t
+         }
+      }
+
+   }
+}
+
+// The implementation copied from Turbine:
+// https://github.com/cashapp/turbine/blob/1.1.0/src/commonMain/kotlin/app/cash/turbine/channel.kt#L93
+private suspend fun <T> withAppropriateTimeout(
+   timeout: Duration,
+   block: suspend CoroutineScope.() -> T,
+): T {
+   return if (coroutineContext[TestCoroutineScheduler] != null) {
+      // withTimeout uses virtual time, which will hang.
+      withWallclockTimeout(timeout, block)
+   } else {
+      withTimeout(timeout, block)
+   }
+}
+
+private suspend fun <T> withWallclockTimeout(
+   timeout: Duration,
+   block: suspend CoroutineScope.() -> T,
+): T = coroutineScope {
+   val blockDeferred = async(start = CoroutineStart.UNDISPATCHED) {
+      yield()
+      block()
+   }
+
+   // Run the timeout on a scope separate from the caller. This ensures that the use of the
+   // Default dispatcher doesn't affect the use of a TestScheduler and its fake time.
+   @OptIn(DelicateCoroutinesApi::class)
+   val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
+
+   select {
+      blockDeferred.onAwait { result ->
+         timeoutJob.cancel()
+         result
+      }
+      timeoutJob.onJoin {
+         blockDeferred.cancel()
+         throw WallclockTimeoutCancellationException("Timed out waiting for $timeout")
       }
    }
 }
+
+// TimeoutCancellationException has an internal constructor, so we need a custom exception to indicate timeout
+private class WallclockTimeoutCancellationException(message: String) : CancellationException(message)
 
 /**
  * Exception used for when a test exceeds its timeout.

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
@@ -50,7 +50,7 @@ internal class TimeoutInterceptor(
             test(testCase, scope.withCoroutineContext(coroutineContext))
          }
       } catch (t: CancellationException) {
-         if (t is WallclockTimeoutCancellationException || t is TimeoutCancellationException) {
+         if (t is NonVirtualTimeTimeoutCancellationException || t is TimeoutCancellationException) {
             logger.log { Pair(testCase.name.testName, "Caught timeout $t") }
             TestResult.Error(mark.elapsedNow(), TestTimeoutException(timeout, testCase.name.testName, t))
          } else {
@@ -69,13 +69,13 @@ private suspend fun <T> withAppropriateTimeout(
 ): T {
    return if (coroutineContext[TestCoroutineScheduler] != null) {
       // withTimeout uses virtual time, which will hang.
-      withWallclockTimeout(timeout, block)
+      withNonVirtualTimeTimeout(timeout, block)
    } else {
       withTimeout(timeout, block)
    }
 }
 
-private suspend fun <T> withWallclockTimeout(
+private suspend fun <T> withNonVirtualTimeTimeout(
    timeout: Duration,
    block: suspend CoroutineScope.() -> T,
 ): T = coroutineScope {
@@ -96,13 +96,13 @@ private suspend fun <T> withWallclockTimeout(
       }
       timeoutJob.onJoin {
          blockDeferred.cancel()
-         throw WallclockTimeoutCancellationException("Timed out waiting for $timeout")
+         throw NonVirtualTimeTimeoutCancellationException("Timed out waiting for $timeout")
       }
    }
 }
 
 // TimeoutCancellationException has an internal constructor, so we need a custom exception to indicate timeout
-private class WallclockTimeoutCancellationException(message: String) : CancellationException(message)
+private class NonVirtualTimeTimeoutCancellationException(message: String) : CancellationException(message)
 
 /**
  * Exception used for when a test exceeds its timeout.

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/BlockedThreadTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/BlockedThreadTimeoutInterceptor.kt
@@ -74,7 +74,7 @@ internal class BlockedThreadTimeoutInterceptor(
             logger.log { Pair(testCase.name.testName, "Caught InterruptedException ${t.message}") }
             TestResult.Error(
                start.elapsedNow(),
-               BlockedThreadTestTimeoutException(testCase.config.timeout, testCase.name.testName)
+               BlockedThreadTestTimeoutException(testCase.config.timeout, testCase.name.testName, t)
             )
          }
       } else {
@@ -86,4 +86,10 @@ internal class BlockedThreadTimeoutInterceptor(
 /**
  * Exception used for when a test exceeds its timeout.
  */
-class BlockedThreadTestTimeoutException(timeout: Duration, testName: String) : TestTimeoutException(timeout, testName)
+class BlockedThreadTestTimeoutException(timeout: Duration, testName: String, cause: Throwable? = null) :
+   TestTimeoutException(timeout, testName, cause) {
+
+   @Suppress("unused")
+   @Deprecated("Maintained for binary compatibility", level = DeprecationLevel.HIDDEN)
+   constructor(timeout: Duration, testName: String) : this(timeout, testName, cause = null)
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutOverriddenMainDispatcherTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutOverriddenMainDispatcherTest.kt
@@ -41,9 +41,5 @@ class ContainerTimeoutOverriddenMainDispatcherTest : FunSpec({
       ) {
          wallclockDelay(1.minutes)
       }
-
-      test("test exceeding parent timeout").config(extensions = listOf(ExpectFailureExtension)) {
-         wallclockDelay(1.minutes)
-      }
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutOverriddenMainDispatcherTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutOverriddenMainDispatcherTest.kt
@@ -1,0 +1,49 @@
+package com.sksamuel.kotest.engine.test.timeout
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.testCoroutineScheduler
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+// Issue: https://github.com/kotest/kotest/issues/3703
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContainerTimeoutOverriddenMainDispatcherTest : FunSpec({
+
+   coroutineTestScope = true
+
+   val dispatcher = StandardTestDispatcher()
+
+   beforeSpec { Dispatchers.setMain(dispatcher) }
+   afterSpec { Dispatchers.resetMain() }
+
+   context("container with timeout").config(timeout = 500.milliseconds) {
+      test("test with delay") {
+         // It will crash if the Main dispatcher wasn't set before
+         withContext(Dispatchers.Main) {
+            delay(100.hours) // Virtual time shouldn't exceed timeout
+         }
+
+         dispatcher.scheduler shouldBe testCoroutineScheduler
+      }
+
+      test("test exceeding invocation timeout").config(
+         invocationTimeout = 100.milliseconds,
+         extensions = listOf(ExpectFailureExtension),
+      ) {
+         wallclockDelay(1.minutes)
+      }
+
+      test("test exceeding parent timeout").config(extensions = listOf(ExpectFailureExtension)) {
+         wallclockDelay(1.minutes)
+      }
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutOverriddenMainDispatcherTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutOverriddenMainDispatcherTest.kt
@@ -39,7 +39,7 @@ class ContainerTimeoutOverriddenMainDispatcherTest : FunSpec({
          invocationTimeout = 100.milliseconds,
          extensions = listOf(ExpectFailureExtension),
       ) {
-         wallclockDelay(1.minutes)
+         nonVirtualTimeDelay(1.minutes)
       }
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
@@ -46,7 +46,7 @@ private class NestedTimeout : FunSpec() {
    init {
       context("a").config(timeout = 100.milliseconds) {
          test("b") {
-            wallclockDelay(2000.milliseconds)
+            nonVirtualTimeDelay(2000.milliseconds)
          }
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
@@ -1,38 +1,42 @@
 package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.assertions.asClue
-import io.kotest.common.testTimeSource
+import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.delay
+import io.kotest.matchers.string.shouldStartWith
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.measureTime
 
 class ContainerTimeoutTest : FunSpec() {
    init {
-      coroutineTestScope = true
+      context("container test should timeout if nested exceeds parent timeout") {
+         withData(
+            nameFn = { (coroutineTestScope, message) -> "coroutineTestScope = $coroutineTestScope -> $message" },
+            false to "Test 'a' did not complete within 100ms",
+            true to "After waiting for 100ms, the test coroutine is not completing, there were active child jobs",
+         ) { (enableCoroutineTestScope, message) ->
+            val collector = CollectingTestEngineListener()
+            val config = ProjectConfiguration().apply {
+               coroutineTestScope = enableCoroutineTestScope
+            }
 
-      test("container test should timeout if nested exceeds parent timeout") {
-         val collector = CollectingTestEngineListener()
-
-         val duration = testTimeSource().measureTime {
             TestEngineLauncher(collector)
+               .withConfiguration(config)
                .withClasses(NestedTimeout::class)
-               .async()
-         }
+               .launch()
 
-         duration shouldBe 100.milliseconds
+            collector.names.shouldContainExactly("a")
 
-         collector.names.shouldContainExactly("a")
-
-         collector.result("a").asClue { result ->
-            result.shouldNotBeNull()
-            result.isError shouldBe true
-            result.errorOrNull?.message shouldBe "Test 'a' did not complete within 100ms"
+            collector.result("a").asClue { result ->
+               result.shouldNotBeNull()
+               result.isErrorOrFailure shouldBe true
+               result.errorOrNull?.message shouldStartWith message
+            }
          }
       }
    }
@@ -42,7 +46,7 @@ private class NestedTimeout : FunSpec() {
    init {
       context("a").config(timeout = 100.milliseconds) {
          test("b") {
-            delay(2000.milliseconds)
+            wallclockDelay(2000.milliseconds)
          }
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutOverrideTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutOverrideTest.kt
@@ -1,0 +1,35 @@
+package com.sksamuel.kotest.engine.test.timeout
+
+import io.kotest.core.spec.style.FunSpec
+import kotlin.time.Duration.Companion.milliseconds
+
+class CoroutinesTimeoutOverrideTest : FunSpec({
+
+   coroutineTestScope = true
+
+   val coroutinesTimeout = 10.milliseconds
+
+   // Configure default test coroutines timeout
+   beforeSpec { System.setProperty("kotlinx.coroutines.test.default_timeout", coroutinesTimeout.toString()) }
+   afterSpec { System.clearProperty("kotlinx.coroutines.test.default_timeout") }
+
+   // Issue: https://github.com/kotest/kotest/issues/3969
+   test("timeout greater than coroutines timeout").config(
+      timeout = coroutinesTimeout + 200.milliseconds,
+   ) {
+      wallclockDelay(coroutinesTimeout + 10.milliseconds)
+   }
+
+   test("invocation timeout greater than coroutines timeout").config(
+      invocationTimeout = coroutinesTimeout + 200.milliseconds,
+   ) {
+      wallclockDelay(coroutinesTimeout + 10.milliseconds)
+   }
+
+   test("unspecified timeouts fallback to defaults").config(
+      timeout = null,
+      invocationTimeout = null,
+   ) {
+      wallclockDelay(coroutinesTimeout + 10.milliseconds)
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutOverrideTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutOverrideTest.kt
@@ -17,19 +17,19 @@ class CoroutinesTimeoutOverrideTest : FunSpec({
    test("timeout greater than coroutines timeout").config(
       timeout = coroutinesTimeout + 200.milliseconds,
    ) {
-      wallclockDelay(coroutinesTimeout + 10.milliseconds)
+      nonVirtualTimeDelay(coroutinesTimeout + 10.milliseconds)
    }
 
    test("invocation timeout greater than coroutines timeout").config(
       invocationTimeout = coroutinesTimeout + 200.milliseconds,
    ) {
-      wallclockDelay(coroutinesTimeout + 10.milliseconds)
+      nonVirtualTimeDelay(coroutinesTimeout + 10.milliseconds)
    }
 
    test("unspecified timeouts fallback to defaults").config(
       timeout = null,
       invocationTimeout = null,
    ) {
-      wallclockDelay(coroutinesTimeout + 10.milliseconds)
+      nonVirtualTimeDelay(coroutinesTimeout + 10.milliseconds)
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
@@ -96,8 +96,8 @@ private suspend fun someCoroutine() {
    }
 }
 
-/** Delay using real (non-virtual) time. */
-suspend fun wallclockDelay(duration: Duration) {
+suspend fun nonVirtualTimeDelay(duration: Duration) {
+   // Default dispatcher knows nothing about virtual time
    withContext(Dispatchers.Default) { delay(duration) }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
@@ -5,9 +5,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.test.toTestResult
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -91,6 +94,11 @@ private suspend fun someCoroutine() {
          delay(10000000)
       }
    }
+}
+
+/** Delay using real (non-virtual) time. */
+suspend fun wallclockDelay(duration: Duration) {
+   withContext(Dispatchers.Default) { delay(duration) }
 }
 
 /**

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
@@ -1,6 +1,10 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.engine.test.toTestResult
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -11,7 +15,7 @@ class CoroutinesTimeoutTest : FunSpec() {
 
    init {
 
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
 
       test("a testcase timeout should interrupt a blocked thread").config(
          timeout = 10.milliseconds,
@@ -85,6 +89,18 @@ private suspend fun someCoroutine() {
    coroutineScope {
       launch {
          delay(10000000)
+      }
+   }
+}
+
+/**
+ * A Test Case extension that expects each test to fail, and will invert the test result.
+ */
+object ExpectFailureExtension : TestCaseExtension {
+   override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
+      return when (val result = execute(testCase)) {
+         is TestResult.Failure, is TestResult.Error -> TestResult.Success(result.duration)
+         else -> AssertionError("${testCase.descriptor.id.value} passed but should fail").toTestResult(result.duration)
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/FunctionOverrideInvocationTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/FunctionOverrideInvocationTimeoutTest.kt
@@ -18,7 +18,7 @@ class FunctionOverrideInvocationTimeoutTest : FunSpec() {
    }
 
    init {
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
       test("should take timeout from spec setting").config(invocations = 3) {
          delay(10.hours)
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -1,39 +1,40 @@
 package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.assertions.asClue
-import io.kotest.common.testTimeSource
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.withData
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.measureTime
 
 class GlobalTimeoutTest : FunSpec() {
    init {
-      coroutineTestScope = true
+      context("global timeouts should apply if no other timeout is set") {
+         withData(
+            nameFn = { "coroutineTestScope = $it" },
+            false,
+            true,
+         ) { enableCoroutineTestScope ->
+            val c = ProjectConfiguration().apply {
+               timeout = 100
+               coroutineTestScope = enableCoroutineTestScope
+            }
+            val collector = CollectingTestEngineListener()
 
-      test("global timeouts should apply if no other timeout is set") {
-         val c = ProjectConfiguration().apply { timeout = 4000 }
-         val collector = CollectingTestEngineListener()
-
-         val duration = testTimeSource().measureTime {
             TestEngineLauncher(collector)
                .withClasses(TestTimeouts::class)
                .withConfiguration(c)
-               .async()
+               .launch()
+
+            collector.names.shouldContainExactly("blocked", "suspend")
+
+            collector.result("blocked").asClue { result -> result?.isErrorOrFailure shouldBe true }
+            collector.result("suspend").asClue { result -> result?.isErrorOrFailure shouldBe true }
          }
-
-         duration shouldBe 4000.milliseconds
-         collector.names.shouldContainExactly("blocked", "suspend")
-
-         collector.result("blocked").asClue { result -> result?.isError shouldBe true }
-         collector.result("suspend").asClue { result -> result?.isError shouldBe true }
       }
    }
 }
@@ -45,6 +46,6 @@ private class TestTimeouts : StringSpec({
    }
 
    "suspend" {
-      delay(28.days)
+      wallclockDelay(28.days)
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -46,6 +46,6 @@ private class TestTimeouts : StringSpec({
    }
 
    "suspend" {
-      wallclockDelay(28.days)
+      nonVirtualTimeDelay(28.days)
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInlineInvocationTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInlineInvocationTimeoutTest.kt
@@ -16,7 +16,7 @@ private val factory = funSpec {
  */
 class SpecInlineInvocationTimeoutTest : FunSpec() {
    init {
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
 
       invocationTimeout = 1
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutFunctionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutFunctionTest.kt
@@ -20,7 +20,7 @@ class SpecTimeoutFunctionTest : FunSpec() {
    override fun timeout(): Long = 10.milliseconds.inWholeMilliseconds
 
    init {
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
 
       test("should timeout from spec setting") {
          delay(10.hours)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutInlineTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutInlineTest.kt
@@ -17,7 +17,7 @@ private val factory = funSpec {
  */
 class SpecTimeoutInlineTest : FunSpec() {
    init {
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
 
       timeout = 10.milliseconds.inWholeMilliseconds
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceedingTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceedingTimeoutTest.kt
@@ -1,0 +1,46 @@
+package com.sksamuel.kotest.engine.test.timeout
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.engine.spec.SpecInstantiationException
+import io.kotest.matchers.throwable.shouldHaveMessage
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.delay
+import java.lang.reflect.InvocationTargetException
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests that an `invocationTimeout` cannot exceed test case `timeout`.
+ */
+class TestInvocationTimeoutExceedingTimeoutTest : FunSpec() {
+   init {
+      test("invocation timeout shouldn't exceed test timeout") {
+         val collector = CollectingTestEngineListener()
+         TestEngineLauncher(collector)
+            .withClasses(SpecWithInvalidInvocationTimeout::class)
+            .launch()
+
+         collector.specs.getValue(SpecWithInvalidInvocationTimeout::class).errorOrNull
+            .shouldBeInstanceOf<SpecInstantiationException>()
+            .cause
+            .shouldBeInstanceOf<InvocationTargetException>()
+            .cause
+            .shouldBeInstanceOf<IllegalArgumentException>()
+            .shouldHaveMessage(
+               "Invocation timeout must not exceed the test case timeout: 10s (invocationTimeout) > 1s (timeout)"
+            )
+      }
+   }
+}
+
+private class SpecWithInvalidInvocationTimeout : FunSpec() {
+   init {
+      test("invalid timeout").config(
+         invocationTimeout = 10.seconds,
+         timeout = 1.seconds
+      ) {
+         delay(1)
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecFunctionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecFunctionTest.kt
@@ -15,7 +15,7 @@ class TestInvocationTimeoutOverridesSpecFunctionTest : FunSpec() {
    }
 
    init {
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
       test("test case config timeout should take precedence").config(
          invocations = 3,
          invocationTimeout = 1.milliseconds,

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecInlineTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecInlineTest.kt
@@ -10,7 +10,7 @@ import kotlin.time.Duration.Companion.milliseconds
  */
 class TestInvocationTimeoutOverridesSpecInlineTest : FunSpec() {
    init {
-      extension(expectFailureExtension)
+      extension(ExpectFailureExtension)
 
       invocationTimeout = 100000000
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
Addressed some issues related to timeouts:
- Use wall clock time for timeouts if `TestCoroutineScheduler` is present in coroutine context (fixes #3703)
- Pass the `timeout` parameter into `runTest` instead of `InvocationTimeoutInterceptor` if `coroutineTestScope` is enabled (fixes #3969)
- Add an original exception as a cause into `TestTimeoutException`

TODO:
- [x] Write tests