### PR TITLE
Deprecate implementations of deprecated `SpecExtension.intercept()`

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/extensions/SpecExtension.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DeprecatedCallableAddReplaceWith")
-
 package io.kotest.core.extensions
 
 import io.kotest.core.spec.Spec
@@ -27,6 +25,7 @@ interface SpecExtension : Extension {
     * @param process callback function required to continue spec processing
     */
    @Deprecated("This function had ambiguous specifications. Instead prefer intercept(spec: Spec, execute: suspend (Spec) -> Unit) which is guaranteed to run once per spec instance or use SpecRefExtension which runs once per spec class. This function was deprecated in 5.0")
+   @Suppress("DeprecatedCallableAddReplaceWith")
    suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
       process()
    }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/DslDrivenSpec.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/DslDrivenSpec.kt
@@ -108,6 +108,8 @@ abstract class DslDrivenSpec : Spec(), RootScope {
    @Deprecated("This has no effect and will be removed in 6.0", level = DeprecationLevel.ERROR)
    fun aroundSpec(aroundSpecFn: AroundSpecFn) {
       extension(object : SpecExtension {
+         @Deprecated("See `SpecExtension.intercept(spec: KClass<out Spec>, process: suspend () -> Unit)`")
+         @Suppress("DeprecatedCallableAddReplaceWith")
          override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
             aroundSpecFn(Tuple2(spec, process))
          }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SpecWrapperExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SpecWrapperExtension.kt
@@ -110,6 +110,8 @@ internal class SpecWrapperExtension(
       if (delegate is PrepareSpecListener && kclass == target) delegate.prepareSpec(kclass)
    }
 
+   @Deprecated("See `SpecExtension.intercept(spec: KClass<out Spec>, process: suspend () -> Unit)`")
+   @Suppress("DeprecatedCallableAddReplaceWith")
    override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
       if (delegate is SpecExtension && spec == target) delegate.intercept(spec, process) else process()
    }

--- a/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
@@ -13,6 +13,7 @@ interface BeforeAndAfterPropertyTestInterceptExtension : SpecExtension {
    suspend fun beforeProperty()
    suspend fun afterProperty()
 
+   @Deprecated("See `SpecExtension.intercept(spec: KClass<out Spec>, process: suspend () -> Unit)`")
    override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
       val before = coroutineContext[BeforePropertyContextElement]?.before
       val after = coroutineContext[AfterPropertyContextElement]?.after
@@ -30,14 +31,19 @@ interface BeforeAndAfterPropertyTestInterceptExtension : SpecExtension {
 
 fun Spec.beforeProperty(f: suspend () -> Unit) {
    extension(object : BeforeAndAfterPropertyTestInterceptExtension {
-      override suspend fun beforeProperty() { f() }
-      override suspend fun afterProperty() { }
+      override suspend fun beforeProperty() {
+         f()
+      }
+
+      override suspend fun afterProperty() {}
    })
 }
 
 fun Spec.afterProperty(f: suspend () -> Unit) {
    extension(object : BeforeAndAfterPropertyTestInterceptExtension {
-      override suspend fun beforeProperty() { }
-      override suspend fun afterProperty() { f() }
+      override suspend fun beforeProperty() {}
+      override suspend fun afterProperty() {
+         f()
+      }
    })
 }


### PR DESCRIPTION
Continuing with resolving build warnings #4085

Avoids warning:

> This declaration overrides deprecated member but not marked as deprecated itself. Please add ``@Deprecated` annotation or suppress. See https://youtrack.jetbrains.com/issue/KT-47902 for details

