### PR TITLE
Suffix Kotest Gradle Plugin snapshot versions with `-SNAPSHOT`

### DIFF
--- a/buildSrc/src/main/kotlin/Ci.kt
+++ b/buildSrc/src/main/kotlin/Ci.kt
@@ -11,16 +11,10 @@ object Ci {
       else -> "$snapshotBase.${githubBuildNumber}-SNAPSHOT"
    }
 
-   private val snapshotGradleVersion = when (githubBuildNumber) {
-      null -> "$snapshotBase-LOCAL"
-      else -> "$snapshotBase.${githubBuildNumber}"
-   }
-
    private val releaseVersion = System.getenv("RELEASE_VERSION")?.ifBlank { null }
 
    val isRelease = releaseVersion != null
    val publishVersion = releaseVersion ?: snapshotVersion
-   val gradleVersion = releaseVersion ?: snapshotGradleVersion
 
    /**
     * Property to flag the build as JVM only, can be used to run checks on local machine much faster.

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/build.gradle.kts
@@ -9,9 +9,6 @@ plugins {
    alias(libs.plugins.gradle.plugin.publish)
 }
 
-group = "io.kotest"
-version = Ci.gradleVersion
-
 dependencies {
    compileOnly(libs.kotlin.gradle.plugin)
 
@@ -105,7 +102,7 @@ val updateKotestPluginConstants by tasks.registering {
       |
       |package io.kotest.framework.multiplatform.gradle
       |
-      |const val KOTEST_COMPILER_PLUGIN_VERSION: String = "${Ci.gradleVersion}"
+      |const val KOTEST_COMPILER_PLUGIN_VERSION: String = "${Ci.publishVersion}"
       |
    """.trimMargin()
 


### PR DESCRIPTION
Use the same versioning scheme for the Kotest Gradle Plugin, so that it also has `-SNAPSHOT` versions.

This change is required by Sonatype to permit publishing Kotest Gradle Plugin snapshots.

Fixes (hopefully!) #4012 (again!)

