### PR TITLE
Fix test assertion in kotest-tests-spec-parallelism

### DIFF
--- a/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-spec-parallelism/src/jvmTest/kotlin/com/sksamuel/kotest/parallelism/ProjectConfig.kt
@@ -107,7 +107,7 @@ object ProjectConfig : AbstractProjectConfig() {
 
          withClue("Expect that no test finished before all tests had started") {
             val lastStartedTest = statuses.filter { it.status == Started }.maxOf { it.elapsed }
-            val firstFinishedTest = statuses.filter { it.status == Finished }.maxOf { it.elapsed }
+            val firstFinishedTest = statuses.filter { it.status == Finished }.minOf { it.elapsed }
 
             lastStartedTest shouldBeLessThan firstFinishedTest
          }


### PR DESCRIPTION
To properly test that no test started after any test finished, `maxOf {}` should be replaced with `minOf {}`

