### PR TITLE
Remove JetBrains nodejs.org cache-redirector repository link

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
 
       //region Declare the Node.js & Yarn download repositories
       // Workaround https://youtrack.jetbrains.com/issue/KT-68533/
-      ivy("https://cache-redirector.jetbrains.com/nodejs.org/dist/") {
+      ivy("https://nodejs.org/dist/") {
          name = "Node Distributions at $url"
          patternLayout { artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]") }
          metadataSources { artifact() }


### PR DESCRIPTION
Using the JetBrains cache redirector for nodejs.org has no benefit. nodejs.org can be used directly.

See #4208