### PR TITLE
Add an `infix` variant of `shouldNotBeNull` that accepts a block

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -27,7 +27,8 @@ Matchers provided by the `kotest-assertions-core` module.
 | `obj.shouldBeTypeOf<T>()`                   | Asserts that the given reference is exactly of type T. Subclass will fail. Ie, `1 should beOfType<Number>` would fail because although 1 _is_ a Number, the runtime type is not Number. |
 | `obj.shouldBeInstanceOf<T>()`               | Asserts that the given reference is of type T or a subclass of T. |
 | `obj.shouldHaveAnnotation(annotationClass)` | Asserts that the object has an annotation of the given type. |
-| `obj.shouldBeNull()`                        | Asserts that a given reference is null.|
+| `obj.shouldBeNull()`                        | Asserts that a given reference is null. |
+| `obj shouldNotBeNull { block }`             | Asserts that a given reference is not null. |
 
 
 | Comparables                                        ||

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1739,6 +1739,7 @@ public final class io/kotest/matchers/nulls/MatchersKt {
 	public static final fun beNull ()Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeNull (Ljava/lang/Object;)V
 	public static final fun shouldNotBeNull (Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun shouldNotBeNull (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/kotest/matchers/optional/MatchersKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
@@ -73,6 +73,17 @@ fun <T> T?.shouldNotBeNull(): T {
    return this!!
 }
 
+/**
+ * Verifies that this is not null and lets you use its value in [block]
+ *
+ * maybeNullString() shouldNotBeNull {
+ *     length should beEven()
+ * }
+ */
+infix fun <T : Any> T?.shouldNotBeNull(block: T.() -> Unit) {
+   this.shouldNotBeNull()
+   block()
+}
 
 /**
  * Matcher that verifies if a reference is null

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ShouldNotBeNullTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ShouldNotBeNullTest.kt
@@ -50,6 +50,16 @@ class ShouldNotBeNullTest : WordSpec() {
                .shouldStartWith("fo")
                .shouldEndWith("oo")
          }
+
+         "accept a block" {
+            val a: String? = "foo"
+
+            a shouldNotBeNull {
+               shouldHaveLength(3)
+               shouldStartWith("fo")
+               shouldEndWith("oo")
+            }
+         }
       }
    }
 }


### PR DESCRIPTION
This allows for some syntactic sugar when dealing with the non-null value.