### PR TITLE
Fix mapcontain and cleanup - take2

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -6,14 +6,34 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 fun <K, V> mapcontain(key: K, v: V) = object : Matcher<Map<K, V>> {
-   override fun test(value: Map<K, V>) = MatcherResult(
-      value[key] == v,
-      { "Map should contain mapping $key=$v but was ${buildActualValue(value)}" },
-      { "Map should not contain mapping $key=$v but was $value" }
-   )
+   override fun test(value: Map<K, V>): MatcherResult {
+      val match = match(value)
+      return MatcherResult(
+         match.passed,
+         { match.message },
+         { "Map should not contain mapping $key=$v but was $value" }
+      )
+   }
+
+   private fun match(value: Map<K, V>): MapContainResult = when {
+      key !in value.keys -> MapContainResult(
+         false,
+         "Map should contain mapping $key=$v but key was not in the map"
+      )
+      key in value.keys && value[key] != v -> MapContainResult(
+         false,
+         "Map should contain mapping $key=$v but was ${buildActualValue(value)}"
+      )
+      else -> MapContainResult(true, "")
+   }
 
    private fun buildActualValue(map: Map<K, V>) = map[key]?.let { "$key=$it" } ?: map
 }
+
+private data class MapContainResult(
+   val passed: Boolean,
+   val message: String
+)
 
 fun <K, V> Map<K, V>.shouldContain(key: K, value: V) = this should mapcontain(key, value)
 fun <K, V> Map<K, V>.shouldNotContain(key: K, value: V) = this shouldNot mapcontain(key, value)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/MapInspectorsTest.kt
@@ -340,8 +340,8 @@ The following elements passed:
   [4] 5=5
 
 The following elements failed:
-  [0] 1=1 => Map should contain mapping 1=1 but was {3=3, 4=4, 5=5}
-  [1] 2=2 => Map should contain mapping 2=2 but was {3=3, 4=4, 5=5}
+  [0] 1=1 => Map should contain mapping 1=1 but key was not in the map
+  [1] 2=2 => Map should contain mapping 2=2 but key was not in the map
 """
          }
          "fail if no entries pass test"  {
@@ -581,9 +581,9 @@ The following elements passed:
   [4] 5=5
 
 The following elements failed:
-  [0] 1=1 => Map should contain mapping 1=1 but was {4=4, 5=5}
-  [1] 2=2 => Map should contain mapping 2=2 but was {4=4, 5=5}
-  [2] 3=3 => Map should contain mapping 3=3 but was {4=4, 5=5}
+  [0] 1=1 => Map should contain mapping 1=1 but key was not in the map
+  [1] 2=2 => Map should contain mapping 2=2 but key was not in the map
+  [2] 3=3 => Map should contain mapping 3=3 but key was not in the map
 """
          }
          "work inside assertSoftly block (for map)" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -80,7 +80,7 @@ class MapMatchersTest : WordSpec() {
       "contain" should {
          "test that a map contains the given pair" {
             val map = mapOf(Pair(1, "a"), Pair(2, "b"))
-            map should contain(1, "a")
+            map shouldContain(1 to "a")
             map.shouldContain(2, "b")
             map.shouldNotContain(3, "A")
             map shouldContain (1 to "a")
@@ -90,7 +90,7 @@ class MapMatchersTest : WordSpec() {
             }.message.shouldBe("Map should contain mapping 1=c but was 1=a")
             shouldThrow<AssertionError> {
                map.shouldContain(4, "e")
-            }.message.shouldBe("Map should contain mapping 4=e but was {1=a, 2=b}")
+            }.message.shouldBe("Map should contain mapping 4=e but key was not in the map")
             shouldThrow<AssertionError> {
                map should contain(2, "a")
             }.message.shouldStartWith("Map should contain mapping 2=a but was 2=b")
@@ -124,6 +124,16 @@ class MapMatchersTest : WordSpec() {
                |  The following fields did not match:
                |    "name" expected: <"apple">, but was: <"pear">
             """.trimMargin()
+         }
+         "fail for key not in map and null value" {
+            val map = mapOf("apple" to "green")
+            shouldThrow<AssertionError> {
+               map shouldContain("lemon" to null)
+            }.message.shouldBe("Map should contain mapping lemon=null but key was not in the map")
+         }
+         "pass for key not in map and null value" {
+            val map = mapOf("apple" to "green")
+            map shouldNotContain("lemon" to null)
          }
       }
 


### PR DESCRIPTION
* fix https://github.com/kotest/kotest/issues/3959
* clean up the following function that has an exact duplicate:
```
fun <K, V> contain(key: K, v: V): Matcher<Map<K, V>> = object : Matcher<Map<K, V>> {
   override fun test(value: Map<K, V>) = MatcherResult(
      value[key] == v,
      { "Map should contain mapping $key=$v but was ${buildActualValue(value)}" },
      { "Map should not contain mapping $key=$v but was $value" }
   )

   private fun buildActualValue(map: Map<K, V>) = map[key]?.let { "$key=$it" } ?: map
}
```