### PR TITLE
Tidy Range matchers

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1864,12 +1864,20 @@ public final class io/kotest/matchers/ranges/BeinKt {
 }
 
 public final class io/kotest/matchers/ranges/BewithinKt {
+	public static final fun beWithin (Lio/kotest/matchers/ranges/Range;)Lio/kotest/matchers/Matcher;
+	public static final fun beWithinRangeOfInt (Lkotlin/ranges/ClosedRange;)Lio/kotest/matchers/Matcher;
+	public static final fun beWithinRangeOfLong (Lkotlin/ranges/ClosedRange;)Lio/kotest/matchers/Matcher;
+	public static final fun resultForWithin (Lkotlin/ranges/ClosedRange;Lkotlin/ranges/OpenEndRange;Ljava/lang/Comparable;)Lio/kotest/matchers/MatcherResult;
 	public static final fun shouldBeWithin (Lkotlin/ranges/ClosedRange;Lkotlin/ranges/ClosedRange;)Lkotlin/ranges/ClosedRange;
 	public static final fun shouldBeWithin (Lkotlin/ranges/ClosedRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/ClosedRange;
 	public static final fun shouldBeWithin (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/OpenEndRange;
+	public static final fun shouldBeWithinRangeOfInt (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/ClosedRange;)V
+	public static final fun shouldBeWithinRangeOfLong (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/ClosedRange;)V
 	public static final fun shouldNotBeWithin (Lkotlin/ranges/ClosedRange;Lkotlin/ranges/ClosedRange;)Lkotlin/ranges/ClosedRange;
 	public static final fun shouldNotBeWithin (Lkotlin/ranges/ClosedRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/ClosedRange;
 	public static final fun shouldNotBeWithin (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/OpenEndRange;
+	public static final fun shouldNotBeWithinRangeOfInt (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/ClosedRange;)V
+	public static final fun shouldNotBeWithinRangeOfLong (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/ClosedRange;)V
 }
 
 public final class io/kotest/matchers/ranges/IntersectKt {
@@ -1881,6 +1889,15 @@ public final class io/kotest/matchers/ranges/IntersectKt {
 	public static final fun shouldNotIntersect (Lkotlin/ranges/ClosedRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/ClosedRange;
 	public static final fun shouldNotIntersect (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/ClosedRange;)Lkotlin/ranges/OpenEndRange;
 	public static final fun shouldNotIntersect (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/OpenEndRange;
+}
+
+public final class io/kotest/matchers/ranges/RangeKt {
+	public static final fun closedClosed (Lio/kotest/matchers/ranges/Range$Companion;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lio/kotest/matchers/ranges/Range;
+	public static final fun closedOpen (Lio/kotest/matchers/ranges/Range$Companion;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lio/kotest/matchers/ranges/Range;
+	public static final fun ofClosedRange (Lio/kotest/matchers/ranges/Range$Companion;Lkotlin/ranges/ClosedRange;)Lio/kotest/matchers/ranges/Range;
+	public static final fun ofOpenEndRange (Lio/kotest/matchers/ranges/Range$Companion;Lkotlin/ranges/OpenEndRange;)Lio/kotest/matchers/ranges/Range;
+	public static final fun openClosed (Lio/kotest/matchers/ranges/Range$Companion;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lio/kotest/matchers/ranges/Range;
+	public static final fun openOpen (Lio/kotest/matchers/ranges/Range$Companion;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lio/kotest/matchers/ranges/Range;
 }
 
 public final class io/kotest/matchers/reflection/CallableMatchersKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/Range.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/Range.kt
@@ -44,46 +44,50 @@ internal data class Range<T: Comparable<T>>(
       else -> false
    }
 
-   companion object {
-      fun<T: Comparable<T>> ofClosedRange(range: ClosedRange<T>) = Range(
-          start = RangeEdge(range.start, RangeEdgeType.INCLUSIVE),
-          end = RangeEdge(range.endInclusive, RangeEdgeType.INCLUSIVE)
-      )
-
-      @OptIn(ExperimentalStdlibApi::class)
-      fun<T: Comparable<T>> ofOpenEndRange(range: OpenEndRange<T>) = Range(
-          start = RangeEdge(range.start, RangeEdgeType.INCLUSIVE),
-          end = RangeEdge(range.endExclusive, RangeEdgeType.EXCLUSIVE)
-      )
-
-      fun<T: Comparable<T>> openOpen(start: T, end: T) = Range(
-          start = RangeEdge(start, RangeEdgeType.EXCLUSIVE),
-          end = RangeEdge(end, RangeEdgeType.EXCLUSIVE)
-      )
-
-      fun<T: Comparable<T>> openClosed(start: T, end: T) = Range(
-          start = RangeEdge(start, RangeEdgeType.EXCLUSIVE),
-          end = RangeEdge(end, RangeEdgeType.INCLUSIVE)
-      )
-
-      fun<T: Comparable<T>> closedOpen(start: T, end: T) = Range(
-          start = RangeEdge(start, RangeEdgeType.INCLUSIVE),
-          end = RangeEdge(end, RangeEdgeType.EXCLUSIVE)
-      )
-
-      fun<T: Comparable<T>> closedClosed(start: T, end: T) = Range(
-          start = RangeEdge(start, RangeEdgeType.INCLUSIVE),
-          end = RangeEdge(end, RangeEdgeType.INCLUSIVE)
-      )
-   }
+   companion object
 }
+
+@PublishedApi
+internal fun<T: Comparable<T>> Range.Companion.ofClosedRange(range: ClosedRange<T>) = Range(
+   start = RangeEdge(range.start, RangeEdgeType.INCLUSIVE),
+   end = RangeEdge(range.endInclusive, RangeEdgeType.INCLUSIVE)
+)
+
+@PublishedApi
+internal fun<T: Comparable<T>> Range.Companion.ofOpenEndRange(range: OpenEndRange<T>) = Range(
+   start = RangeEdge(range.start, RangeEdgeType.INCLUSIVE),
+   end = RangeEdge(range.endExclusive, RangeEdgeType.EXCLUSIVE)
+)
+
+@PublishedApi
+internal fun<T: Comparable<T>> Range.Companion.openOpen(start: T, end: T) = Range(
+   start = RangeEdge(start, RangeEdgeType.EXCLUSIVE),
+   end = RangeEdge(end, RangeEdgeType.EXCLUSIVE)
+)
+
+@PublishedApi
+internal fun<T: Comparable<T>> Range.Companion.openClosed(start: T, end: T) = Range(
+   start = RangeEdge(start, RangeEdgeType.EXCLUSIVE),
+   end = RangeEdge(end, RangeEdgeType.INCLUSIVE)
+)
+
+@PublishedApi
+internal fun<T: Comparable<T>> Range.Companion.closedOpen(start: T, end: T) = Range(
+   start = RangeEdge(start, RangeEdgeType.INCLUSIVE),
+   end = RangeEdge(end, RangeEdgeType.EXCLUSIVE)
+)
+
+@PublishedApi
+internal fun<T: Comparable<T>> Range.Companion.closedClosed(start: T, end: T) = Range(
+   start = RangeEdge(start, RangeEdgeType.INCLUSIVE),
+   end = RangeEdge(end, RangeEdgeType.INCLUSIVE)
+)
 
 internal fun<T: Comparable<T>> ClosedRange<T>.toClosedClosedRange(): Range<T> = Range(
    start = RangeEdge(this.start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(this.endInclusive, RangeEdgeType.INCLUSIVE)
 )
 
-@OptIn(ExperimentalStdlibApi::class)
 internal fun<T: Comparable<T>> OpenEndRange<T>.toClosedOpenRange(): Range<T> = Range(
    start = RangeEdge(this.start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(this.endExclusive, RangeEdgeType.EXCLUSIVE)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/Range.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/Range.kt
@@ -1,8 +1,8 @@
 package io.kotest.matchers.ranges
 
-internal data class Range<T: Comparable<T>>(
-    val start: RangeEdge<T>,
-    val end: RangeEdge<T>
+internal data class Range<T : Comparable<T>>(
+   val start: RangeEdge<T>,
+   val end: RangeEdge<T>
 ) {
    init {
       require(start.value <= end.value) {
@@ -11,11 +11,11 @@ internal data class Range<T: Comparable<T>>(
    }
 
    override fun toString(): String {
-      return "${if(start.edgeType == RangeEdgeType.INCLUSIVE) "[" else "("}${start.value}, ${end.value}${if(end.edgeType == RangeEdgeType.INCLUSIVE) "]" else ")"}"
+      return "${if (start.edgeType == RangeEdgeType.INCLUSIVE) "[" else "("}${start.value}, ${end.value}${if (end.edgeType == RangeEdgeType.INCLUSIVE) "]" else ")"}"
    }
 
    fun isEmpty() = start.value == end.value && (
-         start.edgeType == RangeEdgeType.EXCLUSIVE ||
+      start.edgeType == RangeEdgeType.EXCLUSIVE ||
          end.edgeType == RangeEdgeType.EXCLUSIVE
       )
 
@@ -25,8 +25,8 @@ internal data class Range<T: Comparable<T>>(
       val endOfThis: T = this.end.value
       val startOfOther: T = other.start.value
       return when {
-         (this.end.edgeType== RangeEdgeType.INCLUSIVE && other.start.edgeType == RangeEdgeType.INCLUSIVE) -> (endOfThis < startOfOther)
-         else -> (endOfThis <= startOfOther)
+         (this.end.edgeType == RangeEdgeType.INCLUSIVE && other.start.edgeType == RangeEdgeType.INCLUSIVE) -> (endOfThis < startOfOther)
+         else                                                                                              -> (endOfThis <= startOfOther)
       }
    }
 
@@ -35,64 +35,66 @@ internal data class Range<T: Comparable<T>>(
    fun contains(other: Range<T>) = contains(other.start) && contains(other.end)
 
    fun contains(edge: RangeEdge<T>) = when {
-      edge.value < this.start.value -> false
-      edge.value == this.start.value ->
+      edge.value < this.start.value                                -> false
+      edge.value == this.start.value                               ->
          this.start.edgeType == RangeEdgeType.INCLUSIVE || edge.edgeType == RangeEdgeType.EXCLUSIVE
+
       this.start.value < edge.value && edge.value < this.end.value -> true
-      edge.value == this.end.value ->
+      edge.value == this.end.value                                 ->
          this.end.edgeType == RangeEdgeType.INCLUSIVE || edge.edgeType == RangeEdgeType.EXCLUSIVE
-      else -> false
+
+      else                                                         -> false
    }
 
    companion object
 }
 
 @PublishedApi
-internal fun<T: Comparable<T>> Range.Companion.ofClosedRange(range: ClosedRange<T>) = Range(
+internal fun <T : Comparable<T>> Range.Companion.ofClosedRange(range: ClosedRange<T>) = Range(
    start = RangeEdge(range.start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(range.endInclusive, RangeEdgeType.INCLUSIVE)
 )
 
 @PublishedApi
-internal fun<T: Comparable<T>> Range.Companion.ofOpenEndRange(range: OpenEndRange<T>) = Range(
+internal fun <T : Comparable<T>> Range.Companion.ofOpenEndRange(range: OpenEndRange<T>) = Range(
    start = RangeEdge(range.start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(range.endExclusive, RangeEdgeType.EXCLUSIVE)
 )
 
 @PublishedApi
-internal fun<T: Comparable<T>> Range.Companion.openOpen(start: T, end: T) = Range(
+internal fun <T : Comparable<T>> Range.Companion.openOpen(start: T, end: T) = Range(
    start = RangeEdge(start, RangeEdgeType.EXCLUSIVE),
    end = RangeEdge(end, RangeEdgeType.EXCLUSIVE)
 )
 
 @PublishedApi
-internal fun<T: Comparable<T>> Range.Companion.openClosed(start: T, end: T) = Range(
+internal fun <T : Comparable<T>> Range.Companion.openClosed(start: T, end: T) = Range(
    start = RangeEdge(start, RangeEdgeType.EXCLUSIVE),
    end = RangeEdge(end, RangeEdgeType.INCLUSIVE)
 )
 
 @PublishedApi
-internal fun<T: Comparable<T>> Range.Companion.closedOpen(start: T, end: T) = Range(
+internal fun <T : Comparable<T>> Range.Companion.closedOpen(start: T, end: T) = Range(
    start = RangeEdge(start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(end, RangeEdgeType.EXCLUSIVE)
 )
 
 @PublishedApi
-internal fun<T: Comparable<T>> Range.Companion.closedClosed(start: T, end: T) = Range(
+internal fun <T : Comparable<T>> Range.Companion.closedClosed(start: T, end: T) = Range(
    start = RangeEdge(start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(end, RangeEdgeType.INCLUSIVE)
 )
 
-internal fun<T: Comparable<T>> ClosedRange<T>.toClosedClosedRange(): Range<T> = Range(
+internal fun <T : Comparable<T>> ClosedRange<T>.toClosedClosedRange(): Range<T> = Range(
    start = RangeEdge(this.start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(this.endInclusive, RangeEdgeType.INCLUSIVE)
 )
 
-internal fun<T: Comparable<T>> OpenEndRange<T>.toClosedOpenRange(): Range<T> = Range(
+internal fun <T : Comparable<T>> OpenEndRange<T>.toClosedOpenRange(): Range<T> = Range(
    start = RangeEdge(this.start, RangeEdgeType.INCLUSIVE),
    end = RangeEdge(this.endExclusive, RangeEdgeType.EXCLUSIVE)
 )
 
 internal enum class RangeEdgeType { INCLUSIVE, EXCLUSIVE }
 
-internal data class RangeEdge<T: Comparable<T>>(val value: T, val edgeType: RangeEdgeType)
+internal data class RangeEdge<T : Comparable<T>>(val value: T, val edgeType: RangeEdgeType)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bein.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bein.kt
@@ -13,7 +13,7 @@ import io.kotest.matchers.shouldNot
  * therefore even if the exact instance is not in [ClosedRange] but another instance with same value is present, the
  * test will pass.
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldNotBeIn]
  * @see [beIn]
@@ -29,7 +29,7 @@ infix fun <T: Comparable<T>> T.shouldBeIn(range: ClosedRange<T>): T {
  * Assertion to check that this element is not any of [range]. This assertion checks by value, and not by reference,
  * therefore any instance with same value must not be in [range], or this will fail.
  *
- * An empty range will always fail. If you need to check for empty range, use [Iterable.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldNotBeIn]
  * @see [beIn]
@@ -46,7 +46,7 @@ infix fun <T: Comparable<T>> T.shouldNotBeIn(range: ClosedRange<T>): T {
  * therefore even if the exact instance is not in [range] but another instance with same value is present, the
  * test will pass.
  *
- * An empty range will always fail. If you need to check for empty range, use [Iterable.shouldBeEmpty]
+ * An empty range will always fail.
  *
  */
 fun <T: Comparable<T>> beIn(range: ClosedRange<T>) = object : Matcher<T> {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bewithin.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bewithin.kt
@@ -12,12 +12,12 @@ import io.kotest.matchers.shouldNot
  * For instance, there are two `Int` numbers in range [2, 3], and both are in range [1, 3],
  * so the range [2, 3] is within range [1, 3].
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldBeWithin]
  * @see [beWithin]
  */
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldBeWithin(range: ClosedRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldBeWithin(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should beWithin(Range.ofClosedRange(range))
    return this
 }
@@ -28,18 +28,24 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldBeWithin(range: ClosedRange<T>
  * For instance, there are two `Int` numbers in [OpenEndRange] [1, 3), and both are in [ClosedRange] [1, 3],
  * so the range [1, 3) is within range [1, 2].
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
- * @see [shouldbeWithin]
+ * @see [shouldBeWithin]
  * @see [beWithin]
  */
-@OptIn(ExperimentalStdlibApi::class)
-@Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")
-inline infix fun <reified T: Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: ClosedRange<T>): OpenEndRange<T> {
-   when(T::class) {
-      Int::class -> shouldBeWithinRangeOfInt(this as OpenEndRange<Int>, range as ClosedRange<Int>)
-      Long::class -> shouldBeWithinRangeOfLong(this as OpenEndRange<Long>, range as ClosedRange<Long>)
-      else -> Range.ofOpenEndRange(this) should beWithin(Range.ofClosedRange(range))
+inline infix fun <reified T : Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: ClosedRange<T>): OpenEndRange<T> {
+   when (T::class) {
+      Int::class  -> shouldBeWithinRangeOfInt(
+         @Suppress("UNCHECKED_CAST") (this as OpenEndRange<Int>),
+         @Suppress("UNCHECKED_CAST") (range as ClosedRange<Int>),
+      )
+
+      Long::class -> shouldBeWithinRangeOfLong(
+         @Suppress("UNCHECKED_CAST") (this as OpenEndRange<Long>),
+         @Suppress("UNCHECKED_CAST") (range as ClosedRange<Long>),
+      )
+
+      else        -> Range.ofOpenEndRange(this) should beWithin(Range.ofClosedRange(range))
    }
    return this
 }
@@ -50,11 +56,10 @@ inline infix fun <reified T: Comparable<T>> OpenEndRange<T>.shouldBeWithin(range
  * For instance, there are two `Int` numbers in [ClosedRange] [1, 2], and both are in [OpenEndRange] [1, 3),
  * so the range [1, 2] is within range [1, 3).
  *
- * @see [shouldbeWithin]
+ * @see [shouldBeWithin]
  * @see [beWithin]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldBeWithin(range: OpenEndRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldBeWithin(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should beWithin(Range.ofOpenEndRange(range))
    return this
 }
@@ -65,11 +70,10 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldBeWithin(range: OpenEndRange<T
  * For instance, there are two `Int` numbers in [OpenEndRange] [1, 3), and both are in [OpenEndRange] [0, 3),
  * so the range [1, 3) is within range [0, 3).
  *
- * @see [shouldbeWithin]
+ * @see [shouldBeWithin]
  * @see [beWithin]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: OpenEndRange<T>): OpenEndRange<T> {
+infix fun <T : Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) should beWithin(Range.ofOpenEndRange(range))
    return this
 }
@@ -80,12 +84,12 @@ infix fun <T: Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: OpenEndRange<
  * For instance, there are two `Int` numbers in [ClosedRange] [2, 3], and both are in [ClosedRange] [0, 3],
  * so the range [2, 3] is within range [0, 3].
  *
- * An empty range will always fail. If you need to check for empty range, use [Iterable.shouldBeEmpty]
+ * An empty range will always fail.
  *
- * @see [shouldNotbeWithin]
+ * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: ClosedRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot beWithin(Range.ofClosedRange(range))
    return this
 }
@@ -96,11 +100,10 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: ClosedRange
  * For instance, there are two `Int` numbers in [ClosedRange] [2, 3], and 3 is not in [OpenEndRange] [2, 3),
  * so the range [2, 3] is not within range [2, 3).
  *
- * @see [shouldNotbeWithin]
+ * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: OpenEndRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot beWithin(Range.ofOpenEndRange(range))
    return this
 }
@@ -111,18 +114,25 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: OpenEndRang
  * For instance, there are two `Int` numbers in [OpenEndRange] [1, 3), and 2 is not in [ClosedRange] [0, 1],
  * so the range [1, 3) is not within range [0, 1].
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
- * @see [shouldNotbeWithin]
+ * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
-@OptIn(ExperimentalStdlibApi::class)
-@Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")
-inline infix fun <reified T: Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(range: ClosedRange<T>): OpenEndRange<T> {
-   when(T::class) {
-      Int::class -> shouldNotBeWithinRangeOfInt(this as OpenEndRange<Int>, range as ClosedRange<Int>)
-      Long::class -> shouldNotBeWithinRangeOfLong(this as OpenEndRange<Long>, range as ClosedRange<Long>)
-      else -> Range.ofOpenEndRange(this) shouldNot beWithin(Range.ofClosedRange(range))
+inline infix fun <reified T : Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(range: ClosedRange<T>): OpenEndRange<T> {
+
+   when (T::class) {
+      Int::class  -> shouldNotBeWithinRangeOfInt(
+         @Suppress("UNCHECKED_CAST") (this as OpenEndRange<Int>),
+         @Suppress("UNCHECKED_CAST") (range as ClosedRange<Int>),
+      )
+
+      Long::class -> shouldNotBeWithinRangeOfLong(
+         @Suppress("UNCHECKED_CAST") (this as OpenEndRange<Long>),
+         @Suppress("UNCHECKED_CAST") (range as ClosedRange<Long>),
+      )
+
+      else        -> Range.ofOpenEndRange(this) shouldNot beWithin(Range.ofClosedRange(range))
    }
    return this
 }
@@ -133,16 +143,16 @@ inline infix fun <reified T: Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(ra
  * For instance, there are two `Int` numbers in [OpenEndRange] [1, 3), and 2 is not in [OpenEndRange] [0, 2),
  * so the range [1, 3) is not within range [0, 2).
  *
- * @see [shouldNotbeWithin]
+ * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(range: OpenEndRange<T>): OpenEndRange<T> {
+infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) shouldNot beWithin(Range.ofOpenEndRange(range))
    return this
 }
 
-internal fun <T: Comparable<T>> beWithin(range: Range<T>) = object : Matcher<Range<T>> {
+@PublishedApi
+internal fun <T : Comparable<T>> beWithin(range: Range<T>) = object : Matcher<Range<T>> {
    override fun test(value: Range<T>): MatcherResult {
       if (range.isEmpty()) throw AssertionError("Asserting content on empty range. Use Iterable.shouldBeEmpty() instead.")
 
@@ -156,21 +166,23 @@ internal fun <T: Comparable<T>> beWithin(range: Range<T>) = object : Matcher<Ran
    }
 }
 
-@OptIn(ExperimentalStdlibApi::class)
-internal fun shouldBeWithinRangeOfInt(value: OpenEndRange<Int>,
+@PublishedApi
+internal fun shouldBeWithinRangeOfInt(
+   value: OpenEndRange<Int>,
    range: ClosedRange<Int>
-){
+) {
    value should beWithinRangeOfInt(range)
 }
 
-@OptIn(ExperimentalStdlibApi::class)
-internal fun shouldNotBeWithinRangeOfInt(value: OpenEndRange<Int>,
-                                      range: ClosedRange<Int>
-){
+@PublishedApi
+internal fun shouldNotBeWithinRangeOfInt(
+   value: OpenEndRange<Int>,
+   range: ClosedRange<Int>
+) {
    value shouldNot beWithinRangeOfInt(range)
 }
 
-@OptIn(ExperimentalStdlibApi::class)
+@PublishedApi
 internal fun beWithinRangeOfInt(
    range: ClosedRange<Int>
 ) = object : Matcher<OpenEndRange<Int>> {
@@ -179,21 +191,23 @@ internal fun beWithinRangeOfInt(
    }
 }
 
-@OptIn(ExperimentalStdlibApi::class)
-internal fun shouldBeWithinRangeOfLong(value: OpenEndRange<Long>,
-                             range: ClosedRange<Long>
-){
+@PublishedApi
+internal fun shouldBeWithinRangeOfLong(
+   value: OpenEndRange<Long>,
+   range: ClosedRange<Long>
+) {
    value should beWithinRangeOfLong(range)
 }
 
-@OptIn(ExperimentalStdlibApi::class)
-internal fun shouldNotBeWithinRangeOfLong(value: OpenEndRange<Long>,
-                                       range: ClosedRange<Long>
-){
+@PublishedApi
+internal fun shouldNotBeWithinRangeOfLong(
+   value: OpenEndRange<Long>,
+   range: ClosedRange<Long>
+) {
    value shouldNot beWithinRangeOfLong(range)
 }
 
-@OptIn(ExperimentalStdlibApi::class)
+@PublishedApi
 internal fun beWithinRangeOfLong(
    range: ClosedRange<Long>
 ) = object : Matcher<OpenEndRange<Long>> {
@@ -202,8 +216,12 @@ internal fun beWithinRangeOfLong(
    }
 }
 
-@OptIn(ExperimentalStdlibApi::class)
-internal fun<T: Comparable<T>> resultForWithin(range: ClosedRange<T>, value: OpenEndRange<T>, valueAfterRangeEnd: T): MatcherResult {
+@PublishedApi
+internal fun <T : Comparable<T>> resultForWithin(
+   range: ClosedRange<T>,
+   value: OpenEndRange<T>,
+   valueAfterRangeEnd: T
+): MatcherResult {
    if (range.isEmpty()) throw AssertionError("Asserting content on empty range. Use Iterable.shouldBeEmpty() instead.")
    val match = (range.start <= value.start) && (value.endExclusive <= valueAfterRangeEnd)
    val valueStr = "[${value.start}, ${value.endExclusive})"

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/intersect.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/intersect.kt
@@ -11,12 +11,12 @@ import io.kotest.matchers.shouldNot
  *
  * Assertion to check that this [ClosedRange] intersects with another [ClosedRange].
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldIntersect]
  * @see [intersect]
  */
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldIntersect(range: ClosedRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldIntersect(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should intersect(Range.ofClosedRange(range))
    return this
 }
@@ -26,13 +26,12 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldIntersect(range: ClosedRange<T
  *
  * Assertion to check that this [OpenEndRange] intersects with a [ClosedRange].
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldIntersect]
  * @see [intersect]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> OpenEndRange<T>.shouldIntersect(range: ClosedRange<T>): OpenEndRange<T> {
+infix fun <T : Comparable<T>> OpenEndRange<T>.shouldIntersect(range: ClosedRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) should intersect(Range.ofClosedRange(range))
    return this
 }
@@ -45,8 +44,7 @@ infix fun <T: Comparable<T>> OpenEndRange<T>.shouldIntersect(range: ClosedRange<
  * @see [shouldIntersect]
  * @see [intersect]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldIntersect(range: OpenEndRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldIntersect(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should intersect(Range.ofOpenEndRange(range))
    return this
 }
@@ -59,8 +57,7 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldIntersect(range: OpenEndRange<
  * @see [shouldIntersect]
  * @see [intersect]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> OpenEndRange<T>.shouldIntersect(range: OpenEndRange<T>): OpenEndRange<T> {
+infix fun <T : Comparable<T>> OpenEndRange<T>.shouldIntersect(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) should intersect(Range.ofOpenEndRange(range))
    return this
 }
@@ -70,12 +67,12 @@ infix fun <T: Comparable<T>> OpenEndRange<T>.shouldIntersect(range: OpenEndRange
  *
  * Assertion to check that this [ClosedRange] does not intersect with another [ClosedRange].
  *
- * An empty range will always fail. If you need to check for empty range, use [Iterable.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: ClosedRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot intersect(Range.ofClosedRange(range))
    return this
 }
@@ -88,8 +85,7 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: ClosedRang
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: OpenEndRange<T>): ClosedRange<T> {
+infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot intersect(Range.ofOpenEndRange(range))
    return this
 }
@@ -99,13 +95,12 @@ infix fun <T: Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: OpenEndRan
  *
  * Assertion to check that this [OpenEndRange] does not intersect with a [ClosedRange].
  *
- * An empty range will always fail. If you need to check for empty range, use [ClosedRange.shouldBeEmpty]
+ * An empty range will always fail.
  *
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: ClosedRange<T>): OpenEndRange<T> {
+infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: ClosedRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) shouldNot intersect(Range.ofClosedRange(range))
    return this
 }
@@ -118,8 +113,7 @@ infix fun <T: Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: ClosedRan
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
-@OptIn(ExperimentalStdlibApi::class)
-infix fun <T: Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: OpenEndRange<T>): OpenEndRange<T> {
+infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) shouldNot intersect(Range.ofOpenEndRange(range))
    return this
 }
@@ -129,10 +123,9 @@ infix fun <T: Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: OpenEndRa
  *
  * Assertion to check that this [range] intersects with another [range].
  *
- * An empty range will always fail. If you need to check for empty range, use [Iterable.shouldBeEmpty]
- *
+ * An empty range will always fail.
  */
-internal fun <T: Comparable<T>> intersect(range: Range<T>) = object : Matcher<Range<T>> {
+internal fun <T : Comparable<T>> intersect(range: Range<T>) = object : Matcher<Range<T>> {
    override fun test(value: Range<T>): MatcherResult {
       if (range.isEmpty()) throw AssertionError("Asserting content on empty range. Use Iterable.shouldBeEmpty() instead.")
 
@@ -145,4 +138,3 @@ internal fun <T: Comparable<T>> intersect(range: Range<T>) = object : Matcher<Ra
       )
    }
 }
-

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedBeWithinClosedTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedBeWithinClosedTest.kt
@@ -2,11 +2,13 @@ package com.sksamuel.kotest.matchers.ranges
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.ranges.Range
+import io.kotest.matchers.ranges.closedClosed
+import io.kotest.matchers.ranges.openClosed
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.forAll
 
-class ClosedBeWithinClosedTest: WordSpec() {
+class ClosedBeWithinClosedTest : WordSpec() {
    init {
       "should" should {
          "work" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectClosedTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectClosedTest.kt
@@ -6,20 +6,18 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.ranges.shouldIntersect
 import io.kotest.matchers.ranges.shouldNotIntersect
 import io.kotest.matchers.shouldBe
-import io.kotest.property.Arb
-import io.kotest.property.arbitrary.int
-import io.kotest.property.forAll
 
-class ClosedIntersectClosedTest: WordSpec() {
+class ClosedIntersectClosedTest : WordSpec() {
    private val oneThree: ClosedRange<Int> = (1..3)
    private val threeFive: ClosedRange<Int> = (3..5)
    private val fourSix: ClosedRange<Int> = (4..6)
+
    init {
       "should" should {
          "fail" {
-             shouldThrowAny {
-                oneThree shouldIntersect fourSix
-             }.message shouldBe "Range [1, 3] should intersect [4, 6], but doesn't"
+            shouldThrowAny {
+               oneThree shouldIntersect fourSix
+            }.message shouldBe "Range [1, 3] should intersect [4, 6], but doesn't"
          }
 
          "pass" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectOpenEndTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectOpenEndTest.kt
@@ -7,19 +7,19 @@ import io.kotest.matchers.ranges.shouldIntersect
 import io.kotest.matchers.ranges.shouldNotIntersect
 import io.kotest.matchers.shouldBe
 
-@OptIn(ExperimentalStdlibApi::class)
-class ClosedIntersectOpenEndTest: WordSpec() {
+class ClosedIntersectOpenEndTest : WordSpec() {
    private val oneThree: ClosedRange<Double> = (1.0..3.0)
-   private val twoFour: ClosedRange<Double> = (2.0 .. 4.0)
+   private val twoFour: ClosedRange<Double> = (2.0..4.0)
    private val fourSix: ClosedRange<Double> = (4.0..6.0)
+
    init {
       "should" should {
          "fail" {
-             shouldThrowAny {
-                val openEndRange = oneThree.toOpenEndRange()
-                println(openEndRange)
-                openEndRange shouldIntersect fourSix
-             }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0], but doesn't"
+            shouldThrowAny {
+               val openEndRange = oneThree.toOpenEndRange()
+               println(openEndRange)
+               openEndRange shouldIntersect fourSix
+            }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0], but doesn't"
          }
 
          "pass" {
@@ -46,4 +46,3 @@ class ClosedIntersectOpenEndTest: WordSpec() {
 
    private fun ClosedRange<Double>.toOpenEndRange() = this.start.rangeUntil(this.endInclusive)
 }
-

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/OpenEndIntersectOpenEndTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/OpenEndIntersectOpenEndTest.kt
@@ -7,20 +7,20 @@ import io.kotest.matchers.ranges.shouldIntersect
 import io.kotest.matchers.ranges.shouldNotIntersect
 import io.kotest.matchers.shouldBe
 
-@OptIn(ExperimentalStdlibApi::class)
-class OpenEndIntersectOpenEndTest: WordSpec() {
+class OpenEndIntersectOpenEndTest : WordSpec() {
    private val oneThree: OpenEndRange<Double> = 1.0.rangeUntil(3.0)
    private val twoFour: OpenEndRange<Double> = 2.0.rangeUntil(4.0)
    private val threeFour: OpenEndRange<Double> = 3.0.rangeUntil(4.0)
    private val fourSix: OpenEndRange<Double> = 4.0.rangeUntil(6.0)
+
    init {
       "should" should {
          "fail" {
-             shouldThrowAny {
-                val openEndRange = oneThree
-                println(openEndRange)
-                openEndRange shouldIntersect fourSix
-             }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0), but doesn't"
+            shouldThrowAny {
+               val openEndRange = oneThree
+               println(openEndRange)
+               openEndRange shouldIntersect fourSix
+            }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0), but doesn't"
          }
 
          "pass" {
@@ -45,4 +45,3 @@ class OpenEndIntersectOpenEndTest: WordSpec() {
       }
    }
 }
-

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/RangeTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/RangeTest.kt
@@ -11,6 +11,12 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.ranges.Range
 import io.kotest.matchers.ranges.RangeEdge
 import io.kotest.matchers.ranges.RangeEdgeType
+import io.kotest.matchers.ranges.closedClosed
+import io.kotest.matchers.ranges.closedOpen
+import io.kotest.matchers.ranges.ofClosedRange
+import io.kotest.matchers.ranges.ofOpenEndRange
+import io.kotest.matchers.ranges.openClosed
+import io.kotest.matchers.ranges.openOpen
 import io.kotest.matchers.ranges.toClosedClosedRange
 import io.kotest.matchers.ranges.toClosedOpenRange
 import io.kotest.matchers.shouldBe
@@ -18,8 +24,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.int
 import io.kotest.property.forAll
 
-@OptIn(ExperimentalStdlibApi::class)
-class RangeTest: WordSpec() {
+class RangeTest : WordSpec() {
    private val openOpenRange = Range.openOpen(1, 2)
    private val openClosedRange = Range.openClosed(2, 3)
    private val closedOpenRange = Range.closedOpen(3, 4)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ShouldBeWithinTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ShouldBeWithinTest.kt
@@ -7,7 +7,6 @@ import io.kotest.matchers.ranges.shouldBeWithin
 import io.kotest.matchers.ranges.shouldNotBeWithin
 import io.kotest.matchers.shouldBe
 
-@OptIn(ExperimentalStdlibApi::class)
 class ShouldBeWithinTest : WordSpec() {
    private val smallClosedRange: ClosedRange<Int> = 1..3
    private val smallOpenEndRange: OpenEndRange<Int> = 1 until 3
@@ -17,18 +16,18 @@ class ShouldBeWithinTest : WordSpec() {
    init {
       "shouldBeWithin" should {
          "fail" {
-               shouldThrowAny {
-                  bigClosedRange shouldBeWithin smallClosedRange
-               }.message shouldBe "Range [0, 4] should be within [1, 3], but it isn't"
-               shouldThrowAny {
-                  bigClosedRange shouldBeWithin smallOpenEndRange
-               }.message shouldBe "Range [0, 4] should be within [1, 3), but it isn't"
-               shouldThrowAny {
-                  bigOpenEndRange shouldBeWithin smallClosedRange
-               }.message shouldBe "Range [0, 4) should be within [1, 3], but it isn't"
-               shouldThrowAny {
-                  bigOpenEndRange shouldBeWithin smallOpenEndRange
-               }.message shouldBe "Range [0, 4) should be within [1, 3), but it isn't"
+            shouldThrowAny {
+               bigClosedRange shouldBeWithin smallClosedRange
+            }.message shouldBe "Range [0, 4] should be within [1, 3], but it isn't"
+            shouldThrowAny {
+               bigClosedRange shouldBeWithin smallOpenEndRange
+            }.message shouldBe "Range [0, 4] should be within [1, 3), but it isn't"
+            shouldThrowAny {
+               bigOpenEndRange shouldBeWithin smallClosedRange
+            }.message shouldBe "Range [0, 4) should be within [1, 3], but it isn't"
+            shouldThrowAny {
+               bigOpenEndRange shouldBeWithin smallOpenEndRange
+            }.message shouldBe "Range [0, 4) should be within [1, 3), but it isn't"
          }
 
          "succeed" {
@@ -51,7 +50,7 @@ class ShouldBeWithinTest : WordSpec() {
             val openEndRange: OpenEndRange<Long> = 1L until 3L
             openEndRange shouldBeWithin closedRange
          }
-       }
+      }
 
       "shouldNotBeWithin" should {
          "fail" {


### PR DESCRIPTION
- Remove `@OptIn(ExperimentalStdlibApi::class)` now that Ranges are stable
- `@Suppress("UNCHECKED_CAST")` when casting ranges
- Use [`@PublishedApi`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-published-api/) instead of `@Suppress("NON_PUBLIC_CALL_FROM_PUBLIC_INLINE")`.
- Update ABI dumps, because `@PublishedApi` are technically part of the public ABI.
- Update kdoc to fix typos.
- Remove `If you need to check for empty range, use [ClosedRange.shouldBeEmpty]` from kdoc - no such function exists.
