### PR TITLE
[Chore] Upgrade to the Develocity plugin to remove build warnings

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -100,13 +100,14 @@ include(
 )
 
 plugins {
-   id("com.gradle.enterprise") version "3.17.2"
+   id("com.gradle.develocity") version "3.17.4"
 }
 
-gradleEnterprise {
+develocity {
    buildScan {
-      termsOfServiceUrl = "https://gradle.com/terms-of-service"
-      termsOfServiceAgree = "yes"
+      termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
+      termsOfUseAgree = "yes"
+      publishing.onlyIf { false }
    }
 }
 


### PR DESCRIPTION
## Summary

`com.gradle.enterprise` plugin has been deprecated in favor of `com.gradle.develocity`. The use of the deprecated plugin ID and APIs results in build time warnings like the following:

```
WARNING: The following functionality has been deprecated and will be removed in the next major release of the Develocity Gradle plugin. For assistance with migration, see https://gradle.com/help/gradle-plugin-develocity-migration.
- The deprecated "gradleEnterprise.buildScan.termsOfServiceUrl" API has been replaced by "develocity.buildScan.termsOfUseUrl"
- The deprecated "gradleEnterprise.buildScan.termsOfServiceAgree" API has been replaced by "develocity.buildScan.termsOfUseAgree"
- The "com.gradle.enterprise" plugin has been replaced by "com.gradle.develocity"
```

This PR updates the plugin ID and replaces the deprecated usage.
