### PR TITLE
Add missing annotation to actual declarations

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
+++ b/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
@@ -1,18 +1,22 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.common.JVMOnly
 import io.kotest.common.platform
 import io.kotest.core.concurrency.CoroutineDispatcherFactory
 import io.kotest.core.config.ProjectConfiguration
 import kotlin.time.TimeMark
 
+@JVMOnly
 internal actual fun coroutineDispatcherFactoryInterceptor(
    defaultCoroutineDispatcherFactory: CoroutineDispatcherFactory
 ): TestExecutionInterceptor = error("Unsupported on $platform")
 
+@JVMOnly
 internal actual fun blockedThreadTimeoutInterceptor(
    configuration: ProjectConfiguration,
    start: TimeMark,
 ): TestExecutionInterceptor = error("Unsupported on $platform")
 
+@JVMOnly
 internal actual fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor =
    error("Unsupported on $platform")

--- a/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/test/interceptors/interceptors.kt
@@ -1,20 +1,24 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.common.JVMOnly
 import io.kotest.common.platform
 import io.kotest.core.concurrency.CoroutineDispatcherFactory
 import io.kotest.core.config.ProjectConfiguration
 import kotlin.time.ExperimentalTime
 import kotlin.time.TimeMark
 
+@JVMOnly
 internal actual fun coroutineDispatcherFactoryInterceptor(
    defaultCoroutineDispatcherFactory: CoroutineDispatcherFactory
 ): TestExecutionInterceptor = error("Unsupported on $platform")
 
 @ExperimentalTime
+@JVMOnly
 internal actual fun blockedThreadTimeoutInterceptor(
    configuration: ProjectConfiguration,
    start: TimeMark,
 ): TestExecutionInterceptor = error("Unsupported on $platform")
 
+@JVMOnly
 internal actual fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor =
    error("Unsupported on $platform")

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/BlockedThreadTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/BlockedThreadTimeoutInterceptor.kt
@@ -1,5 +1,6 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.common.JVMOnly
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -27,6 +28,7 @@ private val timeoutDispatcher = newSingleThreadContext("blocking-thread-timeout"
  * If [io.kotest.core.test.config.ResolvedTestConfig.blockingTest] is enabled, then switches the execution
  * to a new thread, so it can be interrupted if the test times out.
  */
+@JVMOnly
 internal actual fun blockedThreadTimeoutInterceptor(
    configuration: ProjectConfiguration,
    start: TimeMark,

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
@@ -2,12 +2,14 @@ package io.kotest.engine.test.interceptors
 
 import io.kotest.assertions.assertionCounterContextElement
 import io.kotest.assertions.errorCollectorContextElement
+import io.kotest.common.JVMOnly
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
 import io.kotest.mpp.Logger
 import kotlinx.coroutines.withContext
 
+@JVMOnly
 internal actual fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor =
    CoroutineErrorCollectorInterceptor
 

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/coroutineDispatcherFactoryInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/coroutineDispatcherFactoryInterceptor.kt
@@ -1,5 +1,6 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.common.JVMOnly
 import io.kotest.core.concurrency.CoroutineDispatcherFactory
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -12,6 +13,7 @@ import kotlinx.coroutines.test.TestDispatcher
 import kotlin.coroutines.coroutineContext
 
 @ExperimentalStdlibApi
+@JVMOnly
 internal actual fun coroutineDispatcherFactoryInterceptor(
    defaultCoroutineDispatcherFactory: CoroutineDispatcherFactory
 ): TestExecutionInterceptor = CoroutineDispatcherFactoryInterceptor(defaultCoroutineDispatcherFactory)


### PR DESCRIPTION
`@JVMOnly` is defined on the `expect fun`, but not on the `actual fun`s.

This triggers a warning:

> Annotation `@JVMOnly` is missing on actual declaration.
> All annotations from expect `fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor defined in io.kotest.engine.test.interceptors in file interceptors.kt` must be present with the same arguments on actual `fun coroutineErrorCollectorInterceptor(): TestExecutionInterceptor defined in io.kotest.engine.test.interceptors in file CoroutineErrorCollectorInterceptor.kt`, otherwise they might behave incorrectly.

Part of #4085

