### PR TITLE
Use centralized repositories for build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,14 +2,6 @@ plugins {
    alias(libs.plugins.kotlinBinaryCompatibilityValidator)
 }
 
-repositories {
-   mavenCentral()
-   mavenLocal()
-   maven("https://oss.sonatype.org/content/repositories/snapshots/")
-   google()
-   gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
-}
-
 apiValidation {
    ignoredPackages.addAll(
       listOf(

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -2,11 +2,6 @@ plugins {
    `kotlin-dsl`
 }
 
-repositories {
-   mavenCentral()
-   gradlePluginPortal()
-}
-
 dependencies {
    implementation(libs.testlogger.gradle.plugin)
    implementation(libs.kotlin.gradle.plugin)

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,6 +1,19 @@
 rootProject.name = "buildSrc"
 
+pluginManagement {
+   repositories {
+      mavenCentral()
+      gradlePluginPortal()
+   }
+}
+
+@Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
+   repositoriesMode = RepositoriesMode.PREFER_SETTINGS
+   repositories {
+      mavenCentral()
+      gradlePluginPortal()
+   }
    versionCatalogs {
       create("libs") {
          from(files("../gradle/libs.versions.toml"))

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -7,17 +7,6 @@ plugins {
    id("com.adarshr.test-logger")
 }
 
-repositories {
-   google()
-   mavenCentral()
-   maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
-   maven("https://oss.sonatype.org/content/repositories/snapshots/") {
-      mavenContent { snapshotsOnly() }
-   }
-   gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
-   mavenLocal()
-}
-
 testlogger {
    showPassed = false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,65 @@ pluginManagement {
    }
 }
 
+@Suppress("UnstableApiUsage")
+dependencyResolutionManagement {
+   repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+
+   repositories {
+      google()
+      mavenCentral()
+      maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental") {
+         name = "JetBrainsKotlinWasm"
+      }
+      maven("https://oss.sonatype.org/content/repositories/snapshots/") {
+         name = "SonatypeSnapshots"
+         mavenContent { snapshotsOnly() }
+      }
+
+      gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
+
+      // workaround for https://youtrack.jetbrains.com/issue/KT-51379
+      // FIXME remove when updating to Kotlin 2.0
+      ivy("https://download.jetbrains.com/kotlin/native/builds") {
+         name = "KotlinNative"
+         patternLayout {
+            listOf(
+               "macos-x86_64",
+               "macos-aarch64",
+               "osx-x86_64",
+               "osx-aarch64",
+               "linux-x86_64",
+               "windows-x86_64",
+            ).forEach { os ->
+               listOf("dev", "releases").forEach { stage ->
+                  artifact("$stage/[revision]/$os/[artifact]-[revision].[ext]")
+               }
+            }
+         }
+         content { includeModuleByRegex(".*", ".*kotlin-native-prebuilt.*") }
+         metadataSources { artifact() }
+      }
+
+      //region Declare the Node.js & Yarn download repositories
+      // Workaround https://youtrack.jetbrains.com/issue/KT-68533/
+      ivy("https://cache-redirector.jetbrains.com/nodejs.org/dist/") {
+         name = "Node Distributions at $url"
+         patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
+         metadataSources { artifact() }
+         content { includeModule("org.nodejs", "node") }
+      }
+      ivy("https://github.com/yarnpkg/yarn/releases/download") {
+         name = "Yarn Distributions at $url"
+         patternLayout { artifact("v[revision]/[artifact](-v[revision]).[ext]") }
+         metadataSources { artifact() }
+         content { includeModule("com.yarnpkg", "yarn") }
+      }
+      //endregion
+
+      mavenLocal()
+   }
+}
+
 include(
    ":kotest-common",
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,22 +9,16 @@ pluginManagement {
 
 @Suppress("UnstableApiUsage")
 dependencyResolutionManagement {
-   repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
+   repositoriesMode = RepositoriesMode.PREFER_SETTINGS
 
    repositories {
-      google()
       mavenCentral()
-      maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental") {
-         name = "JetBrainsKotlinWasm"
-      }
       maven("https://oss.sonatype.org/content/repositories/snapshots/") {
          name = "SonatypeSnapshots"
          mavenContent { snapshotsOnly() }
       }
 
-      gradlePluginPortal() // tvOS builds need to be able to fetch a kotlin gradle plugin
-
-      // workaround for https://youtrack.jetbrains.com/issue/KT-51379
+      //region workaround for https://youtrack.jetbrains.com/issue/KT-51379
       // FIXME remove when updating to Kotlin 2.0
       ivy("https://download.jetbrains.com/kotlin/native/builds") {
          name = "KotlinNative"
@@ -45,6 +39,7 @@ dependencyResolutionManagement {
          content { includeModuleByRegex(".*", ".*kotlin-native-prebuilt.*") }
          metadataSources { artifact() }
       }
+      //endregion
 
       //region Declare the Node.js & Yarn download repositories
       // Workaround https://youtrack.jetbrains.com/issue/KT-68533/


### PR DESCRIPTION
Centrally define the repositories required for the build. This encourages a stable build, as the repositories are defined consistently, in the same order of priority, for all subprojects.

See: https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:centralized-repository-declaration