### PR TITLE
Enable concurrency cancellation in PR test GitHub Action

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -7,6 +7,10 @@ on:
 permissions:
    contents: read
 
+concurrency:
+   group: "PR-Test: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+   cancel-in-progress: true
+
 jobs:
    determine-workflows-to-run:
       name: Determine workflows to run


### PR DESCRIPTION
Enable concurrency to decrease CI pressure. (E.g. If a PR receives several commits in quick succession, only the latest commit will be run and the earlier ones will be cancelled.)
