### PR TITLE
Fix Kotest Gradle Plugin publishing

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -24,9 +24,8 @@ signing {
    if (signingKey != null && signingPassword != null) {
       useInMemoryPgpKeys(signingKey, signingPassword)
    }
-   if (Ci.isRelease) {
-      sign(publishing.publications)
-   }
+   sign(publishing.publications)
+   setRequired { Ci.isRelease } // only require signing when releasing
 }
 
 publishing {

--- a/buildSrc/src/main/kotlin/kotest-watchos-device-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-watchos-device-conventions.gradle.kts
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.KotlinHierarchyTemplate
 
-
 plugins {
    id("kotlin-conventions")
 }

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -72,7 +72,9 @@ tasks.withType<Test>().configureEach {
    }
 }
 
+@Suppress("UnstableApiUsage")
 gradlePlugin {
+   isAutomatedPublishing = true
    website.set("https://kotest.io")
    vcsUrl.set("https://github.com/kotest")
    plugins {
@@ -80,8 +82,8 @@ gradlePlugin {
          id = "io.kotest.multiplatform"
          implementationClass = "io.kotest.framework.multiplatform.gradle.KotestMultiplatformCompilerGradlePlugin"
          displayName = "Kotest Multiplatform Compiler Plugin"
-         description = "Adds support for Javascript and Native tests in Kotest"
-         tags.set(listOf("kotest", "kotlin", "testing", "integrationtesting", "javascript"))
+         description = "Adds support for JavaScript and Native tests in Kotest"
+         tags.addAll("kotest", "kotlin", "testing", "integration testing", "javascript", "native")
       }
    }
 }


### PR DESCRIPTION
- Use `withJavadocJar()` for Gradle Plugin publishing.
- Enable `gradlePlugin.isAutomatedPublishing = true`
- Only require signing if releasing (helps with testing locally)

Also, tidy up Gradle plugin metadata.

Fix #4012 (hopefully!)