### PR TITLE
Removed long deprecated scope names

### DIFF
--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope.kt
@@ -4,12 +4,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
 
-@Deprecated("This interface has been renamed to BehaviorSpecGivenContainerScope. Deprecated since 4.5")
-typealias GivenScope = BehaviorSpecGivenContainerScope
-
-@Deprecated("This interface has been renamed to BehaviorSpecGivenContainerScope. Deprecated since 5.0")
-typealias BehaviorSpecGivenContainerContext = BehaviorSpecGivenContainerScope
-
 /**
  * A context that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
@@ -2,9 +2,6 @@ package io.kotest.core.spec.style.scopes
 
 import io.kotest.core.names.TestName
 
-@Deprecated("Renamed to BehaviorSpecRootScope. Deprecated since 5.0")
-typealias BehaviorSpecRootContext = BehaviorSpecRootScope
-
 /**
  * A context that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope.kt
@@ -4,12 +4,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
 
-@Deprecated("This interface has been renamed to BehaviorSpecWhenContainerScope. Deprecated since 4.5")
-typealias WhenScope = BehaviorSpecWhenContainerScope
-
-@Deprecated("This interface has been renamed to BehaviorSpecWhenContainerScope. Deprecated since 5.0")
-typealias BehaviorSpecWhenContainerContext = BehaviorSpecWhenContainerScope
-
 /**
  * A context that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
@@ -23,9 +23,6 @@ import io.kotest.core.test.TestType
 import io.kotest.core.test.config.TestConfig
 import kotlin.coroutines.CoroutineContext
 
-@Deprecated("Renamed to ContainerScope in 5.0")
-typealias ContainerContext = ContainerScope
-
 private val outOfOrderCallbacksException =
    InvalidDslException("Cannot use afterTest after a test has been defined. To disable this behavior set the global configuration value allowOutOfOrderCallbacks to true")
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
@@ -5,12 +5,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
 
-@Deprecated("This interface has been renamed to DescribeSpecContainerScope. Deprecated since 4.5")
-typealias DescribeScope = DescribeSpecContainerScope
-
-@Deprecated("This interface has been renamed to DescribeSpecContainerScope. Deprecated since 5.0")
-typealias DescribeSpecContainerContext = DescribeSpecContainerScope
-
 /**
  * A scope that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
@@ -4,9 +4,6 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.core.names.TestName
 import io.kotest.core.test.TestScope
 
-@Deprecated("Renamed to DescribeSpecRootScope. Deprecated since 5.0")
-typealias DescribeSpecRootContext = DescribeSpecRootScope
-
 /**
  * A context that allows root tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerScope.kt
@@ -4,12 +4,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
 
-@Deprecated("This interface has been renamed to ExpectSpecContainerScope. Deprecated since 4.5")
-typealias ExpectScope = ExpectSpecContainerScope
-
-@Deprecated("This interface has been renamed to ExpectSpecContainerScope. Deprecated since 5.0")
-typealias ExpectSpecContainerContext = ExpectSpecContainerScope
-
 /**
  * A context that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecRootScope.kt
@@ -4,9 +4,6 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.core.names.TestName
 import io.kotest.core.test.TestScope
 
-@Deprecated("Renamed to ExpectSpecRootScope. Deprecated since 5.0")
-typealias ExpectSpecRootContext = ExpectSpecRootScope
-
 /**
  * Top level registration methods for ExpectSpec methods.
  */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
@@ -1,15 +1,8 @@
 package io.kotest.core.spec.style.scopes
 
-import io.kotest.core.descriptors.append
 import io.kotest.core.names.TestName
 import io.kotest.core.test.NestedTest
 import io.kotest.core.test.TestScope
-
-@Deprecated("renamed to FeatureSpecContainerScope. Deprecated since 4.5")
-typealias FeatureScope = FeatureSpecContainerScope
-
-@Deprecated("renamed to FeatureSpecContainerScope. Deprecated since 5.0")
-typealias FeatureSpecContainerContext = FeatureSpecContainerScope
 
 /**
  * A scope that allows tests to be registered using the syntax:

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecRootScope.kt
@@ -3,9 +3,6 @@ package io.kotest.core.spec.style.scopes
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.names.TestName
 
-@Deprecated("Renamed to FeatureSpecRootContext. Deprecated since 5.0")
-typealias FeatureSpecRootContext = FeatureSpecRootScope
-
 /**
  * Extends [RootScope] with dsl-methods for the 'fun spec' style.
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
@@ -10,12 +10,6 @@ import io.kotest.core.test.TestScope
 import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
-@Deprecated("Renamed to FreeSpecContainerScope. Deprecated since 4.5")
-typealias FreeScope = FreeSpecContainerScope
-
-@Deprecated("Renamed to FreeSpecContainerScope. Deprecated since 5.0")
-typealias FreeSpecContainerContext = FreeSpecContainerScope
-
 @KotestTestScope
 class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(testScope) {
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecRootScope.kt
@@ -9,9 +9,6 @@ import io.kotest.core.test.TestScope
 import io.kotest.core.test.config.TestConfig
 import kotlin.time.Duration
 
-@Deprecated("Renamed to FreeSpecRootContext. Deprecated since 5.0")
-typealias FreeSpecRootContext = FreeSpecRootScope
-
 data class FreeSpecContextConfigBuilder(val name: String, val config: TestConfig)
 
 interface FreeSpecRootScope : RootScope {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
@@ -5,12 +5,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
 
-@Deprecated("This interface has been renamed to FunSpecContainerScope. Deprecated since 4.5")
-typealias FunSpecContextScope = FunSpecContainerScope
-
-@Deprecated("This interface has been renamed to FunSpecContainerScope. Deprecated since 5.0")
-typealias FunSpecContainerContext = FunSpecContainerScope
-
 /**
  * A context that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecRootScope.kt
@@ -5,9 +5,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.RootTest
 import io.kotest.core.test.TestScope
 
-@Deprecated("Renamed to FunSpecRootContext. Deprecated since 5.0")
-typealias FunSpecRootContext = FunSpecRootScope
-
 /**
  * Extends [RootScope] with dsl-methods for the 'fun spec' style.
  */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootScope.kt
@@ -7,9 +7,6 @@ import io.kotest.core.test.TestScope
 import io.kotest.core.test.TestType
 import io.kotest.core.test.config.TestConfig
 
-@Deprecated("Renamed to RootContext. Deprecated since 5.0")
-typealias RootContext = RootScope
-
 /**
  * A [RootScope] allows for [RootTest]s to be registered via a DSL.
  */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerScope.kt
@@ -1,16 +1,9 @@
 package io.kotest.core.spec.style.scopes
 
 import io.kotest.common.ExperimentalKotest
-import io.kotest.core.descriptors.append
 import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
-
-@Deprecated("This interface has been renamed to ShouldSpecContainerScope. Deprecated since 4.5")
-typealias ShouldSpecContextScope = ShouldSpecContainerScope
-
-@Deprecated("This interface has been renamed to ShouldSpecContainerScope. Deprecated since 5.0")
-typealias ShouldSpecContainerContext = ShouldSpecContainerScope
 
 /**
  * A scope that allows tests to be registered using the syntax:

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecRootScope.kt
@@ -4,9 +4,6 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.core.names.TestName
 import io.kotest.core.test.TestScope
 
-@Deprecated("Renamed to ShouldSpecRootContext. Deprecated since 5.0")
-typealias ShouldSpecRootContext = ShouldSpecRootScope
-
 /**
  * Allows tests to be registered in the 'ShouldSpec' fashion.
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/StringSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/StringSpecRootScope.kt
@@ -12,9 +12,6 @@ import io.kotest.core.test.TestScope
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 
-@Deprecated("Renamed to StringSpecRootScope. Deprecated since 5.0")
-typealias StringSpecRootContext = StringSpecRootScope
-
 /**
  * Defines the DSL for creating tests in the 'StringSpec' style.
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
@@ -2,9 +2,6 @@ package io.kotest.core.spec.style.scopes
 
 import io.kotest.core.names.TestName
 
-@Deprecated("Renamed to WordSpecRootContext. Deprecated since 5.0")
-typealias WordSpecRootContext = WordSpecRootScope
-
 interface WordSpecRootScope : RootScope {
 
    infix fun String.should(test: suspend WordSpecShouldContainerScope.() -> Unit) = addShould(this, false, test)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecShouldContainerScope.kt
@@ -9,12 +9,6 @@ import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestScope
 import kotlin.time.Duration
 
-@Deprecated("This interface has been renamed to WordSpecShouldContainerScope. Deprecated since 4.5")
-typealias WordSpecShouldScope = WordSpecShouldContainerScope
-
-@Deprecated("This interface has been renamed to WordSpecShouldContainerScope. Deprecated since 5.0")
-typealias WordSpecShouldContainerContext = WordSpecShouldContainerScope
-
 /**
  * A scope that allows tests to be registered using the syntax:
  *

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecTerminalScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecTerminalScope.kt
@@ -1,7 +1,6 @@
 package io.kotest.core.spec.style.scopes
 
 import io.kotest.core.spec.KotestTestScope
-import io.kotest.core.test.NestedTest
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestScope
 import kotlin.coroutines.CoroutineContext

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
@@ -4,12 +4,6 @@ import io.kotest.core.names.TestName
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.test.TestScope
 
-@Deprecated("Renamed to WordSpecWhenContainerScope. Deprecated since 4.5")
-typealias WordSpecWhenScope = WordSpecWhenContainerScope
-
-@Deprecated("Renamed to WordSpecWhenContainerScope. Deprecated since 5.0")
-typealias WordSpecWhenContainerContext = WordSpecWhenContainerScope
-
 @Suppress("FunctionName")
 @KotestTestScope
 class WordSpecWhenContainerScope(


### PR DESCRIPTION
As part of 6.0 all deprecated methods are being removed.