### PR TITLE
Remove `@ExperimentalStdlibApi` annotation from testCoroutineScheduler

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/delayController.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/delayController.kt
@@ -1,18 +1,15 @@
 package io.kotest.core.test
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 
-@ExperimentalStdlibApi
 val TestScope.testCoroutineScheduler: TestCoroutineScheduler
    get() = coroutineContext.testCoroutineScheduler
 
-@ExperimentalStdlibApi
 val CoroutineContext.testCoroutineScheduler: TestCoroutineScheduler
-   get() = when (val dispatcher = this[CoroutineDispatcher]) {
+   get() = when (val dispatcher = this[ContinuationInterceptor]) {
       is TestDispatcher -> dispatcher.scheduler
-      else -> error("CoroutineDispatcher is not a TestDispatcher [$dispatcher]")
+      else -> error("Dispatcher is not a TestDispatcher: $dispatcher")
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/TestDispatcherTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/TestDispatcherTest.kt
@@ -5,8 +5,7 @@ import io.kotest.core.test.testCoroutineScheduler
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-@ExperimentalCoroutinesApi
-@ExperimentalStdlibApi
+@OptIn(ExperimentalCoroutinesApi::class)
 class TestDispatcherTest : FunSpec() {
    init {
       test("a test with TestDispatcher should advance time virtually").config(testCoroutineDispatcher = true) {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/TestCoroutineSchedulerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/TestCoroutineSchedulerTest.kt
@@ -2,22 +2,19 @@ package com.sksamuel.kotest.engine.test
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.testCoroutineScheduler
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.days
 
-@ExperimentalCoroutinesApi
-@ExperimentalStdlibApi
 class TestCoroutineSchedulerTest : FunSpec() {
    init {
       test("delay controller should control time").config(testCoroutineDispatcher = true) {
          val duration = 1.days
          launch {
-            delay(duration.inWholeMilliseconds)
+            delay(duration)
          }
          // if this isn't working, the above test will just take forever
-         testCoroutineScheduler.advanceTimeBy(duration.inWholeMilliseconds)
+         testCoroutineScheduler.advanceTimeBy(duration)
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TestCoroutineDispatcherInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TestCoroutineDispatcherInterceptorTest.kt
@@ -16,8 +16,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlin.time.Duration.Companion.milliseconds
 
-@ExperimentalStdlibApi
-@ExperimentalCoroutinesApi
+@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
 class TestCoroutineDispatcherInterceptorTest : FunSpec() {
    init {
       test("TestCoroutineDispatcherInterceptor should install a DelayController") {


### PR DESCRIPTION
In addition to #4070

Implementation of `testCoroutineScheduler` extension could be changed to avoid `@ExperimentalStdlibApi` annotation
