### PR TITLE
Lazily apply pom details

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -119,33 +119,30 @@ publishing {
       }
    }
 
-   publications.withType<MavenPublication>().forEach {
-      it.apply {
-         //if (Ci.isRelease)
-         pom {
-            name.set("Kotest")
-            description.set("Kotlin Test Framework")
-            url.set("https://github.com/kotest/kotest")
+   publications.withType<MavenPublication>().configureEach {
+      pom {
+         name.set("Kotest")
+         description.set("Kotlin Test Framework")
+         url.set("https://github.com/kotest/kotest")
 
-            scm {
-               connection.set("scm:git:https://github.com/kotest/kotest/")
-               developerConnection.set("scm:git:https://github.com/sksamuel/")
-               url.set("https://github.com/kotest/kotest/")
+         scm {
+            connection.set("scm:git:https://github.com/kotest/kotest/")
+            developerConnection.set("scm:git:https://github.com/sksamuel/")
+            url.set("https://github.com/kotest/kotest/")
+         }
+
+         licenses {
+            license {
+               name.set("Apache-2.0")
+               url.set("https://opensource.org/licenses/Apache-2.0")
             }
+         }
 
-            licenses {
-               license {
-                  name.set("Apache-2.0")
-                  url.set("https://opensource.org/licenses/Apache-2.0")
-               }
-            }
-
-            developers {
-               developer {
-                  id.set("sksamuel")
-                  name.set("Stephen Samuel")
-                  email.set("sam@sksamuel.com")
-               }
+         developers {
+            developer {
+               id.set("sksamuel")
+               name.set("Stephen Samuel")
+               email.set("sam@sksamuel.com")
             }
          }
       }

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -144,6 +144,12 @@ publishing {
                name.set("Stephen Samuel")
                email.set("sam@sksamuel.com")
             }
+
+            developer {
+               id.set("Kantis")
+               name.set("Emil Kantis")
+               email.set("emil.kantis@protonmail.com")
+            }
          }
       }
    }


### PR DESCRIPTION
I noticed that POM details were not applied correctly when releasing the Android native and watchosDeviceArm64. I suppose it typically works when doing the full release for _reasons_. 

Proposed change will make application of POM details happen lazily, so only when publishing actually comes into play. Meaning it'll work for any potential publication that is registered late will still get the correct stuff. At least that's my interpretation of things, but gradle typically work in mysterious ways.

I think we can keep this PR as a draft for a while. If the same issue arises when doing a full release next time we could consider merging.