### PR TITLE
CI: Enable Configuration Cache re-use

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -52,6 +52,7 @@ jobs:
       needs: [ determine-workflows-to-run ]
       if: ${{ github.repository == 'kotest/kotest' && needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
       uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
       with:
          runs-on: ubuntu-latest
          ref: ${{ inputs.ref }}
@@ -69,6 +70,7 @@ jobs:
                -  os: windows-latest
          fail-fast: false
       uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
       with:
          runs-on: ${{ matrix.os }}
          ref: ${{ inputs.ref }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,6 +20,7 @@ jobs:
       name: Validate API
       if: github.repository == 'kotest/kotest'
       uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
       with:
          runs-on: ubuntu-latest
          ref: ${{ inputs.ref }}
@@ -30,6 +31,7 @@ jobs:
       if: github.repository == 'kotest/kotest'
       needs: validate-api
       uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
       with:
          runs-on: ubuntu-latest
          ref: ${{ inputs.ref }}
@@ -46,6 +48,7 @@ jobs:
                -  os: windows-latest
          fail-fast: false
       uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
       with:
          runs-on: ${{ matrix.os }}
          ref: ${{ inputs.ref }}

--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -51,6 +51,7 @@ jobs:
             uses: gradle/actions/setup-gradle@v3
             with:
                gradle-home-cache-cleanup: true
+               cache-encryption-key: ${{ secrets.GRADLE_CONFIGURATION_CACHE_ENCRYPTION_KEY }}
 
          -  name: Run tests
             run: ./gradlew ${{ inputs.task }} --scan


### PR DESCRIPTION
Configure Gradle Configuration Cache re-use on CI by providing an encryption key.

This will speed up Gradle builds on CI.

See: https://github.com/gradle/actions/blob/v3.4.2/docs/setup-gradle.md#saving-configuration-cache-data
