### PR TITLE
Json path array match take3 (#74)

### DIFF
--- a/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
+++ b/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
@@ -85,6 +85,19 @@ public final class io/kotest/assertions/json/FieldComparison : java/lang/Enum {
 	public static fun values ()[Lio/kotest/assertions/json/FieldComparison;
 }
 
+public final class io/kotest/assertions/json/JsonArrayElementRef {
+	public fun <init> (Ljava/lang/String;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lio/kotest/assertions/json/JsonArrayElementRef;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonArrayElementRef;Ljava/lang/String;IILjava/lang/Object;)Lio/kotest/assertions/json/JsonArrayElementRef;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getPathToArray ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class io/kotest/assertions/json/JsonError {
 	public abstract fun getPath ()Ljava/util/List;
 }
@@ -369,6 +382,43 @@ public final class io/kotest/assertions/json/JsonPathNotFound : io/kotest/assert
 	public static final field INSTANCE Lio/kotest/assertions/json/JsonPathNotFound;
 }
 
+public final class io/kotest/assertions/json/JsonSubPathFound : io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/kotest/assertions/json/JsonSubPathFound;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonSubPathFound;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/assertions/json/JsonSubPathFound;
+	public fun description ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSubPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/assertions/json/JsonSubPathJsonArrayTooShort : io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public fun <init> (Ljava/lang/String;II)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;II)Lio/kotest/assertions/json/JsonSubPathJsonArrayTooShort;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonSubPathJsonArrayTooShort;Ljava/lang/String;IIILjava/lang/Object;)Lio/kotest/assertions/json/JsonSubPathJsonArrayTooShort;
+	public fun description ()Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArraySize ()I
+	public final fun getExpectedIndex ()I
+	public final fun getSubPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/assertions/json/JsonSubPathNotFound : io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public static final field INSTANCE Lio/kotest/assertions/json/JsonSubPathNotFound;
+	public fun description ()Ljava/lang/String;
+}
+
+public abstract interface class io/kotest/assertions/json/JsonSubPathSearchOutcome {
+	public abstract fun description ()Ljava/lang/String;
+}
+
 public final class io/kotest/assertions/json/JsonTree {
 	public fun <init> (Lio/kotest/assertions/json/JsonNode;Ljava/lang/String;)V
 	public final fun component1 ()Lio/kotest/assertions/json/JsonNode;
@@ -389,7 +439,9 @@ public final class io/kotest/assertions/json/KeysKt {
 }
 
 public final class io/kotest/assertions/json/KeyvaluesKt {
-	public static final fun findValidSubPath (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun extractPossiblePathOfJsonArray (Ljava/lang/String;)Lio/kotest/assertions/json/JsonArrayElementRef;
+	public static final fun findValidSubPath (Ljava/lang/String;Ljava/lang/String;)Lio/kotest/assertions/json/JsonSubPathSearchOutcome;
+	public static final fun getPossibleSizeOfJsonArray (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Integer;
 	public static final fun removeLastPartFromPath (Ljava/lang/String;)Ljava/lang/String;
 }
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
@@ -25,7 +25,8 @@ class ContainJsonKeyValueTest : StringSpec({
                     "category": "fiction",
                     "author": "Evelyn Waugh",
                     "title": "Sword of Honour",
-                    "price": 12.99
+                    "price": 12.99,
+                    "comments": []
                  }
               ],
               "bicycle": {
@@ -50,17 +51,33 @@ class ContainJsonKeyValueTest : StringSpec({
    "Failure message states if key is missing, when it's missing" {
       shouldFail {
          json.shouldContainJsonKeyValue("$.bicycle.engine", "V2")
-      }.message shouldBe """
-         Expected given to contain json key <'$.bicycle.engine'> but key was not found.
-      """.trimIndent()
+      }.message shouldBe "Expected given to contain json key <'$.bicycle.engine'> but key was not found. "
    }
 
    "Failure message states if key is missing, shows valid subpath" {
       shouldFail {
          json.shouldContainJsonKeyValue("$.store.bicycle.engine", "V2")
       }.message shouldBe """
-         Expected given to contain json key <'$.store.bicycle.engine'> but key was not found. Found shorter valid subpath: <'$.store.bicycle'>
+         Expected given to contain json key <'$.store.bicycle.engine'> but key was not found. Found shorter valid subpath: <'$.store.bicycle'>.
       """.trimIndent()
+   }
+
+   "Failure message states if key is missing, shows json array index out of bounds" {
+      shouldFail {
+         json.shouldContainJsonKeyValue("$.store.book[2].category", "V2")
+      }.message shouldBe "Expected given to contain json key <'$.store.book[2].category'> but key was not found. The array at path <'$.store.book'> has size 2, so index 2 is out of bounds."
+   }
+
+   "Failure message states if key is missing, shows element is not json array" {
+      shouldFail {
+         json.shouldContainJsonKeyValue("$.store.bicycle[0].color", "V2")
+      }.message shouldBe "Expected given to contain json key <'$.store.bicycle[0].color'> but key was not found. Found shorter valid subpath: <'$.store'>."
+   }
+
+   "Failure message states if key is missing, shows json array index out of bounds when array is empty" {
+      shouldFail {
+         json.shouldContainJsonKeyValue("$.store.book[1].comments[0]", "V2")
+      }.message shouldBe "Expected given to contain json key <'$.store.book[1].comments[0]'> but key was not found. The array at path <'$.store.book[1].comments'> has size 0, so index 0 is out of bounds."
    }
 
    "Failure message states states value mismatch if key is present with different value" {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -1,9 +1,15 @@
 package com.sksamuel.kotest.tests.json
 
 import io.kotest.assertions.json.ExtractedValue
+import io.kotest.assertions.json.JsonArrayElementRef
 import io.kotest.assertions.json.JsonPathNotFound
+import io.kotest.assertions.json.JsonSubPathFound
+import io.kotest.assertions.json.JsonSubPathJsonArrayTooShort
+import io.kotest.assertions.json.JsonSubPathNotFound
 import io.kotest.assertions.json.extractByPath
+import io.kotest.assertions.json.extractPossiblePathOfJsonArray
 import io.kotest.assertions.json.findValidSubPath
+import io.kotest.assertions.json.getPossibleSizeOfJsonArray
 import io.kotest.assertions.json.removeLastPartFromPath
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
@@ -22,9 +28,16 @@ class ExtractByPathTest: WordSpec() {
             "temperature": {
                 "degrees": 320,
                 "unit": "F"
-            }
+            },
+            "comments": []
           },
-          "comments": null
+          "steps": [
+            {
+               "name": "Boil",
+               "comments": ["Heat on 3", "No lid"]
+            }
+          ],
+    "comments": null
       }
    """.trimIndent()
 
@@ -50,15 +63,64 @@ class ExtractByPathTest: WordSpec() {
          }
       }
 
-      "findValidSubPath" should {
-          "find valid sub path" {
-             findValidSubPath(json, "$.regime.temperature.unit.name.some.more.tokens") shouldBe "$.regime.temperature.unit"
-             findValidSubPath(json, "$.regime.temperature.unit.name") shouldBe "$.regime.temperature.unit"
-             findValidSubPath(json, "$.regime.temperature.name") shouldBe "$.regime.temperature"
-             findValidSubPath(json, "$.regime.no_such_element") shouldBe "$.regime"
-          }
+      "findValidSubPath2" should {
+         "find valid sub path" {
+            findValidSubPath(
+               json,
+               "$.regime.temperature.unit.name.some.more.tokens"
+            ) shouldBe JsonSubPathFound("$.regime.temperature.unit")
+            findValidSubPath(
+               json,
+               "$.regime.temperature.unit.name"
+            ) shouldBe JsonSubPathFound("$.regime.temperature.unit")
+            findValidSubPath(json, "$.regime.temperature.name") shouldBe JsonSubPathFound("$.regime.temperature")
+            findValidSubPath(json, "$.regime.no_such_element") shouldBe JsonSubPathFound("$.regime")
+         }
+         "return JsonSubPathJsonArrayTooShort" {
+            findValidSubPath(json, "$.steps[0].comments[2]") shouldBe
+               JsonSubPathJsonArrayTooShort("$.steps[0].comments", 2, 2)
+            findValidSubPath(json, "$.steps[1].comments[2]") shouldBe
+               JsonSubPathJsonArrayTooShort("$.steps", 1, 1)
+         }
          "return null when nothing found" {
-            findValidSubPath(json, "$.no.such.path") shouldBe null
+            findValidSubPath(json, "$.no.such.path") shouldBe JsonSubPathNotFound
+         }
+      }
+
+      "getPossibleSizeOfJsonArray" should {
+         "return size of array" {
+            getPossibleSizeOfJsonArray(json, "$.ingredients") shouldBe 3
+            getPossibleSizeOfJsonArray(json, "$.steps[0].comments") shouldBe 2
+            getPossibleSizeOfJsonArray(json, "$.steps") shouldBe 1
+            getPossibleSizeOfJsonArray(json, "$.regime.comments") shouldBe 0
+         }
+         "return null if not an array" {
+            getPossibleSizeOfJsonArray(json, "$.appliance.type") shouldBe null
+            getPossibleSizeOfJsonArray(json, "$.appliance") shouldBe null
+            getPossibleSizeOfJsonArray(json, "$.steps.name") shouldBe null
+         }
+      }
+
+      "extractPossiblePathOfJsonArray" should {
+         "return null if not array" {
+            extractPossiblePathOfJsonArray("$.not.an.array") shouldBe null
+         }
+         "return null if not valid index" {
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[]") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients]") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42[") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42]]") shouldBe null
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[BAD-INDEX]") shouldBe null
+         }
+         "return path" {
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[42]") shouldBe
+               JsonArrayElementRef("\$.recipe.ingredients", 42)
+         }
+         "handle nested JSONArray" {
+            extractPossiblePathOfJsonArray("$.recipe.ingredients[2].comments[3]") shouldBe
+               JsonArrayElementRef("\$.recipe.ingredients[2].comments", 3)
          }
       }
    }


### PR DESCRIPTION
provide more info when key not found, such as:

```kotlin
   "Failure message states if key is missing, shows json array index out of bounds" {
      shouldFail {
         json.shouldContainJsonKeyValue("$.store.book[2].category", "V2")
      }.message shouldBe "Expected given to contain json key <'$.store.book[2].category'> but key was not found. The array at path <'$.store.book'> has size 2, so index 2 is out of bounds."
   }
```

or 

```kotlin
   "Failure message states if key is missing, shows json array index out of bounds when array is empty" {
      shouldFail {
         json.shouldContainJsonKeyValue("$.store.book[1].comments[0]", "V2")
      }.message shouldBe "Expected given to contain json key <'$.store.book[1].comments[0]'> but key was not found. The array at path <'$.store.book[1].comments'> has size 0, so index 0 is out of bounds."
   }
```