### PR TITLE
Build Config update & enable Configuration Cache

### DIFF
--- a/.github/workflows/release_base.yml
+++ b/.github/workflows/release_base.yml
@@ -17,7 +17,7 @@ env:
    OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
    ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
    contents: read

--- a/.github/workflows/release_ios.yml
+++ b/.github/workflows/release_ios.yml
@@ -17,7 +17,7 @@ env:
    OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
    ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
    contents: read

--- a/.github/workflows/release_macos.yml
+++ b/.github/workflows/release_macos.yml
@@ -17,7 +17,7 @@ env:
    OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
    ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
    contents: read

--- a/.github/workflows/release_multiplatform_plugin_gradle.yml
+++ b/.github/workflows/release_multiplatform_plugin_gradle.yml
@@ -9,7 +9,7 @@ on:
 
 env:
    RELEASE_VERSION: ${{ github.event.inputs.version }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=false -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
   contents: read

--- a/.github/workflows/release_tvos.yml
+++ b/.github/workflows/release_tvos.yml
@@ -17,7 +17,7 @@ env:
    OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
    ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
    contents: read

--- a/.github/workflows/release_watchos.yml
+++ b/.github/workflows/release_watchos.yml
@@ -17,7 +17,7 @@ env:
    OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
    ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
    contents: read

--- a/.github/workflows/release_windows.yml
+++ b/.github/workflows/release_windows.yml
@@ -17,7 +17,7 @@ env:
    OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
    ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
    ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 
 permissions:
    contents: read

--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -47,4 +47,4 @@ jobs:
                path: build-reports.zip
 
 env:
-   GRADLE_OPTS: -Dorg.gradle.configureondemand=false -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx12g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/buildSrc/src/main/kotlin/kotest-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-jvm-conventions.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 kotlin {
-
    jvm {
       withJava()
    }

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -2,6 +2,91 @@ import groovy.util.Node
 import groovy.util.NodeList
 import org.gradle.configurationcache.extensions.capitalized
 
+plugins {
+   signing
+   `maven-publish`
+}
+
+group = "io.kotest"
+version = Ci.publishVersion
+
+val javadocJar by tasks.registering(Jar::class) {
+   group = JavaBasePlugin.DOCUMENTATION_GROUP
+   description = "Assembles java doc to jar"
+   archiveClassifier.set("javadoc")
+   val javadoc = tasks.named("javadoc")
+   from(javadoc)
+}
+
+val ossrhUsername: String by project
+val ossrhPassword: String by project
+val signingKey: String? by project
+val signingPassword: String? by project
+
+//region manually define accessors, because IntelliJ _still_ doesn't index them properly :(
+val Project.signing get() = extensions.getByType<SigningExtension>()
+fun Project.signing(configure: SigningExtension.() -> Unit = {}): Unit = signing.configure()
+val Project.publishing get() = extensions.getByType<PublishingExtension>()
+fun Project.publishing(configure: PublishingExtension.() -> Unit = {}): Unit = publishing.configure()
+//endregion
+
+signing {
+   useGpgCmd()
+   if (signingKey != null && signingPassword != null) {
+      @Suppress("UnstableApiUsage")
+      useInMemoryPgpKeys(signingKey, signingPassword)
+   }
+   if (Ci.isRelease) {
+      sign(publishing.publications)
+   }
+}
+
+publishing {
+   repositories {
+      maven {
+         val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+         val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+         name = "deploy"
+         url = if (Ci.isRelease) releasesRepoUrl else snapshotsRepoUrl
+         credentials {
+            username = System.getenv("OSSRH_USERNAME") ?: ossrhUsername
+            password = System.getenv("OSSRH_PASSWORD") ?: ossrhPassword
+         }
+      }
+   }
+
+   publications.withType<MavenPublication>().configureEach {
+      artifact(javadocJar)
+
+      pom {
+         name.set("Kotest")
+         description.set("Kotlin Test Framework")
+         url.set("https://github.com/kotest/kotest")
+
+         scm {
+            connection.set("scm:git:https://github.com/kotest/kotest/")
+            developerConnection.set("scm:git:https://github.com/sksamuel/")
+            url.set("https://github.com/kotest/kotest/")
+         }
+
+         licenses {
+            license {
+               name.set("Apache-2.0")
+               url.set("https://opensource.org/licenses/Apache-2.0")
+            }
+         }
+
+         developers {
+            developer {
+               id.set("sksamuel")
+               name.set("Stephen Samuel")
+               email.set("sam@sksamuel.com")
+            }
+         }
+      }
+   }
+}
+
 /**
  * Publish the platform JAR and POM so that consumers who depend on this module and can't read Gradle module
  * metadata can still get the platform artifact and transitive dependencies from the POM
@@ -10,7 +95,7 @@ import org.gradle.configurationcache.extensions.capitalized
 fun Project.publishPlatformArtifactsInRootModule() {
    val platformPublication: MavenPublication? =
       extensions
-         .findByType(PublishingExtension::class.java)
+         .findByType(PublishingExtension::class)
          ?.publications
          ?.getByName<MavenPublication>("jvm")
    if (platformPublication != null) {
@@ -19,12 +104,11 @@ fun Project.publishPlatformArtifactsInRootModule() {
       platformPublication.pom?.withXml { platformXml = this }
 
       extensions
-         .findByType(PublishingExtension::class.java)
+         .findByType(PublishingExtension::class)
          ?.publications
          ?.getByName("kotlinMultiplatform")
          ?.let { it as MavenPublication }
          ?.run {
-
             // replace pom
             pom.withXml {
                val xmlProvider = this
@@ -59,97 +143,4 @@ fun Project.publishPlatformArtifactsInRootModule() {
    }
 }
 
-plugins {
-   signing
-   `maven-publish`
-}
-
-val publications: PublicationContainer = (extensions.getByName("publishing") as PublishingExtension).publications
-
-val javadoc = tasks.named("javadoc")
-
-group = "io.kotest"
-version = Ci.publishVersion
-
-val javadocJar by tasks.creating(Jar::class) {
-   group = JavaBasePlugin.DOCUMENTATION_GROUP
-   description = "Assembles java doc to jar"
-   archiveClassifier.set("javadoc")
-   from(javadoc)
-}
-
-
-publishing {
-   publications.withType<MavenPublication>().forEach {
-      it.apply {
-         artifact(javadocJar)
-      }
-   }
-}
-
-val ossrhUsername: String by project
-val ossrhPassword: String by project
-val signingKey: String? by project
-val signingPassword: String? by project
-
-signing {
-   useGpgCmd()
-   if (signingKey != null && signingPassword != null) {
-      @Suppress("UnstableApiUsage")
-      useInMemoryPgpKeys(signingKey, signingPassword)
-   }
-   if (Ci.isRelease) {
-      sign(publications)
-   }
-}
-
 publishPlatformArtifactsInRootModule()
-
-publishing {
-   repositories {
-      maven {
-         val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-         val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-         name = "deploy"
-         url = if (Ci.isRelease) releasesRepoUrl else snapshotsRepoUrl
-         credentials {
-            username = System.getenv("OSSRH_USERNAME") ?: ossrhUsername
-            password = System.getenv("OSSRH_PASSWORD") ?: ossrhPassword
-         }
-      }
-   }
-
-   publications.withType<MavenPublication>().forEach {
-      it.apply {
-         //if (Ci.isRelease)
-         pom {
-            name.set("Kotest")
-            description.set("Kotlin Test Framework")
-            url.set("https://github.com/kotest/kotest")
-
-            scm {
-               connection.set("scm:git:https://github.com/kotest/kotest/")
-               developerConnection.set("scm:git:https://github.com/sksamuel/")
-               url.set("https://github.com/kotest/kotest/")
-            }
-
-            licenses {
-               license {
-                  name.set("Apache-2.0")
-                  url.set("https://opensource.org/licenses/Apache-2.0")
-               }
-            }
-
-            developers {
-               developer {
-                  id.set("sksamuel")
-                  name.set("Stephen Samuel")
-                  email.set("sam@sksamuel.com")
-               }
-            }
-         }
-      }
-   }
-}
-
-

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -1,7 +1,3 @@
-import groovy.util.Node
-import groovy.util.NodeList
-import org.gradle.configurationcache.extensions.capitalized
-
 plugins {
    signing
    `maven-publish`

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -8,12 +8,14 @@ plugins {
 }
 
 repositories {
-   mavenCentral()
-   mavenLocal()
-   maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
-   maven("https://oss.sonatype.org/content/repositories/snapshots/")
    google()
+   mavenCentral()
+   maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+   maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+      mavenContent { snapshotsOnly() }
+   }
    gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
+   mavenLocal()
 }
 
 testlogger {

--- a/buildSrc/src/main/kotlin/publishingUtils.kt
+++ b/buildSrc/src/main/kotlin/publishingUtils.kt
@@ -1,0 +1,71 @@
+import groovy.util.Node
+import groovy.util.NodeList
+import org.gradle.api.Project
+import org.gradle.api.XmlProvider
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.GenerateMavenPom
+import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.named
+import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.SigningExtension
+
+//region manually define accessors, because IntelliJ _still_ doesn't index them properly :(
+internal val Project.signing get() = extensions.getByType<SigningExtension>()
+internal fun Project.signing(configure: SigningExtension.() -> Unit = {}): Unit = signing.configure()
+internal val Project.publishing get() = extensions.getByType<PublishingExtension>()
+internal fun Project.publishing(configure: PublishingExtension.() -> Unit = {}): Unit = publishing.configure()
+//endregion
+
+/**
+ * Publish the platform JAR and POM so that consumers who depend on this module and can't read Gradle module
+ * metadata can still get the platform artifact and transitive dependencies from the POM
+ * (see details in https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
+ */
+internal fun publishPlatformArtifactsInRootModule(project: Project) {
+   val platformPublication: MavenPublication =
+      project.publishing.publications.named<MavenPublication>("jvm").get()
+   val kmpPublication: MavenPublication =
+      project.publishing.publications.named<MavenPublication>("kotlinMultiplatform").get()
+
+   lateinit var platformXml: XmlProvider
+   platformPublication.pom?.withXml { platformXml = this }
+
+   // replace pom
+   kmpPublication.pom.withXml {
+      val xmlProvider = this
+      val root = xmlProvider.asNode()
+      // Remove the original content and add the content from the platform POM:
+      root.children().toList().forEach { root.remove(it as Node) }
+      platformXml.asNode().children().forEach { root.append(it as Node) }
+
+      // Adjust the self artifact ID, as it should match the root module's coordinates:
+      ((root.get("artifactId") as NodeList).get(0) as Node).setValue(kmpPublication.artifactId)
+
+      // Set packaging to POM to indicate that there's no artifact:
+      root.appendNode("packaging", "pom")
+
+      // Remove the original platform dependencies and add a single dependency on the platform
+      // module:
+      val dependencies = (root.get("dependencies") as NodeList).get(0) as Node
+      dependencies.children().toList().forEach { dependencies.remove(it as Node) }
+      val singleDependency = dependencies.appendNode("dependency")
+      singleDependency.appendNode("groupId", platformPublication.groupId)
+      singleDependency.appendNode("artifactId", platformPublication.artifactId)
+      singleDependency.appendNode("version", platformPublication.version)
+      singleDependency.appendNode("scope", "compile")
+   }
+
+   project.tasks
+      .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
+      .configureEach {
+         dependsOn("generatePomFileFor${platformPublication.name.capitalized()}Publication")
+
+         // Disable Config Cache to prevent error:
+         // Task `:[...]:generatePomFileForKotlinMultiplatformPublication` of type `GenerateMavenPom`:
+         // cannot serialize object of type 'DefaultMavenPublication', a subtype of 'Publication',
+         // as these are not supported with the configuration cache.
+         notCompatibleWithConfigurationCache("publishPlatformArtifactsInRootModule")
+      }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,30 +9,22 @@ ossrhPassword=xx
 gradle.publish.key=xx
 gradle.publish.secret=xx
 
-# See https://dev.to/jmfayard/configuring-gradle-with-gradle-properties-211k
-org.gradle.parallel=false
-kotlin.code.style=official
-
 org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=756m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 systemProp.org.gradle.jvmargs=-Xmx3g -XX:MaxMetaspaceSize=756m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.daemon=true
 
+org.gradle.caching=true
+org.gradle.parallel=false
+org.gradle.daemon=true
+org.gradle.configuration-cache=true
+org.gradle.configureondemand=false
 #https://github.com/gradle/gradle/issues/11308
 org.gradle.internal.publish.checksums.insecure=true
 systemProp.org.gradle.internal.publish.checksums.insecure=true
-kotlin.native.disableCompilerDaemon=true
+
 kotlin.native.ignoreDisabledTargets=true
-systemProp.kotlin.native.disableCompilerDaemon=true
-org.gradle.configureondemand=false
 kotlin.mpp.stability.nowarn=true
-# https://youtrack.jetbrains.com/issue/KT-58063 (should be fixed in Kotlin 1.9)
-org.gradle.configuration-cache=false
-
-android.useAndroidX=true
-android.enableJetifier=true
-kotlin.native.ignoreIncorrectDependencies=true
-
 kotlin.incremental=true
 kotlin.incremental.js=true
 
-org.gradle.caching=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ mordant = "1.2.1"
 opentest4j = "1.3.0"
 plugin-publish = "1.2.1"
 rgxgen = "1.4"
-shadowjar = "7.1.2"
+shadowjar = "8.1.1"
 
 [libraries]
 apache-commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }

--- a/kotest-framework/kotest-framework-api/build.gradle.kts
+++ b/kotest-framework/kotest-framework-api/build.gradle.kts
@@ -40,59 +40,65 @@ kotlin {
    }
 }
 
-tasks.create("buildConfigDocs") {
-   // find config files
-   val fileNames = listOf("KotestEngineProperties.kt")
-
-   val foundFiles = File(project.rootDir.absolutePath).walk().maxDepth(25).map { file ->
-      if (fileNames.contains(file.name)) {
-         file
-      } else {
-         null
-      }
-   }.filterNotNull()
-      .toList()
-
-   if (foundFiles.size != fileNames.size)
-      throw RuntimeException("Fail to find files -> {$fileNames} in project, found only these files -> {$foundFiles}")
-
-   // replace in docs
-
-   val docName = "config_props.md"
-   val docsFolder = File(project.rootDir.absolutePath, "documentation/docs/framework")
-   val docFileFullPath = File(docsFolder.absolutePath, docName)
-
-   val configTemplate = """
----
-id: framework_config_props
-title: Framework configuration properties
-sidebar_label: System properties
-slug: framework-config-props.html
----
-
-   """.trimIndent()
-
-   val fileTemplate = """
-
-      ---
-      #### %s
-      ```kotlin
-      %s
-      ```
-
-   """.trimIndent()
-
-   val sb = StringBuilder(configTemplate)
-
-   foundFiles.forEach { file ->
-      val name = file.name
-      // intentionally use \n instead of System.lineSeparator to respect .editorconfig
-      val content = file.readLines().joinToString(separator = "\n")
-
-      sb.append(fileTemplate.format(name, content))
-   }
-
-   docFileFullPath.writeText(sb.toString())
-}
-
-tasks["jvmTest"].mustRunAfter(tasks["buildConfigDocs"].path)
+// TODO reimplement buildConfigDocs task
+//      - It is supposed to update `config_props.md` files, but it's not triggered by anything.
+//        (Replace `mustRunAfter()` with `dependsOn()`)
+//      - It does work in the configuration phase.
+//        (Add a `doLast {}` block)
+//      - Should properly register Task inputs/outputs.
+//tasks.create("buildConfigDocs") {
+//   // find config files
+//   val fileNames = listOf("KotestEngineProperties.kt")
+//
+//   val foundFiles = File(project.rootDir.absolutePath).walk().maxDepth(25).map { file ->
+//      if (fileNames.contains(file.name)) {
+//         file
+//      } else {
+//         null
+//      }
+//   }.filterNotNull()
+//      .toList()
+//
+//   if (foundFiles.size != fileNames.size)
+//      throw RuntimeException("Fail to find files -> {$fileNames} in project, found only these files -> {$foundFiles}")
+//
+//   // replace in docs
+//
+//   val docName = "config_props.md"
+//   val docsFolder = File(project.rootDir.absolutePath, "documentation/docs/framework")
+//   val docFileFullPath = File(docsFolder.absolutePath, docName)
+//
+//   val configTemplate = """
+//---
+//id: framework_config_props
+//title: Framework configuration properties
+//sidebar_label: System properties
+//slug: framework-config-props.html
+//---
+//
+//   """.trimIndent()
+//
+//   val fileTemplate = """
+//
+//      ---
+//      #### %s
+//      ```kotlin
+//      %s
+//      ```
+//
+//   """.trimIndent()
+//
+//   val sb = StringBuilder(configTemplate)
+//
+//   foundFiles.forEach { file ->
+//      val name = file.name
+//      // intentionally use \n instead of System.lineSeparator to respect .editorconfig
+//      val content = file.readLines().joinToString(separator = "\n")
+//
+//      sb.append(fileTemplate.format(name, content))
+//   }
+//
+//   docFileFullPath.writeText(sb.toString())
+//}
+//
+//tasks["jvmTest"].mustRunAfter(tasks["buildConfigDocs"].path)

--- a/kotest-framework/kotest-framework-standalone/build.gradle.kts
+++ b/kotest-framework/kotest-framework-standalone/build.gradle.kts
@@ -5,12 +5,6 @@ plugins {
    alias(libs.plugins.shadowjar)
 }
 
-kotlin {
-   targets {
-      jvm()
-   }
-}
-
 application {
    mainClass.set("io.kotest.engine.launcher.MainKt")
 }

--- a/kotest-framework/kotest-framework-standalone/build.gradle.kts
+++ b/kotest-framework/kotest-framework-standalone/build.gradle.kts
@@ -29,7 +29,11 @@ tasks {
       }
    }
    getByName("jvmJar") {
-      finalizedBy(getByName("shadowJar"))
+      finalizedBy(shadowJar)
+   }
+
+   startScripts {
+      dependsOn(shadowJar)
    }
 }
 

--- a/kotest-tests/kotest-tests-concurrency-specs/gradle.properties
+++ b/kotest-tests/kotest-tests-concurrency-specs/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.parallel=false

--- a/kotest-tests/kotest-tests-concurrency-tests/gradle.properties
+++ b/kotest-tests/kotest-tests-concurrency-tests/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.parallel=false

--- a/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
+++ b/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
 }
 
 kotlin {
-
-   targets {
-      jvm()
-   }
+   jvm()
 
    sourceSets {
       val jvmTest by getting {

--- a/kotest-tests/kotest-tests-spec-parallelism/gradle.properties
+++ b/kotest-tests/kotest-tests-spec-parallelism/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.parallel=false

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -5,6 +5,7 @@ import io.kotest.core.config.ProjectConfiguration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
+import kotlin.time.times
 
 object ProjectConfig : AbstractProjectConfig() {
 
@@ -21,9 +22,9 @@ object ProjectConfig : AbstractProjectConfig() {
 
    override suspend fun afterProject() {
       val duration = start.elapsedNow()
-      // There are 8 specs, and each one has a 100ms delay.
+      // There are 8 specs, and each one has a 500ms delay.
       // If parallel is working, they should all block at the same time.
-      if (duration > 700.milliseconds) {
+      if (duration > 7 * 500.milliseconds) {
          error("Parallel execution failure: Execution time was $duration")
       }
    }

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -2,13 +2,19 @@ package com.sksamuel.kotest.parallelism
 
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.config.ProjectConfiguration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+import kotlinx.coroutines.delay
 
 object ProjectConfig : AbstractProjectConfig() {
 
-   private var start = 0L
+   private lateinit var start: TimeMark
 
    override suspend fun beforeProject() {
-      start = System.currentTimeMillis()
+      // Delay, so that tests can warm up (this is a wild guess - is it actually correct???)
+      delay(1.seconds)
+      start = TimeSource.Monotonic.markNow()
    }
 
    // set the number of threads so that each test runs in its own thread
@@ -17,10 +23,11 @@ object ProjectConfig : AbstractProjectConfig() {
    override val concurrentSpecs: Int = ProjectConfiguration.MaxConcurrency
 
    override suspend fun afterProject() {
-      val duration = System.currentTimeMillis() - start
-      // there are 8 specs, and each one has a delay
-      // if parallel is working they should all block at the same time
-      if (duration > 700)
+      val duration = start.elapsedNow()
+      // There are 8 specs, and each one has a 1-second delay.
+      // If parallel is working, they should all block at the same time.
+      if (duration > 7.seconds) {
          error("Parallel execution failure: Execution time was $duration")
+      }
    }
 }

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -2,18 +2,15 @@ package com.sksamuel.kotest.parallelism
 
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.config.ProjectConfiguration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
-import kotlinx.coroutines.delay
 
 object ProjectConfig : AbstractProjectConfig() {
 
    private lateinit var start: TimeMark
 
    override suspend fun beforeProject() {
-      // Delay, so that tests can warm up (this is a wild guess - is it actually correct???)
-      delay(1.seconds)
       start = TimeSource.Monotonic.markNow()
    }
 
@@ -24,9 +21,9 @@ object ProjectConfig : AbstractProjectConfig() {
 
    override suspend fun afterProject() {
       val duration = start.elapsedNow()
-      // There are 8 specs, and each one has a 1-second delay.
+      // There are 8 specs, and each one has a 100ms delay.
       // If parallel is working, they should all block at the same time.
-      if (duration > 7.seconds) {
+      if (duration > 700.milliseconds) {
          error("Parallel execution failure: Execution time was $duration")
       }
    }

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test1.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test1.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test1 : StringSpec({
    "a" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test2.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test2.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test2 : StringSpec({
    "2" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test3.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test3.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test3 : StringSpec({
    "3" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test4.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test4.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test4 : StringSpec({
    "a" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test5.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test5.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test5 : StringSpec({
    "5" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test6.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test6.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test6 : StringSpec({
    "a" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test7.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test7.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test7 : StringSpec({
    "a" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test8.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test8.kt
@@ -4,6 +4,6 @@ import io.kotest.core.spec.style.StringSpec
 
 class Test8 : StringSpec({
    "a" {
-      Thread.sleep(100)
+      Thread.sleep(500)
    }
 })

--- a/kotest-tests/kotest-tests-tagextension/build.gradle.kts
+++ b/kotest-tests/kotest-tests-tagextension/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
 }
 
 kotlin {
-
-   targets {
-      jvm()
-   }
+   jvm()
 
    sourceSets {
       val jvmTest by getting {

--- a/kotest-tests/kotest-tests-test-parallelism/build.gradle.kts
+++ b/kotest-tests/kotest-tests-test-parallelism/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
 }
 
 kotlin {
-
-   targets {
-      jvm()
-   }
+   jvm()
 
    sourceSets {
       val jvmTest by getting {

--- a/kotest-tests/kotest-tests-test-parallelism/gradle.properties
+++ b/kotest-tests/kotest-tests-test-parallelism/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.parallel=false

--- a/kotest-tests/kotest-tests-timeout-project/build.gradle.kts
+++ b/kotest-tests/kotest-tests-timeout-project/build.gradle.kts
@@ -3,13 +3,9 @@ plugins {
 }
 
 kotlin {
-
-   targets {
-      jvm()
-   }
+   jvm()
 
    sourceSets {
-
       val jvmTest by getting {
          dependencies {
             implementation(projects.kotestFramework.kotestFrameworkEngine)

--- a/kotest-tests/kotest-tests-timeout-sysprop/build.gradle.kts
+++ b/kotest-tests/kotest-tests-timeout-sysprop/build.gradle.kts
@@ -3,10 +3,7 @@ plugins {
 }
 
 kotlin {
-
-   targets {
-      jvm()
-   }
+   jvm()
 
    sourceSets {
 


### PR DESCRIPTION
Minor build config updates, aiming to improve build configuration speed and stability.

- Re-order repositories by stability, and add snapshotsOnly() filter to Sonatype snapshots.
- Update Shadow plugin to 8.1.1 (better config cache support)
- remove deprecated `kotlin { targets {} }` config
- update gradle.properties
  - enable configuration cache - should work fine with KGP 1.9
  - re-enable KN compiler daemon - again, it should be more stable
  - remove ignoreIncorrectDependencies (it doesn't seem to be triggered any more - but if it was, it's an important warning so it shouldn't be ignored)
  - sort & group properties
  - remove `kotlin.code.style` - I don't think it does anything, and besides, the project has an .editorconfig file
- remove nested `gradle.properties` files (it's not clear whether it works, and the only option in the files was `org.gradle.parallel=false` - which only makes sense as a project-wide setting)
- Introduce BuildService for limiting parallel publishing, because Maven Central can't handle parallel uploads.
- Add a delay in `kotest-tests-spec-parallelism` test to try and make it more stable.
- Comment out non-functional `buildConfigDocs` task.
- Update GitHub workflows to make the Gradle flags closer to what's in the project's `gradle.properties`.