### PR TITLE
Removed deprecated TestResult methods

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -3018,12 +3018,10 @@ public final class io/kotest/core/test/TestCaseSeverityLevel : java/lang/Enum {
 }
 
 public abstract interface class io/kotest/core/test/TestResult {
-	public static final field Companion Lio/kotest/core/test/TestResult$Companion;
 	public abstract fun getDuration-UwyO8pc ()J
 	public abstract fun getErrorOrNull ()Ljava/lang/Throwable;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getReasonOrNull ()Ljava/lang/String;
-	public abstract fun getStatus ()Lio/kotest/core/test/TestStatus;
 	public abstract fun isError ()Z
 	public abstract fun isErrorOrFailure ()Z
 	public abstract fun isFailure ()Z
@@ -3031,18 +3029,10 @@ public abstract interface class io/kotest/core/test/TestResult {
 	public abstract fun isSuccess ()Z
 }
 
-public final class io/kotest/core/test/TestResult$Companion {
-	public final fun error (Ljava/lang/Throwable;J)Lio/kotest/core/test/TestResult$Error;
-	public final fun failure (Ljava/lang/AssertionError;J)Lio/kotest/core/test/TestResult$Failure;
-	public final fun getIgnored ()Lio/kotest/core/test/TestResult$Ignored;
-	public final fun success (J)Lio/kotest/core/test/TestResult$Success;
-}
-
 public final class io/kotest/core/test/TestResult$DefaultImpls {
 	public static fun getErrorOrNull (Lio/kotest/core/test/TestResult;)Ljava/lang/Throwable;
 	public static fun getName (Lio/kotest/core/test/TestResult;)Ljava/lang/String;
 	public static fun getReasonOrNull (Lio/kotest/core/test/TestResult;)Ljava/lang/String;
-	public static fun getStatus (Lio/kotest/core/test/TestResult;)Lio/kotest/core/test/TestStatus;
 	public static fun isError (Lio/kotest/core/test/TestResult;)Z
 	public static fun isErrorOrFailure (Lio/kotest/core/test/TestResult;)Z
 	public static fun isFailure (Lio/kotest/core/test/TestResult;)Z
@@ -3062,7 +3052,6 @@ public final class io/kotest/core/test/TestResult$Error : io/kotest/core/test/Te
 	public fun getErrorOrNull ()Ljava/lang/Throwable;
 	public fun getName ()Ljava/lang/String;
 	public fun getReasonOrNull ()Ljava/lang/String;
-	public fun getStatus ()Lio/kotest/core/test/TestStatus;
 	public fun hashCode ()I
 	public fun isError ()Z
 	public fun isErrorOrFailure ()Z
@@ -3084,7 +3073,6 @@ public final class io/kotest/core/test/TestResult$Failure : io/kotest/core/test/
 	public fun getErrorOrNull ()Ljava/lang/Throwable;
 	public fun getName ()Ljava/lang/String;
 	public fun getReasonOrNull ()Ljava/lang/String;
-	public fun getStatus ()Lio/kotest/core/test/TestStatus;
 	public fun hashCode ()I
 	public fun isError ()Z
 	public fun isErrorOrFailure ()Z
@@ -3095,6 +3083,7 @@ public final class io/kotest/core/test/TestResult$Failure : io/kotest/core/test/
 }
 
 public final class io/kotest/core/test/TestResult$Ignored : io/kotest/core/test/TestResult {
+	public fun <init> ()V
 	public fun <init> (Lio/kotest/core/test/Enabled;)V
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -3106,7 +3095,6 @@ public final class io/kotest/core/test/TestResult$Ignored : io/kotest/core/test/
 	public fun getName ()Ljava/lang/String;
 	public final fun getReason ()Ljava/lang/String;
 	public fun getReasonOrNull ()Ljava/lang/String;
-	public fun getStatus ()Lio/kotest/core/test/TestStatus;
 	public fun hashCode ()I
 	public fun isError ()Z
 	public fun isErrorOrFailure ()Z
@@ -3126,7 +3114,6 @@ public final class io/kotest/core/test/TestResult$Success : io/kotest/core/test/
 	public fun getErrorOrNull ()Ljava/lang/Throwable;
 	public fun getName ()Ljava/lang/String;
 	public fun getReasonOrNull ()Ljava/lang/String;
-	public fun getStatus ()Lio/kotest/core/test/TestStatus;
 	public fun hashCode ()I
 	public fun isError ()Z
 	public fun isErrorOrFailure ()Z

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestResult.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestResult.kt
@@ -5,28 +5,6 @@ import kotlin.time.Duration.Companion.milliseconds
 
 sealed interface TestResult {
 
-   companion object {
-      @Deprecated(
-         "Replaced with TestResult.Success. Deprecated since 5.0",
-         ReplaceWith("TestResult.Success(durationMillis.milliseconds)", "kotlin.time.Duration.Companion.milliseconds")
-      )
-      fun success(durationMillis: Long): Success = Success(durationMillis.milliseconds)
-
-      @Deprecated(
-         "Replaced with TestResult.Failure. Deprecated since 5.0",
-         ReplaceWith("TestResult.Failure(durationMillis.milliseconds, error)", "kotlin.time.Duration.Companion.milliseconds")
-      )
-      fun failure(error: AssertionError, durationMillis: Long): Failure = Failure(durationMillis.milliseconds, error)
-
-      @Deprecated(
-         "Replaced with TestResult.Error. Deprecated since 5.0",
-         ReplaceWith("TestResult.Error(durationMillis.milliseconds, error)", "kotlin.time.Duration.Companion.milliseconds")
-      )
-      fun error(error: Throwable, durationMillis: Long): Error = Error(durationMillis.milliseconds, error)
-
-      val Ignored = Ignored(null)
-   }
-
    /**
     * Returns a [TestResult] with a status from the given [reason] string.
     *
@@ -52,15 +30,6 @@ sealed interface TestResult {
    data class Failure(override val duration: Duration, val cause: AssertionError) : TestResult
 
    val duration: Duration
-
-   @Deprecated("No longer has relevance. Pattern match on TestResult directly. Deprecated since 5.0")
-   val status: TestStatus
-      get() = when (this) {
-         is Error -> TestStatus.Error
-         is Failure -> TestStatus.Failure
-         is Ignored -> TestStatus.Ignored
-         is Success -> TestStatus.Success
-      }
 
    val name: String
       get() = when (this) {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestResult.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/test/TestResult.kt
@@ -1,7 +1,6 @@
 package io.kotest.core.test
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 sealed interface TestResult {
 
@@ -17,6 +16,8 @@ sealed interface TestResult {
        * Returns a [TestResult.Ignored] with a reason string resolved from the given [Enabled].
        */
       constructor(enabled: Enabled) : this(enabled.reason)
+
+      constructor() : this(null)
 
       override val duration: Duration = Duration.ZERO
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/createResult.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/createResult.kt
@@ -5,8 +5,8 @@ import io.kotest.mpp.bestName
 import kotlin.time.Duration
 
 /**
- * Creates a [TestResult] which is a [TestResult.success] if the supplied exception is null,
- * a [TestResult.failure] if the supplied error is an assertion failure, or a [TestResult.error]
+ * Creates a [TestResult] which is a [TestResult.Success] if the supplied exception is null,
+ * a [TestResult.Failure] if the supplied error is an assertion failure, or a [TestResult.Error]
  * if the exception is any other type.
  */
 fun createTestResult(duration: Duration, error: Throwable?): TestResult = when {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
@@ -26,7 +26,7 @@ class TestCoroutineInterceptor : TestExecutionInterceptor {
       scope: TestScope,
       test: suspend (TestCase, TestScope) -> TestResult
    ): TestResult {
-      var result: TestResult = TestResult.Ignored
+      var result: TestResult = TestResult.Ignored()
       logger.log { Pair(testCase.name.testName, "Switching context to coroutines runTest") }
       runTest {
          var additionalContext: CoroutineContext = TestScopeElement(this)

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/MarkAbortedExceptionsAsSkippedTestInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/MarkAbortedExceptionsAsSkippedTestInterceptor.kt
@@ -22,7 +22,7 @@ internal object MarkAbortedExceptionsAsSkippedTestInterceptor : TestExecutionInt
    ): TestResult {
       return test(testCase, scope).let { testResult ->
          if (testResult.errorOrNull is TestAbortedException) {
-            TestResult.Ignored
+            TestResult.Ignored()
          } else {
             testResult
          }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/testextension/TestCaseExtensionAroundAdviceTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/testextension/TestCaseExtensionAroundAdviceTest.kt
@@ -13,7 +13,7 @@ class TestCaseExtensionAroundAdviceTest : StringSpec() {
    object MyExt : TestCaseExtension {
       override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
          return when (testCase.descriptor.id.value) {
-            "test1" -> TestResult.Ignored
+            "test1" -> TestResult.Ignored()
             "test2" ->
                when (execute(testCase)) {
                   is TestResult.Error, is TestResult.Failure -> TestResult.Success(0.milliseconds)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/testextension/TestCaseExtensionChainTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/testextension/TestCaseExtensionChainTest.kt
@@ -11,7 +11,7 @@ class TestCaseExtensionChainTest : StringSpec() {
    object MyExt1 : TestCaseExtension {
       override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
          return if (testCase.descriptor.id.value == "test1")
-            TestResult.Ignored
+            TestResult.Ignored()
          else
             execute(testCase)
       }
@@ -20,7 +20,7 @@ class TestCaseExtensionChainTest : StringSpec() {
    object MyExt2 : TestCaseExtension {
       override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
          return if (testCase.descriptor.id.value == "test2")
-            TestResult.Ignored
+            TestResult.Ignored()
          else
             execute(testCase)
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TestFinishedExecutionInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/interceptors/TestFinishedExecutionInterceptorTest.kt
@@ -12,6 +12,7 @@ import io.kotest.engine.test.AbstractTestCaseExecutionListener
 import io.kotest.engine.test.scopes.TerminalTestScope
 import io.kotest.engine.test.interceptors.TestFinishedInterceptor
 import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
 
 class TestFinishedExecutionInterceptorTest : FunSpec({
 
@@ -32,9 +33,9 @@ class TestFinishedExecutionInterceptorTest : FunSpec({
             finished = true
          }
       }
-      
+
       @Suppress("DEPRECATION") // Remove when removing listeners
-      TestFinishedInterceptor(listener).intercept(tc, context) { _, _ -> TestResult.success(0) }
+      TestFinishedInterceptor(listener).intercept(tc, context) { _, _ -> TestResult.Success(0.seconds) }
       finished shouldBe true
    }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
