### PR TITLE
Use caching mirror repositories instead of Maven Central / Gradle Plugin Portal directly

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,8 +2,13 @@ rootProject.name = "kotest"
 
 pluginManagement {
    repositories {
-      mavenCentral()
-      gradlePluginPortal()
+      // use a caching mirror for maven central. https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons
+      maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2") {
+         name = "JetBrains Maven Central mirror"
+      }
+      maven("https://cache-redirector.jetbrains.com/plugins.gradle.org") {
+         name = "JetBrains Gradle Plugin Portal mirror"
+      }
    }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,7 +12,10 @@ dependencyResolutionManagement {
    repositoriesMode = RepositoriesMode.PREFER_SETTINGS
 
    repositories {
-      mavenCentral()
+      // use a caching mirror for maven central. https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons
+      maven("https://cache-redirector.jetbrains.com/repo1.maven.org/maven2") {
+         name = "JetBrains Maven Central mirror"
+      }
       maven("https://oss.sonatype.org/content/repositories/snapshots/") {
          name = "SonatypeSnapshots"
          mavenContent { snapshotsOnly() }


### PR DESCRIPTION
Details in #4208 - using caching mirrors instead of Maven Central / Gradle Plugin Portal directly.
