### PR TITLE
Remove listener interface

### DIFF
--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemExitExtensions.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemExitExtensions.kt
@@ -41,9 +41,9 @@ object SystemExitListener : TestListener {
  * After the spec has completed, the original security manager
  * will be set.
  *
- * To use this, override `listeners`() in your [Spec] class.
+ * To use this, override `extensions`() in your [Spec] class.
  *
- * Note: This listener is only suitable for use if parallelism is
+ * Note: This extension is only suitable for use if parallelism is
  * set to 1 (the default) otherwise a race condition could occur.
  *
  * If you want to change the security manager for the entire

--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -917,7 +917,6 @@ public abstract class io/kotest/core/config/AbstractProjectConfig {
 	public fun beforeAll ()V
 	public fun beforeProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun extensions ()Ljava/util/List;
-	public fun filters ()Ljava/util/List;
 	public fun getAllowOutOfOrderCallbacks ()Ljava/lang/Boolean;
 	public fun getAssertionMode ()Lio/kotest/core/test/AssertionMode;
 	public fun getAutoScanEnabled ()Ljava/lang/Boolean;
@@ -954,7 +953,6 @@ public abstract class io/kotest/core/config/AbstractProjectConfig {
 	public fun getTestNameRemoveWhitespace ()Ljava/lang/Boolean;
 	public fun getTimeout-FghU774 ()Lkotlin/time/Duration;
 	public fun getWriteSpecFailureFile ()Ljava/lang/Boolean;
-	public fun listeners ()Ljava/util/List;
 	public fun setAllowOutOfOrderCallbacks (Ljava/lang/Boolean;)V
 	public fun setDisableTestNestedJarScanning (Ljava/lang/Boolean;)V
 	public fun setDiscoveryClasspathFallbackEnabled (Ljava/lang/Boolean;)V
@@ -1145,7 +1143,6 @@ public final class io/kotest/core/config/ProjectConfiguration {
 	public final fun getThreads ()I
 	public final fun getTimeout ()Ljava/lang/Long;
 	public final fun getWriteSpecFailureFile ()Z
-	public final fun listeners ()Ljava/lang/Void;
 	public final fun setAllowOutOfOrderCallbacks (Z)V
 	public final fun setAssertionMode (Lio/kotest/core/test/AssertionMode;)V
 	public final fun setBlockingTest (Z)V
@@ -1649,7 +1646,7 @@ public final class io/kotest/core/listeners/AfterContainerListener$DefaultImpls 
 	public static fun afterContainer (Lio/kotest/core/listeners/AfterContainerListener;Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/AfterEachListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/AfterEachListener : io/kotest/core/extensions/Extension {
 	public abstract fun afterEach (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1657,7 +1654,7 @@ public final class io/kotest/core/listeners/AfterEachListener$DefaultImpls {
 	public static fun afterEach (Lio/kotest/core/listeners/AfterEachListener;Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/AfterInvocationListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/AfterInvocationListener : io/kotest/core/extensions/Extension {
 	public abstract fun afterInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1665,7 +1662,7 @@ public final class io/kotest/core/listeners/AfterInvocationListener$DefaultImpls
 	public static fun afterInvocation (Lio/kotest/core/listeners/AfterInvocationListener;Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/AfterProjectListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/AfterProjectListener : io/kotest/core/extensions/Extension {
 	public abstract fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1673,7 +1670,7 @@ public final class io/kotest/core/listeners/AfterProjectListener$DefaultImpls {
 	public static fun afterProject (Lio/kotest/core/listeners/AfterProjectListener;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/AfterSpecListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/AfterSpecListener : io/kotest/core/extensions/Extension {
 	public abstract fun afterSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1681,7 +1678,7 @@ public final class io/kotest/core/listeners/AfterSpecListener$DefaultImpls {
 	public static fun afterSpec (Lio/kotest/core/listeners/AfterSpecListener;Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/AfterTestListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/AfterTestListener : io/kotest/core/extensions/Extension {
 	public abstract fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun afterTest (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1699,7 +1696,7 @@ public final class io/kotest/core/listeners/BeforeContainerListener$DefaultImpls
 	public static fun beforeContainer (Lio/kotest/core/listeners/BeforeContainerListener;Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/BeforeEachListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/BeforeEachListener : io/kotest/core/extensions/Extension {
 	public abstract fun beforeEach (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1707,7 +1704,7 @@ public final class io/kotest/core/listeners/BeforeEachListener$DefaultImpls {
 	public static fun beforeEach (Lio/kotest/core/listeners/BeforeEachListener;Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/BeforeInvocationListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/BeforeInvocationListener : io/kotest/core/extensions/Extension {
 	public abstract fun beforeInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1715,7 +1712,7 @@ public final class io/kotest/core/listeners/BeforeInvocationListener$DefaultImpl
 	public static fun beforeInvocation (Lio/kotest/core/listeners/BeforeInvocationListener;Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/BeforeProjectListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/BeforeProjectListener : io/kotest/core/extensions/Extension {
 	public abstract fun beforeProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1723,7 +1720,7 @@ public final class io/kotest/core/listeners/BeforeProjectListener$DefaultImpls {
 	public static fun beforeProject (Lio/kotest/core/listeners/BeforeProjectListener;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/BeforeSpecListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/BeforeSpecListener : io/kotest/core/extensions/Extension {
 	public abstract fun beforeSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1731,7 +1728,7 @@ public final class io/kotest/core/listeners/BeforeSpecListener$DefaultImpls {
 	public static fun beforeSpec (Lio/kotest/core/listeners/BeforeSpecListener;Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/BeforeTestListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/BeforeTestListener : io/kotest/core/extensions/Extension {
 	public abstract fun beforeAny (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
@@ -1741,7 +1738,7 @@ public final class io/kotest/core/listeners/BeforeTestListener$DefaultImpls {
 	public static fun beforeTest (Lio/kotest/core/listeners/BeforeTestListener;Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/FinalizeSpecListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/FinalizeSpecListener : io/kotest/core/extensions/Extension {
 	public abstract fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1761,10 +1758,7 @@ public abstract interface class io/kotest/core/listeners/InstantiationListener {
 	public abstract fun specInstantiated (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/Listener : io/kotest/core/extensions/Extension {
-}
-
-public abstract interface class io/kotest/core/listeners/PrepareSpecListener : io/kotest/core/listeners/Listener {
+public abstract interface class io/kotest/core/listeners/PrepareSpecListener : io/kotest/core/extensions/Extension {
 	public abstract fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -1780,7 +1774,7 @@ public final class io/kotest/core/listeners/ProjectListener$DefaultImpls {
 	public static fun beforeProject (Lio/kotest/core/listeners/ProjectListener;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/TestListener : io/kotest/core/listeners/AfterContainerListener, io/kotest/core/listeners/AfterEachListener, io/kotest/core/listeners/AfterInvocationListener, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/AfterTestListener, io/kotest/core/listeners/BeforeContainerListener, io/kotest/core/listeners/BeforeEachListener, io/kotest/core/listeners/BeforeInvocationListener, io/kotest/core/listeners/BeforeSpecListener, io/kotest/core/listeners/BeforeTestListener, io/kotest/core/listeners/FinalizeSpecListener, io/kotest/core/listeners/Listener, io/kotest/core/listeners/PrepareSpecListener {
+public abstract interface class io/kotest/core/listeners/TestListener : io/kotest/core/listeners/AfterContainerListener, io/kotest/core/listeners/AfterEachListener, io/kotest/core/listeners/AfterInvocationListener, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/AfterTestListener, io/kotest/core/listeners/BeforeContainerListener, io/kotest/core/listeners/BeforeEachListener, io/kotest/core/listeners/BeforeInvocationListener, io/kotest/core/listeners/BeforeSpecListener, io/kotest/core/listeners/BeforeTestListener, io/kotest/core/listeners/FinalizeSpecListener, io/kotest/core/listeners/PrepareSpecListener {
 }
 
 public final class io/kotest/core/listeners/TestListener$DefaultImpls {

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/AbstractProjectConfig.kt
@@ -2,8 +2,6 @@ package io.kotest.core.config
 
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.extensions.Extension
-import io.kotest.core.filter.Filter
-import io.kotest.core.listeners.Listener
 import io.kotest.core.listeners.ProjectListener
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.names.TestNameCase
@@ -40,20 +38,6 @@ abstract class AbstractProjectConfig {
     * List of project wide [Extension] instances.
     */
    open fun extensions(): List<Extension> = emptyList()
-
-   /**
-    * List of project wide [Listener] instances.
-    */
-   @Suppress("DEPRECATION") // Remove when removing function
-   @Deprecated("Use extensions. This will be removed in 6.0")
-   open fun listeners(): List<Listener> = emptyList()
-
-   /**
-    * List of project wide [Filter] instances.
-    */
-   @Suppress("DEPRECATION") // Remove when removing function
-   @Deprecated("Use extensions. This will be removed in 6.0")
-   open fun filters(): List<Filter> = emptyList()
 
    /**
     * Override this function and return an instance of [SpecExecutionOrder] which will

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -4,7 +4,6 @@ package io.kotest.core.config
 
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.extensions.Extension
-import io.kotest.core.listeners.Listener
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.names.TestNameCase
 import io.kotest.core.spec.IsolationMode
@@ -365,12 +364,6 @@ class ProjectConfiguration {
     * Defaults to false.
     */
    var ignorePrivateClasses: Boolean = Defaults.ignorePrivateClasses
-
-   /**
-    * Returns all globally registered [Listener]s.
-    */
-   @Deprecated("Listeners have been subsumed into extensions", level = DeprecationLevel.ERROR)
-   fun listeners(): Nothing = throw UnsupportedOperationException()
 
    @Deprecated("Use registry. Deprecated since 5.0")
    fun extensions(): List<Extension> = registry.all()

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/AfterSpecListener.kt
@@ -1,9 +1,9 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.Spec
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface AfterSpecListener : Listener {
+interface AfterSpecListener : Extension {
 
    /**
     * Is invoked after the [io.kotest.core.test.TestCase]s that are part of a particular

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/BeforeSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/BeforeSpecListener.kt
@@ -1,9 +1,9 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.Spec
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface BeforeSpecListener : Listener {
+interface BeforeSpecListener : Extension {
 
    /**
     * This callback is invoked just before the first test (or only test) is executed

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/FinalizeSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/FinalizeSpecListener.kt
@@ -1,5 +1,6 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -9,8 +10,7 @@ import kotlin.reflect.KClass
  * Invoked once per spec class if the spec has enabled root tests.
  * This listener is only invoked if the spec had at least one enabled test.
  */
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface FinalizeSpecListener : Listener {
+interface FinalizeSpecListener : Extension {
 
    /**
     * Called once per [Spec], after all tests have completed for that spec.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/Listener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/Listener.kt
@@ -1,9 +1,0 @@
-package io.kotest.core.listeners
-
-import io.kotest.core.extensions.Extension
-
-/**
- * A [Listener] is a just an [Extension] that is passive.
- */
-@Deprecated("This marker interface is being subsumed by Extension and should be ignored in favor of Extension. Deprecated in 5.0.")
-interface Listener : Extension

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/PrepareSpecListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/PrepareSpecListener.kt
@@ -1,5 +1,6 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.Spec
 import kotlin.reflect.KClass
 
@@ -12,8 +13,7 @@ import kotlin.reflect.KClass
  * is set to create multiple instances, then this listener will not be
  * invoked multiple times.
  */
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface PrepareSpecListener : Listener {
+interface PrepareSpecListener : Extension {
 
    /**
     * Called once per [Spec], when the engine is preparing to

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/TestListener.kt
@@ -9,7 +9,6 @@ import io.kotest.core.test.TestCase
  * This interface is a union of the various test related listeners interfaces.
  * Users can choose to extend this interface, or the constituent interfaces separately.
  */
-@Suppress("DEPRECATION") // Remove when removing Listener
 interface TestListener :
    BeforeTestListener,
    AfterTestListener,
@@ -22,6 +21,4 @@ interface TestListener :
    BeforeInvocationListener,
    AfterInvocationListener,
    PrepareSpecListener,
-   FinalizeSpecListener,
-   Listener {
-}
+   FinalizeSpecListener

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterEach.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterEach.kt
@@ -1,11 +1,11 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface BeforeEachListener : Listener {
+interface BeforeEachListener : Extension {
 
    /**
     * Registers a new before-each callback to be executed before every [TestCase]
@@ -15,8 +15,7 @@ interface BeforeEachListener : Listener {
    suspend fun beforeEach(testCase: TestCase): Unit = Unit
 }
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface AfterEachListener : Listener {
+interface AfterEachListener : Extension {
 
    /**
     * Registers a new after-each callback to be executed after every [TestCase]

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterTest.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/beforeAfterTest.kt
@@ -1,12 +1,12 @@
 package io.kotest.core.listeners
 
 import io.kotest.common.SoftDeprecated
+import io.kotest.core.extensions.Extension
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 
-@Suppress("DEPRECATION") // Remove when removing Listener
 @SoftDeprecated("Use beforeAny")
-interface BeforeTestListener : Listener {
+interface BeforeTestListener : Extension {
 
    /**
     * This callback will be invoked before a [TestCase] is executed.
@@ -25,9 +25,8 @@ interface BeforeTestListener : Listener {
    suspend fun beforeAny(testCase: TestCase): Unit = Unit
 }
 
-@Suppress("DEPRECATION") // Remove when removing Listener
 @SoftDeprecated("Use afterContainer, afterEach, or afterAny")
-interface AfterTestListener : Listener {
+interface AfterTestListener : Extension {
 
    /**
     * This callback is invoked after a [TestCase] has finished.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/invocation.kt
@@ -1,9 +1,9 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.test.TestCase
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface BeforeInvocationListener : Listener {
+interface BeforeInvocationListener : Extension {
 
    /**
     * Invoked before each 'run' of a test, with a flag indicating the iteration number.
@@ -19,8 +19,7 @@ interface BeforeInvocationListener : Listener {
    suspend fun beforeInvocation(testCase: TestCase, iteration: Int): Unit = Unit
 }
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface AfterInvocationListener : Listener {
+interface AfterInvocationListener : Extension {
 
    /**
     * Invoked after each 'run' of a test, with a flag indicating the iteration number.

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/project.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/listeners/project.kt
@@ -1,21 +1,21 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
+
 /**
  * Brings together [BeforeProjectListener] and [AfterProjectListener]. Exists for historical reasons.
  * Users can choose to extend this, or the constituent interfaces.
  */
 interface ProjectListener : BeforeProjectListener, AfterProjectListener
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface BeforeProjectListener : Listener {
+interface BeforeProjectListener : Extension {
    /**
     * Callback which is invoked before the first test of the project.
     */
    suspend fun beforeProject() {}
 }
 
-@Suppress("DEPRECATION") // Remove when removing Listener
-interface AfterProjectListener : Listener {
+interface AfterProjectListener : Extension {
    /**
     * Callback which is invoked after the last test of the project.
     */

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/applyConfigFromAbstractProjectConfig.kt
@@ -82,7 +82,6 @@ internal fun applyConfigFromProjectConfig(config: AbstractProjectConfig, configu
       }
    }
 
-   @Suppress("DEPRECATION") // Remove when removing Listener
-   val exts = config.listeners() + listOf(projectListener) + config.extensions() + config.filters()
+   val exts = listOf(projectListener) + config.extensions()
    exts.forEach { configuration.registry.add(it) }
 }

--- a/kotest-tests/kotest-tests-htmlreporter/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-htmlreporter/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
@@ -1,16 +1,16 @@
 package com.sksamuel.kotest
 
-import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.core.listeners.Listener
-import io.kotest.extensions.junitxml.JunitXmlReporter
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.extensions.htmlreporter.HtmlReporter
+import io.kotest.extensions.junitxml.JunitXmlReporter
 
 class ProjectConfig : AbstractProjectConfig() {
 
    override val specExecutionOrder = SpecExecutionOrder.Annotated
 
-   override fun listeners(): List<Listener> {
+   override fun extensions(): List<Extension> {
       return listOf(
          JunitXmlReporter(
             includeContainers = false,

--- a/kotest-tests/kotest-tests-multipleconfig/src/jvmTest/kotlin/io/kotest/engine/multiconfig/MultiConfigTest.kt
+++ b/kotest-tests/kotest-tests-multipleconfig/src/jvmTest/kotlin/io/kotest/engine/multiconfig/MultiConfigTest.kt
@@ -10,7 +10,7 @@ class MultiConfigTest : WordSpec() {
    init {
       "detecting two configs" should {
          "merge listeners" {
-            listeners.get() shouldBe 2
+            counter.get() shouldBe 2
          }
          "merge project listeners" {
             beforeAll.get() shouldBe 2

--- a/kotest-tests/kotest-tests-multipleconfig/src/jvmTest/kotlin/io/kotest/engine/multiconfig/configs.kt
+++ b/kotest-tests/kotest-tests-multipleconfig/src/jvmTest/kotlin/io/kotest/engine/multiconfig/configs.kt
@@ -1,25 +1,25 @@
 package io.kotest.engine.multiconfig
 
 import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.core.listeners.Listener
+import io.kotest.core.extensions.Extension
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestCaseOrder
 import java.util.concurrent.atomic.AtomicInteger
 
-val listeners = AtomicInteger(0)
+val counter = AtomicInteger(0)
 val beforeAll = AtomicInteger(0)
 
-object Listener : TestListener {
+object MyExtension : TestListener {
    override suspend fun beforeEach(testCase: TestCase) {
-      listeners.incrementAndGet()
+      counter.incrementAndGet()
    }
 }
 
 class Config1 : AbstractProjectConfig() {
    override val testCaseOrder = TestCaseOrder.Random
-   override fun listeners(): List<Listener> = listOf(Listener)
+   override fun extensions(): List<Extension> = listOf(MyExtension)
    override suspend fun beforeProject() {
       beforeAll.incrementAndGet()
    }
@@ -27,7 +27,7 @@ class Config1 : AbstractProjectConfig() {
 
 class Config2 : AbstractProjectConfig() {
    override val specExecutionOrder: SpecExecutionOrder = SpecExecutionOrder.Random
-   override fun listeners(): List<Listener> = listOf(Listener)
+   override fun extensions(): List<Extension> = listOf(MyExtension)
    override suspend fun beforeProject() {
       beforeAll.incrementAndGet()
    }


### PR DESCRIPTION
Removes the deprecated Listener interface. Since 5.0 all "extensions" whether the old style listeners, or the interceptors, all extend a single Extension marker interface.