### PR TITLE
Opt in for expect-actual classes

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import utils.SystemPropertiesArgumentProvider
@@ -35,6 +36,10 @@ tasks.withType<KotlinCompile>().configureEach {
 
 kotlin {
    sourceSets.configureEach {
+      @OptIn(ExperimentalKotlinGradlePluginApi::class)
+      compilerOptions {
+         freeCompilerArgs.add("-Xexpect-actual-classes")
+      }
       languageSettings {
          optIn("kotlin.time.ExperimentalTime")
          optIn("kotlin.experimental.ExperimentalTypeInference")


### PR DESCRIPTION
> Expected and actual classes are in [Beta](https://kotlinlang.org/docs/components-stability.html). They are almost stable, but migration steps may be required in the future. We'll do our best to minimize any further changes for you to make.
> 
> https://kotlinlang.org/docs/multiplatform-expect-actual.html#expected-and-actual-classes

Part of #4085
