### PR TITLE
Optimise PBT seed files

### DIFF
--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -53,6 +53,15 @@ jobs:
                gradle-home-cache-cleanup: true
                cache-encryption-key: ${{ secrets.GRADLE_CONFIGURATION_CACHE_ENCRYPTION_KEY }}
 
+         -  name: Cache Kotest user directory
+            uses: actions/cache@v4
+            with:
+               path: ~/.kotest
+               key: kotest-user-dir-${{ runner.os }}
+               enableCrossOsArchive: true
+               restore-keys: |
+                  kotest-user-dir-
+
          -  name: Run tests
             run: ./gradlew ${{ inputs.task }} --scan
             shell: bash

--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -31,6 +31,8 @@ jobs:
                mklink /D C:\Users\runneradmin\.gradle D:\.gradle
                mkdir D:\.konan
                mklink /D C:\Users\runneradmin\.konan D:\.konan
+               mkdir D:\.kotest
+               mklink /D C:\Users\runneradmin\.kotest D:\.kotest
             shell: cmd
 
          -  name: Checkout the repo
@@ -52,6 +54,15 @@ jobs:
             with:
                gradle-home-cache-cleanup: true
                cache-encryption-key: ${{ secrets.GRADLE_CONFIGURATION_CACHE_ENCRYPTION_KEY }}
+
+         -  name: Cache Kotest user directory
+            uses: actions/cache@v4
+            with:
+               path: ~/.kotest
+               key: kotest-user-dir-${{ runner.os }}
+               enableCrossOsArchive: true
+               restore-keys: |
+                  kotest-user-dir-
 
          -  name: Run tests
             run: ./gradlew ${{ inputs.task }} --scan

--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -63,7 +63,7 @@ jobs:
                   kotest-user-dir-
 
          -  name: Run tests
-            run: ./gradlew ${{ inputs.task }} --scan
+            run: ./gradlew ${{ inputs.task }} --scan --stacktrace
             shell: bash
 
          -  name: Upload build reports

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -25,16 +25,18 @@ fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
          MatcherResult(
             contents.isEmpty(),
             { "$value should be an empty directory but contained ${contents.size} file(s) [${contents.joinToString(", ")}]" },
-            { "$value should not be a non empty directory" }
+            { "$value should not be a non-empty directory" },
          )
       } else {
-         val x = if (value.isFile) "was a file"
-         else if (!value.exists()) "it does not exist"
-         else "<unknown>"
+         val reason = when {
+            value.isFile -> "was a regular file"
+            !value.exists() -> "it does not exist"
+            else -> "could not determine type"
+         }
          MatcherResult(
             false,
-            { "$value should be an empty directory but $x" },
-            { "$value should not be a non empty directory" }
+            { "$value should be an empty directory, but $reason" },
+            { "$value should not be a non-empty directory, but $reason" },
          )
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -25,13 +25,18 @@ fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
          MatcherResult(
             contents.isEmpty(),
             { "$value should be an empty directory but contained ${contents.size} file(s) [${contents.joinToString(", ")}]" },
-            { "$value should not be a non empty directory" }
+            { "$value should not be a non-empty directory" },
          )
       } else {
+         val reason = when {
+            value.isFile -> "was a regular file"
+            !value.exists() -> "it does not exist"
+            else -> "could not determine type"
+         }
          MatcherResult(
             false,
-            { "$value should be an empty directory but was a file" },
-            { "$value should not be a non empty directory" }
+            { "$value should be an empty directory, but $reason" },
+            { "$value should not be a non-empty directory, but $reason" },
          )
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -28,9 +28,12 @@ fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
             { "$value should not be a non empty directory" }
          )
       } else {
+         val x = if (value.isFile) "was a file"
+         else if (!value.exists()) "it does not exist"
+         else "<unknown>"
          MatcherResult(
             false,
-            { "$value should be an empty directory but was a file" },
+            { "$value should be an empty directory but $x" },
             { "$value should not be a non empty directory" }
          )
       }

--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -1574,13 +1574,6 @@ public final class io/kotest/property/seed/SeedKt {
 	public static final fun writeFailedSeedIfEnabled (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class io/kotest/property/seed/SeedioKt {
-	public static final fun clearSeed (Lio/kotest/common/TestPath;)V
-	public static final fun readSeed (Lio/kotest/common/TestPath;)Ljava/lang/Long;
-	public static final fun seedPath (Lio/kotest/common/TestPath;)Ljava/nio/file/Path;
-	public static final fun writeSeed (Lio/kotest/common/TestPath;J)V
-}
-
 public final class io/kotest/property/statistics/CoverageKt {
 	public static final fun withCoverageCount (Ljava/lang/Object;ILkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun withCoverageCounts (Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
+++ b/kotest-property/kotest-property-lifecycle/src/commonMain/kotlin/io/kotest/property/lifecycle/lifecycle.kt
@@ -13,6 +13,7 @@ interface BeforeAndAfterPropertyTestInterceptExtension : SpecExtension {
    suspend fun beforeProperty()
    suspend fun afterProperty()
 
+   /** See [SpecExtension.intercept]. */
    @Deprecated("See `SpecExtension.intercept(spec: KClass<out Spec>, process: suspend () -> Unit)`")
    override suspend fun intercept(spec: KClass<out Spec>, process: suspend () -> Unit) {
       val before = coroutineContext[BeforePropertyContextElement]?.before

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest10.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest10.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest11.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest11.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest12.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest12.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest13.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest13.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest14.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest14.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest15.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest15.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest16.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest16.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest17.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest17.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest18.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest18.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest19.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest19.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest20.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest20.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest21.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest21.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest22.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest22.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest7.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest7.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F, G> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest8.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest8.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest9.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest9.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/context.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/context.kt
@@ -4,8 +4,8 @@ import io.kotest.property.statistics.Label
 import kotlin.math.roundToInt
 
 /**
- * A [PropertyContext] is used when executing a propery test.
- * It allows feedback and tracking of the state of the property test.
+ * A [PropertyContext] is used when executing a property test.
+ * It allows feedback and state-tracking of the property test.
  */
 class PropertyContext(val config: PropTestConfig = PropTestConfig()) {
 
@@ -53,10 +53,10 @@ class PropertyContext(val config: PropTestConfig = PropTestConfig()) {
       return sample.value
    }
 
-   fun markEvaluation() = evals++
+   fun markEvaluation(): Int = evals++
 
-   fun successes() = successes
-   fun failures() = failures
+   fun successes(): Int = successes
+   fun failures(): Int = failures
 
    /**
     * Returns the number of invocations of the test function was invoked after checking for assumptions.

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.complete.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.complete.kt
@@ -1,0 +1,20 @@
+package io.kotest.property.internal
+
+import io.kotest.property.PropertyContext
+import io.kotest.property.RandomSource
+import io.kotest.property.checkMaxDiscards
+import io.kotest.property.classifications.outputClassifications
+import io.kotest.property.seed.cleanUpSeedFiles
+import io.kotest.property.statistics.outputStatistics
+
+
+internal suspend fun PropertyContext.onSuccess(
+   args: Int,
+   random: RandomSource,
+) {
+   outputStatistics(this, args, true)
+   outputClassifications(args, config, random.seed)
+   checkMinSuccess(config, random.seed)
+   if (args > 1) checkMaxDiscards()
+   cleanUpSeedFiles()
+}

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
@@ -8,10 +8,7 @@ import io.kotest.property.PropTestConfig
 import io.kotest.property.PropertyContext
 import io.kotest.property.PropertyTesting
 import io.kotest.property.RandomSource
-import io.kotest.property.checkMaxDiscards
-import io.kotest.property.classifications.outputClassifications
 import io.kotest.property.seed.createRandom
-import io.kotest.property.statistics.outputStatistics
 
 suspend fun <A> proptest(
    genA: Gen<A>,
@@ -51,6 +48,7 @@ suspend fun <A> proptest(
                config.listeners.forEach { it.afterTest() }
             }
       }
+
       is Exhaustive -> {
          genA.values.forEach { a ->
             config.listeners.forEach { it.beforeTest() }
@@ -70,9 +68,10 @@ suspend fun <A> proptest(
       }
    }
 
-   outputStatistics(context, 1, true)
-   context.outputClassifications(1, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
+//   outputStatistics(context, 1, true)
+//   context.outputClassifications(1, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+   context.onSuccess(1, random)
    return context
 }
 
@@ -134,10 +133,11 @@ suspend fun <A, B> proptest(
          }
    }
 
-   outputStatistics(context, 2, true)
-   context.outputClassifications(2, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 2, true)
+//   context.outputClassifications(2, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(2, random)
    return context
 }
 
@@ -204,10 +204,11 @@ suspend fun <A, B, C> proptest(
          }
    }
 
-   outputStatistics(context, 3, true)
-   context.outputClassifications(3, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 3, true)
+//   context.outputClassifications(3, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(3, random)
    return context
 }
 
@@ -274,10 +275,11 @@ suspend fun <A, B, C, D> proptest(
          }
    }
 
-   outputStatistics(context, 4, true)
-   context.outputClassifications(4, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 4, true)
+//   context.outputClassifications(4, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(4, random)
    return context
 }
 
@@ -366,10 +368,11 @@ suspend fun <A, B, C, D, E> proptest(
          }
    }
 
-   outputStatistics(context, 5, true)
-   context.outputClassifications(5, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 5, true)
+//   context.outputClassifications(5, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(5, random)
    return context
 }
 
@@ -465,10 +468,11 @@ suspend fun <A, B, C, D, E, F> proptest(
          }
    }
 
-   outputStatistics(context, 6, true)
-   context.outputClassifications(6, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 6, true)
+//   context.outputClassifications(6, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(6, random)
    return context
 }
 
@@ -571,10 +575,11 @@ suspend fun <A, B, C, D, E, F, G> proptest(
          }
    }
 
-   outputStatistics(context, 7, true)
-   context.outputClassifications(7, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 7, true)
+//   context.outputClassifications(7, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(7, random)
    return context
 }
 
@@ -684,10 +689,11 @@ suspend fun <A, B, C, D, E, F, G, H> proptest(
          }
    }
 
-   outputStatistics(context, 8, true)
-   context.outputClassifications(8, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 8, true)
+//   context.outputClassifications(8, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(8, random)
    return context
 }
 
@@ -804,10 +810,11 @@ suspend fun <A, B, C, D, E, F, G, H, I> proptest(
          }
    }
 
-   outputStatistics(context, 9, true)
-   context.outputClassifications(9, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 9, true)
+//   context.outputClassifications(9, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(9, random)
    return context
 }
 
@@ -942,10 +949,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> proptest(
          }
    }
 
-   outputStatistics(context, 10, true)
-   context.outputClassifications(10, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 10, true)
+//   context.outputClassifications(10, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(10, random)
    return context
 }
 
@@ -1100,10 +1108,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> proptest(
          }
    }
 
-   outputStatistics(context, 11, true)
-   context.outputClassifications(11, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 11, true)
+//   context.outputClassifications(11, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(11, random)
    return context
 }
 
@@ -1267,10 +1276,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> proptest(
          }
    }
 
-   outputStatistics(context, 12, true)
-   context.outputClassifications(12, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 12, true)
+//   context.outputClassifications(12, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(12, random)
    return context
 }
 
@@ -1384,7 +1394,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn =
+               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -1443,10 +1454,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> proptest(
          }
    }
 
-   outputStatistics(context, 13, true)
-   context.outputClassifications(13, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 13, true)
+//   context.outputClassifications(13, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(13, random)
    return context
 }
 
@@ -1566,7 +1578,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn =
+               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -1628,10 +1641,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> proptest(
          }
    }
 
-   outputStatistics(context, 14, true)
-   context.outputClassifications(14, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 14, true)
+//   context.outputClassifications(14, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(14, random)
    return context
 }
 
@@ -1757,7 +1771,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn =
+               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -1822,10 +1837,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> proptest(
          }
    }
 
-   outputStatistics(context, 15, true)
-   context.outputClassifications(15, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 15, true)
+//   context.outputClassifications(15, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(15, random)
    return context
 }
 
@@ -1974,7 +1990,8 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn =
+               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2042,10 +2059,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> proptest(
          }
    }
 
-   outputStatistics(context, 16, true)
-   context.outputClassifications(16, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 16, true)
+//   context.outputClassifications(16, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(16, random)
    return context
 }
 
@@ -2201,7 +2219,28 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(
+               a,
+               b,
+               c,
+               d,
+               e,
+               f,
+               g,
+               h,
+               i,
+               j,
+               k,
+               l,
+               m,
+               n,
+               o,
+               p,
+               q,
+               property,
+               config.shrinkingMode,
+               contextualSeed
+            )
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2272,10 +2311,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> proptest(
          }
    }
 
-   outputStatistics(context, 17, true)
-   context.outputClassifications(17, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 17, true)
+//   context.outputClassifications(17, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(17, random)
    return context
 }
 
@@ -2457,7 +2497,29 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(
+               a,
+               b,
+               c,
+               d,
+               e,
+               f,
+               g,
+               h,
+               i,
+               j,
+               k,
+               l,
+               m,
+               n,
+               o,
+               p,
+               q,
+               r,
+               property,
+               config.shrinkingMode,
+               contextualSeed
+            )
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2531,10 +2593,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> proptest(
          }
    }
 
-   outputStatistics(context, 18, true)
-   context.outputClassifications(18, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 18, true)
+//   context.outputClassifications(18, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(18, random)
    return context
 }
 
@@ -2724,7 +2787,30 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(
+               a,
+               b,
+               c,
+               d,
+               e,
+               f,
+               g,
+               h,
+               i,
+               j,
+               k,
+               l,
+               m,
+               n,
+               o,
+               p,
+               q,
+               r,
+               s,
+               property,
+               config.shrinkingMode,
+               contextualSeed
+            )
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2801,10 +2887,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> proptest(
          }
    }
 
-   outputStatistics(context, 19, true)
-   context.outputClassifications(19, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 19, true)
+//   context.outputClassifications(19, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(19, random)
    return context
 }
 
@@ -3002,7 +3089,31 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> proptes
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(
+               a,
+               b,
+               c,
+               d,
+               e,
+               f,
+               g,
+               h,
+               i,
+               j,
+               k,
+               l,
+               m,
+               n,
+               o,
+               p,
+               q,
+               r,
+               s,
+               t,
+               property,
+               config.shrinkingMode,
+               contextualSeed
+            )
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -3082,10 +3193,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> proptes
          }
    }
 
-   outputStatistics(context, 20, true)
-   context.outputClassifications(20, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 20, true)
+//   context.outputClassifications(20, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(20, random)
    return context
 }
 
@@ -3291,7 +3403,32 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> prop
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(
+               a,
+               b,
+               c,
+               d,
+               e,
+               f,
+               g,
+               h,
+               i,
+               j,
+               k,
+               l,
+               m,
+               n,
+               o,
+               p,
+               q,
+               r,
+               s,
+               t,
+               u,
+               property,
+               config.shrinkingMode,
+               contextualSeed
+            )
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -3374,10 +3511,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> prop
          }
    }
 
-   outputStatistics(context, 21, true)
-   context.outputClassifications(21, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 21, true)
+//   context.outputClassifications(21, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(21, random)
    return context
 }
 
@@ -3591,7 +3729,33 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> p
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(
+               a,
+               b,
+               c,
+               d,
+               e,
+               f,
+               g,
+               h,
+               i,
+               j,
+               k,
+               l,
+               m,
+               n,
+               o,
+               p,
+               q,
+               r,
+               s,
+               t,
+               u,
+               v,
+               property,
+               config.shrinkingMode,
+               contextualSeed
+            )
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -3677,9 +3841,10 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> p
          }
    }
 
-   outputStatistics(context, 22, true)
-   context.outputClassifications(22, config, random.seed)
-   context.checkMinSuccess(config, random.seed)
-   context.checkMaxDiscards()
+//   outputStatistics(context, 22, true)
+//   context.outputClassifications(22, config, random.seed)
+//   context.checkMinSuccess(config, random.seed)
+//   context.checkMaxDiscards()
+   context.onSuccess(22, random)
    return context
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
@@ -67,10 +67,6 @@ suspend fun <A> proptest(
          }
       }
    }
-
-//   outputStatistics(context, 1, true)
-//   context.outputClassifications(1, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
    context.onSuccess(1, random)
    return context
 }
@@ -132,11 +128,6 @@ suspend fun <A, B> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 2, true)
-//   context.outputClassifications(2, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(2, random)
    return context
 }
@@ -203,11 +194,6 @@ suspend fun <A, B, C> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 3, true)
-//   context.outputClassifications(3, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(3, random)
    return context
 }
@@ -274,11 +260,6 @@ suspend fun <A, B, C, D> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 4, true)
-//   context.outputClassifications(4, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(4, random)
    return context
 }
@@ -367,11 +348,6 @@ suspend fun <A, B, C, D, E> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 5, true)
-//   context.outputClassifications(5, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(5, random)
    return context
 }
@@ -467,11 +443,6 @@ suspend fun <A, B, C, D, E, F> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 6, true)
-//   context.outputClassifications(6, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(6, random)
    return context
 }
@@ -574,11 +545,6 @@ suspend fun <A, B, C, D, E, F, G> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 7, true)
-//   context.outputClassifications(7, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(7, random)
    return context
 }
@@ -688,11 +654,6 @@ suspend fun <A, B, C, D, E, F, G, H> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 8, true)
-//   context.outputClassifications(8, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(8, random)
    return context
 }
@@ -809,11 +770,6 @@ suspend fun <A, B, C, D, E, F, G, H, I> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 9, true)
-//   context.outputClassifications(9, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(9, random)
    return context
 }
@@ -948,11 +904,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 10, true)
-//   context.outputClassifications(10, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(10, random)
    return context
 }
@@ -1107,11 +1058,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 11, true)
-//   context.outputClassifications(11, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(11, random)
    return context
 }
@@ -1275,11 +1221,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 12, true)
-//   context.outputClassifications(12, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(12, random)
    return context
 }
@@ -1394,8 +1335,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn =
-               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -1453,11 +1393,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 13, true)
-//   context.outputClassifications(13, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(13, random)
    return context
 }
@@ -1578,8 +1513,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn =
-               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -1640,11 +1574,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 14, true)
-//   context.outputClassifications(14, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(14, random)
    return context
 }
@@ -1771,8 +1700,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn =
-               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -1836,11 +1764,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 15, true)
-//   context.outputClassifications(15, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(15, random)
    return context
 }
@@ -1990,8 +1913,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn =
-               shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, property, config.shrinkingMode, contextualSeed)
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2058,11 +1980,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 16, true)
-//   context.outputClassifications(16, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(16, random)
    return context
 }
@@ -2219,28 +2136,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(
-               a,
-               b,
-               c,
-               d,
-               e,
-               f,
-               g,
-               h,
-               i,
-               j,
-               k,
-               l,
-               m,
-               n,
-               o,
-               p,
-               q,
-               property,
-               config.shrinkingMode,
-               contextualSeed
-            )
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2310,11 +2206,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 17, true)
-//   context.outputClassifications(17, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(17, random)
    return context
 }
@@ -2497,29 +2388,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(
-               a,
-               b,
-               c,
-               d,
-               e,
-               f,
-               g,
-               h,
-               i,
-               j,
-               k,
-               l,
-               m,
-               n,
-               o,
-               p,
-               q,
-               r,
-               property,
-               config.shrinkingMode,
-               contextualSeed
-            )
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2592,11 +2461,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 18, true)
-//   context.outputClassifications(18, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(18, random)
    return context
 }
@@ -2787,30 +2651,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> proptest(
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(
-               a,
-               b,
-               c,
-               d,
-               e,
-               f,
-               g,
-               h,
-               i,
-               j,
-               k,
-               l,
-               m,
-               n,
-               o,
-               p,
-               q,
-               r,
-               s,
-               property,
-               config.shrinkingMode,
-               contextualSeed
-            )
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -2886,11 +2727,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> proptest(
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 19, true)
-//   context.outputClassifications(19, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(19, random)
    return context
 }
@@ -3089,31 +2925,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> proptes
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(
-               a,
-               b,
-               c,
-               d,
-               e,
-               f,
-               g,
-               h,
-               i,
-               j,
-               k,
-               l,
-               m,
-               n,
-               o,
-               p,
-               q,
-               r,
-               s,
-               t,
-               property,
-               config.shrinkingMode,
-               contextualSeed
-            )
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -3192,11 +3004,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> proptes
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 20, true)
-//   context.outputClassifications(20, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(20, random)
    return context
 }
@@ -3403,32 +3210,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> prop
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(
-               a,
-               b,
-               c,
-               d,
-               e,
-               f,
-               g,
-               h,
-               i,
-               j,
-               k,
-               l,
-               m,
-               n,
-               o,
-               p,
-               q,
-               r,
-               s,
-               t,
-               u,
-               property,
-               config.shrinkingMode,
-               contextualSeed
-            )
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -3510,11 +3292,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> prop
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 21, true)
-//   context.outputClassifications(21, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(21, random)
    return context
 }
@@ -3729,33 +3506,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> p
             val (ab, c) = abc
             val (a, b) = ab
             val contextualSeed = contextRandom.random.nextLong()
-            val shrinkfn = shrinkfn(
-               a,
-               b,
-               c,
-               d,
-               e,
-               f,
-               g,
-               h,
-               i,
-               j,
-               k,
-               l,
-               m,
-               n,
-               o,
-               p,
-               q,
-               r,
-               s,
-               t,
-               u,
-               v,
-               property,
-               config.shrinkingMode,
-               contextualSeed
-            )
+            val shrinkfn = shrinkfn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, property, config.shrinkingMode, contextualSeed)
             config.listeners.forEach { it.beforeTest() }
             test(
                context,
@@ -3840,11 +3591,6 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> p
             config.listeners.forEach { it.afterTest() }
          }
    }
-
-//   outputStatistics(context, 22, true)
-//   context.outputClassifications(22, config, random.seed)
-//   context.checkMinSuccess(config, random.seed)
-//   context.checkMaxDiscards()
    context.onSuccess(22, random)
    return context
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.onSuccess.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.onSuccess.kt
@@ -4,7 +4,7 @@ import io.kotest.property.PropertyContext
 import io.kotest.property.RandomSource
 import io.kotest.property.checkMaxDiscards
 import io.kotest.property.classifications.outputClassifications
-import io.kotest.property.seed.cleanUpSeedFiles
+import io.kotest.property.seed.clearFailedSeed
 import io.kotest.property.statistics.outputStatistics
 
 
@@ -16,5 +16,5 @@ internal suspend fun PropertyContext.onSuccess(
    outputClassifications(args, config, random.seed)
    checkMinSuccess(config, random.seed)
    if (args > 1) checkMaxDiscards()
-   cleanUpSeedFiles()
+   clearFailedSeed()
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/test.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/test.kt
@@ -41,7 +41,9 @@ internal suspend fun test(
          val value = inputs[k]
          val classifier = classifiers[k]
          if (classifier != null) {
-            val label = (classifier as Classifier<Any?>).classify(value)
+            @Suppress("UNCHECKED_CAST")
+            classifier as Classifier<Any?>
+            val label = classifier.classify(value)
             if (label != null) context.classify(k, label)
          }
       }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
@@ -1,5 +1,3 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest3.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest3.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest5.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest5.kt
@@ -1,10 +1,8 @@
-@file:Suppress("NOTHING_TO_INLINE")
-
 package io.kotest.property
 
 import io.kotest.matchers.shouldBe
-import io.kotest.property.resolution.default
 import io.kotest.property.internal.proptest
+import io.kotest.property.resolution.default
 
 suspend fun <A, B, C, D, E> checkAll(
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/seed/seed.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/seed/seed.kt
@@ -14,6 +14,7 @@ suspend fun createRandom(config: PropTestConfig): RandomSource {
    return config.seed?.random() ?: getFailedSeedIfEnabled()?.random() ?: RandomSource.default()
 }
 
+@ExperimentalKotest
 suspend fun getFailedSeedIfEnabled(): Long? {
    return if (PropertyTesting.writeFailedSeed) getFailedSeed() else null
 }
@@ -26,8 +27,9 @@ suspend fun getFailedSeed(): Long? {
 
 @ExperimentalKotest
 suspend fun writeFailedSeedIfEnabled(seed: Long) {
-   if (PropertyTesting.writeFailedSeed)
+   if (PropertyTesting.writeFailedSeed) {
       writeFailedSeed(seed)
+   }
 }
 
 @ExperimentalKotest
@@ -42,6 +44,10 @@ suspend fun clearFailedSeed() {
    clearSeed(path)
 }
 
-expect fun readSeed(path: TestPath): Long?
-expect fun writeSeed(path: TestPath, seed: Long)
-expect fun clearSeed(path: TestPath)
+internal expect fun readSeed(path: TestPath): Long?
+
+internal expect fun writeSeed(path: TestPath, seed: Long)
+
+internal expect fun clearSeed(path: TestPath)
+
+internal expect suspend fun cleanUpSeedFiles()

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/seed/seed.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/seed/seed.kt
@@ -11,31 +11,30 @@ import kotlinx.coroutines.currentCoroutineContext
 
 @ExperimentalKotest
 suspend fun createRandom(config: PropTestConfig): RandomSource {
-   return config.seed?.random() ?: getFailedSeedIfEnabled()?.random() ?: RandomSource.default()
+   return config.seed?.random() ?: getFailedSeed()?.random() ?: RandomSource.default()
 }
 
 @ExperimentalKotest
-suspend fun getFailedSeedIfEnabled(): Long? {
-   return if (PropertyTesting.writeFailedSeed) getFailedSeed() else null
-}
+@Deprecated("Renamed", ReplaceWith("getFailedSeed()"))
+suspend fun getFailedSeedIfEnabled(): Long? = getFailedSeed()
 
 @ExperimentalKotest
 suspend fun getFailedSeed(): Long? {
+   if (!PropertyTesting.writeFailedSeed) return null
    val path = currentCoroutineContext()[TestPathContextElement]?.testPath ?: return null
    return readSeed(path)
 }
 
 @ExperimentalKotest
-suspend fun writeFailedSeedIfEnabled(seed: Long) {
-   if (PropertyTesting.writeFailedSeed) {
-      writeFailedSeed(seed)
-   }
-}
+@Deprecated("Renamed", ReplaceWith("writeFailedSeed(seed)"))
+suspend fun writeFailedSeedIfEnabled(seed: Long): Unit = writeFailedSeed(seed)
 
 @ExperimentalKotest
 suspend fun writeFailedSeed(seed: Long) {
-   val path = currentCoroutineContext()[TestPathContextElement]?.testPath ?: return
-   writeSeed(path, seed)
+   if (PropertyTesting.writeFailedSeed) {
+      val path = currentCoroutineContext()[TestPathContextElement]?.testPath ?: return
+      writeSeed(path, seed)
+   }
 }
 
 @ExperimentalKotest
@@ -49,5 +48,3 @@ internal expect fun readSeed(path: TestPath): Long?
 internal expect fun writeSeed(path: TestPath, seed: Long)
 
 internal expect fun clearSeed(path: TestPath)
-
-internal expect suspend fun cleanUpSeedFiles()

--- a/kotest-property/src/desktopMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
+++ b/kotest-property/src/desktopMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
@@ -5,4 +5,3 @@ import io.kotest.common.TestPath
 internal actual fun readSeed(path: TestPath): Long? = null
 internal actual fun writeSeed(path: TestPath, seed: Long) {}
 internal actual fun clearSeed(path: TestPath) {}
-internal actual suspend fun cleanUpSeedFiles() {}

--- a/kotest-property/src/desktopMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
+++ b/kotest-property/src/desktopMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
@@ -2,6 +2,7 @@ package io.kotest.property.seed
 
 import io.kotest.common.TestPath
 
-actual fun readSeed(path: TestPath): Long? = null
-actual fun writeSeed(path: TestPath, seed: Long) {}
-actual fun clearSeed(path: TestPath) {}
+internal actual fun readSeed(path: TestPath): Long? = null
+internal actual fun writeSeed(path: TestPath, seed: Long) {}
+internal actual fun clearSeed(path: TestPath) {}
+internal actual suspend fun cleanUpSeedFiles() {}

--- a/kotest-property/src/jsHostedMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
+++ b/kotest-property/src/jsHostedMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
@@ -5,4 +5,3 @@ import io.kotest.common.TestPath
 internal actual fun readSeed(path: TestPath): Long? = null
 internal actual fun writeSeed(path: TestPath, seed: Long) {}
 internal actual fun clearSeed(path: TestPath) {}
-internal actual suspend fun cleanUpSeedFiles() {}

--- a/kotest-property/src/jsHostedMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
+++ b/kotest-property/src/jsHostedMain/kotlin/io/kotest/property/seed/loadSeedFromFile.kt
@@ -2,6 +2,7 @@ package io.kotest.property.seed
 
 import io.kotest.common.TestPath
 
-actual fun readSeed(path: TestPath): Long? = null
-actual fun writeSeed(path: TestPath, seed: Long) {}
-actual fun clearSeed(path: TestPath) {}
+internal actual fun readSeed(path: TestPath): Long? = null
+internal actual fun writeSeed(path: TestPath, seed: Long) {}
+internal actual fun clearSeed(path: TestPath) {}
+internal actual suspend fun cleanUpSeedFiles() {}

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
@@ -5,7 +5,6 @@ import io.kotest.common.TestPath
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.createDirectories
-import kotlin.io.path.createFile
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.deleteIfExists
 import kotlin.io.path.exists
@@ -57,18 +56,13 @@ internal actual fun clearSeed(path: TestPath) {
 
 internal fun seedDirectory(): Path = seedDirectory
 
-private val kotestConfigDir by lazy {
-   val xdgCacheHome = System.getenv("XDG_CACHE_HOME")?.ifBlank { null }
-
-   Path(
-      xdgCacheHome ?: System.getProperty("user.home")
-   ).apply {
-      createDirectories()
-   }
-}
-
 private val seedDirectory: Path by lazy {
-   kotestConfigDir.resolve(".kotest/seeds/").apply {
+   val baseDir = System.getenv("XDG_CACHE_HOME")?.ifBlank { null }
+      ?: System.getProperty("user.home")
+
+   val kotestConfigDir = Path(baseDir).resolve(".kotest")
+
+   kotestConfigDir.resolve("seeds").apply {
       createDirectories()
    }
 }

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/seed/seedio.kt
@@ -32,7 +32,6 @@ internal actual fun writeSeed(path: TestPath, seed: Long) {
    try {
       val f = path.seedPath()
       f.createParentDirectories()
-      f.createFile()
       f.writeText(seed.toString())
    } catch (e: Exception) {
       println("Error writing seed $seed for $path")

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/ForAllExhaustivesIterationTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/ForAllExhaustivesIterationTest.kt
@@ -22,7 +22,6 @@ class ForAllExhaustivesIterationTest : FunSpec() {
       }
 
       test("forAll with 2 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..100),
@@ -35,7 +34,6 @@ class ForAllExhaustivesIterationTest : FunSpec() {
       }
 
       test("forAll with 3 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..50),
@@ -49,7 +47,6 @@ class ForAllExhaustivesIterationTest : FunSpec() {
       }
 
       test("forAll with 4 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..5),
@@ -64,7 +61,6 @@ class ForAllExhaustivesIterationTest : FunSpec() {
       }
 
       test("forAll with 5 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..5),
@@ -82,7 +78,6 @@ class ForAllExhaustivesIterationTest : FunSpec() {
       fun Int.pow(exp: Int) = toBigInteger().pow(exp).toInt()
 
       test("forAll with 6 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..1),
@@ -96,11 +91,9 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(6)
          context.successes() shouldBe 2.pow(6)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 7 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..1),
@@ -115,11 +108,9 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(7)
          context.successes() shouldBe 2.pow(7)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 8 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..1),
@@ -135,11 +126,9 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(8)
          context.successes() shouldBe 2.pow(8)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 9 exhaustives should run for each cross product") {
-
          val context = forAll(
             1000,
             Exhaustive.ints(0..1),
@@ -156,11 +145,9 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(9)
          context.successes() shouldBe 2.pow(9)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 10 exhaustives should run for each cross product") {
-
          val context = forAll(
             Int.MAX_VALUE,
             Exhaustive.ints(0..1),
@@ -178,11 +165,9 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(10)
          context.successes() shouldBe 2.pow(10)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 11 exhaustives should run for each cross product") {
-
          val context = forAll(
             Int.MAX_VALUE,
             Exhaustive.ints(0..1),
@@ -201,11 +186,9 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(11)
          context.successes() shouldBe 2.pow(11)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 12 exhaustives should run for each cross product") {
-
          val context = forAll(
             Int.MAX_VALUE,
             Exhaustive.ints(0..1),
@@ -225,13 +208,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(12)
          context.successes() shouldBe 2.pow(12)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 13 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -250,13 +231,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(13)
          context.successes() shouldBe 2.pow(13)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 14 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -276,13 +255,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(14)
          context.successes() shouldBe 2.pow(14)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 15 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -303,13 +280,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(15)
          context.successes() shouldBe 2.pow(15)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 16 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -331,13 +306,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(16)
          context.successes() shouldBe 2.pow(16)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 17 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -360,13 +333,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(17)
          context.successes() shouldBe 2.pow(17)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 18 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -390,13 +361,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(18)
          context.successes() shouldBe 2.pow(18)
          context.failures() shouldBe 0
-
       }
 
-      xtest("forAll with 19 exhaustives should run for each cross product") {
-
+      test("forAll with 19 exhaustives should run for each cross product") {
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -421,13 +390,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(19)
          context.successes() shouldBe 2.pow(19)
          context.failures() shouldBe 0
-
       }
 
-      xtest("forAll with 20 exhaustives should run for each cross product") {
-
+      test("forAll with 20 exhaustives should run for each cross product") {
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -453,13 +420,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(20)
          context.successes() shouldBe 2.pow(20)
          context.failures() shouldBe 0
-
       }
 
       test("forAll with 21 exhaustives should run for each cross product") {
-
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -486,13 +451,11 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(21)
          context.successes() shouldBe 2.pow(21)
          context.failures() shouldBe 0
-
       }
 
-      xtest("forAll with 22 exhaustives should run for each cross product") {
-
+      test("forAll with 22 exhaustives should run for each cross product") {
          val context = forAll(
-            PropTestConfig(iterations =  Int.MAX_VALUE),
+            PropTestConfig(iterations = Int.MAX_VALUE),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
             Exhaustive.ints(0..1),
@@ -520,8 +483,6 @@ class ForAllExhaustivesIterationTest : FunSpec() {
          context.attempts() shouldBe 2.pow(22)
          context.successes() shouldBe 2.pow(22)
          context.failures() shouldBe 0
-
       }
-
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/seed/PersistSeedsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/seed/PersistSeedsTest.kt
@@ -3,17 +3,21 @@ package com.sksamuel.kotest.property.seed
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.paths.shouldBeEmptyDirectory
+import io.kotest.matchers.paths.shouldNotExist
 import io.kotest.matchers.shouldBe
 import io.kotest.property.PropTestConfig
 import io.kotest.property.PropertyTesting
 import io.kotest.property.checkAll
 import io.kotest.property.seed.seedDirectory
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
 import kotlin.io.path.readText
 
 class PersistSeedsTest : FunSpec({
 
    fun clearSeedDirectory() {
-      seedDirectory().toFile().listFiles().forEach { it.delete() }
+      @OptIn(ExperimentalPathApi::class)
+      seedDirectory().deleteRecursively()
    }
 
    afterTest {
@@ -22,7 +26,7 @@ class PersistSeedsTest : FunSpec({
 
    test("failed tests should persist seeds") {
       shouldThrowAny {
-         checkAll<Int, Int>(PropTestConfig(seed = 2344324)) { a, b ->
+         checkAll<Int, Int>(PropTestConfig(seed = 2344324)) { a, _ ->
             a shouldBe 0
          }
       }
@@ -33,7 +37,7 @@ class PersistSeedsTest : FunSpec({
 
    test("failed tests should persist seeds even for illegal chars ():<>/\\") {
       shouldThrowAny {
-         checkAll<Int, Int>(PropTestConfig(seed = 623515)) { a, b ->
+         checkAll<Int, Int>(PropTestConfig(seed = 623515)) { a, _ ->
             a shouldBe 0
          }
       }
@@ -55,9 +59,7 @@ class PersistSeedsTest : FunSpec({
 
    test("a successful test should not write seed") {
       clearSeedDirectory()
-      checkAll<Int, Int> { a, b ->
-      }
-      seedDirectory().shouldBeEmptyDirectory()
+      checkAll<Int, Int> { _, _ -> }
+      seedDirectory().shouldNotExist()
    }
-
 })

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/seed/PersistSeedsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/seed/PersistSeedsTest.kt
@@ -2,7 +2,6 @@ package com.sksamuel.kotest.property.seed
 
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.paths.shouldBeEmptyDirectory
 import io.kotest.matchers.paths.shouldNotExist
 import io.kotest.matchers.shouldBe
 import io.kotest.property.PropTestConfig
@@ -54,7 +53,7 @@ class PersistSeedsTest : FunSpec({
             a shouldBe b
          }
       }
-      seedDirectory().shouldBeEmptyDirectory()
+      seedDirectory().shouldNotExist()
    }
 
    test("a successful test should not write seed") {


### PR DESCRIPTION
Improve performance of property-based tests by avoiding file IO operations.

- Delete seed files once PBT iterations have completed sucessfully, instead of after every individual sucessful PBT iteration.
- General tidying.
- Now that performance is better, re-enable tests for `forAll` with 19, 20, 22 inputs.
- Make `proptest()` a bit simpler - create new `onSuccess()` helper function.
- Lazily initialise directories.
- Remove unnecessary `@file:Suppress("NOTHING_TO_INLINE")` (helps with #4085)


### Related

- #4113 This PR will improve performance.
- [Slack discussion with flamegraphs](https://slack-chats.kotlinlang.org/t/22733478/i-ve-been-doing-some-digging-into-some-of-the-https-scans-gr#29192b52-b79d-4f2d-83c0-1650329b269a).


