### PR TITLE
suppress deprecation warnings for deprecated `io.kotest.assertions.until.*` utils

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/ExponentialInterval.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/ExponentialInterval.kt
@@ -16,6 +16,7 @@ import kotlin.time.Duration.Companion.hours
  * @param max the maximum duration to clamp the resulting duration to defaults to [ExponentialInterval.defaultMax]
  */
 @Deprecated("Replaced with the io.kotest.assertions.nondeterministic utils. Deprecated in 5.7")
+@Suppress("DEPRECATION")
 class ExponentialInterval(private val base: Duration, private val factor: Double, private val max: Duration?) : Interval {
    override fun toString() = "ExponentialInterval(${::base.name}=$base, ${::factor.name}=$factor, ${::max.name}=$max)"
 
@@ -31,5 +32,6 @@ class ExponentialInterval(private val base: Duration, private val factor: Double
 }
 
 @Deprecated("Replaced with the io.kotest.assertions.nondeterministic utils. Deprecated in 5.7")
+@Suppress("DEPRECATION")
 fun Duration.exponential(factor: Double = ExponentialInterval.defaultFactor, max: Duration? = ExponentialInterval.defaultMax) =
    ExponentialInterval(this, factor, max)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/FibonacciInterval.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/FibonacciInterval.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.until.Interval is removed
+
 package io.kotest.assertions.until
 
 import kotlin.time.Duration

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/FixedInterval.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/FixedInterval.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.until.Interval is removed
+
 package io.kotest.assertions.until
 
 import kotlin.time.Duration

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/until/until.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.until.Interval is removed
+
 package io.kotest.assertions.until
 
 import io.kotest.assertions.failure

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/ExponentialIntervalTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/ExponentialIntervalTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.until.Interval is removed
+
 package com.sksamuel.kotest.assertions.until
 
 import io.kotest.assertions.assertSoftly
@@ -9,7 +11,6 @@ import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import kotlin.math.pow
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -32,55 +33,55 @@ class ExponentialIntervalTest : FunSpec() {
       }
 
       test("exponential interval should have a reasonable default max") {
-          val max = ExponentialInterval.defaultMax
-          val default = 25.milliseconds.exponential()
-          val unbounded = 25.milliseconds.exponential(max = null)
+         val max = ExponentialInterval.defaultMax
+         val default = 25.milliseconds.exponential()
+         val unbounded = 25.milliseconds.exponential(max = null)
 
-          val first = 0
-          val last = 20
+         val first = 0
+         val last = 20
 
-          unbounded.next(first) shouldBeLessThan max
-          unbounded.next(last) shouldBeGreaterThan max
+         unbounded.next(first) shouldBeLessThan max
+         unbounded.next(last) shouldBeGreaterThan max
 
-          for (i in first..last) {
-              val u = unbounded.next(i)
-              val d = default.next(i)
+         for (i in first..last) {
+            val u = unbounded.next(i)
+            val d = default.next(i)
 
-              if (u < max) {
-                  d shouldBe u
-              } else {
-                  d shouldBe max
-                  u shouldBeGreaterThan max
-              }
-          }
+            if (u < max) {
+               d shouldBe u
+            } else {
+               d shouldBe max
+               u shouldBeGreaterThan max
+            }
+         }
       }
 
       test("exponential interval should respect user specified max") {
-          val base = 25.milliseconds
-          val n = 5
-          val max = base * ExponentialInterval.defaultFactor.pow(n)
-          val bounded = base.exponential(max = max)
-          val unbounded = base.exponential(max = null)
+         val base = 25.milliseconds
+         val n = 5
+         val max = base * ExponentialInterval.defaultFactor.pow(n)
+         val bounded = base.exponential(max = max)
+         val unbounded = base.exponential(max = null)
 
-          val first = 0
-          val last = 20
+         val first = 0
+         val last = 20
 
-          unbounded.next(first) shouldBeLessThan max
-          unbounded.next(last) shouldBeGreaterThan max
+         unbounded.next(first) shouldBeLessThan max
+         unbounded.next(last) shouldBeGreaterThan max
 
-          for (i in first..last) {
-              val u = unbounded.next(i)
-              val b = bounded.next(i)
+         for (i in first..last) {
+            val u = unbounded.next(i)
+            val b = bounded.next(i)
 
-              if (u < max) {
-                  b shouldBe u
-                  i shouldBeLessThan n
-              } else {
-                  i shouldBeGreaterThanOrEqualTo n
-                  b shouldBe max
-                  u shouldBeGreaterThanOrEqualTo max
-              }
-          }
+            if (u < max) {
+               b shouldBe u
+               i shouldBeLessThan n
+            } else {
+               i shouldBeGreaterThanOrEqualTo n
+               b shouldBe max
+               u shouldBeGreaterThanOrEqualTo max
+            }
+         }
       }
    }
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/FibonacciIntervalTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/until/FibonacciIntervalTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.until.Interval is removed
+
 package com.sksamuel.kotest.assertions.until
 
 import io.kotest.assertions.until.FibonacciInterval


### PR DESCRIPTION
Part of #4085
