### PR TITLE
Apply publishing conventions to kotest-bom

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -49,8 +49,6 @@ publishing {
    }
 
    publications.withType<MavenPublication>().configureEach {
-      artifact(javadocJar)
-
       pom {
          name.set("Kotest")
          description.set("Kotlin Test Framework")
@@ -81,6 +79,10 @@ publishing {
 }
 
 pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+   publishing.publications.withType<MavenPublication>().configureEach {
+      artifact(javadocJar)
+   }
+
    publishPlatformArtifactsInRootModule(project)
 }
 

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -41,6 +41,11 @@ publishing {
             password = System.getenv("OSSRH_PASSWORD") ?: ossrhPassword
          }
       }
+      maven(rootDir.resolve("build/maven-repo")) {
+         // Publish to a project-local directory, for easier verification of published artifacts
+         // Run ./gradlew publishAllPublicationsToRootBuildDirRepository, and check `$rootDir/build/maven-repo/`
+         name = "RootBuildDir"
+      }
    }
 
    publications.withType<MavenPublication>().configureEach {

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -75,7 +75,9 @@ publishing {
    }
 }
 
-publishPlatformArtifactsInRootModule(project)
+pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+   publishPlatformArtifactsInRootModule(project)
+}
 
 //region Maven Central can't handle parallel uploads, so limit parallel uploads with a BuildService
 abstract class MavenPublishLimiter : BuildService<BuildServiceParameters.None>

--- a/buildSrc/src/main/kotlin/publishingUtils.kt
+++ b/buildSrc/src/main/kotlin/publishingUtils.kt
@@ -1,15 +1,20 @@
-import groovy.util.Node
-import groovy.util.NodeList
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
 import org.gradle.api.Project
-import org.gradle.api.XmlProvider
 import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.GenerateMavenPom
-import org.gradle.configurationcache.extensions.capitalized
+import org.gradle.api.tasks.PathSensitivity.NAME_ONLY
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.withType
 import org.gradle.plugins.signing.SigningExtension
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+import org.w3c.dom.NodeList
 
 //region manually define accessors, because IntelliJ _still_ doesn't index them properly :(
 internal val Project.signing get() = extensions.getByType<SigningExtension>()
@@ -24,48 +29,89 @@ internal fun Project.publishing(configure: PublishingExtension.() -> Unit = {}):
  * (see details in https://youtrack.jetbrains.com/issue/KT-39184#focus=streamItem-27-4115233.0-0)
  */
 internal fun publishPlatformArtifactsInRootModule(project: Project) {
-   val platformPublication: MavenPublication =
-      project.publishing.publications.named<MavenPublication>("jvm").get()
-   val kmpPublication: MavenPublication =
-      project.publishing.publications.named<MavenPublication>("kotlinMultiplatform").get()
+   val jvmPomTask = project.tasks.named<GenerateMavenPom>("generatePomFileForJvmPublication")
 
-   lateinit var platformXml: XmlProvider
-   platformPublication.pom?.withXml { platformXml = this }
+   project.tasks.named<GenerateMavenPom>("generatePomFileForKotlinMultiplatformPublication").configure {
 
-   // replace pom
-   kmpPublication.pom.withXml {
-      val xmlProvider = this
-      val root = xmlProvider.asNode()
-      // Remove the original content and add the content from the platform POM:
-      root.children().toList().forEach { root.remove(it as Node) }
-      platformXml.asNode().children().forEach { root.append(it as Node) }
+      val jvmPom = jvmPomTask.map { it.destination }
+      inputs.file(jvmPom)
+         .withPropertyName("jvmPom")
+         .normalizeLineEndings()
+         .withPathSensitivity(NAME_ONLY)
 
-      // Adjust the self artifact ID, as it should match the root module's coordinates:
-      ((root.get("artifactId") as NodeList).get(0) as Node).setValue(kmpPublication.artifactId)
+      doLast("re-write KMP common POM") {
+         val original = destination.readText()
 
-      // Set packaging to POM to indicate that there's no artifact:
-      root.appendNode("packaging", "pom")
+         val jvmPomFile = jvmPom.get()
 
-      // Remove the original platform dependencies and add a single dependency on the platform
-      // module:
-      val dependencies = (root.get("dependencies") as NodeList).get(0) as Node
-      dependencies.children().toList().forEach { dependencies.remove(it as Node) }
-      val singleDependency = dependencies.appendNode("dependency")
-      singleDependency.appendNode("groupId", platformPublication.groupId)
-      singleDependency.appendNode("artifactId", platformPublication.artifactId)
-      singleDependency.appendNode("version", platformPublication.version)
-      singleDependency.appendNode("scope", "compile")
-   }
+         val docFactory = DocumentBuilderFactory.newInstance()
+         val docBuilder = docFactory.newDocumentBuilder()
 
-   project.tasks
-      .matching { it.name == "generatePomFileForKotlinMultiplatformPublication" }
-      .configureEach {
-         dependsOn("generatePomFileFor${platformPublication.name.capitalized()}Publication")
+         val doc = docBuilder.parse(destination).apply {
+            removeWhitespaceNodes()
+            // set standalone=true to prevent `standalone="no"` in the output
+            xmlStandalone = true
+         }
 
-         // Disable Config Cache to prevent error:
-         // Task `:[...]:generatePomFileForKotlinMultiplatformPublication` of type `GenerateMavenPom`:
-         // cannot serialize object of type 'DefaultMavenPublication', a subtype of 'Publication',
-         // as these are not supported with the configuration cache.
-         notCompatibleWithConfigurationCache("publishPlatformArtifactsInRootModule")
+         val jvmDoc = docBuilder.parse(jvmPomFile)
+         val jvmGroupId = jvmDoc.getElementsByTagName("groupId").item(0).textContent
+         val jvmArtifactId = jvmDoc.getElementsByTagName("artifactId").item(0).textContent
+         val jvmVersion = jvmDoc.getElementsByTagName("version").item(0).textContent
+
+         val root = doc.documentElement
+
+         val dependencies = root.getElementsByTagName("dependencies").item(0)
+
+         // Remove the original platform dependencies
+         while (dependencies.hasChildNodes()) {
+            dependencies.removeChild(dependencies.firstChild)
+         }
+         // and add a single dependency on the platform module:
+         dependencies.appendChild(
+            doc.createElement("dependency") {
+               appendChild(doc.createElement("groupId", jvmGroupId))
+               appendChild(doc.createElement("artifactId", jvmArtifactId))
+               appendChild(doc.createElement("version", jvmVersion))
+               appendChild(doc.createElement("scope", "compile"))
+            }
+         )
+
+         // Set packaging to POM to indicate that there's no artifact:
+         doc.createElement("packaging", "pom")
+
+         // Write the updated XML to the destination file
+         val transformer = TransformerFactory.newInstance().newTransformer().apply {
+            setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no")
+            setOutputProperty(OutputKeys.INDENT, "yes")
+            setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2")
+         }
+         val source = DOMSource(doc)
+         val result = StreamResult(destination)
+         transformer.transform(source, result)
       }
+   }
+}
+
+private fun Document.createElement(name: String, content: String): Element {
+   val element = createElement(name)
+   element.textContent = content
+   return element
+}
+
+private fun Document.createElement(name: String, configure: Element.() -> Unit): Element =
+   createElement(name).apply(configure)
+
+// https://stackoverflow.com/a/979606/4161471
+private fun Document.removeWhitespaceNodes() {
+   val xpathFactory = XPathFactory.newInstance()
+
+   // XPath to find empty text nodes
+   val xpathExp = xpathFactory.newXPath().compile("//text()[normalize-space(.) = '']")
+   val emptyTextNodes = xpathExp.evaluate(this, XPathConstants.NODESET) as NodeList
+
+   // Remove each empty text node from document
+   for (i in 0 until emptyTextNodes.length) {
+      val emptyTextNode = emptyTextNodes.item(i)
+      emptyTextNode.getParentNode().removeChild(emptyTextNode)
+   }
 }

--- a/kotest-bom/build.gradle.kts
+++ b/kotest-bom/build.gradle.kts
@@ -1,11 +1,7 @@
 plugins {
    `java-platform`
-   `maven-publish`
-   signing
+   id("kotest-publishing-conventions")
 }
-
-group = "io.kotest"
-version = Ci.publishVersion
 
 val bomProject = project
 
@@ -44,64 +40,10 @@ dependencies {
    }
 }
 
-val ossrhUsername: String by project
-val ossrhPassword: String by project
-val signingKey: String? by project
-val signingPassword: String? by project
-
 publishing {
-   repositories {
-      maven {
-         val releasesRepoUrl = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-         val snapshotsRepoUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-         name = "deploy"
-         url = if (Ci.isRelease) releasesRepoUrl else snapshotsRepoUrl
-         credentials {
-            username = System.getenv("OSSRH_USERNAME") ?: ossrhUsername
-            password = System.getenv("OSSRH_PASSWORD") ?: ossrhPassword
-         }
-      }
-   }
-
    publications {
       create<MavenPublication>("KotestBom") {
          from(components["javaPlatform"])
-         pom {
-            name.set("Kotest")
-            description.set("Kotlin Test Framework")
-            url.set("https://github.com/kotest/kotest")
-
-            scm {
-               connection.set("scm:git:https://github.com/kotest/kotest/")
-               developerConnection.set("scm:git:https://github.com/sksamuel/")
-               url.set("https://github.com/kotest/kotest/")
-            }
-
-            licenses {
-               license {
-                  name.set("Apache-2.0")
-                  url.set("https://opensource.org/licenses/Apache-2.0")
-               }
-            }
-
-            developers {
-               developer {
-                  id.set("sksamuel")
-                  name.set("Stephen Samuel")
-                  email.set("sam@sksamuel.com")
-               }
-            }
-         }
       }
-   }
-}
-
-signing {
-   useGpgCmd()
-   if (signingKey != null && signingPassword != null) {
-      useInMemoryPgpKeys(signingKey, signingPassword)
-   }
-   if (Ci.isRelease) {
-      sign(publishing.publications)
    }
 }


### PR DESCRIPTION
apply the publishing convention plugin in kotest-bom

- update publishing-convention to only adds a Javadoc JAR for KMP subprojects
- remove duplicated configuration in kotest-bom

