### PR TITLE
Fix typo in documentation

### DIFF
--- a/documentation/docs/proptest/seed.md
+++ b/documentation/docs/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.

--- a/documentation/versioned_docs/version-5.4/proptest/seed.md
+++ b/documentation/versioned_docs/version-5.4/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.

--- a/documentation/versioned_docs/version-5.5/proptest/seed.md
+++ b/documentation/versioned_docs/version-5.5/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.

--- a/documentation/versioned_docs/version-5.6/proptest/seed.md
+++ b/documentation/versioned_docs/version-5.6/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.

--- a/documentation/versioned_docs/version-5.7/proptest/seed.md
+++ b/documentation/versioned_docs/version-5.7/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.

--- a/documentation/versioned_docs/version-5.8/proptest/seed.md
+++ b/documentation/versioned_docs/version-5.8/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.

--- a/documentation/versioned_docs/version-5.9/proptest/seed.md
+++ b/documentation/versioned_docs/version-5.9/proptest/seed.md
@@ -53,7 +53,7 @@ This feature can be disabled by setting `PropertyTesting.writeFailedSeed = false
 ### Failing when seeds set
 
 Some users prefer to avoid manually specifying seeds. They want to use them locally only, when developing, but to avoid
-checking them in. If is your style, then set `PropertyTesting.failOnSeed = false` or the env
+checking them in. If this is your style, then set `PropertyTesting.failOnSeed = false` or the env
 var `kotest.proptest.seed.fail-if-set` to `false` on your server.
 
 Then if a seed is detected, the test suite will fail.


### PR DESCRIPTION
This pull request fixes a typo in the documentation.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
