### PR TITLE
remove `@OptIn(ExperimentalStdlibApi::class)` from `startWith()`

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
@@ -41,13 +41,11 @@ infix fun <A : CharSequence?> A.shouldStartWith(regex: Regex): A {
    return this
 }
 
-@OptIn(ExperimentalStdlibApi::class)
 fun startWith(regex: Regex): Matcher<CharSequence?> = neverNullMatcher { value ->
    val ok = regex.matchesAt(value, 0)
    MatcherResult(
       ok,
       { "${value.print().value} should start with regex ${regex.pattern}" },
-      {
-         "${value.print().value} should not start with regex ${regex.pattern}"
-      })
+      { "${value.print().value} should not start with regex ${regex.pattern}" }
+   )
 }


### PR DESCRIPTION
`@OptIn(ExperimentalStdlibApi::class)` is no longer necessary.
