### PR TITLE
add more specific reason to `beEmptyDirectory()` failure message

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -25,13 +25,18 @@ fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
          MatcherResult(
             contents.isEmpty(),
             { "$value should be an empty directory but contained ${contents.size} file(s) [${contents.joinToString(", ")}]" },
-            { "$value should not be a non empty directory" }
+            { "$value should not be a non-empty directory" },
          )
       } else {
+         val reason = when {
+            value.isFile -> "was a regular file"
+            !value.exists() -> "it does not exist"
+            else -> "could not determine type"
+         }
          MatcherResult(
             false,
-            { "$value should be an empty directory but was a file" },
-            { "$value should not be a non empty directory" }
+            { "$value should be an empty directory, but $reason" },
+            { "$value should not be a non-empty directory, but $reason" },
          )
       }
    }


### PR DESCRIPTION
Add a more specific reason to the directory check, because the current message can be unhelpful if the file does not exist, or it does exist but is a file.