### PR TITLE
Update plugins used to build Kotest Gradle Plugin

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -4,10 +4,8 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-   kotlin("jvm")
-   `maven-publish`
-   `java-gradle-plugin`
    `kotlin-dsl`
+   `maven-publish`
    alias(libs.plugins.gradle.plugin.publish)
 }
 


### PR DESCRIPTION
- The `kotlin-dsl` plugin also applies `java-gradle-plugin`, so applying both plugins is unnecessary
- Gradle Plugins should use the version of Kotlin embedded into Gradle. Applying `kotlin("jvm")` can cause issues, as it will use a non-embedded Kotlin, and configure some defaults that might cause issues (for example, adding an API dependency on kotlin-stdlib, and this might clash with other plugins)
