### PR TITLE
Fix compiler warnings in kotest-assertions-json

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/JsonMatchers.kt
@@ -16,11 +16,10 @@ import kotlin.reflect.KClass
 internal val pretty by lazy { Json { prettyPrint = true; prettyPrintIndent = "  " } }
 
 /**
- * Verifies that the [expected] string is valid json, and that it matches this string.
+ * Verifies that the [expected] string is valid JSON, and that it matches this string.
  *
- * This matcher will consider two json strings matched if they have the same key-values pairs,
+ * This matcher will consider two JSON strings matched if they have the same key-values pairs,
  * regardless of order.
- *
  */
 @Deprecated("Use shouldEqualJson. Deprecated since 5.6. Will be removed in 6.0")
 infix fun String?.shouldMatchJson(expected: String?) =
@@ -102,18 +101,16 @@ fun beJsonType(kClass: KClass<*>) = object : Matcher<String?> {
 }
 
 /**
- * Verifies that the [expected] string is valid json, and that it matches this string.
+ * Verifies that the [expected] string is valid JSON, and that it matches this string.
  *
- * This matcher will consider two json strings matched if they have the same key-values pairs,
+ * This matcher will consider two JSON strings matched if they have the same key-values pairs,
  * regardless of order.
- *
  */
 @Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldEqualJson(expected: String, mode: CompareMode, order: CompareOrder) =
    this.shouldEqualJson(expected, legacyOptions(mode, order))
 
-@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldEqualJson(expected: String, options: CompareJsonOptions) {
    this should equalJson(expected, options)
@@ -124,7 +121,6 @@ fun String.shouldEqualJson(expected: String, options: CompareJsonOptions) {
 fun String.shouldNotEqualJson(expected: String, mode: CompareMode, order: CompareOrder) =
    this.shouldNotEqualJson(expected, legacyOptions(mode, order))
 
-@Suppress("DEPRECATION") // Remove when removing shouldEqualJson legacy options
 @Deprecated("Use shouldNotEqualJson which uses a lambda. Deprecated since 5.6. Will be removed in 6.0")
 fun String.shouldNotEqualJson(expected: String, options: CompareJsonOptions) {
    this shouldNot equalJson(expected, options)

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/compare.kt
@@ -1,5 +1,3 @@
-@file:Suppress("unused")
-
 package io.kotest.assertions.json
 
 @Deprecated("Json comparison options is now specified with `CompareJsonOptions`", ReplaceWith("TypeCoercion"))
@@ -20,8 +18,8 @@ enum class CompareMode {
    /**
     * Compare by value, coercing if possible.
     *
-    * For example, "true" and true will match because the string value can be coerced into a valid boolean.
-    * Similarly, "100" and 100 will match as the former can be coerced into an int.
+    * For example, `true` and `true` will match because the string value can be coerced into a valid boolean.
+    * Similarly, `100` and `100` will match as the former can be coerced into an int.
     */
    @Deprecated(
       "Json comparison options is now specified with `CompareJsonOptions`",
@@ -35,7 +33,7 @@ enum class CompareOrder {
    /**
     * All object properties must be in same order as expected.
     *
-    * For example, { "x": 14.2, "y": 13.0 }` and `{ "y": 13.0, "x: 14.2 }` will NOT be considered equal.
+    * For example, `{ "x": 14.2, "y": 13.0 }` and `{ "y": 13.0, "x: 14.2 }` will NOT be considered equal.
     */
    @Deprecated(
       "Json comparison options is now specified with `CompareJsonOptions`",
@@ -66,8 +64,6 @@ internal fun legacyOptions(mode: CompareMode, order: CompareOrder) =
          CompareOrder.Lenient -> PropertyOrder.Lenient
       }
    }
-
-internal val defaultCompareJsonOptions = CompareJsonOptions()
 
 class CompareJsonOptions(
 
@@ -127,7 +123,7 @@ enum class ArrayOrder {
 enum class FieldComparison {
 
    /**
-    * Default. Objects in [expected] and [actual] must contain the same fields.
+    * Default. Objects in `expected` and `actual` must contain the same fields.
     */
    Strict,
 
@@ -172,7 +168,7 @@ fun compareJsonOptions(builder: CompareJsonOptions.() -> Unit): CompareJsonOptio
    CompareJsonOptions().apply(builder)
 
 /**
- * Compares two json trees, returning a detailed error message if they differ.
+ * Compares two JSON trees, returning a detailed error message if they differ.
  */
 internal fun compare(
    path: List<String>,
@@ -185,10 +181,12 @@ internal fun compare(
          is JsonNode.ObjectNode -> compareObjects(path, expected, actual, options)
          else -> JsonError.ExpectedObject(path, actual)
       }
+
       is JsonNode.ArrayNode -> when (actual) {
          is JsonNode.ArrayNode -> compareArrays(path, expected, actual, options)
          else -> JsonError.ExpectedArray(path, actual)
       }
+
       is JsonNode.BooleanNode -> compareBoolean(path, expected, actual, options)
       is JsonNode.StringNode -> compareString(path, expected, actual, options)
       is JsonNode.NumberNode -> compareNumbers(path, expected, actual, options)
@@ -226,6 +224,7 @@ internal fun compareObjects(
             val error = compare(path + a.key, e.value.value, a.value, options)
             if (error != null) return error
          }
+
       PropertyOrder.Lenient ->
          expected.elements.entries.forEach { (name, e) ->
             val a = actual.elements[name] ?: return JsonError.ObjectMissingKeys(path, setOf(name))
@@ -294,7 +293,8 @@ internal fun compareArrays(
 }
 
 /**
- * When comparing a string, if the [mode] is [CompareMode.Lenient] we can convert the actual node to a string.
+ * When comparing a string, if [CompareJsonOptions.typeCoercion] is [TypeCoercion.Enabled]
+ * we can convert the actual node to a string.
  */
 internal fun compareString(
    path: List<String>,
@@ -311,8 +311,10 @@ internal fun compareString(
             expected.toNumberNode(),
             actual
          )
+
          else -> JsonError.IncompatibleTypes(path, expected, actual)
       }
+
       else -> JsonError.IncompatibleTypes(path, expected, actual)
    }
 }
@@ -325,8 +327,8 @@ internal fun compareStrings(path: List<String>, expected: String, actual: String
 }
 
 /**
- * When comparing a boolean, if the [mode] is [CompareMode.Lenient] and the actual node is a text
- * node with "true" or "false", then we convert.
+ * When comparing a boolean, if [CompareJsonOptions.typeCoercion] is [TypeCoercion.Enabled]
+ * and the actual node is a text node with "true" or "false", then we convert.
  */
 internal fun compareBoolean(
    path: List<String>,
@@ -341,6 +343,7 @@ internal fun compareBoolean(
          "false" -> compareBooleans(path, expected.value, false)
          else -> JsonError.UnequalValues(path, expected, actual)
       }
+
       else -> JsonError.IncompatibleTypes(path, expected, actual)
    }
 }
@@ -365,9 +368,11 @@ private fun compareNumbers(
                if (expected.content != actual.content) JsonError.UnequalValues(path, expected.content, actual.content)
                else null
             }
+
             NumberFormat.Lenient -> compareNumberNodes(path, expected, actual)
          }
       }
+
       is JsonNode.StringNode -> {
          if (options.typeCoercion.isEnabled() && actual.contentIsNumber()) compareNumberNodes(
             path,
@@ -376,6 +381,7 @@ private fun compareNumbers(
          )
          else JsonError.IncompatibleTypes(path, expected, actual)
       }
+
       else -> JsonError.IncompatibleTypes(path, expected, actual)
    }
 }

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -7,9 +7,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 /**
- * Returns a [Matcher] that verifies that two json strings are equal.
+ * Returns a [Matcher] that verifies that two JSON strings are equal.
  *
- * This matcher will consider two json strings matched if they have the same key-values pairs.
+ * This matcher will consider two JSON strings matched if they have the same key-values pairs.
  * The [CompareJsonOptions] parameter can be used to configure the matcher behavior.
  */
 fun equalJson(
@@ -30,13 +30,13 @@ fun equalJson(
    }
 
 /**
- * Returns a [Matcher] that verifies json trees are equal.
+ * Returns a [Matcher] that verifies JSON trees are equal.
  *
- * This common matcher requires json in kotest's [JsonNode] abstraction.
+ * This common matcher requires JSON in Kotest's [JsonNode] abstraction.
  *
  * The jvm module provides wrappers to convert from Jackson to this format.
  *
- * This matcher will consider two json strings matched if they have the same key-values pairs,
+ * This matcher will consider two JSON strings matched if they have the same key-values pairs,
  * regardless of order.
  */
 private fun equalJsonTree(

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
@@ -44,7 +44,7 @@ sealed class JsonNode {
 
          if (other.content == content) return true
 
-         // if one or the other is exponent notation, we must compare by parsed value
+         // if one or the other uses exponent notation, we must compare by parsed value
          if (content.matches(exponentRegex) xor other.content.matches(exponentRegex)) {
             return content.toDouble() == other.content.toDouble()
          }

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -76,8 +76,8 @@ data class JsonSchema(
       var requiredProperties: MutableList<String> = mutableListOf()
 
       /**
-       * By default properties are optional.
-       * Using [required], you can specify that it must be included.
+       * By default, properties are optional.
+       * Using [requiredProperties], you can specify that it must be included.
        */
       fun withProperty(
          name: String,
@@ -161,7 +161,7 @@ data class JsonSchema(
        */
       val requiredProperties: List<String> = emptyList(),
    ) : JsonSchemaElement {
-      operator fun get(name: String) = properties.get(name)
+      operator fun get(name: String): JsonSchemaElement? = properties[name]
       override fun typeName() = "object"
    }
 
@@ -242,7 +242,7 @@ fun JsonSchema.Builder.`null`() = JsonSchema.Null
 
 /**
  * Creates a [JsonSchema.JsonObject] node. Expand on the object configuration using the [dsl] which lets you specify
- * properties using [withProperty]
+ * properties using [JsonSchema.JsonObjectBuilder.withProperty]
  *
  * Example:
  * ```kotlin

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
@@ -14,11 +14,11 @@ import kotlinx.serialization.json.JsonElement
 
 @ExperimentalKotest
 infix fun String?.shouldMatchSchema(schema: JsonSchema) =
-   this should parseToJson.and(matchSchema(schema).contramap<String?> { it?.let(Json::parseToJsonElement) })
+   this should parseToJson.and(matchSchema(schema).contramap { it?.let(Json::parseToJsonElement) })
 
 @ExperimentalKotest
 infix fun String?.shouldNotMatchSchema(schema: JsonSchema) =
-   this shouldNot parseToJson.and(matchSchema(schema).contramap<String?> { it?.let(Json::parseToJsonElement) })
+   this shouldNot parseToJson.and(matchSchema(schema).contramap { it?.let(Json::parseToJsonElement) })
 
 @ExperimentalKotest
 infix fun JsonElement.shouldMatchSchema(schema: JsonSchema) = this should matchSchema(schema)
@@ -115,6 +115,7 @@ private fun validate(
             matcherViolation + sizeViolation + containsViolation + elementTypeViolation
          } else violation("Expected ${expected.typeName()}, but was array")
       }
+
       is JsonNode.ObjectNode -> {
          if (expected is JsonSchema.JsonObject) {
             val extraKeyViolations =
@@ -148,9 +149,11 @@ private fun validate(
                if (tree.content.contains(".")) violation("Expected integer, but was number")
                else violation(expected.matcher, tree.content.toLong())
             }
+
             is JsonSchema.JsonDecimal -> {
                violation(expected.matcher, tree.content.toDouble())
             }
+
             else -> violation("Expected ${expected.typeName()}, but was ${tree.type()}")
          }
 
@@ -158,6 +161,7 @@ private fun validate(
          if (expected is JsonSchema.JsonString) {
             violation(expected.matcher, tree.value)
          } else violation("Expected ${expected.typeName()}, but was ${tree.type()}")
+
       is JsonNode.BooleanNode ->
          if (!isCompatible(tree, expected))
             violation("Expected ${expected.typeName()}, but was ${tree.type()}")
@@ -175,4 +179,3 @@ private fun isCompatible(actual: JsonNode, schema: JsonSchemaElement) =
    (actual is JsonNode.BooleanNode && schema is JsonSchema.JsonBoolean) ||
       (actual is JsonNode.StringNode && schema is JsonSchema.JsonString) ||
       (actual is JsonNode.NumberNode && schema is JsonSchema.JsonNumber)
-

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
@@ -48,8 +48,8 @@ fun parseSchema(jsonSchema: String): JsonSchema =
 
 @ExperimentalKotest
 internal object SchemaDeserializer : JsonContentPolymorphicSerializer<JsonSchemaElement>(JsonSchemaElement::class) {
-   override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out JsonSchemaElement> {
-      return when (val type = element.jsonObject.get("type")?.jsonPrimitive?.content) {
+   override fun selectDeserializer(element: JsonElement): DeserializationStrategy<JsonSchemaElement> {
+      return when (val type = element.jsonObject["type"]?.jsonPrimitive?.content) {
          "array" -> JsonSchemaArraySerializer
          "object" -> JsonSchema.JsonObject.serializer()
          "string" -> JsonSchemaStringSerializer

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/wrappers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/wrappers.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.json.longOrNull
 
 fun JsonElement.toJsonNode(): JsonNode = when (this) {
    JsonNull -> JsonNode.NullNode
-   is JsonObject -> JsonNode.ObjectNode(entries.map { it.key to it.value.toJsonNode() }.toMap())
+   is JsonObject -> JsonNode.ObjectNode(entries.associate { it.key to it.value.toJsonNode() })
    is JsonArray -> JsonNode.ArrayNode(map { it.toJsonNode() })
    is JsonPrimitive -> when {
       isString -> JsonNode.StringNode(content)

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/EmptyJsonTests.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/EmptyJsonTests.kt
@@ -1,7 +1,5 @@
 package io.kotest.assertions.json
 
-import io.kotest.assertions.json.shouldBeEmptyJsonArray
-import io.kotest.assertions.json.shouldBeEmptyJsonObject
 import io.kotest.core.spec.style.FunSpec
 
 class EmptyJsonTests : FunSpec() {

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/EqualIgnoringUnknownTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/EqualIgnoringUnknownTest.kt
@@ -1,6 +1,5 @@
 package io.kotest.assertions.json
 
-import io.kotest.assertions.json.shouldEqualSpecifiedJson
 import io.kotest.assertions.shouldFail
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.throwable.shouldHaveMessage

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/JsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/JsonAssertionsTest.kt
@@ -12,12 +12,14 @@ class JsonAssertionsTest : StringSpec({
 
    "should return correct error message on failure" {
       shouldThrow<AssertionError> {
+         @Suppress("DEPRECATION")
          json1 shouldMatchJson json3
       }.message shouldBe """expected json to match, but they differed
          |
          |expected:<{"location":"chicago","name":"sam"}> but was:<{"name":"sam","location":"london"}>""".trimMargin()
 
       shouldThrow<AssertionError> {
+         @Suppress("DEPRECATION")
          json1 shouldNotMatchJson json2
       }.message shouldBe """expected not to match with: {"location":"london","name":"sam"} but match: {"name":"sam","location":"london"}"""
    }

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/LenientOrderArrayTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/LenientOrderArrayTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.throwable.shouldHaveMessage
 class LenientOrderArrayTest : FunSpec(
    {
       infix fun String.shouldEqualJsonIgnoringOrder(other: String) =
+         @Suppress("DEPRECATION")
          this.shouldEqualJson(other, compareJsonOptions { arrayOrder = ArrayOrder.Lenient })
 
       test("simple") {

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/MatchTypeTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/MatchTypeTest.kt
@@ -1,16 +1,8 @@
 package io.kotest.assertions.json
 
-import io.kotest.assertions.json.shouldBeJsonArray
-import io.kotest.assertions.json.shouldBeJsonObject
-import io.kotest.assertions.json.shouldBeValidJson
-import io.kotest.assertions.json.shouldNotBeJsonArray
-import io.kotest.assertions.json.shouldNotBeJsonObject
-import io.kotest.assertions.json.shouldNotBeValidJson
 import io.kotest.core.spec.style.StringSpec
 
 class MatchTypeTest : StringSpec() {
-
-
    init {
       "should be valid json" {
          """
@@ -68,7 +60,5 @@ class MatchTypeTest : StringSpec() {
             [{"key":"value"},{"key2":"value2"}]
          """.shouldNotBeJsonObject()
       }
-
    }
 }
-

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/ReuseMatcherSyntaxTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/ReuseMatcherSyntaxTest.kt
@@ -9,11 +9,9 @@ class ReuseMatcherSyntaxTest : FreeSpec({
 
    "syntax" - {
       //  these are mainly to see how the syntax looks, no real assertions here
-      fun matcherReUse1(matcher: Matcher<String>) {
-      }
+      fun matcherReUse1(@Suppress("UNUSED_PARAMETER") matcher: Matcher<String>) {}
 
-      fun matcherReUse2(matcher: Matcher<String?>) {
-      }
+      fun matcherReUse2(@Suppress("UNUSED_PARAMETER") matcher: Matcher<String?>) {}
 
       "can re-use basic matchers" {
          matcherReUse1(beValidJson())

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ObjectSchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ObjectSchemaTest.kt
@@ -5,7 +5,6 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-
 @OptIn(ExperimentalKotest::class)
 class ObjectSchemaTest : FunSpec(
    {

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
@@ -20,9 +20,7 @@ class SchemaWithMatcherTest : FunSpec(
          "2" shouldMatchSchema evenNumbers
 
          shouldFail { "3" shouldMatchSchema evenNumbers }
-            .message shouldBe """
-               $ => 3.0 should be multiple of 2.0
-         """.trimIndent()
+            .message shouldBe "$ => 3.0 should be multiple of 2.0"
       }
 
       context("smoke") {
@@ -57,7 +55,7 @@ class SchemaWithMatcherTest : FunSpec(
                       "age": 12
                     }
                   ]
-               """ shouldMatchSchema schema
+               """.trimIndent() shouldMatchSchema schema
             }.message shouldBe """
                $[0].name => "bo" should have minimum length of 3
                $[2].age => -1.0 should be >= 0.0

--- a/kotest-assertions/kotest-assertions-json/src/jsTest/kotlin/io/kotest/assertions/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jsTest/kotlin/io/kotest/assertions/json/EqualTest.kt
@@ -1,706 +1,708 @@
-//package io.kotest.assertions.json
-//
-//import io.kotest.assertions.shouldFail
-//import io.kotest.core.spec.style.FunSpec
-//import io.kotest.matchers.throwable.shouldHaveMessage
-//import io.kotest.property.Arb
-//import io.kotest.property.Exhaustive
-//import io.kotest.property.arbitrary.Codepoint
-//import io.kotest.property.arbitrary.az
-//import io.kotest.property.arbitrary.numericDouble
-//import io.kotest.property.arbitrary.string
-//import io.kotest.property.checkAll
-//import io.kotest.property.exhaustive.boolean
-//
-//class EqualTest : FunSpec() {
-//   init {
-//
-//      test("comparing strings in objects") {
-//
-//         checkAll(Arb.string(1..10, Codepoint.az())) { string ->
-//            val a = """ { "a" : "$string" } """
-//            a shouldEqualJson a
-//         }
-//
-//         val a = """ { "a": "foo", "b": "bar" } """
-//         val b = """ { "a": "foo", "b": "baz" } """
-//         a shouldEqualJson a
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected 'baz' but was 'bar'
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": "baz"
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}"""
-//         )
-//      }
-//
-//      test("comparing boolean in objects") {
-//         checkAll(Exhaustive.boolean(), Exhaustive.boolean()) { a, b ->
-//            val json = """ { "a" : $a, "b": $b } """
-//            json shouldEqualJson json
-//         }
-//         val a = """ { "a": true, "b": false } """
-//         val b = """ { "a": true, "b": true } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected true but was false
-//
-//expected:
-//{
-//  "a": true,
-//  "b": true
-//}
-//
-//actual:
-//{
-//  "a": true,
-//  "b": false
-//}"""
-//         )
-//      }
-//
-//      test("comparing long in objects") {
-//
-//         checkAll<Long> { long ->
-//            val a = """ { "a" : $long } """
-//            a shouldEqualJson a
-//         }
-//
-//         val a = """ { "a": 123, "b": 354 } """
-//         val b = """ { "a": 123, "b": 326 } """
-//         a shouldEqualJson a
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected 326 but was 354
-//
-//expected:
-//{
-//  "a": 123,
-//  "b": 326
-//}
-//
-//actual:
-//{
-//  "a": 123,
-//  "b": 354
-//}"""
-//         )
-//      }
-//
-//      test("comparing doubles in objects") {
-//
-//         checkAll(Arb.numericDouble()) { double ->
-//            val a = """ { "a" : $double } """
-//            a shouldEqualJson a
-//         }
-//
-//         val a = """ { "a" : 123, "b": 354 } """
-//         val b = """ { "a" : 123, "b" : 9897 } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected 9897 but was 354
-//
-//expected:
-//{
-//  "a": 123,
-//  "b": 9897
-//}
-//
-//actual:
-//{
-//  "a": 123,
-//  "b": 354
-//}"""
-//         )
-//      }
-//
-//      test("comparing object with extra key") {
-//         val a = """ { "a" : "foo", "b" : "bar", "c": "baz" } """
-//         val b = """ { "a" : "foo", "b" : "bar" } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """The top level object was missing expected field(s) [c]
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar",
-//  "c": "baz"
-//}"""
-//         )
-//      }
-//
-//      test("comparing objects with differing keys") {
-//         val a = """ { "a" : "foo", "b" : "bar" } """
-//         val b = """ { "a" : "foo", "c" : "bar" } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """The top level object was missing expected field(s) [c]
-//
-//expected:
-//{
-//  "a": "foo",
-//  "c": "bar"
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}"""
-//         )
-//      }
-//
-//      test("comparing object with extra keys") {
-//         val a = """ { "a" : "foo", "b" : "bar", "c": "baz", "d": true } """
-//         val b = """ { "a" : "foo", "b" : "bar" } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """The top level object was missing expected field(s) [c,d]
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar",
-//  "c": "baz",
-//  "d": true
-//}"""
-//         )
-//      }
-//
-//      test("comparing object with missing key") {
-//         val a = """ { "a" : "foo", "b" : "bar" } """
-//         val b = """ { "a" : "foo", "b" : "bar", "c": "baz" } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """The top level object has extra field(s) [c]
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": "bar",
-//  "c": "baz"
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}"""
-//         )
-//      }
-//
-//      test("comparing object with missing keys") {
-//         val a = """ { "a" : "foo", "b" : "bar" } """
-//         val b = """ { "a" : "foo", "b" : "bar", "c": "baz", "d": 123 } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """The top level object has extra field(s) [c,d]
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": "bar",
-//  "c": "baz",
-//  "d": 123
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}"""
-//         )
-//      }
-//
-//
-//      test("comparing boolean to string with lenient mode") {
-//         val a = """ { "a" : "foo", "b" : true } """
-//         val b = """ { "a" : "foo", "b" : "true" } """
-//         a.shouldEqualJson(b, CompareMode.Lenient)
-//
-//         val c = """ { "a" : "foo", "b" : false } """
-//         val d = """ { "a" : "foo", "b" : "false" } """
-//         c.shouldEqualJson(d, CompareMode.Lenient)
-//      }
-//
-//      test("comparing long to string with lenient mode") {
-//         val a = """ { "a" : "foo", "b" : 123 } """
-//         val b = """ { "a" : "foo", "b" : "123" } """
-//         a.shouldEqualJson(b, CompareMode.Lenient)
-//      }
-//
-//      test("comparing double to string with lenient mode") {
-//         val a = """ { "a" : "foo", "b" : 12.45 } """
-//         val b = """ { "a" : "foo", "b" : "12.45" } """
-//         a.shouldEqualJson(b, CompareMode.Lenient)
-//      }
-//
-//      test("comparing string to long with lenient mode") {
-//         val a = """ { "a" : "foo", "b" : "12" } """
-//         val b = """ { "a" : "foo", "b" : 12 } """
-//         a.shouldEqualJson(b, CompareMode.Lenient)
-//      }
-//
-//      test("comparing string to boolean with lenient mode") {
-//         val a = """ { "a" : "foo", "b" : "true" } """
-//         val b = """ { "a" : "foo", "b" : true } """
-//         a.shouldEqualJson(b, CompareMode.Lenient)
-//
-//         val c = """ { "a" : "foo", "b" : "false" } """
-//         val d = """ { "a" : "foo", "b" : false } """
-//         c.shouldEqualJson(d, CompareMode.Lenient)
-//      }
-//
-//      test("comparing string to double with lenient mode") {
-//         val a = """ { "a" : "foo", "b" : "12.45" } """
-//         val b = """ { "a" : "foo", "b" : 12.45 } """
-//         a.shouldEqualJson(b, CompareMode.Lenient)
-//      }
-//
-//      test("comparing string to null") {
-//         val a = """ { "a" : "foo", "b" : "bar" } """
-//         val b = """ { "a" : "foo", "b" : null } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected null but was string
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": null
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}"""
-//         )
-//      }
-//
-//      test("comparing boolean to null") {
-//         val a = """ { "a" : "foo", "b" : true } """
-//         val b = """ { "a" : "foo", "b" : null } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected null but was boolean
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": null
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": true
-//}"""
-//         )
-//      }
-//
-//      test("comparing int to null") {
-//         val a = """ { "a" : "foo", "b" : 234 } """
-//         val b = """ { "a" : "foo", "b" : null } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected null but was int
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": null
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": 234
-//}"""
-//         )
-//      }
-//
-//      test("comparing double to null") {
-//         val a = """ { "a" : "foo", "b" : 12.34 } """
-//         val b = """ { "a" : "foo", "b" : null } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected null but was double
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": null
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": 12.34
-//}"""
-//         )
-//      }
-//
-//      test("comparing string to object") {
-//         val a = """ { "a" : "foo", "b" : "bar" } """
-//         val b = """ { "a" : "foo", "b" : { "c": true } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected object type but was string
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": "bar"
-//}"""
-//         )
-//      }
-//
-//      test("comparing boolean to object") {
-//         val a = """ { "a" : "foo", "b" : true } """
-//         val b = """ { "a" : "foo", "b" : { "c": true } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected object type but was boolean
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": true
-//}"""
-//         )
-//      }
-//
-//      test("comparing double to object") {
-//         val a = """ { "a" : "foo", "b" : 12.45 } """
-//         val b = """ { "a" : "foo", "b" : { "c": true } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected object type but was double
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": 12.45
-//}"""
-//         )
-//      }
-//
-//      test("comparing array to object") {
-//         val a = """ { "a" : "foo", "b" : [1,2,3] } """
-//         val b = """ { "a" : "foo", "b" : { "c": true } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected object type but was array
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": [
-//    1,
-//    2,
-//    3
-//  ]
-//}"""
-//         )
-//      }
-//
-//      test("comparing object to boolean") {
-//         val a = """ { "a" : "foo", "b" : { "c": true } } """
-//         val b = """ { "a" : "foo", "b" : true } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected boolean but was object
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": true
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}"""
-//         )
-//      }
-//
-//      test("comparing object to long") {
-//         val a = """ { "a" : "foo", "b" : { "c": true } } """
-//         val b = """ { "a" : "foo", "b" : 2067120338512882656 } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected long but was object
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": 2067120338512882656
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}"""
-//         )
-//      }
-//
-//      test("comparing array to string") {
-//         val a = """ { "a" : "foo", "b" : { "c": true } } """
-//         val b = """ { "a" : "foo", "b" : "werqe" } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b' expected string but was object
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": "werqe"
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": true
-//  }
-//}"""
-//         )
-//      }
-//
-//      test("deep comparison of objects should show full path to error") {
-//         val a = """ { "a" : "foo", "b" : { "c": { "d": 123 } } } """
-//         val b = """ { "a" : "foo", "b" : { "c": { "d": 534 } } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b.c.d' expected 534 but was 123
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": {
-//      "d": 534
-//    }
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": {
-//      "d": 123
-//    }
-//  }
-//}"""
-//         )
-//      }
-//
-//      test("deep comparison of arrays should show full path to error") {
-//         val a = """ { "a" : "foo", "b" : { "c": { "d": [1,2,3] } } } """
-//         val b = """ { "a" : "foo", "b" : { "c": { "d": [1,2,4] } } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b.c.d.[2]' expected 4 but was 3
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": {
-//      "d": [
-//        1,
-//        2,
-//        4
-//      ]
-//    }
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": {
-//      "d": [
-//        1,
-//        2,
-//        3
-//      ]
-//    }
-//  }
-//}"""
-//         )
-//      }
-//
-//      test("comparing arrays of different length") {
-//         val a = """ { "a" : "foo", "b" : { "c": { "d": [1,2,3,4] } } } """
-//         val b = """ { "a" : "foo", "b" : { "c": { "d": [1,2,4] } } } """
-//         shouldFail {
-//            a shouldEqualJson b
-//         }.shouldHaveMessage(
-//            """At 'b.c.d' expected array length 3 but was 4
-//
-//expected:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": {
-//      "d": [
-//        1,
-//        2,
-//        4
-//      ]
-//    }
-//  }
-//}
-//
-//actual:
-//{
-//  "a": "foo",
-//  "b": {
-//    "c": {
-//      "d": [
-//        1,
-//        2,
-//        3,
-//        4
-//      ]
-//    }
-//  }
-//}"""
-//         )
-//      }
-//
-//      test("key order should use CompareOrder enum") {
-//         val a = """
-//            {
-//               "id": 32672932069455,
-//               "title": "Default Title",
-//               "sku": "RIND-TOTEO-001-MCF",
-//               "requires_shipping": true,
-//               "taxable": true,
-//               "featured_image": null
-//            }
-//            """
-//
-//         val b = """
-//            {
-//               "sku": "RIND-TOTEO-001-MCF",
-//               "id": 32672932069455,
-//               "title": "Default Title",
-//               "requires_shipping": true,
-//               "taxable": true,
-//               "featured_image": null
-//            }
-//            """
-//         a.shouldEqualJson(b)
-//         shouldFail {
-//            a.shouldEqualJson(b, CompareOrder.Strict)
-//         }.shouldHaveMessage("""The top level object expected field 0 to be 'sku' but was 'id'
-//
-//expected:
-//{
-//  "sku": "RIND-TOTEO-001-MCF",
-//  "id": 32672932069455,
-//  "title": "Default Title",
-//  "requires_shipping": true,
-//  "taxable": true,
-//  "featured_image": null
-//}
-//
-//actual:
-//{
-//  "id": 32672932069455,
-//  "title": "Default Title",
-//  "sku": "RIND-TOTEO-001-MCF",
-//  "requires_shipping": true,
-//  "taxable": true,
-//  "featured_image": null
-//}""")
-//      }
-//   }
-//}
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.json.JsonMatchersKt.shouldMatchJson is removed
+
+package io.kotest.assertions.json
+
+import io.kotest.assertions.shouldFail
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.throwable.shouldHaveMessage
+import io.kotest.property.Arb
+import io.kotest.property.Exhaustive
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.az
+import io.kotest.property.arbitrary.numericDouble
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import io.kotest.property.exhaustive.boolean
+
+class EqualTest : FunSpec() {
+   init {
+
+      test("comparing strings in objects") {
+
+         checkAll(Arb.string(1..10, Codepoint.az())) { string ->
+            val a = """ { "a" : "$string" } """
+            a shouldEqualJson a
+         }
+
+         val a = """ { "a": "foo", "b": "bar" } """
+         val b = """ { "a": "foo", "b": "baz" } """
+         a shouldEqualJson a
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected 'baz' but was 'bar'
+
+expected:
+{
+  "a": "foo",
+  "b": "baz"
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar"
+}"""
+         )
+      }
+
+      test("comparing boolean in objects") {
+         checkAll(Exhaustive.boolean(), Exhaustive.boolean()) { a, b ->
+            val json = """ { "a" : $a, "b": $b } """
+            json shouldEqualJson json
+         }
+         val a = """ { "a": true, "b": false } """
+         val b = """ { "a": true, "b": true } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected true but was false
+
+expected:
+{
+  "a": true,
+  "b": true
+}
+
+actual:
+{
+  "a": true,
+  "b": false
+}"""
+         )
+      }
+
+      test("comparing long in objects") {
+
+         checkAll<Long> { long ->
+            val a = """ { "a" : $long } """
+            a shouldEqualJson a
+         }
+
+         val a = """ { "a": 123, "b": 354 } """
+         val b = """ { "a": 123, "b": 326 } """
+         a shouldEqualJson a
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected 326 but was 354
+
+expected:
+{
+  "a": 123,
+  "b": 326
+}
+
+actual:
+{
+  "a": 123,
+  "b": 354
+}"""
+         )
+      }
+
+      test("comparing doubles in objects") {
+
+         checkAll(Arb.numericDouble()) { double ->
+            val a = """ { "a" : $double } """
+            a shouldEqualJson a
+         }
+
+         val a = """ { "a" : 123, "b": 354 } """
+         val b = """ { "a" : 123, "b" : 9897 } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected 9897 but was 354
+
+expected:
+{
+  "a": 123,
+  "b": 9897
+}
+
+actual:
+{
+  "a": 123,
+  "b": 354
+}"""
+         )
+      }
+
+      test("comparing object with extra key") {
+         val a = """ { "a" : "foo", "b" : "bar", "c": "baz" } """
+         val b = """ { "a" : "foo", "b" : "bar" } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """The top level object was missing expected field(s) [c]
+
+expected:
+{
+  "a": "foo",
+  "b": "bar"
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar",
+  "c": "baz"
+}"""
+         )
+      }
+
+      test("comparing objects with differing keys") {
+         val a = """ { "a" : "foo", "b" : "bar" } """
+         val b = """ { "a" : "foo", "c" : "bar" } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """The top level object was missing expected field(s) [c]
+
+expected:
+{
+  "a": "foo",
+  "c": "bar"
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar"
+}"""
+         )
+      }
+
+      test("comparing object with extra keys") {
+         val a = """ { "a" : "foo", "b" : "bar", "c": "baz", "d": true } """
+         val b = """ { "a" : "foo", "b" : "bar" } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """The top level object was missing expected field(s) [c,d]
+
+expected:
+{
+  "a": "foo",
+  "b": "bar"
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar",
+  "c": "baz",
+  "d": true
+}"""
+         )
+      }
+
+      test("comparing object with missing key") {
+         val a = """ { "a" : "foo", "b" : "bar" } """
+         val b = """ { "a" : "foo", "b" : "bar", "c": "baz" } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """The top level object has extra field(s) [c]
+
+expected:
+{
+  "a": "foo",
+  "b": "bar",
+  "c": "baz"
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar"
+}"""
+         )
+      }
+
+      test("comparing object with missing keys") {
+         val a = """ { "a" : "foo", "b" : "bar" } """
+         val b = """ { "a" : "foo", "b" : "bar", "c": "baz", "d": 123 } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """The top level object has extra field(s) [c,d]
+
+expected:
+{
+  "a": "foo",
+  "b": "bar",
+  "c": "baz",
+  "d": 123
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar"
+}"""
+         )
+      }
+
+
+      test("comparing boolean to string with lenient mode") {
+         val a = """ { "a" : "foo", "b" : true } """
+         val b = """ { "a" : "foo", "b" : "true" } """
+         a.shouldEqualJson(b, CompareMode.Lenient)
+
+         val c = """ { "a" : "foo", "b" : false } """
+         val d = """ { "a" : "foo", "b" : "false" } """
+         c.shouldEqualJson(d, CompareMode.Lenient)
+      }
+
+      test("comparing long to string with lenient mode") {
+         val a = """ { "a" : "foo", "b" : 123 } """
+         val b = """ { "a" : "foo", "b" : "123" } """
+         a.shouldEqualJson(b, CompareMode.Lenient)
+      }
+
+      test("comparing double to string with lenient mode") {
+         val a = """ { "a" : "foo", "b" : 12.45 } """
+         val b = """ { "a" : "foo", "b" : "12.45" } """
+         a.shouldEqualJson(b, CompareMode.Lenient)
+      }
+
+      test("comparing string to long with lenient mode") {
+         val a = """ { "a" : "foo", "b" : "12" } """
+         val b = """ { "a" : "foo", "b" : 12 } """
+         a.shouldEqualJson(b, CompareMode.Lenient)
+      }
+
+      test("comparing string to boolean with lenient mode") {
+         val a = """ { "a" : "foo", "b" : "true" } """
+         val b = """ { "a" : "foo", "b" : true } """
+         a.shouldEqualJson(b, CompareMode.Lenient)
+
+         val c = """ { "a" : "foo", "b" : "false" } """
+         val d = """ { "a" : "foo", "b" : false } """
+         c.shouldEqualJson(d, CompareMode.Lenient)
+      }
+
+      test("comparing string to double with lenient mode") {
+         val a = """ { "a" : "foo", "b" : "12.45" } """
+         val b = """ { "a" : "foo", "b" : 12.45 } """
+         a.shouldEqualJson(b, CompareMode.Lenient)
+      }
+
+      test("comparing string to null") {
+         val a = """ { "a" : "foo", "b" : "bar" } """
+         val b = """ { "a" : "foo", "b" : null } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected null but was string
+
+expected:
+{
+  "a": "foo",
+  "b": null
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar"
+}"""
+         )
+      }
+
+      test("comparing boolean to null") {
+         val a = """ { "a" : "foo", "b" : true } """
+         val b = """ { "a" : "foo", "b" : null } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected null but was boolean
+
+expected:
+{
+  "a": "foo",
+  "b": null
+}
+
+actual:
+{
+  "a": "foo",
+  "b": true
+}"""
+         )
+      }
+
+      test("comparing int to null") {
+         val a = """ { "a" : "foo", "b" : 234 } """
+         val b = """ { "a" : "foo", "b" : null } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected null but was int
+
+expected:
+{
+  "a": "foo",
+  "b": null
+}
+
+actual:
+{
+  "a": "foo",
+  "b": 234
+}"""
+         )
+      }
+
+      test("comparing double to null") {
+         val a = """ { "a" : "foo", "b" : 12.34 } """
+         val b = """ { "a" : "foo", "b" : null } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected null but was double
+
+expected:
+{
+  "a": "foo",
+  "b": null
+}
+
+actual:
+{
+  "a": "foo",
+  "b": 12.34
+}"""
+         )
+      }
+
+      test("comparing string to object") {
+         val a = """ { "a" : "foo", "b" : "bar" } """
+         val b = """ { "a" : "foo", "b" : { "c": true } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected object type but was string
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": "bar"
+}"""
+         )
+      }
+
+      test("comparing boolean to object") {
+         val a = """ { "a" : "foo", "b" : true } """
+         val b = """ { "a" : "foo", "b" : { "c": true } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected object type but was boolean
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": true
+}"""
+         )
+      }
+
+      test("comparing double to object") {
+         val a = """ { "a" : "foo", "b" : 12.45 } """
+         val b = """ { "a" : "foo", "b" : { "c": true } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected object type but was double
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": 12.45
+}"""
+         )
+      }
+
+      test("comparing array to object") {
+         val a = """ { "a" : "foo", "b" : [1,2,3] } """
+         val b = """ { "a" : "foo", "b" : { "c": true } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected object type but was array
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": [
+    1,
+    2,
+    3
+  ]
+}"""
+         )
+      }
+
+      test("comparing object to boolean") {
+         val a = """ { "a" : "foo", "b" : { "c": true } } """
+         val b = """ { "a" : "foo", "b" : true } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected boolean but was object
+
+expected:
+{
+  "a": "foo",
+  "b": true
+}
+
+actual:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}"""
+         )
+      }
+
+      test("comparing object to long") {
+         val a = """ { "a" : "foo", "b" : { "c": true } } """
+         val b = """ { "a" : "foo", "b" : 2067120338512882656 } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected long but was object
+
+expected:
+{
+  "a": "foo",
+  "b": 2067120338512882656
+}
+
+actual:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}"""
+         )
+      }
+
+      test("comparing array to string") {
+         val a = """ { "a" : "foo", "b" : { "c": true } } """
+         val b = """ { "a" : "foo", "b" : "werqe" } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b' expected string but was object
+
+expected:
+{
+  "a": "foo",
+  "b": "werqe"
+}
+
+actual:
+{
+  "a": "foo",
+  "b": {
+    "c": true
+  }
+}"""
+         )
+      }
+
+      test("deep comparison of objects should show full path to error") {
+         val a = """ { "a" : "foo", "b" : { "c": { "d": 123 } } } """
+         val b = """ { "a" : "foo", "b" : { "c": { "d": 534 } } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b.c.d' expected 534 but was 123
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": {
+      "d": 534
+    }
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": {
+    "c": {
+      "d": 123
+    }
+  }
+}"""
+         )
+      }
+
+      test("deep comparison of arrays should show full path to error") {
+         val a = """ { "a" : "foo", "b" : { "c": { "d": [1,2,3] } } } """
+         val b = """ { "a" : "foo", "b" : { "c": { "d": [1,2,4] } } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b.c.d.[2]' expected 4 but was 3
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": {
+      "d": [
+        1,
+        2,
+        4
+      ]
+    }
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": {
+    "c": {
+      "d": [
+        1,
+        2,
+        3
+      ]
+    }
+  }
+}"""
+         )
+      }
+
+      test("comparing arrays of different length") {
+         val a = """ { "a" : "foo", "b" : { "c": { "d": [1,2,3,4] } } } """
+         val b = """ { "a" : "foo", "b" : { "c": { "d": [1,2,4] } } } """
+         shouldFail {
+            a shouldEqualJson b
+         }.shouldHaveMessage(
+            """At 'b.c.d' expected array length 3 but was 4
+
+expected:
+{
+  "a": "foo",
+  "b": {
+    "c": {
+      "d": [
+        1,
+        2,
+        4
+      ]
+    }
+  }
+}
+
+actual:
+{
+  "a": "foo",
+  "b": {
+    "c": {
+      "d": [
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  }
+}"""
+         )
+      }
+
+      test("key order should use CompareOrder enum") {
+         val a = """
+            {
+               "id": 32672932069455,
+               "title": "Default Title",
+               "sku": "RIND-TOTEO-001-MCF",
+               "requires_shipping": true,
+               "taxable": true,
+               "featured_image": null
+            }
+            """
+
+         val b = """
+            {
+               "sku": "RIND-TOTEO-001-MCF",
+               "id": 32672932069455,
+               "title": "Default Title",
+               "requires_shipping": true,
+               "taxable": true,
+               "featured_image": null
+            }
+            """
+         a.shouldEqualJson(b)
+         shouldFail {
+            a.shouldEqualJson(b, CompareOrder.Strict)
+         }.shouldHaveMessage("""The top level object expected field 0 to be 'sku' but was 'id'
+
+expected:
+{
+  "sku": "RIND-TOTEO-001-MCF",
+  "id": 32672932069455,
+  "title": "Default Title",
+  "requires_shipping": true,
+  "taxable": true,
+  "featured_image": null
+}
+
+actual:
+{
+  "id": 32672932069455,
+  "title": "Default Title",
+  "sku": "RIND-TOTEO-001-MCF",
+  "requires_shipping": true,
+  "taxable": true,
+  "featured_image": null
+}""")
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-json/src/jsTest/kotlin/io/kotest/assertions/json/JsonLiteralsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jsTest/kotlin/io/kotest/assertions/json/JsonLiteralsTest.kt
@@ -1,211 +1,213 @@
-//package io.kotest.assertions.json
-//
-//import io.kotest.assertions.shouldFail
-//import io.kotest.assertions.throwables.shouldThrow
-//import io.kotest.core.spec.style.FunSpec
-//import io.kotest.matchers.string.shouldContain
-//import io.kotest.matchers.throwable.shouldHaveMessage
-//
-//class JsonLiteralsTest : FunSpec(
-//   {
-//      test("Unsupported type") {
-//         shouldThrow<IllegalArgumentException> {
-//            "0x03" shouldEqualJson "0x03"
-//         }.shouldHaveMessage("Unsupported kotlinx-serialization type 0x03")
-//      }
-//
-//      context("Strict (default) comparisons") {
-//         test("comparing float and int") {
-//            shouldFail {
-//               "3.2" shouldEqualJson "3"
-//            }.shouldHaveMessage(
-//               """
-//               The top level expected 3 but was 3.2
-//
-//               expected:
-//               3
-//
-//               actual:
-//               3.2
-//            """.trimIndent()
-//            )
-//         }
-//
-//         test("quoted numbers are treated as strings") {
-//            shouldFail { "\"1E3\"" shouldEqualJson "1000.0" }
-//            // Unquoted 1E3 is parsed to double and back due to prettifying output
-//            shouldFail { "\"1000.0\"" shouldEqualJson "1E3" }.message shouldContain
-//               "The top level expected number but was string"
-//            shouldFail { "10.0" shouldEqualJson "\"10.0\"" }.message shouldContain
-//               "The top level expected string but was number"
-//         }
-//
-//         test("comparing exponent-based float with regular float") {
-//            "1E3" shouldEqualJson "1000.0"
-//            "1000.0" shouldEqualJson "1E3"
-//            "1000.0" shouldEqualJson "1000"
-//            "5E0" shouldEqualJson "5.0"
-//            "2E-1" shouldEqualJson "0.2"
-//         }
-//
-//         test("comparing high-precision floating point numbers") {
-//
-//            // Note: In the middle paragraph of the failure message the expected JSON has been
-//            //       formatted as a JSON tree using KotlinX.serialization which parses the
-//            //       number to a double and back, hence the loss of precision.
-//
-//            shouldFail {
-//               "0.12345678912345678" shouldEqualJson "0.123456789123456789"
-//            }.shouldHaveMessage(
-//               """
-//               The top level expected 0.123456789123456789 but was 0.12345678912345678
-//
-//               expected:
-//               0.123456789123456789
-//
-//               actual:
-//               0.12345678912345678
-//            """.trimIndent()
-//            )
-//         }
-//
-//         test("comparing string and boolean") {
-//            shouldFail {
-//               "true" shouldEqualJson "\"true\""
-//            }.shouldHaveMessage(
-//               """
-//               The top level expected string but was boolean
-//
-//               expected:
-//               "true"
-//
-//               actual:
-//               true
-//            """.trimIndent()
-//            )
-//         }
-//      }
-//
-//      context("CompareMode.Exact requires same format for numbers") {
-//         infix fun String.shouldExactlyEqualJson(expected: String) =
-//            this.shouldEqualJson(expected, compareJsonOptions { numberFormat = NumberFormat.Strict })
-//
-//         test("comparing float and exponent") {
-//            shouldFail {
-//               "10.0" shouldExactlyEqualJson "1e1"
-//            }.shouldHaveMessage(
-//               """
-//               The top level expected 1e1 but was 10.0
-//
-//               expected:
-//               1e1
-//
-//               actual:
-//               10.0
-//            """.trimIndent()
-//            )
-//         }
-//
-//         test("comparing int and exponent") {
-//            shouldFail {
-//               "10" shouldExactlyEqualJson "1e1"
-//            }.shouldHaveMessage(
-//               """
-//               The top level expected 1e1 but was 10
-//
-//               expected:
-//               1e1
-//
-//               actual:
-//               10
-//            """.trimIndent()
-//            )
-//         }
-//
-//         test("comparing float and int") {
-//            shouldFail {
-//               "10.0" shouldExactlyEqualJson "10"
-//            }.shouldHaveMessage(
-//               """
-//               The top level expected 10 but was 10.0
-//
-//               expected:
-//               10
-//
-//               actual:
-//               10.0
-//            """.trimIndent()
-//            )
-//         }
-//
-//         test("quoted numbers are treated as strings") {
-//            shouldFail { "\"1E3\"" shouldEqualJson "1000.0" }
-//            // Unquoted 1E3 is parsed to double and back due to prettifying output
-//            shouldFail { "\"1000.0\"" shouldEqualJson "1E3" }.message shouldContain
-//               "The top level expected number but was string"
-//            shouldFail { "10.0" shouldEqualJson "\"10.0\"" }.message shouldContain
-//               "The top level expected string but was number"
-//         }
-//      }
-//
-//      context("Lenient type-conversions") {
-//
-//         infix fun String.lenientShouldEqualJson(expected: String) =
-//            this.shouldEqualJson(expected, compareJsonOptions { typeCoercion = TypeCoercion.Enabled })
-//
-//         test("comparing exponent-based float with regular float") {
-//            "1E3" lenientShouldEqualJson "\"1000.0\""
-//            "1000.0" lenientShouldEqualJson "\"1E3\""
-//            "2E-1" lenientShouldEqualJson "0.2"
-//            "2E-1" lenientShouldEqualJson "\"0.2\""
-//            "0.2" lenientShouldEqualJson "\"2e-1\""
-//            "5E0" lenientShouldEqualJson "5.0"
-//         }
-//
-//         test("Strings with numbers") {
-//            shouldFail {
-//               "\"abc 123\"" lenientShouldEqualJson "123"
-//            }.shouldHaveMessage(
-//               """
-//                  The top level expected number but was string
-//
-//                  expected:
-//                  123
-//
-//                  actual:
-//                  "abc 123"
-//               """.trimIndent()
-//            )
-//
-//            shouldFail {
-//               "123" lenientShouldEqualJson "\"abc 123\""
-//            }
-//         }
-//
-//         test("booleans in strings are ok") {
-//            "true" lenientShouldEqualJson "\"true\""
-//            "\"true\"" lenientShouldEqualJson "true"
-//         }
-//
-//         test("float and int can be mixed, if exactly same") {
-//            "1.0" lenientShouldEqualJson "1"
-//            "1" lenientShouldEqualJson "1.0"
-//         }
-//
-//         test("Dont trim necessary zeroes") {
-//            shouldFail {
-//               "10" lenientShouldEqualJson "1.0"
-//            }
-//
-//            shouldFail {
-//               "1" lenientShouldEqualJson "10.0"
-//            }
-//         }
-//
-//         test("high-precision float with only trailing zeros") {
-//            "1" lenientShouldEqualJson "1.0000000000000000000000000"
-//            "1.0000000000000000000000000" lenientShouldEqualJson "1"
-//         }
-//      }
-//   }
-//)
+@file:Suppress("DEPRECATION") // FIXME remove deprecation suppression when io.kotest.assertions.json.JsonMatchersKt.shouldMatchJson is removed
+
+package io.kotest.assertions.json
+
+import io.kotest.assertions.shouldFail
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.throwable.shouldHaveMessage
+
+class JsonLiteralsTest : FunSpec(
+   {
+      test("Unsupported type") {
+         shouldThrow<IllegalArgumentException> {
+            "0x03" shouldEqualJson "0x03"
+         }.shouldHaveMessage("Unsupported kotlinx-serialization type 0x03")
+      }
+
+      context("Strict (default) comparisons") {
+         test("comparing float and int") {
+            shouldFail {
+               "3.2" shouldEqualJson "3"
+            }.shouldHaveMessage(
+               """
+               The top level expected 3 but was 3.2
+
+               expected:
+               3
+
+               actual:
+               3.2
+            """.trimIndent()
+            )
+         }
+
+         test("quoted numbers are treated as strings") {
+            shouldFail { "\"1E3\"" shouldEqualJson "1000.0" }
+            // Unquoted 1E3 is parsed to double and back due to prettifying output
+            shouldFail { "\"1000.0\"" shouldEqualJson "1E3" }.message shouldContain
+               "The top level expected number but was string"
+            shouldFail { "10.0" shouldEqualJson "\"10.0\"" }.message shouldContain
+               "The top level expected string but was number"
+         }
+
+         test("comparing exponent-based float with regular float") {
+            "1E3" shouldEqualJson "1000.0"
+            "1000.0" shouldEqualJson "1E3"
+            "1000.0" shouldEqualJson "1000"
+            "5E0" shouldEqualJson "5.0"
+            "2E-1" shouldEqualJson "0.2"
+         }
+
+         test("comparing high-precision floating point numbers") {
+
+            // Note: In the middle paragraph of the failure message the expected JSON has been
+            //       formatted as a JSON tree using KotlinX.serialization which parses the
+            //       number to a double and back, hence the loss of precision.
+
+            shouldFail {
+               "0.12345678912345678" shouldEqualJson "0.123456789123456789"
+            }.shouldHaveMessage(
+               """
+               The top level expected 0.123456789123456789 but was 0.12345678912345678
+
+               expected:
+               0.123456789123456789
+
+               actual:
+               0.12345678912345678
+            """.trimIndent()
+            )
+         }
+
+         test("comparing string and boolean") {
+            shouldFail {
+               "true" shouldEqualJson "\"true\""
+            }.shouldHaveMessage(
+               """
+               The top level expected string but was boolean
+
+               expected:
+               "true"
+
+               actual:
+               true
+            """.trimIndent()
+            )
+         }
+      }
+
+      context("CompareMode.Exact requires same format for numbers") {
+         infix fun String.shouldExactlyEqualJson(expected: String) =
+            this.shouldEqualJson(expected, compareJsonOptions { numberFormat = NumberFormat.Strict })
+
+         test("comparing float and exponent") {
+            shouldFail {
+               "10.0" shouldExactlyEqualJson "1e1"
+            }.shouldHaveMessage(
+               """
+               The top level expected 1e1 but was 10.0
+
+               expected:
+               1e1
+
+               actual:
+               10.0
+            """.trimIndent()
+            )
+         }
+
+         test("comparing int and exponent") {
+            shouldFail {
+               "10" shouldExactlyEqualJson "1e1"
+            }.shouldHaveMessage(
+               """
+               The top level expected 1e1 but was 10
+
+               expected:
+               1e1
+
+               actual:
+               10
+            """.trimIndent()
+            )
+         }
+
+         test("comparing float and int") {
+            shouldFail {
+               "10.0" shouldExactlyEqualJson "10"
+            }.shouldHaveMessage(
+               """
+               The top level expected 10 but was 10.0
+
+               expected:
+               10
+
+               actual:
+               10.0
+            """.trimIndent()
+            )
+         }
+
+         test("quoted numbers are treated as strings") {
+            shouldFail { "\"1E3\"" shouldEqualJson "1000.0" }
+            // Unquoted 1E3 is parsed to double and back due to prettifying output
+            shouldFail { "\"1000.0\"" shouldEqualJson "1E3" }.message shouldContain
+               "The top level expected number but was string"
+            shouldFail { "10.0" shouldEqualJson "\"10.0\"" }.message shouldContain
+               "The top level expected string but was number"
+         }
+      }
+
+      context("Lenient type-conversions") {
+
+         infix fun String.lenientShouldEqualJson(expected: String) =
+            this.shouldEqualJson(expected, compareJsonOptions { typeCoercion = TypeCoercion.Enabled })
+
+         test("comparing exponent-based float with regular float") {
+            "1E3" lenientShouldEqualJson "\"1000.0\""
+            "1000.0" lenientShouldEqualJson "\"1E3\""
+            "2E-1" lenientShouldEqualJson "0.2"
+            "2E-1" lenientShouldEqualJson "\"0.2\""
+            "0.2" lenientShouldEqualJson "\"2e-1\""
+            "5E0" lenientShouldEqualJson "5.0"
+         }
+
+         test("Strings with numbers") {
+            shouldFail {
+               "\"abc 123\"" lenientShouldEqualJson "123"
+            }.shouldHaveMessage(
+               """
+                  The top level expected number but was string
+
+                  expected:
+                  123
+
+                  actual:
+                  "abc 123"
+               """.trimIndent()
+            )
+
+            shouldFail {
+               "123" lenientShouldEqualJson "\"abc 123\""
+            }
+         }
+
+         test("booleans in strings are ok") {
+            "true" lenientShouldEqualJson "\"true\""
+            "\"true\"" lenientShouldEqualJson "true"
+         }
+
+         test("float and int can be mixed, if exactly same") {
+            "1.0" lenientShouldEqualJson "1"
+            "1" lenientShouldEqualJson "1.0"
+         }
+
+         test("Dont trim necessary zeroes") {
+            shouldFail {
+               "10" lenientShouldEqualJson "1.0"
+            }
+
+            shouldFail {
+               "1" lenientShouldEqualJson "10.0"
+            }
+         }
+
+         test("high-precision float with only trailing zeros") {
+            "1" lenientShouldEqualJson "1.0000000000000000000000000"
+            "1.0000000000000000000000000" lenientShouldEqualJson "1"
+         }
+      }
+   }
+)

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
@@ -1,12 +1,5 @@
 package io.kotest.assertions.json
 
-import com.jayway.jsonpath.InvalidPathException
-import com.jayway.jsonpath.JsonPath
-import com.jayway.jsonpath.PathNotFoundException
-import io.kotest.assertions.Actual
-import io.kotest.assertions.Expected
-import io.kotest.assertions.intellijFormatError
-import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ExtractByPathTest.kt
@@ -1,6 +1,5 @@
 package com.sksamuel.kotest.tests.json
 
-import io.kotest.assertions.json.ExtractValueOutcome
 import io.kotest.assertions.json.ExtractValueOutcome.ExtractedValue
 import io.kotest.assertions.json.ExtractValueOutcome.JsonPathNotFound
 import io.kotest.assertions.json.JsonArrayElementRef
@@ -46,7 +45,11 @@ class ExtractByPathTest : WordSpec() {
    init {
       "extractByPath" should {
          "find not null value by valid path" {
-            extractByPath(json, "$.regime.temperature.unit", String::class.java) shouldBe ExtractValueOutcome.ExtractedValue("F")
+            extractByPath(
+               json,
+               "$.regime.temperature.unit",
+               String::class.java
+            ) shouldBe ExtractedValue("F")
          }
          "find null value by valid path" {
             extractByPath(json, "$.comments", String::class.java) shouldBe ExtractedValue(null)

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonLiteralsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JsonLiteralsTest.kt
@@ -84,6 +84,7 @@ class JsonLiteralsTest : FunSpec(
 
       context("CompareMode.Exact requires same format for numbers") {
          infix fun String.shouldExactlyEqualJson(expected: String) =
+            @Suppress("DEPRECATION")
             this.shouldEqualJson(expected, compareJsonOptions { numberFormat = NumberFormat.Strict })
 
          test("comparing float and exponent") {
@@ -135,6 +136,7 @@ class JsonLiteralsTest : FunSpec(
       context("Lenient type-conversions") {
 
          infix fun String.lenientShouldEqualJson(expected: String) =
+            @Suppress("DEPRECATION")
             this.shouldEqualJson(expected, compareJsonOptions { typeCoercion = TypeCoercion.Enabled })
 
          test("comparing exponent-based float with regular float") {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JvmJsonAssertionsTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/JvmJsonAssertionsTest.kt
@@ -1,124 +1,129 @@
 package com.sksamuel.kotest.tests.json
 
 import io.kotest.assertions.asClue
-import io.kotest.assertions.json.shouldContainJsonKey
-import io.kotest.assertions.json.shouldContainJsonKeyValue
-import io.kotest.assertions.json.shouldMatchJsonResource
-import io.kotest.assertions.json.shouldNotContainJsonKey
-import io.kotest.assertions.json.shouldNotContainJsonKeyValue
-import io.kotest.assertions.json.shouldNotMatchJsonResource
+import io.kotest.assertions.json.*
 import io.kotest.assertions.shouldFail
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import org.intellij.lang.annotations.Language
 
-const val json = """{
-    "store": {
-        "book": [
-            {
-                "category": "reference",
-                "author": "Nigel Rees",
-                "title": "Sayings of the Century",
-                "price": 8.95
-            },
-            {
-                "category": "fiction",
-                "author": "Evelyn Waugh",
-                "title": "Sword of Honour",
-                "price": 12.99
-            }
-        ],
-        "bicycle": {
-            "color": "red",
-            "price": 19.95,
-            "code": 1
-        }
+@Language("JSON")
+private const val json = """
+{
+  "store": {
+    "book": [
+      {
+        "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      {
+        "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      }
+    ],
+    "bicycle": {
+      "color": "red",
+      "price": 19.95,
+      "code": 1
     }
-}"""
+  }
+}
+"""
 
 class JvmJsonAssertionsTest : StringSpec({
 
-   "test json path" {
-      json.shouldContainJsonKey("$.store.bicycle")
-      json.shouldContainJsonKey("$.store.book")
-      json.shouldContainJsonKey("$.store.book[0]")
-      json.shouldContainJsonKey("$.store.book[0].category")
-      json.shouldContainJsonKey("$.store.book[1].price")
+    "test json path" {
+        json.shouldContainJsonKey("$.store.bicycle")
+        json.shouldContainJsonKey("$.store.book")
+        json.shouldContainJsonKey("$.store.book[0]")
+        json.shouldContainJsonKey("$.store.book[0].category")
+        json.shouldContainJsonKey("$.store.book[1].price")
 
-      json.shouldNotContainJsonKey("$.store.table")
+        json.shouldNotContainJsonKey("$.store.table")
 
-      shouldThrow<AssertionError> {
-         json.shouldContainJsonKey("$.store.table")
-      }.message shouldBe
-         """Expected given to contain json key <'${'$'}.store.table'> but key was not found. Found shorter valid subpath: <'${'$'}.store'>."""
+        shouldThrow<AssertionError> {
+            json.shouldContainJsonKey("$.store.table")
+        }.message shouldBe
+                """Expected given to contain json key <'${'$'}.store.table'> but key was not found. Found shorter valid subpath: <'${'$'}.store'>."""
 
-      shouldThrow<AssertionError> { null.shouldContainJsonKey("abc") }
+        shouldThrow<AssertionError> { null.shouldContainJsonKey("abc") }
 
-      "contract should work".asClue {
-         fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
+        "contract should work".asClue {
+            fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
 
-         val nullableJson = """{"data": "value"}"""
-         nullableJson.shouldContainJsonKey("data")
-         use(nullableJson)
-      }
-   }
+            val nullableJson = """{"data": "value"}"""
+            nullableJson.shouldContainJsonKey("data")
+            use(nullableJson)
+        }
+    }
 
-   "test json match by resource" {
+    "test json match by resource" {
 
-      val testJson1 = """ { "name" : "sam", "location" : "chicago" } """
-      val testJson2 = """ { "name" : "sam", "location" : "london" } """
+        val testJson1 = """ { "name" : "sam", "location" : "chicago" } """
+        val testJson2 = """ { "name" : "sam", "location" : "london" } """
 
-      testJson1.shouldMatchJsonResource("/json1.json")
-      testJson2.shouldNotMatchJsonResource("/json1.json")
+        testJson1.shouldMatchJsonResource("/json1.json")
+        testJson2.shouldNotMatchJsonResource("/json1.json")
 
-      shouldThrow<AssertionError> {
-         testJson2.shouldMatchJsonResource("/json1.json")
-      }.message shouldBe """expected json to match, but they differed
+        shouldThrow<AssertionError> {
+            testJson2.shouldMatchJsonResource("/json1.json")
+        }.message shouldBe """expected json to match, but they differed
          |
          |expected:<{"name":"sam","location":"chicago"}> but was:<{"name":"sam","location":"london"}>
       """.trimMargin()
 
-      shouldThrow<AssertionError> { null shouldMatchJsonResource "/json1.json" }
+        shouldThrow<AssertionError> { null shouldMatchJsonResource "/json1.json" }
 
-      "contract should work".asClue {
-         fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
+        "contract should work".asClue {
+            fun use(@Suppress("UNUSED_PARAMETER") json: String) {}
 
-         val nullableJson = testJson1
-         nullableJson.shouldMatchJsonResource("/json1.json")
-         use(nullableJson)
-      }
-   }
+            val nullableJson: String? = testJson1.takeIf { it.isNotEmpty() }
+            nullableJson.shouldMatchJsonResource("/json1.json")
+            use(nullableJson)
+        }
+    }
 
-   "matchJsonResource - property order does not matter" {
-      val testJson1 = """ { "location" : "chicago", "name" : "sam" } """
-      testJson1.shouldMatchJsonResource("/json1.json")
-   }
+    "matchJsonResource - property order does not matter" {
+        val testJson1 = """ { "location" : "chicago", "name" : "sam" } """
+        testJson1.shouldMatchJsonResource("/json1.json")
+    }
 
-   "matchJsonResource - array order matters" {
-      "[1,2]" shouldMatchJsonResource "/array.json"
+    "matchJsonResource - array order matters" {
+        "[1,2]" shouldMatchJsonResource "/array.json"
 
-      shouldFail {
-         "[2,1]" shouldMatchJsonResource "/array.json"
-      }.message shouldBe """
+        shouldFail {
+            "[2,1]" shouldMatchJsonResource "/array.json"
+        }.message shouldBe """
          expected json to match, but they differed
 
          expected:<[1,2]> but was:<[2,1]>
       """.trimIndent()
-   }
+    }
 
-   "invalid json path" {
-      val testJson1 = """ { "nullable" : null } """
+    "invalid json path" {
+        val testJson1 = """ { "nullable" : null } """
 
-      shouldFail { testJson1 shouldContainJsonKey "@@" }
-         .message shouldBe "@@ is not a valid JSON path"
+        shouldFail { testJson1 shouldContainJsonKey "@@" }
+            .message shouldBe "@@ is not a valid JSON path"
 
-      shouldFail { testJson1.shouldContainJsonKeyValue("@@", null as Any?) }
-         .message shouldBe "@@ is not a valid JSON path"
-   }
+        shouldFail {
+            testJson1.shouldContainJsonKeyValue(
+                /* language=text */
+                "@@",
+                null as Any?,
+            )
+        }
+            .message shouldBe "@@ is not a valid JSON path"
+    }
 
-   "test key with null value" {
-      val testJson1 = """ { "nullable" : null } """
-      testJson1.shouldContainJsonKey("$.nullable")
-      testJson1.shouldContainJsonKeyValue("$.nullable", null as Any?)
-   }
+    "test key with null value" {
+        val testJson1 = """ { "nullable" : null } """
+        testJson1.shouldContainJsonKey("$.nullable")
+        testJson1.shouldContainJsonKeyValue("$.nullable", null as Any?)
+    }
 })


### PR DESCRIPTION
Refactor kotest-assertions-json main and test code to fix compiler warnings - #4085.

Also, update KDoc.

Also, uncomment `JsonLiteralsTest` and `EqualTest`. I'm not sure why they were commented out. Maybe they can just be deleted?
