### PR TITLE
replace deprecated getTimeMillis with posix clock_gettime

### DIFF
--- a/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/time.kt
+++ b/kotest-common/src/desktopMain/kotlin/io/kotest/mpp/time.kt
@@ -1,5 +1,23 @@
 package io.kotest.mpp
 
-import kotlin.system.getTimeMillis
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UnsafeNumber
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
 
-actual fun timeInMillis(): Long = getTimeMillis()
+@OptIn(ExperimentalForeignApi::class)
+actual fun timeInMillis(): Long {
+   return memScoped {
+      val timespec = alloc<platform.posix.timespec>().ptr
+      platform.posix.clock_gettime(platform.posix.CLOCK_REALTIME.convert(), timespec)
+      @OptIn(UnsafeNumber::class)
+      timespec.pointed
+         .run { tv_sec.seconds + tv_nsec.nanoseconds }
+         .inWholeMilliseconds
+   }
+}


### PR DESCRIPTION
`getTimeMillis()` is deprecated https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.system/get-time-millis.html

The alternative in this PR was discussed in Slack: https://slack-chats.kotlinlang.org/t/13154128/https-kotlinlang-org-api-latest-jvm-stdlib-kotlin-system-get

Part of #4085 