### PR TITLE
Remove java-library Gradle plugin

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -11,14 +11,6 @@ plugins {
 group = "io.kotest"
 version = Ci.publishVersion
 
-val javadocJar by tasks.registering(Jar::class) {
-   group = JavaBasePlugin.DOCUMENTATION_GROUP
-   description = "Assembles java doc to jar"
-   archiveClassifier.set("javadoc")
-   val javadoc = tasks.named("javadoc")
-   from(javadoc)
-}
-
 val ossrhUsername: String by project
 val ossrhPassword: String by project
 val signingKey: String? by project
@@ -103,6 +95,12 @@ publishing {
 }
 
 pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
+   val javadocJar by tasks.registering(Jar::class) {
+      group = JavaBasePlugin.DOCUMENTATION_GROUP
+      description = "Create Javadoc JAR"
+      archiveClassifier.set("javadoc")
+   }
+
    publishing.publications.withType<MavenPublication>().configureEach {
       artifact(javadocJar)
    }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -4,7 +4,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import utils.SystemPropertiesArgumentProvider
 
 plugins {
-   `java-library`
    kotlin("multiplatform")
    id("com.adarshr.test-logger")
 }


### PR DESCRIPTION
Soon KGP will be incompatible with Gradle's Java plugins. See https://kotlinlang.org/docs/whatsnew-eap.html#deprecated-compatibility-with-gradle-java-plugins.

`java-library` is not necessary for Kotest, and it can simply be removed.

The reference to the `javadoc` task can be removed. Because this is a KMP project there is no Javadoc.
