### PR TITLE
`--continue` publishing

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -63,4 +63,6 @@ jobs:
       with:
          runs-on: macos-latest
          ref: ${{ inputs.ref }}
-         task: publishAllPublicationsToDeployRepository
+         # TODO remove `--continue` when Kotest Gradle Plugin publishing works
+         #      https://github.com/kotest/kotest/issues/4012#issuecomment-2241294938
+         task: publishAllPublicationsToDeployRepository --continue


### PR DESCRIPTION
Ignore errors when publishing.

Temp workaround for #4012, while we wait for Sonatype to fix it.
