### PR TITLE
CI: run Gradle check on all OSes in parallel

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -57,24 +57,15 @@ jobs:
          ref: ${{ inputs.ref }}
          task: apiCheck --continue
 
-   validate-primary:
-      name: Validate on primary runner
+   gradle-check:
+      name: Run gradle check
       if: ${{ github.repository == 'kotest/kotest' && needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
       needs: [ determine-workflows-to-run, validate-api ]
-      uses: ./.github/workflows/run-gradle.yml
-      with:
-         runs-on: ubuntu-latest
-         ref: ${{ inputs.ref }}
-         task: check --continue
-
-   validate-secondary:
-      name: Validate on secondary runners
-      if: ${{ github.repository == 'kotest/kotest' && needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
-      needs: [ determine-workflows-to-run, validate-api, validate-primary ]
       strategy:
          matrix:
             include:
                -  os: macos-latest
+               -  os: ubuntu-latest
                -  os: windows-latest
          fail-fast: false
       uses: ./.github/workflows/run-gradle.yml
@@ -102,7 +93,7 @@ jobs:
    finalize:
       # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7
       name: Final PR results
-      needs: [ validate-api, validate-primary, validate-secondary, validate-docs ]
+      needs: [ validate-api, gradle-check, validate-docs ]
       if: ${{ always() }}
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
Currently CI has to complete tests on Ubuntu before starting macOS and Windows test. This adds ~20 minutes to the CI run.

This PR runs tests in all PRs in parallel, immediately. This will reduce the duration of testing PRs and the merge queue.