### PR TITLE
update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -41,7 +41,7 @@ jobs:
 
          -  name: Upload the build report
             if: failure()
-            uses: actions/upload-artifact@v3
+            uses: actions/upload-artifact@v4
             with:
                name: error-report
                path: build-reports.zip


### PR DESCRIPTION
It's deprecated https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
