### PR TITLE
remove `@ExperimentalCoroutinesApi` opt-in from no-longer-experimental code

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/coroutines/BackgroundScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/coroutines/BackgroundScope.kt
@@ -3,9 +3,7 @@ package io.kotest.core.coroutines
 import io.kotest.common.KotestInternal
 import io.kotest.core.test.TestScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-@ExperimentalCoroutinesApi
 @OptIn(KotestInternal::class)
 val TestScope.backgroundScope: CoroutineScope
    get() {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/delayController.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/delayController.kt
@@ -7,12 +7,10 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlin.coroutines.CoroutineContext
 
 @ExperimentalStdlibApi
-@ExperimentalCoroutinesApi
 val TestScope.testCoroutineScheduler: TestCoroutineScheduler
    get() = coroutineContext.testCoroutineScheduler
 
 @ExperimentalStdlibApi
-@ExperimentalCoroutinesApi
 val CoroutineContext.testCoroutineScheduler: TestCoroutineScheduler
    get() = when (val dispatcher = this[CoroutineDispatcher]) {
       is TestDispatcher -> dispatcher.scheduler


### PR DESCRIPTION
`TestScope` and `TestDispatcher` used to be experimental in Coroutines, but it is not any more https://github.com/Kotlin/kotlinx.coroutines/pull/3622

Leaving the annotation on `testCoroutineScheduler` leads to unnecessary `@OptIn`s in user's projects.