### PR TITLE
Suppressing usage of deprecated Kotest functionality

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -412,7 +412,7 @@ infix fun <T> Sequence<T>.shouldHaveAtMostSize(n: Int) = this shouldHave atMostC
 
 
 @Deprecated(
-   "Use `forAny` inspection instead",
+   "Use `forAny` inspection instead. Will be removed in 6.0",
    ReplaceWith(
       "forAny { p() shouldBe true }",
       "io.kotest.matchers.shouldBe",

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -41,7 +41,6 @@ import io.kotest.matchers.sequences.shouldNotContainNull
 import io.kotest.matchers.sequences.shouldNotContainOnlyNulls
 import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.throwable.shouldHaveMessage
 
@@ -489,6 +488,7 @@ class SequenceMatchersTest : WordSpec() {
          }
       }
 
+      @Suppress("DEPRECATION") // Remove when removing shouldExist
       "exist" should {
          fail("for empty") {
             sampleData.empty.shouldExist { true }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when removing shouldExist
+
 package com.sksamuel.kotest.matchers.collections
 
 import io.kotest.assertions.throwables.shouldThrow

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -108,19 +108,23 @@ fun beJsonType(kClass: KClass<*>) = object : Matcher<String?> {
  * regardless of order.
  *
  */
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldEqualJson(expected: String, mode: CompareMode, order: CompareOrder) =
    this.shouldEqualJson(expected, legacyOptions(mode, order))
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldEqualJson(expected: String, options: CompareJsonOptions) {
    this should equalJson(expected, options)
 }
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldNotEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldNotEqualJson(expected: String, mode: CompareMode, order: CompareOrder) =
    this.shouldNotEqualJson(expected, legacyOptions(mode, order))
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldNotEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldNotEqualJson(expected: String, options: CompareJsonOptions) {
    this shouldNot equalJson(expected, options)

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
@@ -53,6 +53,7 @@ enum class CompareOrder {
 /**
  * helper method for bridging old compare options into new
  */
+@Suppress("DEPRECATION") // Remove when removing legacy options
 internal fun legacyOptions(mode: CompareMode, order: CompareOrder) =
    compareJsonOptions {
       typeCoercion = when (mode) {

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -93,18 +93,22 @@ infix fun String.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOpti
    return this
 }
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldEqualJson(expected: String, mode: CompareMode) =
    shouldEqualJson(expected, legacyOptions(mode, CompareOrder.Strict))
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldNotEqualJson(expected: String, mode: CompareMode) =
    shouldNotEqualJson(expected, legacyOptions(mode, CompareOrder.Strict))
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldEqualJson(expected: String, order: CompareOrder) =
    shouldEqualJson(expected, legacyOptions(CompareMode.Strict, order))
 
+@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldNotEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldNotEqualJson(expected: String, order: CompareOrder) =
    shouldNotEqualJson(expected, legacyOptions(CompareMode.Strict, order))

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
+
 package com.sksamuel.kotest.tests.json
 
 import io.kotest.assertions.json.CompareMode

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
+
 
 package com.sksamuel.kotest.tests.json
 
@@ -276,7 +276,7 @@ expected:<{
             }
          }
 
-
+         @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
          test("Using old CompareMode flags") {
             a.shouldEqualJson(b, CompareMode.Lenient)
             c.shouldEqualJson(d, CompareMode.Lenient)
@@ -286,21 +286,26 @@ expected:<{
       test("comparing long to string with lenient mode") {
          val a = """ { "a" : "foo", "b" : 123 } """
          val b = """ { "a" : "foo", "b" : "123" } """
+         @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
          a.shouldEqualJson(b, CompareMode.Lenient)
       }
 
+      @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
       test("comparing double to string with lenient mode") {
          val a = """ { "a" : "foo", "b" : 12.45 } """
          val b = """ { "a" : "foo", "b" : "12.45" } """
+         @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
          a.shouldEqualJson(b, CompareMode.Lenient)
       }
 
       test("comparing string to long with lenient mode") {
          val a = """ { "a" : "foo", "b" : "12" } """
          val b = """ { "a" : "foo", "b" : 12 } """
+         @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
          a.shouldEqualJson(b, CompareMode.Lenient)
       }
 
+      @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
       test("comparing string to boolean with lenient mode") {
          val a = """ { "a" : "foo", "b" : "true" } """
          val b = """ { "a" : "foo", "b" : true } """
@@ -314,6 +319,7 @@ expected:<{
       test("comparing string to double with lenient mode") {
          val a = """ { "a" : "foo", "b" : "12.45" } """
          val b = """ { "a" : "foo", "b" : 12.45 } """
+         @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
          a.shouldEqualJson(b, CompareMode.Lenient)
       }
 
@@ -774,6 +780,7 @@ expected:<{
             """
          a.shouldEqualJson(b)
          shouldFail {
+            @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
             a.shouldEqualJson(b, CompareOrder.Strict)
          }.shouldHaveMessage(
             """The top level object expected field 0 to be 'sku' but was 'id'

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -1,4 +1,4 @@
-
+@file:Suppress("DEPRECATION") // Remove when removing legacy shouldEqualJson options
 
 package com.sksamuel.kotest.tests.json
 

--- a/kotest-common/src/jvmTest/kotlin/io/kotest/mpp/StableTest.kt
+++ b/kotest-common/src/jvmTest/kotlin/io/kotest/mpp/StableTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when making isStable internal
+
 package io.kotest.mpp
 
 import io.kotest.core.spec.style.FreeSpec

--- a/kotest-extensions/kotest-extensions-http/src/jvmMain/kotlin/io/kotest/extensions/http/test.kt
+++ b/kotest-extensions/kotest-extensions-http/src/jvmMain/kotlin/io/kotest/extensions/http/test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when removing http extension
+
 package io.kotest.extensions.http
 
 import io.ktor.client.statement.HttpResponse

--- a/kotest-extensions/kotest-extensions-http/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/http/HttpRequestTest.kt
+++ b/kotest-extensions/kotest-extensions-http/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/http/HttpRequestTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when removing http extension
+
 package com.sksamuel.kotest.extensions.http
 
 import io.kotest.core.spec.style.FunSpec

--- a/kotest-extensions/kotest-extensions-http/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/http/LongHttpRequestTest.kt
+++ b/kotest-extensions/kotest-extensions-http/src/jvmTest/kotlin/com/sksamuel/kotest/extensions/http/LongHttpRequestTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when removing http extension
+
 package com.sksamuel.kotest.extensions.http
 
 import io.kotest.assertions.throwables.shouldThrow

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -56,6 +56,7 @@ abstract class TestConfiguration {
     *
     * Any test case config set a test itself will override any value here.
     */
+   @Suppress("DEPRECATION") // Remove when removing legacy option
    @Deprecated("These settings should be specified individually to provide finer grain control. Deprecated since 5.0")
    var defaultTestConfig: TestCaseConfig? = null
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -44,12 +44,14 @@ abstract class AbstractProjectConfig {
    /**
     * List of project wide [Listener] instances.
     */
+   @Suppress("DEPRECATION") // Remove when removing function
    @Deprecated("Use extensions. This will be removed in 6.0")
    open fun listeners(): List<Listener> = emptyList()
 
    /**
     * List of project wide [Filter] instances.
     */
+   @Suppress("DEPRECATION") // Remove when removing function
    @Deprecated("Use extensions. This will be removed in 6.0")
    open fun filters(): List<Filter> = emptyList()
 
@@ -202,6 +204,7 @@ abstract class AbstractProjectConfig {
     * Any [TestCaseConfig] set here is used as the default for tests, unless overridden in a spec,
     * or in a test itself. In other words the order is test -> spec -> project config default -> kotest default
     */
+   @Suppress("DEPRECATION") // Remove when removing legacy option
    @Deprecated("use the individual settings instead of the test case config class. Deprecated since 5.8.1")
    open val defaultTestCaseConfig: TestCaseConfig? = null
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
@@ -15,6 +15,7 @@ object Defaults {
    const val disableTestNestedJarScanning: Boolean = true
 
    val assertionMode: AssertionMode = AssertionMode.None
+   @Suppress("DEPRECATION") // Remove when removing legacy option
    val testCaseConfig: TestCaseConfig = TestCaseConfig()
    val testCaseOrder: TestCaseOrder = TestCaseOrder.Sequential
    val isolationMode: IsolationMode = IsolationMode.SingleInstance

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -237,6 +237,7 @@ class ProjectConfiguration {
     *
     * Defaults to [Defaults.testCaseConfig]
     */
+   @Suppress("DEPRECATION") // Remove when removing legacy option
    @Deprecated("These settings can be specified individually to provide finer grain control. Deprecated since 5.0")
    var defaultTestConfig: TestCaseConfig = Defaults.testCaseConfig
 
@@ -352,8 +353,10 @@ class ProjectConfiguration {
 
    var allowOutOfOrderCallbacks: Boolean = Defaults.allowOutOfOrderCallbacks
 
+   @Suppress("DEPRECATION") // Remove when removing legacy option
    var threads: Int = defaultTestConfig.threads
 
+   @Suppress("DEPRECATION") // Remove when removing legacy option
    var invocations: Int = defaultTestConfig.invocations
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/TestFilter.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/filter/TestFilter.kt
@@ -8,6 +8,7 @@ import io.kotest.core.test.TestCase
  *
  * A descriptor must be included by all filters for it to be considered enabled at runtime.
  */
+@Suppress("DEPRECATION") // Remove when removing Filter
 interface TestFilter : Filter {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
@@ -2,6 +2,7 @@ package io.kotest.core.listeners
 
 import io.kotest.core.spec.Spec
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface AfterSpecListener : Listener {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/BeforeSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/BeforeSpecListener.kt
@@ -2,6 +2,7 @@ package io.kotest.core.listeners
 
 import io.kotest.core.spec.Spec
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface BeforeSpecListener : Listener {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/FinalizeSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/FinalizeSpecListener.kt
@@ -9,6 +9,7 @@ import kotlin.reflect.KClass
  * Invoked once per spec class if the spec has enabled root tests.
  * This listener is only invoked if the spec had at least one enabled test.
  */
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface FinalizeSpecListener : Listener {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/PrepareSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/PrepareSpecListener.kt
@@ -12,6 +12,7 @@ import kotlin.reflect.KClass
  * is set to create multiple instances, then this listener will not be
  * invoked multiple times.
  */
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface PrepareSpecListener : Listener {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/SpecInstantiationListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/SpecInstantiationListener.kt
@@ -3,6 +3,7 @@ package io.kotest.core.listeners
 import io.kotest.core.spec.Spec
 import kotlin.reflect.KClass
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 @Deprecated("Deprecated in favour of InstantiationListener and InstantiationErrorListener which support suspension. Deprecated since 5.0.")
 interface SpecInstantiationListener : Listener {
    fun specInstantiated(spec: Spec) {}

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
@@ -14,6 +14,7 @@ typealias SpecIgnoredListner = IgnoredSpecListener
  * This interface is a union of the various test related listeners interfaces.
  * Users can choose to extend this interface, or the constituent interfaces separately.
  */
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface TestListener :
    BeforeTestListener,
    AfterTestListener,

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterEach.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterEach.kt
@@ -4,6 +4,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface BeforeEachListener : Listener {
 
    /**
@@ -14,6 +15,7 @@ interface BeforeEachListener : Listener {
    suspend fun beforeEach(testCase: TestCase): Unit = Unit
 }
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface AfterEachListener : Listener {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterTest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterTest.kt
@@ -4,6 +4,7 @@ import io.kotest.common.SoftDeprecated
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 @SoftDeprecated("Use beforeAny")
 interface BeforeTestListener : Listener {
 
@@ -24,6 +25,7 @@ interface BeforeTestListener : Listener {
    suspend fun beforeAny(testCase: TestCase): Unit = Unit
 }
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 @SoftDeprecated("Use afterContainer, afterEach, or afterAny")
 interface AfterTestListener : Listener {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
@@ -2,6 +2,7 @@ package io.kotest.core.listeners
 
 import io.kotest.core.test.TestCase
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface BeforeInvocationListener : Listener {
 
    /**
@@ -18,6 +19,7 @@ interface BeforeInvocationListener : Listener {
    suspend fun beforeInvocation(testCase: TestCase, iteration: Int): Unit = Unit
 }
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface AfterInvocationListener : Listener {
 
    /**

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/project.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/project.kt
@@ -6,6 +6,7 @@ package io.kotest.core.listeners
  */
 interface ProjectListener : BeforeProjectListener, AfterProjectListener
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface BeforeProjectListener : Listener {
    /**
     * Callback which is invoked before the first test of the project.
@@ -13,6 +14,7 @@ interface BeforeProjectListener : Listener {
    suspend fun beforeProject() {}
 }
 
+@Suppress("DEPRECATION") // Remove when removing Listener
 interface AfterProjectListener : Listener {
    /**
     * Callback which is invoked after the last test of the project.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -104,6 +104,7 @@ abstract class Spec : TestConfiguration() {
     *
     * Any test case config set a test itself will override any value here.
     */
+   @Suppress("DEPRECATION") // Remove when removing TestCaseConfig
    @Deprecated("These settings should be specified individually to provide finer grain control. Deprecated since 5.0")
    open fun defaultTestCaseConfig(): TestCaseConfig? = null
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecTerminalScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecTerminalScope.kt
@@ -12,6 +12,7 @@ class FreeSpecTerminalScope(val testScope: TestScope) : TerminalScope() {
    override val coroutineContext: CoroutineContext = testScope.coroutineContext
 
    // exists to stop nesting
+   @Suppress("UNUSED_PARAMETER", "RedundantSuspendModifier") // function signature must match to stop nesting
    @Deprecated("Cannot nest leaf test inside another leaf test", level = DeprecationLevel.ERROR)
    suspend infix operator fun String.invoke(test: suspend TestScope.() -> Unit) {
    }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/names.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/names.kt
@@ -2,6 +2,7 @@ package io.kotest.core.test
 
 import io.kotest.core.names.TestName
 
+@Suppress("DEPRECATION") // Internal deprecation usage. Remove when deprecated functions are removed.
 @Deprecated("use TestName directly, eg TestName(name). Deprecated in 5.0", ReplaceWith("TestName(name)"))
 fun createTestName(name: String): TestName = createTestName(null, name, false)
 
@@ -16,6 +17,7 @@ fun createTestName(prefix: String?, name: String, defaultIncludeAffix: Boolean):
       defaultIncludeAffix
    )
 
+@Suppress("DEPRECATION") // Internal deprecation usage. Remove when deprecated functions are removed.
 @Deprecated(
    "use TestName directly, eg TestName(prefix, name, includeAffixesInDisplayName). Deprecated in 5.0",
    ReplaceWith("TestName(prefix, name, includeAffixesInDisplayName)")

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
@@ -51,6 +51,7 @@ internal fun applyConfigFromProjectConfig(config: AbstractProjectConfig, configu
    config.displayFullTestPath?.let { configuration.displayFullTestPath = it }
 
    // config
+   @Suppress("DEPRECATION") // Remove when removing TestCaseConfig
    config.defaultTestCaseConfig?.let { configuration.defaultTestConfig = it }
    config.logLevel?.let { configuration.logLevel = it }
    config.tagInheritance?.let { configuration.tagInheritance = it }
@@ -58,6 +59,7 @@ internal fun applyConfigFromProjectConfig(config: AbstractProjectConfig, configu
 
    // coroutines
    config.coroutineDebugProbes?.let { configuration.coroutineDebugProbes = it }
+   @Suppress("DEPRECATION") // Remove when removing testCoroutineDispatcher
    config.testCoroutineDispatcher.let { configuration.testCoroutineDispatcher = it }
    config.coroutineTestScope?.let { configuration.coroutineTestScope = it }
 
@@ -67,15 +69,18 @@ internal fun applyConfigFromProjectConfig(config: AbstractProjectConfig, configu
 
       override suspend fun beforeProject() {
          config.beforeProject()
+         @Suppress("DEPRECATION") // Remove when removing beforeAll
          config.beforeAll()
       }
 
       override suspend fun afterProject() {
          config.afterProject()
+         @Suppress("DEPRECATION") // Remove when removing afterAll
          config.afterAll()
       }
    }
 
+   @Suppress("DEPRECATION") // Remove when removing Listener
    val exts = config.listeners() + listOf(projectListener) + config.extensions() + config.filters()
    exts.forEach { configuration.registry.add(it) }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SpecWrapperExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SpecWrapperExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // Remove when removing Listener
+
 package io.kotest.engine.extensions
 
 import io.kotest.core.extensions.Extension

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExtensions.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExtensions.kt
@@ -86,12 +86,14 @@ internal class SpecExtensions(private val registry: ExtensionRegistry) {
       }
    }
 
+   @Suppress("DEPRECATION")  // remove when removing Listeners
    suspend fun specInstantiated(spec: Spec) = runCatching {
       logger.log { Pair(spec::class.bestName(), "specInstantiated $spec") }
       registry.all().filterIsInstance<SpecInstantiationListener>().forEach { it.specInstantiated(spec) }
       registry.all().filterIsInstance<InstantiationListener>().forEach { it.specInstantiated(spec) }
    }
 
+   @Suppress("DEPRECATION")  // remove when removing Listeners
    suspend fun specInstantiationError(kclass: KClass<out Spec>, t: Throwable) = runCatching {
       logger.log { Pair(kclass.bestName(), "specInstantiationError $t") }
       registry.all().filterIsInstance<SpecInstantiationListener>().forEach { it.specInstantiationError(kclass, t) }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/resolveConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/resolveConfig.kt
@@ -23,6 +23,7 @@ internal fun resolveConfig(
    projectConfiguration: ProjectConfiguration
 ): ResolvedTestConfig {
 
+   @Suppress("DEPRECATION")  // remove when removing TestCaseConfig
    val defaultTestConfig = spec.defaultTestConfig
       ?: spec.defaultTestCaseConfig()
       ?: projectConfiguration.defaultTestConfig
@@ -67,6 +68,7 @@ internal fun resolveConfig(
       defaultTestConfig.extensions +
       defaultTestConfig.listeners
 
+   @Suppress("DEPRECATION") // Remove when removing testCoroutineDispatcher
    return ResolvedTestConfig(
       enabled = enabled,
       threads = threads,

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TestFinishedExecutionInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TestFinishedExecutionInterceptorTest.kt
@@ -32,6 +32,8 @@ class TestFinishedExecutionInterceptorTest : FunSpec({
             finished = true
          }
       }
+      
+      @Suppress("DEPRECATION") // Remove when removing listeners
       TestFinishedInterceptor(listener).intercept(tc, context) { _, _ -> TestResult.success(0) }
       finished shouldBe true
    }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
@@ -29,7 +29,6 @@ import io.kotest.property.arbitrary.take
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.constant
 import io.kotest.property.forAll
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class CollectionsTest : DescribeSpec({


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

@aSemy I accidentally started doing this all in one go. In the end, I don't think it's too big a deal to handle as a single PR. 

Partially addresses #4085 
