### PR TITLE
Tidy kotest-common logger

### DIFF
--- a/kotest-common/src/commonMain/kotlin/io/kotest/common/annotations.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/common/annotations.kt
@@ -16,7 +16,12 @@ annotation class DelicateKotest
 /**
  * An internal Kotest feature that is public for operational reasons but should not be used by end users.
  */
-@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.TYPEALIAS)
+@Target(
+   AnnotationTarget.CLASS,
+   AnnotationTarget.FUNCTION,
+   AnnotationTarget.TYPEALIAS,
+   AnnotationTarget.PROPERTY,
+)
 @MustBeDocumented
 @Retention(value = AnnotationRetention.BINARY)
 @RequiresOptIn(level = RequiresOptIn.Level.WARNING)

--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
@@ -1,16 +1,19 @@
 package io.kotest.mpp
 
+import io.kotest.common.KotestInternal
 import io.kotest.common.MonotonicTimeSourceCompat
 import io.kotest.common.TimeMarkCompat
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 
+@KotestInternal
 val start by lazy { MonotonicTimeSourceCompat.markNow() }
 
 @PublishedApi
 internal fun isLoggingEnabled() =
    syspropOrEnv("KOTEST_DEBUG")?.uppercase() == "TRUE"
 
+@KotestInternal
 class Logger(private val kclass: KClass<*>) {
 
    @OverloadResolutionByLambdaReturnType
@@ -31,10 +34,12 @@ class Logger(private val kclass: KClass<*>) {
 }
 
 @OverloadResolutionByLambdaReturnType
+@KotestInternal
 fun log(f: () -> String) {
    log(null, f)
 }
 
+@KotestInternal
 fun log(t: Throwable?, f: () -> String) {
    if (isLoggingEnabled()) {
       writeLog(start, t, f)
@@ -43,4 +48,5 @@ fun log(t: Throwable?, f: () -> String) {
    }
 }
 
+@KotestInternal
 expect fun writeLog(start: TimeMarkCompat, t: Throwable?, f: () -> String)

--- a/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/mpp/logger.kt
@@ -33,7 +33,6 @@ class Logger(private val kclass: KClass<*>) {
    fun log(f: () -> String): Unit = log { Pair(null, f()) }
 }
 
-@OverloadResolutionByLambdaReturnType
 @KotestInternal
 fun log(f: () -> String) {
    log(null, f)

--- a/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/writeLog.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/writeLog.kt
@@ -1,6 +1,8 @@
 package io.kotest.mpp
 
+import io.kotest.common.KotestInternal
 import io.kotest.common.TimeMarkCompat
 
+@KotestInternal
 actual fun writeLog(start: TimeMarkCompat, t: Throwable?, f: () -> String) {
 }

--- a/kotest-common/src/jsHostedMain/kotlin/io/kotest/mpp/writeLog.kt
+++ b/kotest-common/src/jsHostedMain/kotlin/io/kotest/mpp/writeLog.kt
@@ -1,8 +1,10 @@
 package io.kotest.mpp
 
+import io.kotest.common.KotestInternal
 import io.kotest.common.TimeMarkCompat
 import io.kotest.common.console
 
+@KotestInternal
 actual fun writeLog(start: TimeMarkCompat, t: Throwable?, f: () -> String) {
    console.log(start.elapsedNow().inWholeMicroseconds.toString())
    console.log("  ")


### PR DESCRIPTION
- Annotate vals/funs with `@KotestInternal` to avoid opt-in warnings
- Remove `@OverloadResolutionByLambdaReturnType` from log function (it has no overloads)


I saw that the failure in [this build](https://github.com/kotest/kotest/actions/runs/9431572967/job/25980529942?pr=4076) had an error relating to the logger functions, so maybe tidying it up will help.

```stacktrace
org.gradle.api.internal.tasks.testing.TestSuiteExecutionException: Could not complete execution for Gradle Test Executor 1.
	[...]
Caused by: org.junit.platform.commons.JUnitException: TestEngine with ID 'kotest' failed to discover tests
	[...]
Caused by: java.lang.NoSuchMethodError: 'void io.kotest.mpp.Logger.logsimple(kotlin.jvm.functions.Function0)'
	at io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine.discover(KotestJunitPlatformTestEngine.kt:101)
	at io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine.discover(KotestJunitPlatformTestEngine.kt:35)
	at org.junit.platform.launcher.core.EngineDiscoveryOrchestrator.discoverEngineRoot(EngineDiscoveryOrchestrator.java:152)
	... 28 more
```