### PR TITLE
Include private specs by default #3915

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -936,7 +936,7 @@ public abstract class io/kotest/core/config/AbstractProjectConfig {
 	public fun getFailOnEmptyTestSuite ()Ljava/lang/Boolean;
 	public fun getFailOnIgnoredTests ()Ljava/lang/Boolean;
 	public fun getGlobalAssertSoftly ()Ljava/lang/Boolean;
-	public fun getIncludePrivateClasses ()Ljava/lang/Boolean;
+	public fun getIgnorePrivateClasses ()Ljava/lang/Boolean;
 	public fun getIncludeTestScopePrefixes ()Ljava/lang/Boolean;
 	public fun getInvocationTimeout ()Ljava/lang/Long;
 	public fun getIsolationMode ()Lio/kotest/core/spec/IsolationMode;
@@ -960,7 +960,7 @@ public abstract class io/kotest/core/config/AbstractProjectConfig {
 	public fun setDiscoveryClasspathFallbackEnabled (Ljava/lang/Boolean;)V
 	public fun setDispatcherAffinity (Ljava/lang/Boolean;)V
 	public fun setDisplayFullTestPath (Ljava/lang/Boolean;)V
-	public fun setIncludePrivateClasses (Ljava/lang/Boolean;)V
+	public fun setIgnorePrivateClasses (Ljava/lang/Boolean;)V
 	public fun setProjectWideFailFast (Ljava/lang/Boolean;)V
 	public fun setRandomOrderSeed (Ljava/lang/Long;)V
 	public fun setTestCoroutineDispatcher (Z)V

--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -936,6 +936,7 @@ public abstract class io/kotest/core/config/AbstractProjectConfig {
 	public fun getFailOnEmptyTestSuite ()Ljava/lang/Boolean;
 	public fun getFailOnIgnoredTests ()Ljava/lang/Boolean;
 	public fun getGlobalAssertSoftly ()Ljava/lang/Boolean;
+	public fun getIncludePrivateClasses ()Ljava/lang/Boolean;
 	public fun getIncludeTestScopePrefixes ()Ljava/lang/Boolean;
 	public fun getInvocationTimeout ()Ljava/lang/Long;
 	public fun getIsolationMode ()Lio/kotest/core/spec/IsolationMode;
@@ -959,6 +960,7 @@ public abstract class io/kotest/core/config/AbstractProjectConfig {
 	public fun setDiscoveryClasspathFallbackEnabled (Ljava/lang/Boolean;)V
 	public fun setDispatcherAffinity (Ljava/lang/Boolean;)V
 	public fun setDisplayFullTestPath (Ljava/lang/Boolean;)V
+	public fun setIncludePrivateClasses (Ljava/lang/Boolean;)V
 	public fun setProjectWideFailFast (Ljava/lang/Boolean;)V
 	public fun setRandomOrderSeed (Ljava/lang/Long;)V
 	public fun setTestCoroutineDispatcher (Z)V
@@ -1012,6 +1014,7 @@ public final class io/kotest/core/config/Defaults {
 	public static final field failOnIgnoredTests Z
 	public static final field failfast Z
 	public static final field globalAssertSoftly Z
+	public static final field ignorePrivateClasses Z
 	public static final field parallelism I
 	public static final field projectWideFailFast Z
 	public static final field specFailureFilePath Ljava/lang/String;
@@ -1119,6 +1122,7 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun getFailOnIgnoredTests ()Z
 	public final fun getFailfast ()Z
 	public final fun getGlobalAssertSoftly ()Z
+	public final fun getIgnorePrivateClasses ()Z
 	public final fun getIncludeTestScopeAffixes ()Ljava/lang/Boolean;
 	public final fun getInvocationTimeout ()Ljava/lang/Long;
 	public final fun getInvocations ()I
@@ -1160,6 +1164,7 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun setFailOnIgnoredTests (Z)V
 	public final fun setFailfast (Z)V
 	public final fun setGlobalAssertSoftly (Z)V
+	public final fun setIgnorePrivateClasses (Z)V
 	public final fun setIncludeTestScopeAffixes (Ljava/lang/Boolean;)V
 	public final fun setInvocationTimeout (Ljava/lang/Long;)V
 	public final fun setInvocations (I)V
@@ -1620,6 +1625,7 @@ public final class io/kotest/core/internal/KotestEngineProperties {
 	public static final field filterSpecs Ljava/lang/String;
 	public static final field filterTests Ljava/lang/String;
 	public static final field globalAssertSoftly Ljava/lang/String;
+	public static final field ignorePrivateClasses Ljava/lang/String;
 	public static final field includeTags Ljava/lang/String;
 	public static final field invocationTimeout Ljava/lang/String;
 	public static final field isolationMode Ljava/lang/String;

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -298,6 +298,12 @@ abstract class AbstractProjectConfig {
    open var testCoroutineDispatcher: Boolean = Defaults.testCoroutineDispatcher
 
    /**
+    * If set to false then private spec classes will be ignored by the test engine.
+    * Defaults to true.
+    */
+   open var includePrivateClasses: Boolean? = null
+
+   /**
     * Executed before the first test of the project, but after the
     * [ProjectListener.beforeProject] methods.
     */

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -301,7 +301,7 @@ abstract class AbstractProjectConfig {
     * If set to false then private spec classes will be ignored by the test engine.
     * Defaults to true.
     */
-   open var includePrivateClasses: Boolean? = null
+   open var ignorePrivateClasses: Boolean? = null
 
    /**
     * Executed before the first test of the project, but after the

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -299,7 +299,6 @@ abstract class AbstractProjectConfig {
 
    /**
     * If set to false then private spec classes will be ignored by the test engine.
-    * Defaults to true.
     */
    open var ignorePrivateClasses: Boolean? = null
 

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/Defaults.kt
@@ -14,6 +14,7 @@ object Defaults {
    const val threads = 1
    const val discoveryClasspathFallbackEnabled: Boolean = false
    const val disableTestNestedJarScanning: Boolean = true
+   const val ignorePrivateClasses: Boolean = false
 
    val assertionMode: AssertionMode = AssertionMode.None
    @Suppress("DEPRECATION") // Remove when removing legacy option

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -361,6 +361,12 @@ class ProjectConfiguration {
    var invocations: Int = defaultTestConfig.invocations
 
    /**
+    * If set to false then private spec classes will be ignored by the test engine.
+    * Defaults to false.
+    */
+   var ignorePrivateClasses: Boolean = Defaults.ignorePrivateClasses
+
+   /**
     * Returns all globally registered [Listener]s.
     */
    @Deprecated("Listeners have been subsumed into extensions", level = DeprecationLevel.ERROR)

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineProperties.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/internal/KotestEngineProperties.kt
@@ -131,4 +131,9 @@ object KotestEngineProperties {
    const val duplicateTestNameMode = "kotest.framework.testname.duplicate.mode"
 
    const val disableJarDiscovery = "kotest.framework.discovery.jar.scan.disable"
+
+   /**
+    * If set to true, then private classes will not be included in the test plan.
+    */
+   const val ignorePrivateClasses = "kotest.framework.discovery.ignore.private.classes"
 }

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -466,6 +466,11 @@ public final class io/kotest/engine/project/ProjectExtensions {
 	public final fun beforeProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor : io/kotest/engine/spec/interceptor/SpecRefInterceptor {
+	public fun <init> (Lio/kotest/engine/interceptors/EngineContext;)V
+	public fun intercept-0E7RQCE (Lio/kotest/core/spec/SpecRef;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/kotest/engine/spec/InstantiateSpecKt {
 	public static final fun createAndInitializeSpec (Lkotlin/reflect/KClass;Lio/kotest/core/config/ExtensionRegistry;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
@@ -42,6 +42,7 @@ internal fun applyConfigFromProjectConfig(config: AbstractProjectConfig, configu
    // discovery
    config.discoveryClasspathFallbackEnabled?.let { configuration.discoveryClasspathFallbackEnabled = it }
    config.disableTestNestedJarScanning?.let { configuration.disableTestNestedJarScanning = it }
+   config.includePrivateClasses?.let { configuration.ignorePrivateClasses = it }
 
    // test names
    config.includeTestScopePrefixes?.let { configuration.includeTestScopeAffixes = it }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
@@ -42,7 +42,7 @@ internal fun applyConfigFromProjectConfig(config: AbstractProjectConfig, configu
    // discovery
    config.discoveryClasspathFallbackEnabled?.let { configuration.discoveryClasspathFallbackEnabled = it }
    config.disableTestNestedJarScanning?.let { configuration.disableTestNestedJarScanning = it }
-   config.includePrivateClasses?.let { configuration.ignorePrivateClasses = it }
+   config.ignorePrivateClasses?.let { configuration.ignorePrivateClasses = it }
 
    // test names
    config.includeTestScopePrefixes?.let { configuration.includeTestScopeAffixes = it }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.kt
@@ -43,14 +43,14 @@ internal class SpecRefInterceptorPipeline(
       ref: SpecRef,
       inner: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
    ): Result<Map<TestCase, TestResult>> {
-      val interceptors = createPipeline()
+      val interceptors = platformInterceptors(context) + createCommonInterceptors()
       logger.log { Pair(ref.kclass.bestName(), "Executing ${interceptors.size} reference interceptors") }
       return interceptors.foldRight(inner) { interceptor, fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>> ->
          { ref -> interceptor.intercept(ref, fn) }
       }.invoke(ref)
    }
 
-   private fun createPipeline(): List<SpecRefInterceptor> {
+   private fun createCommonInterceptors(): List<SpecRefInterceptor> {
       return listOfNotNull(
          RequiresPlatformInterceptor(listener, context, configuration.registry),
          if (platform == Platform.JVM) EnabledIfInterceptor(listener, configuration.registry) else null,
@@ -73,3 +73,4 @@ internal class SpecRefInterceptorPipeline(
       )
    }
 }
+internal expect fun platformInterceptors(context: EngineContext): List<SpecRefInterceptor>

--- a/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.desktop.kt
+++ b/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.desktop.kt
@@ -1,0 +1,5 @@
+package io.kotest.engine.spec.interceptor
+
+import io.kotest.engine.interceptors.EngineContext
+
+internal actual fun platformInterceptors(context: EngineContext): List<SpecRefInterceptor> = emptyList()

--- a/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.jsHosted.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.jsHosted.kt
@@ -1,0 +1,5 @@
+package io.kotest.engine.spec.interceptor
+
+import io.kotest.engine.interceptors.EngineContext
+
+internal actual fun platformInterceptors(context: EngineContext): List<SpecRefInterceptor> = emptyList()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
@@ -24,7 +24,7 @@ class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : Sp
    }
 
    /**
-    * We allow private classes if the configuration flag or system property to ignore is set to true.
+    * We ignore private classes if the configuration flag or system property to ignore is set to true.
     */
    private fun ignorePrivate(): Boolean {
       return context.configuration.ignorePrivateClasses ||

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
@@ -1,0 +1,34 @@
+package io.kotest.engine.spec
+
+import io.kotest.core.internal.KotestEngineProperties
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.kotest.engine.interceptors.EngineContext
+import io.kotest.engine.spec.interceptor.SpecRefInterceptor
+import kotlin.reflect.KVisibility
+
+/**
+ * A [SpecRefInterceptor] which will ignore private specs unless the include private flag
+ * is true in project config.
+ */
+class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : SpecRefInterceptor {
+
+   override suspend fun intercept(
+      ref: SpecRef,
+      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
+   ): Result<Map<TestCase, TestResult>> {
+      return when {
+         ref.kclass.visibility == KVisibility.PRIVATE && !allowPrivate() -> Result.success(emptyMap())
+         else -> fn(ref)
+      }
+   }
+
+   /**
+    * We allow private classes if the configuration flag or system property to ignore is set to true.
+    */
+   private fun allowPrivate(): Boolean {
+      return context.configuration.ignorePrivateClasses ||
+         System.getProperty(KotestEngineProperties.ignorePrivateClasses) == "true"
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
@@ -9,8 +9,7 @@ import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import kotlin.reflect.KVisibility
 
 /**
- * A [SpecRefInterceptor] which will ignore private specs unless the include private flag
- * is true in project config.
+ * A [SpecRefInterceptor] which will ignore private specs when the configuration values are set.
  */
 class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : SpecRefInterceptor {
 
@@ -19,7 +18,7 @@ class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : Sp
       fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
    ): Result<Map<TestCase, TestResult>> {
       return when {
-         ref.kclass.visibility == KVisibility.PRIVATE && !allowPrivate() -> Result.success(emptyMap())
+         ref.kclass.visibility == KVisibility.PRIVATE && ignorePrivate() -> Result.success(emptyMap())
          else -> fn(ref)
       }
    }
@@ -27,7 +26,7 @@ class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : Sp
    /**
     * We allow private classes if the configuration flag or system property to ignore is set to true.
     */
-   private fun allowPrivate(): Boolean {
+   private fun ignorePrivate(): Boolean {
       return context.configuration.ignorePrivateClasses ||
          System.getProperty(KotestEngineProperties.ignorePrivateClasses) == "true"
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.jvm.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.jvm.kt
@@ -1,0 +1,8 @@
+package io.kotest.engine.spec.interceptor
+
+import io.kotest.engine.interceptors.EngineContext
+import io.kotest.engine.spec.ClassVisibilitySpecRefInterceptor
+
+internal actual fun platformInterceptors(context: EngineContext): List<SpecRefInterceptor> {
+   return listOf(ClassVisibilitySpecRefInterceptor(context))
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
@@ -1,14 +1,41 @@
 package com.sksamuel.kotest.engine
 
+import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.matchers.shouldBe
+
+// controls if the failing test is included
+// need this so when the overall test engine runs, the failing test inside PrivateClassesAreIgnoredTest is not included
+private var includeTest = false
 
 /**
- * Tests that by default, private classes are not executed.
+ * Tests that private classes can be ignored when the option is set
  */
+class PrivateClassesIngoreOptionTest : FunSpec() {
+   init {
+      test("private class should be ignore") {
+         includeTest = true // causes the error test to be included when this engine runs
+         val c = ProjectConfiguration()
+         c.ignorePrivateClasses = true
+         val listener = CollectingTestEngineListener()
+         TestEngineLauncher(listener)
+            .withClasses(PrivateClassesAreIgnoredTest::class)
+            .withConfiguration(c)
+            .launch()
+         listener.errors shouldBe false
+         listener.tests.size shouldBe 0
+         includeTest = false
+      }
+   }
+}
+
 private class PrivateClassesAreIgnoredTest : FunSpec() {
    init {
-      test("should not be invoked") {
-         error("boom")
-      }
+      if (includeTest)
+         test("should not be invoked") {
+            error("boom")
+         }
    }
 }


### PR DESCRIPTION
This is a breaking change. In 5.x private classes were excluded.
The system property and config option allows users to revert to this behavior.

Closes #3879 