### PR TITLE
Optimise parallel test launching test

### DIFF
--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -44,8 +44,8 @@ object ProjectConfig : AbstractProjectConfig() {
    /**
     * Listen for test [TestStatus]s in an independent [CoroutineScope].
     */
-   private val TestMsgCollectorScope: CoroutineScope =
-      CoroutineScope(Dispatchers.IO) + CoroutineName("TestMsgCollector")
+   private val TestStatusCollectorScope: CoroutineScope =
+      CoroutineScope(Dispatchers.IO) + CoroutineName("TestStatusCollector")
 
    /** Marks the start of the entire tests, when [beforeProject] is called, before any tests are launched. */
    internal lateinit var projectStart: TimeMark
@@ -70,7 +70,7 @@ object ProjectConfig : AbstractProjectConfig() {
                testCompletionLock.unlock()
             }
          }
-         .launchIn(TestMsgCollectorScope)
+         .launchIn(TestStatusCollectorScope)
    }
 
    override suspend fun beforeProject() {

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -1,31 +1,134 @@
 package com.sksamuel.kotest.parallelism
 
+import com.sksamuel.kotest.parallelism.ProjectConfig.projectStart
+import com.sksamuel.kotest.parallelism.StateMsg.Status.Finished
+import com.sksamuel.kotest.parallelism.StateMsg.Status.Started
+import io.kotest.assertions.withClue
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.config.ProjectConfiguration
-import kotlin.time.Duration.Companion.milliseconds
+import io.kotest.core.test.TestScope
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.mpp.log
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeMark
 import kotlin.time.TimeSource
-import kotlin.time.times
 
 object ProjectConfig : AbstractProjectConfig() {
 
-   private lateinit var start: TimeMark
-
-   override suspend fun beforeProject() {
-      start = TimeSource.Monotonic.markNow() // We cannot use virtual time with concurrency
-   }
+   /**
+    * Listen for test [StateMsg]s in an independent [CoroutineScope].
+    */
+   private val TestMsgCollectorScope: CoroutineScope =
+      CoroutineScope(Dispatchers.IO) + CoroutineName("TestMsgCollector")
 
    // set the number of threads so that each test runs in its own thread
    override val parallelism = 10
 
+   /** The expected number of test cases. All should be launched simultaneously. */
+   private const val EXPECTED_TEST_COUNT = 8
+
    override val concurrentSpecs: Int = ProjectConfiguration.MaxConcurrency
 
+   /** Marks the start of the entire tests, when [beforeProject] is called, before any tests are launched. */
+   lateinit var projectStart: TimeMark
+      private set
+
+   init {
+      // Start listening for launched tests in an independent CoroutineScope.
+      testStateMessages
+         .onEach { msg -> log { "$msg" } }
+         .filter { msg -> msg.status == Started }
+         // Count the number of started tests by name
+         .runningFold(setOf<String>()) { acc, msg -> acc + msg.testName }
+         .map { testNames -> testNames.size }
+         // Once all tests are launched, unlock testCompletionLock
+         .onEach { startedTestCount ->
+            log { "startedTestCount: $startedTestCount" }
+            if (startedTestCount == EXPECTED_TEST_COUNT) {
+               log {
+                  "$EXPECTED_TEST_COUNT tests have been successfully launched simultaneously. " +
+                     "Unlocking testCompletionLock and allowing the tests to complete."
+               }
+               testCompletionLock.unlock()
+            }
+         }
+         .launchIn(TestMsgCollectorScope)
+   }
+
+   override suspend fun beforeProject() {
+      projectStart = TimeSource.Monotonic.markNow()
+   }
+
    override suspend fun afterProject() {
-      val duration = start.elapsedNow()
-      // There are 8 specs, and each one has a 500ms delay.
-      // If parallel is working, they should all block at the same time.
-      if (duration > 7 * 500.milliseconds) {
-         error("Parallel execution failure: Execution time was $duration")
+      val messages = testStateMessages.replayCache
+
+      StateMsg.Status.entries.forEach { status ->
+         withClue("Expect exactly $EXPECTED_TEST_COUNT tests have status:$status") {
+            messages
+               .filter { it.status == status }
+               .map { it.testName }
+               .shouldContainExactlyInAnyOrder(List(EXPECTED_TEST_COUNT) { "test ${it + 1}" })
+         }
+      }
+
+      withClue("Expect that all tests started before any test finished") {
+         val startedTests = messages.filter { it.status == Started }
+         val finishedTests = messages.filter { it.status == Finished }
+
+         startedTests.forEach { startedTest ->
+            finishedTests.shouldForAll { finishedTest ->
+               startedTest.elapsed shouldBeLessThan finishedTest.elapsed
+            }
+         }
       }
    }
+}
+
+/**
+ * Register the start of a test, and wait until all other test cases have been launched.
+ *
+ * Only when all tests have been launched simultaneously will the test be unlocked and permitted to finish.
+ */
+suspend fun TestScope.startAndLockTest() {
+   withTimeout(10.seconds) {
+      testStateMessages.emit(StateMsg(testCase.name.testName, Started))
+      testCompletionLock.withLock {
+         testStateMessages.emit(StateMsg(testCase.name.testName, Finished))
+      }
+   }
+}
+
+/**
+ * Once a test has launched, stop it from completing by using this [Mutex].
+ * We want to stop tests from completing to ensure that all tests are launched in parallel.
+ */
+private val testCompletionLock = Mutex(locked = true)
+
+private val testStateMessages = MutableSharedFlow<StateMsg>(replay = 100)
+
+/**
+ * Information about the execution status of a test.
+ */
+private data class StateMsg(
+   val testName: String,
+   val status: Status,
+   val elapsed: Duration = projectStart.elapsedNow(),
+) {
+   enum class Status { Started, Finished }
 }

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -77,16 +77,27 @@ object ProjectConfig : AbstractProjectConfig() {
    override suspend fun afterProject() {
       val messages = testStateMessages.replayCache
 
+      val expectedTestNames = listOf(
+         "test 1",
+         "test 2",
+         "test 3",
+         "test 4",
+         "test 5",
+         "test 6",
+         "test 7",
+         "test 8",
+      )
+
       StateMsg.Status.entries.forEach { status ->
+         val actualTestNames =
+            messages.filter { it.status == status }.map { it.testName }
+
          withClue("Expect exactly $EXPECTED_TEST_COUNT tests have status:$status") {
-            messages
-               .filter { it.status == status }
-               .map { it.testName }
-               .shouldContainExactlyInAnyOrder(List(EXPECTED_TEST_COUNT) { "test ${it + 1}" })
+            actualTestNames shouldContainExactlyInAnyOrder expectedTestNames
          }
       }
 
-      withClue("Expect that all tests started before any test finished") {
+      withClue("Expect that all tests had started before any test had finished") {
          val startedTests = messages.filter { it.status == Started }
          val finishedTests = messages.filter { it.status == Finished }
 

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -30,6 +30,13 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 object ProjectConfig : AbstractProjectConfig() {
+   // set the number of threads so that each test runs in its own thread
+   override val parallelism = 10
+
+   override val concurrentSpecs: Int = ProjectConfiguration.MaxConcurrency
+
+   /** The expected number of test cases. All should be launched simultaneously. */
+   private const val EXPECTED_TEST_COUNT = 8
 
    /**
     * Listen for test [StateMsg]s in an independent [CoroutineScope].
@@ -37,16 +44,8 @@ object ProjectConfig : AbstractProjectConfig() {
    private val TestMsgCollectorScope: CoroutineScope =
       CoroutineScope(Dispatchers.IO) + CoroutineName("TestMsgCollector")
 
-   // set the number of threads so that each test runs in its own thread
-   override val parallelism = 10
-
-   /** The expected number of test cases. All should be launched simultaneously. */
-   private const val EXPECTED_TEST_COUNT = 8
-
-   override val concurrentSpecs: Int = ProjectConfiguration.MaxConcurrency
-
    /** Marks the start of the entire tests, when [beforeProject] is called, before any tests are launched. */
-   lateinit var projectStart: TimeMark
+   internal lateinit var projectStart: TimeMark
       private set
 
    init {

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -80,36 +80,37 @@ object ProjectConfig : AbstractProjectConfig() {
    override suspend fun afterProject() {
       val statuses = testStatuses.replayCache
 
-      println("testStateMessages:\n" + statuses.joinToString("\n") { " - $it" })
+      withClue("testStateMessages:\n" + statuses.joinToString("\n") { " - $it" }) {
 
-      withClue("Expect no tests timed out") {
-         statuses.shouldForNone { it.status shouldBe TimedOut }
-      }
-
-      val expectedTestNames = listOf(
-         "test 1",
-         "test 2",
-         "test 3",
-         "test 4",
-         "test 5",
-         "test 6",
-         "test 7",
-         "test 8",
-      )
-
-      listOf(Started, Finished).forEach { status ->
-         val actualTestNames = statuses.filter { it.status == status }.map { it.testName }
-
-         withClue("Expect exactly $EXPECTED_TEST_COUNT tests have status:$status") {
-            actualTestNames shouldContainExactlyInAnyOrder expectedTestNames
+         withClue("Expect no tests timed out") {
+            statuses.shouldForNone { it.status shouldBe TimedOut }
          }
-      }
 
-      withClue("Expect that no test finished before all tests had started") {
-         val lastStartedTest = statuses.filter { it.status == Started }.maxOf { it.elapsed }
-         val firstFinishedTest = statuses.filter { it.status == Finished }.maxOf { it.elapsed }
+         val expectedTestNames = listOf(
+            "test 1",
+            "test 2",
+            "test 3",
+            "test 4",
+            "test 5",
+            "test 6",
+            "test 7",
+            "test 8",
+         )
 
-         lastStartedTest shouldBeLessThan firstFinishedTest
+         listOf(Started, Finished).forEach { status ->
+            val actualTestNames = statuses.filter { it.status == status }.map { it.testName }
+
+            withClue("Expect exactly $EXPECTED_TEST_COUNT tests have status:$status") {
+               actualTestNames shouldContainExactlyInAnyOrder expectedTestNames
+            }
+         }
+
+         withClue("Expect that no test finished before all tests had started") {
+            val lastStartedTest = statuses.filter { it.status == Started }.maxOf { it.elapsed }
+            val firstFinishedTest = statuses.filter { it.status == Finished }.maxOf { it.elapsed }
+
+            lastStartedTest shouldBeLessThan firstFinishedTest
+         }
       }
    }
 }

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test1.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test1.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test1 : StringSpec({
-   "a" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test2.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test2.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test2 : StringSpec({
-   "2" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test3.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test3.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test3 : StringSpec({
-   "3" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test4.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test4.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test4 : StringSpec({
-   "a" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test5.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test5.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test5 : StringSpec({
-   "5" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test6.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test6.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test6 : StringSpec({
-   "a" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test7.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test7.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test7 : StringSpec({
-   "a" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test8.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Test8.kt
@@ -1,9 +1,0 @@
-package com.sksamuel.kotest.parallelism
-
-import io.kotest.core.spec.style.StringSpec
-
-class Test8 : StringSpec({
-   "a" {
-      Thread.sleep(500)
-   }
-})

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/TestSpecs.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/TestSpecs.kt
@@ -2,49 +2,49 @@ package com.sksamuel.kotest.parallelism
 
 import io.kotest.core.spec.style.StringSpec
 
-class Test1 : StringSpec({
+class TestSpec1 : StringSpec({
    "test 1" {
       startAndLockTest()
    }
 })
 
-class Test2 : StringSpec({
+class TestSpec2 : StringSpec({
    "test 2" {
       startAndLockTest()
    }
 })
 
-class Test3 : StringSpec({
+class TestSpec3 : StringSpec({
    "test 3" {
       startAndLockTest()
    }
 })
 
-class Test4 : StringSpec({
+class TestSpec4 : StringSpec({
    "test 4" {
       startAndLockTest()
    }
 })
 
-class Test5 : StringSpec({
+class TestSpec5 : StringSpec({
    "test 5" {
       startAndLockTest()
    }
 })
 
-class Test6 : StringSpec({
+class TestSpec6 : StringSpec({
    "test 6" {
       startAndLockTest()
    }
 })
 
-class Test7 : StringSpec({
+class TestSpec7 : StringSpec({
    "test 7" {
       startAndLockTest()
    }
 })
 
-class Test8 : StringSpec({
+class TestSpec8 : StringSpec({
    "test 8" {
       startAndLockTest()
    }

--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Tests.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/Tests.kt
@@ -1,0 +1,51 @@
+package com.sksamuel.kotest.parallelism
+
+import io.kotest.core.spec.style.StringSpec
+
+class Test1 : StringSpec({
+   "test 1" {
+      startAndLockTest()
+   }
+})
+
+class Test2 : StringSpec({
+   "test 2" {
+      startAndLockTest()
+   }
+})
+
+class Test3 : StringSpec({
+   "test 3" {
+      startAndLockTest()
+   }
+})
+
+class Test4 : StringSpec({
+   "test 4" {
+      startAndLockTest()
+   }
+})
+
+class Test5 : StringSpec({
+   "test 5" {
+      startAndLockTest()
+   }
+})
+
+class Test6 : StringSpec({
+   "test 6" {
+      startAndLockTest()
+   }
+})
+
+class Test7 : StringSpec({
+   "test 7" {
+      startAndLockTest()
+   }
+})
+
+class Test8 : StringSpec({
+   "test 8" {
+      startAndLockTest()
+   }
+})


### PR DESCRIPTION
Instead of tracking the elapsed duration of parallel tests (which is sensitive to available resources, and can be flaky on CI), manually track when tests are launched, and block each test from finishing until all expected tests are launched.


Related to #4113 
