### PR TITLE
Disable coroutineTestScope for WasmJs

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -15,7 +15,6 @@ import io.kotest.engine.test.interceptors.AssertionModeInterceptor
 import io.kotest.engine.test.interceptors.BeforeSpecListenerInterceptor
 import io.kotest.engine.test.interceptors.CoroutineDebugProbeInterceptor
 import io.kotest.engine.test.interceptors.CoroutineLoggingInterceptor
-import io.kotest.engine.test.interceptors.TestEnabledCheckInterceptor
 import io.kotest.engine.test.interceptors.ExpectExceptionTestInterceptor
 import io.kotest.engine.test.interceptors.InvocationCountCheckInterceptor
 import io.kotest.engine.test.interceptors.InvocationTimeoutInterceptor
@@ -25,6 +24,7 @@ import io.kotest.engine.test.interceptors.SupervisorScopeInterceptor
 import io.kotest.engine.test.interceptors.TestCaseExtensionInterceptor
 import io.kotest.engine.test.interceptors.TestCoroutineInterceptor
 import io.kotest.engine.test.interceptors.TestDispatcherInterceptor
+import io.kotest.engine.test.interceptors.TestEnabledCheckInterceptor
 import io.kotest.engine.test.interceptors.TestFinishedInterceptor
 import io.kotest.engine.test.interceptors.TestNameContextInterceptor
 import io.kotest.engine.test.interceptors.TestPathContextInterceptor
@@ -55,6 +55,13 @@ internal class TestCaseExecutor(
 
       val timeMark = MonotonicTimeSourceCompat.markNow()
 
+      // JS platforms require extra care when runTest is used, so skip it for now.
+      // Issue: https://github.com/kotest/kotest/issues/4077
+      val useCoroutineTestScope = when (platform) {
+         Platform.JVM, Platform.Native -> testCase.config.coroutineTestScope
+         Platform.JS, Platform.WasmJs -> false
+      }
+
       val interceptors = listOfNotNull(
          TestPathContextInterceptor,
          TestNameContextInterceptor,
@@ -80,7 +87,7 @@ internal class TestCaseExecutor(
             listOfNotNull(
                InvocationTimeoutInterceptor,
                if (platform == Platform.JVM && testCase.config.testCoroutineDispatcher) TestDispatcherInterceptor() else null,
-               if (platform != Platform.JS && testCase.config.coroutineTestScope) TestCoroutineInterceptor() else null,
+               if (useCoroutineTestScope) TestCoroutineInterceptor() else null,
             )
          ),
          CoroutineDebugProbeInterceptor,


### PR DESCRIPTION
It seems like this option was accidentally enabled for the Wasm JS platform. I've disabled it until #4077 is fixed