### PR TITLE
kotest-publishing-conventions: Verify that signing credentials are neither null nor blank

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -19,7 +19,7 @@ val signingPassword: String? by project
 val mavenCentralRepoName = "Deploy"
 
 signing {
-   if (signingKey != null && signingPassword != null) {
+   if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
       useGpgCmd()
       useInMemoryPgpKeys(signingKey, signingPassword)
    }


### PR DESCRIPTION
Check that the signing credentials are neither null nor blank.

Hopefully this fixes the `Could not read PGP secret key > secret key ring doesn't start with secret key tag: tag 0xffffffff` error?

I've created this PR from my fork of Kotest, to try and more accurately recreate the issue, although I don't know if my fork will have access to the GitHub secrets because I'm a contributor.