### PR TITLE
Open up java.base/java.lang to use withEnvironment() with JDK17+

### DIFF
--- a/documentation/docs/extensions/system.md
+++ b/documentation/docs/extensions/system.md
@@ -40,13 +40,14 @@ test("foo") {
 ```
 
 :::info
-To use `withEnvironment` with JDK17+ you need to add `--add-opens=java.base/java.util=ALL-UNNAMED` to the arguments for the JVM that runs the tests.
+To use `withEnvironment` with JDK17+ you need to add `--add-opens=java.base/java.util=ALL-UNNAMED`
+and `--add-opens=java.base/java.lang=ALL-UNNAMED` to the arguments for the JVM that runs the tests.
 
 If you run tests with gradle, you can add the following to your `build.gradle.kts`:
 
 ```kotlin
 tasks.withType<Test>().configureEach {
-    jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+    jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=java.base/java.lang=ALL-UNNAMED")
 }
 ```
 :::

--- a/kotest-extensions/build.gradle.kts
+++ b/kotest-extensions/build.gradle.kts
@@ -27,5 +27,5 @@ kotlin {
 }
 
 tasks.withType<Test>().configureEach {
-   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=java.base/java.lang=ALL-UNNAMED")
 }

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -56,5 +56,5 @@ kotlin {
 }
 
 tasks.withType<Test>().configureEach {
-   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=java.base/java.lang=ALL-UNNAMED")
 }


### PR DESCRIPTION
Fixes #2849