### PR TITLE
Use test TimeSource in framework Timeout tests

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.assertions.asClue
+import io.kotest.common.testTimeSource
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
@@ -10,17 +11,25 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.measureTime
 
 class GlobalTimeoutTest : FunSpec() {
    init {
+      coroutineTestScope = true
+
       test("global timeouts should apply if no other timeout is set") {
          val c = ProjectConfiguration().apply { timeout = 4000 }
          val collector = CollectingTestEngineListener()
-         TestEngineLauncher(collector)
-            .withClasses(TestTimeouts::class)
-            .withConfiguration(c)
-            .launch()
 
+         val duration = testTimeSource().measureTime {
+            TestEngineLauncher(collector)
+               .withClasses(TestTimeouts::class)
+               .withConfiguration(c)
+               .async()
+         }
+
+         duration shouldBe 4000.milliseconds
          collector.names.shouldContainExactly("blocked", "suspend")
 
          collector.result("blocked").asClue { result -> result?.isError shouldBe true }


### PR DESCRIPTION
Improve test stability by using the deterministic `testTimeSource()` in  ContainerTimeoutTest and GlobalTimeoutTest.

Part of #4113
