### PR TITLE
Json path array match take3

### DIFF
--- a/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
+++ b/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
@@ -85,6 +85,19 @@ public final class io/kotest/assertions/json/FieldComparison : java/lang/Enum {
 	public static fun values ()[Lio/kotest/assertions/json/FieldComparison;
 }
 
+public final class io/kotest/assertions/json/JsonArrayElementRef {
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lio/kotest/assertions/json/JsonArrayElementRef;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonArrayElementRef;Ljava/lang/String;IILjava/lang/Object;)Lio/kotest/assertions/json/JsonArrayElementRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getPathToArray ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class io/kotest/assertions/json/JsonError {
 	public abstract fun getPath ()Ljava/util/List;
 }
@@ -369,6 +382,43 @@ public final class io/kotest/assertions/json/JsonPathNotFound : io/kotest/assert
 	public static final field INSTANCE Lio/kotest/assertions/json/JsonPathNotFound;
 }
 
+public final class io/kotest/assertions/json/JsonSubPathFound : io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/kotest/assertions/json/JsonSubPathFound;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonSubPathFound;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/assertions/json/JsonSubPathFound;
+	public fun description ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSubPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/assertions/json/JsonSubPathJsonArrayTooShort : io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public fun <init> (Ljava/lang/String;II)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;II)Lio/kotest/assertions/json/JsonSubPathJsonArrayTooShort;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonSubPathJsonArrayTooShort;Ljava/lang/String;IIILjava/lang/Object;)Lio/kotest/assertions/json/JsonSubPathJsonArrayTooShort;
+	public fun description ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArraySize ()I
+	public final fun getExpectedIndex ()I
+	public final fun getSubPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/assertions/json/JsonSubPathNotFound : io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public static final field INSTANCE Lio/kotest/assertions/json/JsonSubPathNotFound;
+	public fun description ()Ljava/lang/String;
+}
+
+public abstract interface class io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public abstract fun description ()Ljava/lang/String;
+}
+
 public final class io/kotest/assertions/json/JsonTree {
 	public fun <init> (Lio/kotest/assertions/json/JsonNode;Ljava/lang/String;)V
 	public final fun component1 ()Lio/kotest/assertions/json/JsonNode;
@@ -389,7 +439,9 @@ public final class io/kotest/assertions/json/KeysKt {
 }
 
 public final class io/kotest/assertions/json/KeyvaluesKt {
-	public static final fun findValidSubPath (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun extractPossiblePathOfJsonArray (Ljava/lang/String;)Lio/kotest/assertions/json/JsonArrayElementRef;
+	public static final fun findValidSubPath (Ljava/lang/String;Ljava/lang/String;)Lio/kotest/assertions/json/JsonSubPathSearchOutcome;
+	public static final fun getPossibleSizeOfJsonArray (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Integer;
 	public static final fun removeLastPartFromPath (Ljava/lang/String;)Ljava/lang/String;
 }
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -6,6 +6,7 @@ import com.jayway.jsonpath.PathNotFoundException
 import io.kotest.assertions.Actual
 import io.kotest.assertions.Expected
 import io.kotest.assertions.intellijFormatError
+import io.kotest.assertions.json.schema.JsonSchema
 import io.kotest.assertions.print.print
 import io.kotest.common.KotestInternal
 import io.kotest.matchers.Matcher
@@ -135,6 +136,17 @@ inline fun findValidSubPath2(json: String?, path: String): JsonSubPathSearchOutc
       }
    }
    return JsonSubPathNotFound
+}
+
+@KotestInternal
+fun possibleSizeOfJsonArray(json: String?, path: String): Int? {
+   return try {
+      val parsedJson = JsonPath.parse(json)
+      val possibleJsonArray = parsedJson.read(path, List::class.java)
+      return possibleJsonArray.size
+   } catch (ignore: Exception) {
+      null
+   }
 }
 
 @KotestInternal

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -137,7 +137,23 @@ inline fun findValidSubPath2(json: String?, path: String): JsonSubPathSearchOutc
    return JsonSubPathNotFound
 }
 
-
+@KotestInternal
+fun extractPossiblePathOfJsonArray(pathElement: String): String? {
+   val tokens = pathElement.split("[")
+   when {
+      pathElement.last() != ']' -> return null
+      tokens.size != 2 -> return null
+      else -> {
+         val possibleNumber = tokens[1].dropLast(1)
+         possibleNumber.toIntOrNull()?.let {
+            if(it > 0) {
+               return tokens[0]
+            }
+         }
+      }
+   }
+   return null
+}
 @KotestInternal
 sealed interface JsonSubPathSearchOutcome
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -79,21 +79,6 @@ inline fun<reified T> extractByPath(json: String?, path: String): ExtractValueOu
 }
 
 @KotestInternal
-inline fun findValidSubPath(json: String?, path: String): String? {
-   val parsedJson = JsonPath.parse(json)
-   var subPath = path
-   while(subPath.isNotEmpty() && subPath != "$") {
-      try {
-         parsedJson.read(subPath, Any::class.java)
-         return subPath
-      } catch (e: PathNotFoundException) {
-         subPath = removeLastPartFromPath(subPath)
-      }
-   }
-   return null
-}
-
-@KotestInternal
 fun removeLastPartFromPath(path: String): String {
    val tokens = path.split(".")
    return tokens.take(tokens.size - 1).joinToString(".")

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -132,11 +132,11 @@ inline fun findValidSubPath2(json: String?, path: String): JsonSubPathSearchOutc
          return JsonSubPathFound(subPath)
       } catch (e: PathNotFoundException) {
          extractPossiblePathOfJsonArray(subPath)?.let { possiblePathOfJsonArray ->
-            getPossibleSizeOfJsonArray(json, possiblePathOfJsonArray)?.let { sizeOfJsonArray ->
+            getPossibleSizeOfJsonArray(json, possiblePathOfJsonArray.pathToArray)?.let { sizeOfJsonArray ->
                return JsonSubPathJsonArrayTooShort(
-                  subPath = possiblePathOfJsonArray,
+                  subPath = possiblePathOfJsonArray.pathToArray,
                   arraySize = sizeOfJsonArray,
-                  expectedIndex = 42
+                  expectedIndex = possiblePathOfJsonArray.index
                )
             }
          }
@@ -159,7 +159,7 @@ fun getPossibleSizeOfJsonArray(json: String?, path: String): Int? {
 }
 
 @KotestInternal
-fun extractPossiblePathOfJsonArray(path: String): String? {
+fun extractPossiblePathOfJsonArray(path: String): JsonArrayElementRef? {
    val pathElements = path.split(".")
    val lastPathElement = pathElements.last()
    val tokens = lastPathElement.split("[")
@@ -169,14 +169,22 @@ fun extractPossiblePathOfJsonArray(path: String): String? {
       else -> {
          val possibleNumber = tokens[1].dropLast(1)
          possibleNumber.toIntOrNull()?.let {
-            if(it > 0) {
-               return (pathElements.dropLast(1) + tokens[0]).joinToString(".")
-            }
+            return JsonArrayElementRef(
+               pathToArray = (pathElements.dropLast(1) + tokens[0]).joinToString("."),
+               index = it
+            )
          }
       }
    }
    return null
 }
+
+@KotestInternal
+data class JsonArrayElementRef(
+   val pathToArray: String,
+   val index: Int
+)
+
 @KotestInternal
 sealed interface JsonSubPathSearchOutcome
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -58,7 +58,7 @@ inline fun <reified T> containJsonKeyValue(path: String, t: T) = object : Matche
              )
           }
           is JsonPathNotFound -> {
-             val subPathDescription = findValidSubPath2(value, path).description()
+             val subPathDescription = findValidSubPath(value, path).description()
              return keyIsAbsentFailure(subPathDescription)
           }
       }
@@ -96,7 +96,7 @@ data class ExtractedValue<T>(
 object JsonPathNotFound : ExtractValueOutcome
 
 @KotestInternal
-inline fun findValidSubPath2(json: String?, path: String): JsonSubPathSearchOutcome {
+inline fun findValidSubPath(json: String?, path: String): JsonSubPathSearchOutcome {
    val parsedJson = JsonPath.parse(json)
    var subPath = path
    while(subPath.isNotEmpty() && subPath != "$") {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
@@ -68,6 +68,12 @@ class ContainJsonKeyValueTest : StringSpec({
       }.message shouldBe "Expected given to contain json key <'$.store.book[2].category'> but key was not found. The array at path <'$.store.book'> has size 2, so index 2 is out of bounds."
    }
 
+   "Failure message states if key is missing, shows element is not json array" {
+      shouldFail {
+         json.shouldContainJsonKeyValue("$.store.bicycle[0].color", "V2")
+      }.message shouldBe "Expected given to contain json key <'$.store.bicycle[0].color'> but key was not found. Found shorter valid subpath: <'$.store'>."
+   }
+
    "Failure message states if key is missing, shows json array index out of bounds when array is empty" {
       shouldFail {
          json.shouldContainJsonKeyValue("$.store.book[1].comments[0]", "V2")

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
@@ -25,7 +25,8 @@ class ContainJsonKeyValueTest : StringSpec({
                     "category": "fiction",
                     "author": "Evelyn Waugh",
                     "title": "Sword of Honour",
-                    "price": 12.99
+                    "price": 12.99,
+                    "comments": []
                  }
               ],
               "bicycle": {
@@ -50,17 +51,27 @@ class ContainJsonKeyValueTest : StringSpec({
    "Failure message states if key is missing, when it's missing" {
       shouldFail {
          json.shouldContainJsonKeyValue("$.bicycle.engine", "V2")
-      }.message shouldBe """
-         Expected given to contain json key <'$.bicycle.engine'> but key was not found.
-      """.trimIndent()
+      }.message shouldBe "Expected given to contain json key <'$.bicycle.engine'> but key was not found. "
    }
 
    "Failure message states if key is missing, shows valid subpath" {
       shouldFail {
          json.shouldContainJsonKeyValue("$.store.bicycle.engine", "V2")
       }.message shouldBe """
-         Expected given to contain json key <'$.store.bicycle.engine'> but key was not found. Found shorter valid subpath: <'$.store.bicycle'>
+         Expected given to contain json key <'$.store.bicycle.engine'> but key was not found. Found shorter valid subpath: <'$.store.bicycle'>.
       """.trimIndent()
+   }
+
+   "Failure message states if key is missing, shows json array index out of bounds" {
+      shouldFail {
+         json.shouldContainJsonKeyValue("$.store.book[2].category", "V2")
+      }.message shouldBe "Expected given to contain json key <'$.store.book[2].category'> but key was not found. The array at path <'$.store.book'> has size 2, so index 2 is out of bounds."
+   }
+
+   "Failure message states if key is missing, shows json array index out of bounds when array is empty" {
+      shouldFail {
+         json.shouldContainJsonKeyValue("$.store.book[1].comments[0]", "V2")
+      }.message shouldBe "Expected given to contain json key <'$.store.book[1].comments[0]'> but key was not found. The array at path <'$.store.book[1].comments'> has size 0, so index 0 is out of bounds."
    }
 
    "Failure message states states value mismatch if key is present with different value" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.json.JsonPathNotFound
 import io.kotest.assertions.json.JsonSubPathFound
 import io.kotest.assertions.json.JsonSubPathNotFound
 import io.kotest.assertions.json.extractByPath
+import io.kotest.assertions.json.extractPossiblePathOfJsonArray
 import io.kotest.assertions.json.findValidSubPath
 import io.kotest.assertions.json.findValidSubPath2
 import io.kotest.assertions.json.removeLastPartFromPath
@@ -54,12 +55,15 @@ class ExtractByPathTest: WordSpec() {
       }
 
       "findValidSubPath" should {
-          "find valid sub path" {
-             findValidSubPath(json, "$.regime.temperature.unit.name.some.more.tokens") shouldBe "$.regime.temperature.unit"
-             findValidSubPath(json, "$.regime.temperature.unit.name") shouldBe "$.regime.temperature.unit"
-             findValidSubPath(json, "$.regime.temperature.name") shouldBe "$.regime.temperature"
-             findValidSubPath(json, "$.regime.no_such_element") shouldBe "$.regime"
-          }
+         "find valid sub path" {
+            findValidSubPath(
+               json,
+               "$.regime.temperature.unit.name.some.more.tokens"
+            ) shouldBe "$.regime.temperature.unit"
+            findValidSubPath(json, "$.regime.temperature.unit.name") shouldBe "$.regime.temperature.unit"
+            findValidSubPath(json, "$.regime.temperature.name") shouldBe "$.regime.temperature"
+            findValidSubPath(json, "$.regime.no_such_element") shouldBe "$.regime"
+         }
          "return null when nothing found" {
             findValidSubPath(json, "$.no.such.path") shouldBe null
          }
@@ -67,13 +71,37 @@ class ExtractByPathTest: WordSpec() {
 
       "findValidSubPath2" should {
          "find valid sub path" {
-            findValidSubPath2(json, "$.regime.temperature.unit.name.some.more.tokens") shouldBe JsonSubPathFound("$.regime.temperature.unit")
-            findValidSubPath2(json, "$.regime.temperature.unit.name") shouldBe JsonSubPathFound("$.regime.temperature.unit")
+            findValidSubPath2(
+               json,
+               "$.regime.temperature.unit.name.some.more.tokens"
+            ) shouldBe JsonSubPathFound("$.regime.temperature.unit")
+            findValidSubPath2(
+               json,
+               "$.regime.temperature.unit.name"
+            ) shouldBe JsonSubPathFound("$.regime.temperature.unit")
             findValidSubPath2(json, "$.regime.temperature.name") shouldBe JsonSubPathFound("$.regime.temperature")
             findValidSubPath2(json, "$.regime.no_such_element") shouldBe JsonSubPathFound("$.regime")
          }
          "return null when nothing found" {
             findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
+         }
+      }
+
+      "extractPossiblePathOfJsonArray" should {
+         "return null if not array" {
+            extractPossiblePathOfJsonArray("$.not.an.array") shouldBe null
+         }
+         "return null if not valid index" {
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[]") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients]") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42[") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42]]") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[BAD-INDEX]") shouldBe null
+         }
+         "return path" {
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42]") shouldBe "\$.recipe.ingredients"
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -98,7 +98,7 @@ class ExtractByPathTest: WordSpec() {
                JsonSubPathJsonArrayTooShort("$.steps", 1, 42)
          }
          "return null when nothing found" {
-            findValidSubPath2(json, "$.no.such.path") shouldBe null
+            findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
          }
       }
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -3,12 +3,13 @@ package com.sksamuel.kotest.tests.json
 import io.kotest.assertions.json.ExtractedValue
 import io.kotest.assertions.json.JsonPathNotFound
 import io.kotest.assertions.json.JsonSubPathFound
+import io.kotest.assertions.json.JsonSubPathJsonArrayTooShort
 import io.kotest.assertions.json.JsonSubPathNotFound
 import io.kotest.assertions.json.extractByPath
 import io.kotest.assertions.json.extractPossiblePathOfJsonArray
 import io.kotest.assertions.json.findValidSubPath
 import io.kotest.assertions.json.findValidSubPath2
-import io.kotest.assertions.json.possibleSizeOfJsonArray
+import io.kotest.assertions.json.getPossibleSizeOfJsonArray
 import io.kotest.assertions.json.removeLastPartFromPath
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
@@ -90,22 +91,28 @@ class ExtractByPathTest: WordSpec() {
             findValidSubPath2(json, "$.regime.temperature.name") shouldBe JsonSubPathFound("$.regime.temperature")
             findValidSubPath2(json, "$.regime.no_such_element") shouldBe JsonSubPathFound("$.regime")
          }
+         "return JsonSubPathJsonArrayTooShort" {
+            findValidSubPath2(json, "$.steps[0].comments[2]") shouldBe
+               JsonSubPathJsonArrayTooShort("$.steps[0].comments", 2, 42)
+            findValidSubPath2(json, "$.steps[1].comments[2]") shouldBe
+               JsonSubPathJsonArrayTooShort("$.steps", 1, 42)
+         }
          "return null when nothing found" {
-            findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
+            findValidSubPath2(json, "$.no.such.path") shouldBe null
          }
       }
 
-      "possibleSizeOfJsonArray" should {
+      "getPossibleSizeOfJsonArray" should {
          "return size of array" {
-            possibleSizeOfJsonArray(json, "$.ingredients") shouldBe 3
-            possibleSizeOfJsonArray(json, "$.steps[0].comments") shouldBe 2
-            possibleSizeOfJsonArray(json, "$.steps") shouldBe 1
-            possibleSizeOfJsonArray(json, "$.regime.comments") shouldBe 0
+            getPossibleSizeOfJsonArray(json, "$.ingredients") shouldBe 3
+            getPossibleSizeOfJsonArray(json, "$.steps[0].comments") shouldBe 2
+            getPossibleSizeOfJsonArray(json, "$.steps") shouldBe 1
+            getPossibleSizeOfJsonArray(json, "$.regime.comments") shouldBe 0
          }
          "return null if not an array" {
-            possibleSizeOfJsonArray(json, "$.appliance.type") shouldBe null
-            possibleSizeOfJsonArray(json, "$.appliance") shouldBe null
-            possibleSizeOfJsonArray(json, "$.steps.name") shouldBe null
+            getPossibleSizeOfJsonArray(json, "$.appliance.type") shouldBe null
+            getPossibleSizeOfJsonArray(json, "$.appliance") shouldBe null
+            getPossibleSizeOfJsonArray(json, "$.steps.name") shouldBe null
          }
       }
 
@@ -124,6 +131,9 @@ class ExtractByPathTest: WordSpec() {
          }
          "return path" {
             extractPossiblePathOfJsonArray("$.recipe.ingredients[42]") shouldBe "\$.recipe.ingredients"
+         }
+         "handle nested JSONArray" {
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[2].comments[3]") shouldBe "\$.recipe.ingredients[2].comments"
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -2,8 +2,11 @@ package com.sksamuel.kotest.tests.json
 
 import io.kotest.assertions.json.ExtractedValue
 import io.kotest.assertions.json.JsonPathNotFound
+import io.kotest.assertions.json.JsonSubPathFound
+import io.kotest.assertions.json.JsonSubPathNotFound
 import io.kotest.assertions.json.extractByPath
 import io.kotest.assertions.json.findValidSubPath
+import io.kotest.assertions.json.findValidSubPath2
 import io.kotest.assertions.json.removeLastPartFromPath
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
@@ -59,6 +62,18 @@ class ExtractByPathTest: WordSpec() {
           }
          "return null when nothing found" {
             findValidSubPath(json, "$.no.such.path") shouldBe null
+         }
+      }
+
+      "findValidSubPath2" should {
+         "find valid sub path" {
+            findValidSubPath2(json, "$.regime.temperature.unit.name.some.more.tokens") shouldBe JsonSubPathFound("$.regime.temperature.unit")
+            findValidSubPath2(json, "$.regime.temperature.unit.name") shouldBe JsonSubPathFound("$.regime.temperature.unit")
+            findValidSubPath2(json, "$.regime.temperature.name") shouldBe JsonSubPathFound("$.regime.temperature")
+            findValidSubPath2(json, "$.regime.no_such_element") shouldBe JsonSubPathFound("$.regime")
+         }
+         "return null when nothing found" {
+            findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.tests.json
 
 import io.kotest.assertions.json.ExtractedValue
+import io.kotest.assertions.json.JsonArrayElementRef
 import io.kotest.assertions.json.JsonPathNotFound
 import io.kotest.assertions.json.JsonSubPathFound
 import io.kotest.assertions.json.JsonSubPathJsonArrayTooShort
@@ -93,9 +94,9 @@ class ExtractByPathTest: WordSpec() {
          }
          "return JsonSubPathJsonArrayTooShort" {
             findValidSubPath2(json, "$.steps[0].comments[2]") shouldBe
-               JsonSubPathJsonArrayTooShort("$.steps[0].comments", 2, 42)
+               JsonSubPathJsonArrayTooShort("$.steps[0].comments", 2, 2)
             findValidSubPath2(json, "$.steps[1].comments[2]") shouldBe
-               JsonSubPathJsonArrayTooShort("$.steps", 1, 42)
+               JsonSubPathJsonArrayTooShort("$.steps", 1, 1)
          }
          "return null when nothing found" {
             findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
@@ -130,10 +131,12 @@ class ExtractByPathTest: WordSpec() {
             extractPossiblePathOfJsonArray("$.recipe.ingredients[BAD-INDEX]") shouldBe null
          }
          "return path" {
-            extractPossiblePathOfJsonArray("$.recipe.ingredients[42]") shouldBe "\$.recipe.ingredients"
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42]") shouldBe
+               JsonArrayElementRef("\$.recipe.ingredients", 42)
          }
          "handle nested JSONArray" {
-            extractPossiblePathOfJsonArray("$.recipe.ingredients[2].comments[3]") shouldBe "\$.recipe.ingredients[2].comments"
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[2].comments[3]") shouldBe
+               JsonArrayElementRef("\$.recipe.ingredients[2].comments", 3)
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -8,7 +8,7 @@ import io.kotest.assertions.json.JsonSubPathJsonArrayTooShort
 import io.kotest.assertions.json.JsonSubPathNotFound
 import io.kotest.assertions.json.extractByPath
 import io.kotest.assertions.json.extractPossiblePathOfJsonArray
-import io.kotest.assertions.json.findValidSubPath2
+import io.kotest.assertions.json.findValidSubPath
 import io.kotest.assertions.json.getPossibleSizeOfJsonArray
 import io.kotest.assertions.json.removeLastPartFromPath
 import io.kotest.core.spec.style.WordSpec
@@ -65,25 +65,25 @@ class ExtractByPathTest: WordSpec() {
 
       "findValidSubPath2" should {
          "find valid sub path" {
-            findValidSubPath2(
+            findValidSubPath(
                json,
                "$.regime.temperature.unit.name.some.more.tokens"
             ) shouldBe JsonSubPathFound("$.regime.temperature.unit")
-            findValidSubPath2(
+            findValidSubPath(
                json,
                "$.regime.temperature.unit.name"
             ) shouldBe JsonSubPathFound("$.regime.temperature.unit")
-            findValidSubPath2(json, "$.regime.temperature.name") shouldBe JsonSubPathFound("$.regime.temperature")
-            findValidSubPath2(json, "$.regime.no_such_element") shouldBe JsonSubPathFound("$.regime")
+            findValidSubPath(json, "$.regime.temperature.name") shouldBe JsonSubPathFound("$.regime.temperature")
+            findValidSubPath(json, "$.regime.no_such_element") shouldBe JsonSubPathFound("$.regime")
          }
          "return JsonSubPathJsonArrayTooShort" {
-            findValidSubPath2(json, "$.steps[0].comments[2]") shouldBe
+            findValidSubPath(json, "$.steps[0].comments[2]") shouldBe
                JsonSubPathJsonArrayTooShort("$.steps[0].comments", 2, 2)
-            findValidSubPath2(json, "$.steps[1].comments[2]") shouldBe
+            findValidSubPath(json, "$.steps[1].comments[2]") shouldBe
                JsonSubPathJsonArrayTooShort("$.steps", 1, 1)
          }
          "return null when nothing found" {
-            findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
+            findValidSubPath(json, "$.no.such.path") shouldBe JsonSubPathNotFound
          }
       }
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.json.extractByPath
 import io.kotest.assertions.json.extractPossiblePathOfJsonArray
 import io.kotest.assertions.json.findValidSubPath
 import io.kotest.assertions.json.findValidSubPath2
+import io.kotest.assertions.json.possibleSizeOfJsonArray
 import io.kotest.assertions.json.removeLastPartFromPath
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
@@ -26,9 +27,16 @@ class ExtractByPathTest: WordSpec() {
             "temperature": {
                 "degrees": 320,
                 "unit": "F"
-            }
+            },
+            "comments": []
           },
-          "comments": null
+          "steps": [
+            {
+               "name": "Boil",
+               "comments": ["Heat on 3", "No lid"]
+            }
+          ],
+    "comments": null
       }
    """.trimIndent()
 
@@ -84,6 +92,20 @@ class ExtractByPathTest: WordSpec() {
          }
          "return null when nothing found" {
             findValidSubPath2(json, "$.no.such.path") shouldBe JsonSubPathNotFound
+         }
+      }
+
+      "possibleSizeOfJsonArray" should {
+         "return size of array" {
+            possibleSizeOfJsonArray(json, "$.ingredients") shouldBe 3
+            possibleSizeOfJsonArray(json, "$.steps[0].comments") shouldBe 2
+            possibleSizeOfJsonArray(json, "$.steps") shouldBe 1
+            possibleSizeOfJsonArray(json, "$.regime.comments") shouldBe 0
+         }
+         "return null if not an array" {
+            possibleSizeOfJsonArray(json, "$.appliance.type") shouldBe null
+            possibleSizeOfJsonArray(json, "$.appliance") shouldBe null
+            possibleSizeOfJsonArray(json, "$.steps.name") shouldBe null
          }
       }
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -8,7 +8,6 @@ import io.kotest.assertions.json.JsonSubPathJsonArrayTooShort
 import io.kotest.assertions.json.JsonSubPathNotFound
 import io.kotest.assertions.json.extractByPath
 import io.kotest.assertions.json.extractPossiblePathOfJsonArray
-import io.kotest.assertions.json.findValidSubPath
 import io.kotest.assertions.json.findValidSubPath2
 import io.kotest.assertions.json.getPossibleSizeOfJsonArray
 import io.kotest.assertions.json.removeLastPartFromPath
@@ -61,21 +60,6 @@ class ExtractByPathTest: WordSpec() {
             removeLastPartFromPath("$.regime.temperature.unit") shouldBe "$.regime.temperature"
             removeLastPartFromPath("$.regime.temperature") shouldBe "$.regime"
             removeLastPartFromPath("$.regime") shouldBe "$"
-         }
-      }
-
-      "findValidSubPath" should {
-         "find valid sub path" {
-            findValidSubPath(
-               json,
-               "$.regime.temperature.unit.name.some.more.tokens"
-            ) shouldBe "$.regime.temperature.unit"
-            findValidSubPath(json, "$.regime.temperature.unit.name") shouldBe "$.regime.temperature.unit"
-            findValidSubPath(json, "$.regime.temperature.name") shouldBe "$.regime.temperature"
-            findValidSubPath(json, "$.regime.no_such_element") shouldBe "$.regime"
-         }
-         "return null when nothing found" {
-            findValidSubPath(json, "$.no.such.path") shouldBe null
          }
       }
 


### PR DESCRIPTION
print partial matches when key not found, such as
```kotlin
   "Failure message states if key is missing, shows json array index out of bounds" {
      shouldFail {
         json.shouldContainJsonKeyValue("$.store.book[2].category", "V2")
      }.message shouldBe "Expected given to contain json key <'$.store.book[2].category'> but key was not found. The array at path <'$.store.book'> has size 2, so index 2 is out of bounds."
   }

   "Failure message states if key is missing, shows json array index out of bounds when array is empty" {
      shouldFail {
         json.shouldContainJsonKeyValue("$.store.book[1].comments[0]", "V2")
      }.message shouldBe "Expected given to contain json key <'$.store.book[1].comments[0]'> but key was not found. The array at path <'$.store.book[1].comments'> has size 0, so index 0 is out of bounds."
   }
```
