### PR TITLE
add-similarity-to-containExactly-take2

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.jvm.JvmName
+import io.kotest.similarity.possibleMatchesDescription
 
 /**
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
@@ -102,6 +103,7 @@ fun <T, C : Collection<T>> containExactly(
 
          appendMissingAndExtra(missing, extra)
          appendLine()
+         appendPossibleMatches(missing, expected)
       }
    }
 
@@ -199,5 +201,17 @@ fun StringBuilder.appendMissingAndExtra(missing: Collection<Any?>, extra: Collec
             extra.take(AssertionsConfig.maxCollectionPrintSize.value).print().value
          }"
       )
+   }
+}
+
+internal fun<T> StringBuilder.appendPossibleMatches(missing: Collection<T>, expected: Collection<T>) {
+   val possibleMatches = missing
+      .map { possibleMatchesDescription(expected.toSet(), it) }
+      .filter { it.isNotEmpty() }
+   if(possibleMatches.isNotEmpty()) {
+      append("\nPossible matches:\n${possibleMatches.take(AssertionsConfig.maxSimilarityPrintSize.value).joinToString("\n\n")}")
+   }
+   if(AssertionsConfig.maxSimilarityPrintSize.value < possibleMatches.size) {
+      append("\nPrinted first ${AssertionsConfig.maxSimilarityPrintSize.value} similarities out of ${possibleMatches.size}, (set the 'kotest.assertions.similarity.print.size' JVM property to see full output for similarity)\n")
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/PossibleMatches.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/PossibleMatches.kt
@@ -1,10 +1,16 @@
 package io.kotest.similarity
 
+import io.kotest.assertions.AssertionsConfig
+
 actual fun<T> possibleMatchesDescription(expected: Set<T>, actual: T): String {
    val possibleMatches = closestMatches(expected, actual)
    return if(possibleMatches.isEmpty()) ""
    else {
-      "\n${possibleMatches.joinToString("\n\n"){it.comparisonResult.description()}}"
+      val someEntriesSkippedDescription = if(AssertionsConfig.maxSimilarityPrintSize.value < possibleMatches.size) {
+         "\nPrinted first ${AssertionsConfig.maxSimilarityPrintSize.value} similarities out of ${possibleMatches.size}, (set the 'kotest.assertions.similarity.print.size' JVM property to see full output for similarity)"
+      }
+      else ""
+      "\n${possibleMatches.take(AssertionsConfig.maxSimilarityPrintSize.value).joinToString("\n\n"){it.comparisonResult.description()}}$someEntriesSkippedDescription"
    }
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.matchers.collections
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.shouldFailWithMessage
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
@@ -18,6 +19,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.kotest.property.Arb
 import io.kotest.property.Exhaustive
@@ -184,20 +186,33 @@ class ShouldContainExactlyTest : WordSpec() {
          }
 
          "include extras when too many" {
-            shouldThrow<AssertionError> {
+            val message = shouldThrow<AssertionError> {
                listOf(
                   Blonde("foo", true, 23423, inputPath)
                ).shouldContainExactly(
                   Blonde("foo", true, 23423, inputPath),
                   Blonde("woo", true, 97821, inputPath)
                )
-            }.message?.trim() shouldBe
+            }.message?.trim()
+            message shouldContain(
                """
                   |Collection should contain exactly: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath)]
                   |Some elements were missing: [Blonde(a=woo, b=true, c=97821, p=$expectedPath)]
-                  |
+               """.trimMargin()
+            )
+            assertSoftly {
+               message.shouldContain("Possible matches:")
+               message.shouldContain("expected: Blonde(a=foo, b=true, c=23423, p=a/b/c),")
+               message.shouldContain("but was: Blonde(a=woo, b=true, c=97821, p=a/b/c),")
+               message.shouldContain("The following fields did not match:")
+               message.shouldContain("\"a\" expected: <\"foo\">, but was: <\"woo\">")
+               message.shouldContain("\"c\" expected: <23423>, but was: <97821>")
+            }
+            message.shouldContain(
+               """
                   |expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath)]>
                """.trimMargin()
+            )
          }
 
          "include missing when too few" {
@@ -219,7 +234,7 @@ class ShouldContainExactlyTest : WordSpec() {
          }
 
          "include missing and extras when not the right amount" {
-            shouldThrow<AssertionError> {
+            val message = shouldThrow<AssertionError> {
                listOf(
                   Blonde("foo", true, 23423, inputPath),
                   Blonde("hoo", true, 96915, inputPath)
@@ -227,17 +242,28 @@ class ShouldContainExactlyTest : WordSpec() {
                   Blonde("woo", true, 97821, inputPath),
                   Blonde("goo", true, 51984, inputPath)
                )
-            }.message?.trim() shouldBe
+            }.message?.trim()
+            message shouldStartWith
                """
                   |Collection should contain exactly: [Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]
                   |Some elements were missing: [Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)] and some elements were unexpected: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]
-                  |
+               """.trimMargin()
+            assertSoftly {
+               message.shouldContain("Possible matches:")
+               message.shouldContain("expected: Blonde(a=goo, b=true, c=51984, p=a/b/c),")
+               message.shouldContain("but was: Blonde(a=woo, b=true, c=97821, p=a/b/c),")
+               message.shouldContain("The following fields did not match:")
+               message.shouldContain("\"a\" expected: <\"goo\">, but was: <\"woo\">")
+               message.shouldContain("\"c\" expected: <51984>, but was: <97821>")
+            }
+            message shouldContain
+               """
                   |expected:<[Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=hoo, b=true, c=96915, p=$expectedPath)]>
                """.trimMargin()
          }
 
          "exclude full print with warning on large collections" {
-            shouldThrow<AssertionError> {
+            val message = shouldThrow<AssertionError> {
                listOf(
                   Blonde("foo", true, 1, inputPath),
                   Blonde("foo", true, 2, inputPath),
@@ -283,11 +309,23 @@ class ShouldContainExactlyTest : WordSpec() {
                   Blonde("foo", true, 20, inputPath),
                   Blonde("foo", true, 21, inputPath),
                )
-            }.message?.trim() shouldBe
+            }.message?.trim()
+            message shouldContain
                """
                   |Collection should contain exactly: [Blonde(a=foo, b=true, c=77, p=$expectedPath), Blonde(a=foo, b=true, c=2, p=$expectedPath), Blonde(a=foo, b=true, c=3, p=$expectedPath), Blonde(a=foo, b=true, c=4, p=$expectedPath), Blonde(a=foo, b=true, c=5, p=$expectedPath), Blonde(a=foo, b=true, c=6, p=$expectedPath), Blonde(a=foo, b=true, c=7, p=$expectedPath), Blonde(a=foo, b=true, c=8, p=$expectedPath), Blonde(a=foo, b=true, c=9, p=$expectedPath), Blonde(a=foo, b=true, c=10, p=$expectedPath), Blonde(a=foo, b=true, c=11, p=$expectedPath), Blonde(a=foo, b=true, c=12, p=$expectedPath), Blonde(a=foo, b=true, c=13, p=$expectedPath), Blonde(a=foo, b=true, c=14, p=$expectedPath), Blonde(a=foo, b=true, c=15, p=$expectedPath), Blonde(a=foo, b=true, c=16, p=$expectedPath), Blonde(a=foo, b=true, c=17, p=$expectedPath), Blonde(a=foo, b=true, c=18, p=$expectedPath), Blonde(a=foo, b=true, c=19, p=$expectedPath), Blonde(a=foo, b=true, c=20, p=$expectedPath), ...and 1 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)] but was: [Blonde(a=foo, b=true, c=1, p=$expectedPath), Blonde(a=foo, b=true, c=2, p=$expectedPath), Blonde(a=foo, b=true, c=3, p=$expectedPath), Blonde(a=foo, b=true, c=4, p=$expectedPath), Blonde(a=foo, b=true, c=5, p=$expectedPath), Blonde(a=foo, b=true, c=6, p=$expectedPath), Blonde(a=foo, b=true, c=7, p=$expectedPath), Blonde(a=foo, b=true, c=8, p=$expectedPath), Blonde(a=foo, b=true, c=9, p=$expectedPath), Blonde(a=foo, b=true, c=10, p=$expectedPath), Blonde(a=foo, b=true, c=11, p=$expectedPath), Blonde(a=foo, b=true, c=12, p=$expectedPath), Blonde(a=foo, b=true, c=13, p=$expectedPath), Blonde(a=foo, b=true, c=14, p=$expectedPath), Blonde(a=foo, b=true, c=15, p=$expectedPath), Blonde(a=foo, b=true, c=16, p=$expectedPath), Blonde(a=foo, b=true, c=17, p=$expectedPath), Blonde(a=foo, b=true, c=18, p=$expectedPath), Blonde(a=foo, b=true, c=19, p=$expectedPath), Blonde(a=foo, b=true, c=20, p=$expectedPath), ...and 1 more (set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)]
                   |Some elements were missing: [Blonde(a=foo, b=true, c=77, p=$expectedPath)] and some elements were unexpected: [Blonde(a=foo, b=true, c=1, p=$expectedPath)]
-                  |(set the 'kotest.assertions.collection.enumerate.size' JVM property to see full output)
+               """.trimMargin()
+            assertSoftly {
+               message.shouldContain("Possible matches:")
+               message.shouldContain("expected: Blonde(a=foo, b=true, c=2, p=a/b/c),")
+               message.shouldContain("but was: Blonde(a=foo, b=true, c=77, p=a/b/c),")
+               message.shouldContain("The following fields did not match:")
+               message.shouldContain("\"c\" expected: <2>, but was: <77>")
+            }
+            message shouldContain "Printed first 5 similarities out of 20, (set the 'kotest.assertions.similarity.print.size' JVM property to see full output for similarity)"
+            message shouldContain
+               """
+                  |(set the 'kotest.assertions.collection.print.size' JVM property to see more / less items)
                """.trimMargin()
          }
 

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -54,6 +54,7 @@ public final class io/kotest/assertions/AssertionsConfig {
 	public final fun getMaxCollectionEnumerateSize ()I
 	public final fun getMaxCollectionPrintSize ()Lio/kotest/assertions/ConfigValue;
 	public final fun getMaxErrorsOutput ()I
+	public final fun getMaxSimilarityPrintSize ()Lio/kotest/assertions/ConfigValue;
 	public final fun getMultiLineDiff ()Ljava/lang/String;
 	public final fun getShowDataClassDiff ()Z
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -31,6 +31,9 @@ object AssertionsConfig {
 
    val maxCollectionPrintSize: ConfigValue<Int> =
       EnvironmentConfigValue<Int>("kotest.assertions.collection.print.size", 20, String::toInt)
+
+   val maxSimilarityPrintSize: ConfigValue<Int> =
+      EnvironmentConfigValue<Int>("kotest.assertions.similarity.print.size", 5, String::toInt)
 }
 
 interface ConfigValue<T> {


### PR DESCRIPTION
add search for similar elements to `containExactly`, for example:
```
val message = shouldThrow<AssertionError> {
               listOf(
                  Blonde("foo", true, 23423, inputPath)
               ).shouldContainExactly(
                  Blonde("foo", true, 23423, inputPath),
                  Blonde("woo", true, 97821, inputPath)
               )
            }.message?.trim()
(snip)
                  |Possible matches:
                  | expected: Blonde(a=foo, b=true, c=23423, p=a/b/c),
                  |  but was: Blonde(a=woo, b=true, c=97821, p=a/b/c),
                  |  The following fields did not match:
                  |    "a" expected: <"foo">, but was: <"woo">
                  |    "c" expected: <23423>, but was: <97821>
 ```

reopening old PR https://github.com/kotest/kotest/pull/3910 - it's easier to just start from scratch than to resolve all those conflicts