### PR TITLE
Make TestCaseSourceRefTest more stable

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/MySpecForTestCaseSourceRefTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/MySpecForTestCaseSourceRefTest.kt
@@ -1,0 +1,18 @@
+package com.sksamuel.kotest.engine.test
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Test case for [TestCaseSourceRefTest], defined in a separate file so that the line numbers are stable.
+ */
+internal class MySpecForTestCaseSourceRefTest : FunSpec() {
+   init {
+      test("my test case") {
+         1 shouldBe 1
+      }
+      test("test case 2") {
+         1 shouldBe 1
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/TestCaseSourceRefTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/TestCaseSourceRefTest.kt
@@ -1,35 +1,31 @@
 package com.sksamuel.kotest.engine.test
 
-import io.kotest.core.source.SourceRef
 import io.kotest.core.config.ProjectConfiguration
+import io.kotest.core.source.SourceRef.ClassSource
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.Materializer
-import io.kotest.matchers.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.comparables.shouldBeLessThan
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
 
 class TestCaseSourceRefTest : FunSpec() {
    init {
       test("source ref should include file name and line number") {
-         val tests = Materializer(ProjectConfiguration()).materialize(MySpec())
-         tests.first().source shouldBe SourceRef.ClassSource("com.sksamuel.kotest.engine.test.MySpec", 28)
-         tests[1].source shouldBe SourceRef.ClassSource("com.sksamuel.kotest.engine.test.MySpec", 31)
+         val tests = Materializer(ProjectConfiguration()).materialize(MySpecForTestCaseSourceRefTest())
+         tests.map { it.source }.shouldContainExactly(
+            ClassSource("com.sksamuel.kotest.engine.test.MySpecForTestCaseSourceRefTest", 11),
+            ClassSource("com.sksamuel.kotest.engine.test.MySpecForTestCaseSourceRefTest", 14),
+         )
       }
 
-      test("source ref should be performant").config(timeout = 30.seconds) {
-         repeat(100000) {
-            Materializer(ProjectConfiguration()).materialize(MySpec()).first().source
+      test("source ref should be performant").config(timeout = 60.seconds) {
+         val duration = measureTime {
+            repeat(100_000) {
+               Materializer(ProjectConfiguration()).materialize(MySpecForTestCaseSourceRefTest()).first().source
+            }
          }
-      }
-   }
-}
-
-private class MySpec : FunSpec() {
-   init {
-      test("my test case") {
-         1 shouldBe 1
-      }
-      test("test case 2") {
-         1 shouldBe 1
+         duration shouldBeLessThan 30.seconds
       }
    }
 }


### PR DESCRIPTION
- Assert the duration and increase timeout (make it easier to see exactly how much slower the test is, rather than just 'test timed out').
- Split out the tested spec into a different file, so the line numbers are stable.
- Misc refactoring

