### PR TITLE
Refactor retry, and retry tests

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/RetryTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/RetryTest.kt
@@ -2,23 +2,37 @@ package com.sksamuel.kotest.assertions
 
 import io.kotest.assertions.retry
 import io.kotest.assertions.retryConfig
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.core.test.TestScope
+import io.kotest.core.test.testCoroutineScheduler
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
 import kotlinx.coroutines.delay
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeMark
 
 class RetryTest : StringSpec() {
    init {
+      coroutineTestScope = true
 
       "should allow execution of suspend functions" {
-         retry(5, 500.milliseconds, 100.milliseconds) {
-            dummySuspend()
+         val retryTester = retryTester(4)
+         retry(maxRetry = 5, timeout = 500.milliseconds, delay = 100.milliseconds) {
+            delay(100)
+            retryTester.isReady() shouldBe true
          }
-
-         retry(5, 500.milliseconds, 20.milliseconds, 1, IllegalArgumentException::class) {
-            dummySuspend()
-         }
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            100.milliseconds + (100.milliseconds * 0),
+            100.milliseconds + (100.milliseconds * 2),
+            100.milliseconds + (100.milliseconds * 4),
+            100.milliseconds + (100.milliseconds * 6),
+         )
       }
 
       "should allow config" {
@@ -27,100 +41,185 @@ class RetryTest : StringSpec() {
             timeout = 500.milliseconds
             delay = 100.milliseconds
          }
+         val retryTester = retryTester(4)
          retry(config) {
-            delay(10)
+            delay(100)
+            retryTester.isReady() shouldBe true
          }
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            100.milliseconds + (config.delay * 0),
+            100.milliseconds + (config.delay * 2),
+            100.milliseconds + (config.delay * 4),
+            100.milliseconds + (config.delay * 6),
+         )
       }
 
-      "should call given assertion when until it pass in given number of times" {
-         val testClass = TestClass(4)
-         retry(5, 500.milliseconds, 100.milliseconds) {
-            testClass.isReady() shouldBe true
+      "should run test until it passes in given number of times" {
+         val retryTester = retryTester(4)
+         shouldNotThrow<Exception> {
+            retry(maxRetry = 5, timeout = 500.milliseconds, delay = 100.milliseconds) {
+               retryTester.isReady() shouldBe true
+            }
          }
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            0.milliseconds,
+            100.milliseconds,
+            200.milliseconds,
+            300.milliseconds,
+         )
       }
 
       "should not call given assertion beyond given number of times" {
-         val testClass = TestClass(4)
-         runSafely {
-            retry(2, 500.milliseconds, 100.milliseconds, 1) {
-               testClass.isReady() shouldBe true
+         val retryTester = retryTester(4)
+         val retryException = shouldThrow<AssertionError> {
+            retry(maxRetry = 2, timeout = 500.milliseconds, delay = 100.milliseconds) {
+               retryTester.isReady() shouldBe true
             }
          }
-         testClass.times shouldBe 2
+         retryException shouldHaveMessage "Test failed after 100ms; attempted 2 times; underlying cause was expected:<true> but was:<false>"
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            0.milliseconds,
+            100.milliseconds,
+         )
       }
 
       "should not call given assertion beyond given max duration" {
-         val testClass = TestClass(4)
-         runSafely {
-            retry(5, 500.milliseconds, 400.milliseconds, 1) {
-               testClass.isReady() shouldBe true
+
+         val config = retryConfig {
+            maxRetry = 5
+            timeout = 500.milliseconds
+            delay = 400.milliseconds
+            multiplier = 1
+            timeSource = testCoroutineScheduler.timeSource
+         }
+
+         val retryTester = retryTester(4)
+         val retryException = shouldThrow<AssertionError> {
+            retry(config) {
+               retryTester.isReady() shouldBe true
             }
          }
-         testClass.times shouldBe 2
+         retryTester.calledAtTimeInstance shouldHaveSize 2
+         retryException shouldHaveMessage "Test failed after 800ms; attempted 2 times; underlying cause was expected:<true> but was:<false>"
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            0.milliseconds,
+            400.milliseconds,
+         )
       }
 
       "should call given assertion exponentially" {
-         val testClass = TestClass(4)
-         runSafely {
-            retry(5, 500.milliseconds, 100.milliseconds, 2) {
-               testClass.isReady() shouldBe true
+         val retryTester = retryTester(4)
+         shouldNotThrow<Exception> {
+            retry(maxRetry = 5, timeout = 500.milliseconds, delay = 100.milliseconds, multiplier = 2) {
+               retryTester.isReady() shouldBe true
             }
          }
-         val calledAt = testClass.calledAtTimeInstance
-         val delayInFirstRetry = (calledAt[1] - calledAt[0])
-         val delayInSecondRetry = calledAt[2] - calledAt[1]
-         delayInFirstRetry shouldBeGreaterThanOrEqual 100
-         delayInSecondRetry shouldBeGreaterThanOrEqual 200
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            0.milliseconds,
+            100.milliseconds,
+            300.milliseconds,
+            700.milliseconds,
+         )
       }
 
       "should not retry in case of unexpected exception" {
-         val testClass = TestClass(2)
-         runSafely {
+         val retryTester = retryTester(2)
+         val retryException = shouldThrow<IllegalStateException> {
             retry(5, 500.milliseconds, 20.milliseconds, 1, IllegalArgumentException::class) {
-               testClass.throwUnexpectedException()
+               retryTester.throwUnexpectedException()
             }
          }
-
-         testClass.times shouldBe 1
+         retryException shouldHaveMessage "unexpected exception from RetryTester"
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            0.milliseconds,
+         )
       }
 
-      "should retry in case of subclass exception"{
-         val testClass = TestClass(3)
-         runSafely {
+      "should retry in case of subclass exception" {
+         val retryTester = retryTester(3)
+         val retryException = shouldThrow<AssertionError> {
             retry(2, 500.milliseconds, 20.milliseconds, 1, Exception::class) {
-               testClass.throwUnexpectedException()
+               retryTester.throwUnexpectedException()
             }
          }
-         testClass.times shouldBe 2
+         retryException shouldHaveMessage "Test failed after 20ms; attempted 2 times; underlying cause was unexpected exception from RetryTester"
+         retryTester.calledAtTimeInstance shouldHaveSize 2
+      }
+
+      "when maxRetry is negative, expect zero invocations" {
+         val retryTester = retryTester(4)
+         val retryException = shouldThrow<AssertionError> {
+            retry(maxRetry = -1, timeout = 500.milliseconds) {
+               retryTester.isReady() shouldBe true
+            }
+         }
+         retryException shouldHaveMessage "Test failed after 0s; attempted 0 times"
+         retryTester.calledAtTimeInstance.shouldBeEmpty()
+      }
+
+      "when multiplier is negative, expect ..." { // TODO
+         val retryTester = retryTester(4)
+         retry(maxRetry = 5, timeout = 500.milliseconds, delay = 100.milliseconds, multiplier = -1) {
+            delay(100)
+            retryTester.isReady() shouldBe true
+         }
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            100.milliseconds,
+            300.milliseconds,
+            400.milliseconds,
+            600.milliseconds,
+         )
+      }
+
+      "when delay is negative, expect ..." { // TODO
+         val retryTester = retryTester(4)
+         shouldNotThrow<Exception> {
+            retry(maxRetry = 5, timeout = 500.milliseconds, delay = (-100).milliseconds) {
+               delay(100)
+               retryTester.isReady() shouldBe true
+            }
+         }
+         retryTester.calledAtTimeInstance.shouldContainExactly(
+            100.milliseconds,
+            200.milliseconds,
+            300.milliseconds,
+            400.milliseconds,
+         )
+      }
+
+      "when timeout is negative, expect zero invocations" {
+         val retryTester = retryTester(4)
+         val retryException = shouldThrow<AssertionError> {
+            retry(maxRetry = 5, timeout = (-500).milliseconds) {
+               retryTester.isReady() shouldBe true
+            }
+         }
+         retryException shouldHaveMessage "Test failed after 0s; attempted 0 times"
+         retryTester.calledAtTimeInstance.shouldBeEmpty()
       }
    }
 
-   private class TestClass(private val readyAfter: Int) {
-      var calledAtTimeInstance = listOf<Long>()
-      var times = 0
+   private class RetryTester(
+      private val readyAfter: Int,
+      private val timeMark: TimeMark,
+   ) {
+      val calledAtTimeInstance = mutableListOf<Duration>()
+
       fun isReady(): Boolean {
-         calledAtTimeInstance = calledAtTimeInstance.plus(System.currentTimeMillis())
-         times += 1
-         return readyAfter == times
+         calledAtTimeInstance += timeMark.elapsedNow()
+         return readyAfter == calledAtTimeInstance.size
       }
 
-      fun throwUnexpectedException() {
-         times += 1
-         throw NullPointerException("")
-      }
-   }
-
-   private suspend fun runSafely(block: suspend () -> Unit) {
-      try {
-         block()
-      } catch (assertionError: AssertionError) {
-         // Eating assertion error
-      } catch (exception: Exception) {
-         // Eating other exception
+      fun throwUnexpectedException(): Nothing {
+         calledAtTimeInstance += timeMark.elapsedNow()
+         error("unexpected exception from RetryTester")
       }
    }
 
-   private suspend fun dummySuspend() {
-      delay(0)
+   private fun TestScope.retryTester(readyAfter: Int): RetryTester {
+      return RetryTester(
+         readyAfter = readyAfter,
+         timeMark = testCoroutineScheduler.timeSource.markNow()
+      )
    }
 }

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -260,20 +260,22 @@ public final class io/kotest/assertions/OneKt {
 }
 
 public final class io/kotest/assertions/RetryConfig {
-	public synthetic fun <init> (IJJILkotlin/reflect/KClass;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (IJJILkotlin/reflect/KClass;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IJJILkotlin/reflect/KClass;Lkotlin/time/TimeSource;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (IJJILkotlin/reflect/KClass;Lkotlin/time/TimeSource;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2-UwyO8pc ()J
 	public final fun component3-UwyO8pc ()J
 	public final fun component4 ()I
 	public final fun component5 ()Lkotlin/reflect/KClass;
-	public final fun copy-jKevqZI (IJJILkotlin/reflect/KClass;)Lio/kotest/assertions/RetryConfig;
-	public static synthetic fun copy-jKevqZI$default (Lio/kotest/assertions/RetryConfig;IJJILkotlin/reflect/KClass;ILjava/lang/Object;)Lio/kotest/assertions/RetryConfig;
+	public final fun component6 ()Lkotlin/time/TimeSource;
+	public final fun copy-FbhrOv8 (IJJILkotlin/reflect/KClass;Lkotlin/time/TimeSource;)Lio/kotest/assertions/RetryConfig;
+	public static synthetic fun copy-FbhrOv8$default (Lio/kotest/assertions/RetryConfig;IJJILkotlin/reflect/KClass;Lkotlin/time/TimeSource;ILjava/lang/Object;)Lio/kotest/assertions/RetryConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDelay-UwyO8pc ()J
 	public final fun getExceptionClass ()Lkotlin/reflect/KClass;
 	public final fun getMaxRetry ()I
 	public final fun getMultiplier ()I
+	public final fun getTimeSource ()Lkotlin/time/TimeSource;
 	public final fun getTimeout-UwyO8pc ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -285,18 +287,18 @@ public final class io/kotest/assertions/RetryConfigBuilder {
 	public final fun getExceptionClass ()Lkotlin/reflect/KClass;
 	public final fun getMaxRetry ()I
 	public final fun getMultiplier ()I
+	public final fun getTimeSource ()Lkotlin/time/TimeSource;
 	public final fun getTimeout-UwyO8pc ()J
 	public final fun setDelay-LRDsOJo (J)V
 	public final fun setExceptionClass (Lkotlin/reflect/KClass;)V
 	public final fun setMaxRetry (I)V
 	public final fun setMultiplier (I)V
+	public final fun setTimeSource (Lkotlin/time/TimeSource;)V
 	public final fun setTimeout-LRDsOJo (J)V
 }
 
 public final class io/kotest/assertions/RetryKt {
 	public static final fun retry (Lio/kotest/assertions/RetryConfig;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun retry-FbhrOv8 (IJJILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun retry-FbhrOv8$default (IJJILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun retry-G6guFE4 (IJJILkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun retry-G6guFE4$default (IJJILkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun retryConfig (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/RetryConfig;

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -1,77 +1,52 @@
 package io.kotest.assertions
 
-import io.kotest.common.MonotonicTimeSourceCompat
+import io.kotest.common.KotestInternal
 import io.kotest.mpp.bestName
 import kotlinx.coroutines.delay
 import kotlin.reflect.KClass
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
 
 /**
- * Retry [f] until it's a success or [maxRetry]/[timeout] is reached
- *
- * This will treat any Exception as a failure, along with [AssertionError].
- *
- * Retry delay might increase exponentially if you choose a [multiplier] value. For example, if you want to configure
- * 5 [maxRetry], with an initial [delay] of 1s between requests, the delay between requests will increase when you
- * choose 2 as your [multiplier]:
- * 1 - Failed (wait 1s before retrying)
- * 2 - Failed (wait 2s before retrying)
- * 3 - Failed (wait 4s before retrying)
- * ..
- *
- * If either timeout or max retries is reached, the execution will be aborted and an exception will be thrown.
- *
- * */
-suspend fun <T> retry(
-   maxRetry: Int,
-   timeout: Duration,
-   delay: Duration = 1.seconds,
-   multiplier: Int = 1,
-   f: suspend () -> T
-): T = retry(maxRetry, timeout, delay, multiplier, Exception::class, f)
-
-
-/**
- * Retry [f] until it's a success or [maxRetry]/[timeout] is reached
+ * Retry [f] until it's a success or [maxRetry]/[timeout] is reached.
  *
  * This will treat only [exceptionClass] as a failure, along with [AssertionError].
  *
  * Retry delay will increase exponentially if you choose a [multiplier] value. For example, if you want to configure
  * 5 [maxRetry], with an initial [delay] of 1s between requests, the delay between requests will increase when you
  * choose 2 as your [multiplier]:
- * 1 - Failed (wait 1s before retrying)
- * 2 - Failed (wait 2s before retrying)
- * 3 - Failed (wait 4s before retrying)
- * ..
  *
- * If either timeout or max retries is reached, the execution will be aborted and an exception will be thrown.
+ * - 1 - Failed (wait 1s before retrying)
+ * - 2 - Failed (wait 2s before retrying)
+ * - 3 - Failed (wait 4s before retrying)
+ * - ...
  *
- * */
+ * If either [timeout] or [maxRetry] is reached, the execution will be aborted and an exception will be thrown.
+ */
 suspend fun <T> retry(
    maxRetry: Int,
    timeout: Duration,
    delay: Duration = 1.seconds,
    multiplier: Int = 1,
-   exceptionClass: KClass<out Throwable>,
-   f: suspend () -> T
+   exceptionClass: KClass<out Throwable> = Exception::class,
+   f: suspend () -> T,
 ): T {
    return retry(RetryConfig(maxRetry, timeout, delay, multiplier, exceptionClass), f)
 }
 
 suspend fun <T> retry(
    config: RetryConfig,
-   test: suspend () -> T
+   test: suspend () -> T,
 ): T {
-   val mark = MonotonicTimeSourceCompat.markNow()
+   val mark = config.timeSource?.markNow() ?: TimeSource.Monotonic.markNow()
    val end = mark.plus(config.timeout)
-   var retrySoFar = 0
+   var attemptedRetries = 0
    var nextAwaitDuration = config.delay
    var delayedTime = 0.seconds
    var lastError: Throwable? = null
 
-   while (end.hasNotPassedNow() && retrySoFar < config.maxRetry) {
+   while (end.hasNotPassedNow() && attemptedRetries < config.maxRetry) {
       try {
          return test()
       } catch (e: Throwable) {
@@ -85,15 +60,15 @@ suspend fun <T> retry(
          lastError = e
          // else ignore and continue
       }
-      retrySoFar++
-      if (retrySoFar >= config.maxRetry || end.hasPassedNow()) break
+      attemptedRetries++
+      if (attemptedRetries >= config.maxRetry || end.hasPassedNow()) break
       delay(nextAwaitDuration)
       delayedTime += nextAwaitDuration
       nextAwaitDuration *= config.multiplier
    }
    val underlyingCause = if (lastError == null) "" else "; underlying cause was ${lastError.message}"
    throw failure(
-      "Test failed after ${delayedTime.toLong(DurationUnit.SECONDS)} seconds; attempted $retrySoFar times$underlyingCause",
+      "Test failed after ${delayedTime}; attempted $attemptedRetries times$underlyingCause",
       lastError
    )
 }
@@ -110,6 +85,9 @@ class RetryConfigBuilder {
    var delay: Duration = Duration.ZERO
    var multiplier: Int = 1
    var exceptionClass: KClass<out Throwable>? = null
+
+   @KotestInternal
+   var timeSource: TimeSource? = null
 }
 
 internal fun RetryConfigBuilder.build(): RetryConfig {
@@ -119,6 +97,7 @@ internal fun RetryConfigBuilder.build(): RetryConfig {
       delay = this.delay,
       multiplier = this.multiplier,
       exceptionClass = this.exceptionClass,
+      timeSource = timeSource,
    )
 }
 
@@ -128,4 +107,6 @@ data class RetryConfig(
    val delay: Duration = 1.seconds,
    val multiplier: Int = 1,
    val exceptionClass: KClass<out Throwable>?,
+   @KotestInternal
+   val timeSource: TimeSource? = null,
 )


### PR DESCRIPTION
The retry tests were unstable when running on master, so I thought I'd refactor them.

- Merge two `retry()` functions into a single function with a default argument (they were both the same, except for the `exceptionClass` parameter)
- Print duration in "Test failed after $delayedTime ..." instead of converting to exceptions, to avoid "Test failed after 0 seconds" message if the duration was less than 1 second.
- use `coroutineTestScope` to speed up tests (delays are emulated)
- assert the actual invocation times
- add TimeSource to Retry config (marked as `@KotestInternal`) so that the retry could be tested using the test scheduler TimeSource
- Replace `runSafely` with shouldThrow/shouldNotThrow assertions
- rename 'TestClass' to more descriptive name
