### PR TITLE
Stabilize GlobalTimeoutTest and EngineTimeoutTest

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -314,6 +314,7 @@ public abstract class io/kotest/engine/listener/AbstractTestEngineListener : io/
 public final class io/kotest/engine/listener/CollectingTestEngineListener : io/kotest/engine/listener/AbstractTestEngineListener, kotlinx/coroutines/sync/Mutex {
 	public fun <init> ()V
 	public fun engineFinished (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun engineStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getErrors ()Z
 	public final fun getNames ()Ljava/util/List;
 	public fun getOnLock ()Lkotlinx/coroutines/selects/SelectClause2;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
@@ -22,7 +22,7 @@ class CollectingTestEngineListener : AbstractTestEngineListener(), Mutex by Mute
    /**
     * Counts the number of times [engineStarted] and [engineFinished] have been invoked.
     *
-    * Used by [waitForEngineFinished], so that internal Kotest tests can wait until engines
+    * Used by [waitForEnginesFinished], so that internal Kotest tests can wait until engines
     * are finished before performing assertions.
     */
    private val activeEngineCount = MutableStateFlow<Int?>(null)
@@ -74,7 +74,7 @@ class CollectingTestEngineListener : AbstractTestEngineListener(), Mutex by Mute
    }
 
    /** Suspends until at least one engine has started, and all engines have finished. */
-   internal suspend fun waitForEngineFinished() {
+   internal suspend fun waitForEnginesFinished() {
       // wait until `engineFinished()` has been invoked the same number of times as `engineStarted()`
       activeEngineCount.first { it == 0 }
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
@@ -73,7 +73,7 @@ class CollectingTestEngineListener : AbstractTestEngineListener(), Mutex by Mute
       return TestCaseKey(this.descriptor, this.name, this.spec::class)
    }
 
-   /** Suspends until all engines have finished. */
+   /** Suspends until at least one engine has started, and all engines have finished. */
    internal suspend fun waitForEngineFinished() {
       // wait until `engineFinished()` has been invoked the same number of times as `engineStarted()`
       activeEngines.first { it == 0 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
@@ -22,10 +22,8 @@ class CollectingTestEngineListener : AbstractTestEngineListener(), Mutex by Mute
    /**
     * Counts the number of times [engineStarted] and [engineFinished] have been invoked.
     *
-    * (Using a read-write mutex would be more appropriate, but it's not available yet.
-    * See https://github.com/Kotlin/kotlinx.coroutines/issues/94)
-    *
-    * @see waitForEngineFinished
+    * Used by [waitForEngineFinished], so that internal Kotest tests can wait until engines
+    * are finished before performing assertions.
     */
    private val activeEngines = MutableStateFlow<Int?>(null)
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
@@ -18,7 +18,7 @@ class EngineTimeoutTest : FunSpec() {
          TestEngineLauncher(collector)
             .withClasses(DannyDelay::class)
             .launch()
-         collector.waitForEngineFinished()
+         collector.waitForEnginesFinished()
          collector.names shouldBe listOf("a")
          collector.result("a").asClue { result ->
             result?.errorOrNull?.message shouldBe "Test 'a' did not complete within 1ms"
@@ -30,7 +30,7 @@ class EngineTimeoutTest : FunSpec() {
          TestEngineLauncher(collector)
             .withClasses(LarryLauncher::class)
             .launch()
-         collector.waitForEngineFinished()
+         collector.waitForEnginesFinished()
          collector.names shouldBe listOf("a")
          collector.result("a").asClue { result ->
             result?.errorOrNull?.message shouldBe "Test 'a' did not complete within 1ms"
@@ -42,7 +42,7 @@ class EngineTimeoutTest : FunSpec() {
          TestEngineLauncher(collector)
             .withClasses(BillyBlocked::class)
             .launch()
-         collector.waitForEngineFinished()
+         collector.waitForEnginesFinished()
          collector.names shouldBe listOf("a")
          collector.result("a").asClue { result ->
             result?.errorOrNull?.message shouldBe "sleep interrupted"

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.assertions.asClue
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -17,8 +18,11 @@ class EngineTimeoutTest : FunSpec() {
          TestEngineLauncher(collector)
             .withClasses(DannyDelay::class)
             .launch()
+         collector.waitForEngineFinished()
          collector.names shouldBe listOf("a")
-         collector.result("a")!!.errorOrNull!!.message!! shouldBe "Test 'a' did not complete within 1ms"
+         collector.result("a").asClue { result ->
+            result?.errorOrNull?.message shouldBe "Test 'a' did not complete within 1ms"
+         }
       }
 
       test("timeouts should be applied by the engine to suspend inside launched coroutines") {
@@ -26,8 +30,11 @@ class EngineTimeoutTest : FunSpec() {
          TestEngineLauncher(collector)
             .withClasses(LarryLauncher::class)
             .launch()
+         collector.waitForEngineFinished()
          collector.names shouldBe listOf("a")
-         collector.result("a")!!.errorOrNull!!.message!! shouldBe "Test 'a' did not complete within 1ms"
+         collector.result("a").asClue { result ->
+            result?.errorOrNull?.message shouldBe "Test 'a' did not complete within 1ms"
+         }
       }
 
       test("timeouts should be applied by the engine to blocked threads") {
@@ -35,8 +42,11 @@ class EngineTimeoutTest : FunSpec() {
          TestEngineLauncher(collector)
             .withClasses(BillyBlocked::class)
             .launch()
+         collector.waitForEngineFinished()
          collector.names shouldBe listOf("a")
-         collector.result("a")!!.errorOrNull!!.message!! shouldBe "sleep interrupted"
+         collector.result("a").asClue { result ->
+            result?.errorOrNull?.message shouldBe "sleep interrupted"
+         }
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -33,15 +33,8 @@ class GlobalTimeoutTest : FunSpec() {
 
 private class TestTimeouts : StringSpec() {
    init {
-
-      "blocked".config(blockingTest = true) {
-         // Long delay, to ensure tests will be interrupted. We'd notice a test that runs for a month.
-         Thread.sleep(28.days.inWholeMilliseconds)
-      }
-
-      "suspend" {
-         // Long delay, to ensure tests will be interrupted. We'd notice a test that runs for a month.
-         delay(28.days)
-      }
+      // Long delays, to ensure tests will be interrupted. We'd notice a test that runs for a month.
+      "blocked".config(blockingTest = true) { Thread.sleep(28.days.inWholeMilliseconds) }
+      "suspend" { delay(28.days) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -21,7 +21,7 @@ class GlobalTimeoutTest : FunSpec() {
             .withConfiguration(c)
             .launch()
 
-         collector.waitForEngineFinished()
+         collector.waitForEnginesFinished()
 
          collector.names.shouldContainExactly("blocked", "suspend")
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -21,7 +21,6 @@ class GlobalTimeoutTest : FunSpec() {
             .withConfiguration(c)
             .launch()
 
-         // wait until the engine has finished
          collector.waitForEngineFinished()
 
          collector.names.shouldContainExactly("blocked", "suspend")

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -1,39 +1,48 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.assertions.asClue
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
+import kotlin.time.Duration.Companion.days
 
 class GlobalTimeoutTest : FunSpec() {
    init {
-      test("global timeouts should apply if no other timeout is set")
-      {
+      test("global timeouts should apply if no other timeout is set") {
          val c = ProjectConfiguration().apply { timeout = 3 }
          val collector = CollectingTestEngineListener()
          TestEngineLauncher(collector)
             .withClasses(TestTimeouts::class)
             .withConfiguration(c)
             .launch()
-         collector.tests.mapKeys { it.key.name.testName }["blocked"]?.isError shouldBe true
-         collector.tests.mapKeys { it.key.name.testName }["suspend"]?.isError shouldBe true
+
+         // wait until the engine has finished
+         collector.waitForEngineFinished()
+
+         collector.names.shouldContainExactly("blocked", "suspend")
+
+         collector.result("blocked").asClue { result -> result?.isError shouldBe true }
+         collector.result("suspend").asClue { result -> result?.isError shouldBe true }
       }
    }
 }
 
 private class TestTimeouts : StringSpec() {
    init {
+
       "blocked".config(blockingTest = true) {
-         // high value to ensure its interrupted, we'd notice a test that runs for 10 weeks
-         Thread.sleep(1000000)
+         // Long delay, to ensure tests will be interrupted. We'd notice a test that runs for a month.
+         Thread.sleep(28.days.inWholeMilliseconds)
       }
 
       "suspend" {
-         // high value to ensure its interrupted, we'd notice a test that runs for 10 weeks
-         delay(1000000)
+         // Long delay, to ensure tests will be interrupted. We'd notice a test that runs for a month.
+         delay(28.days)
       }
    }
 }


### PR DESCRIPTION
Wait until the engine has completed before asserting the results.

Part of #4113 