### PR TITLE
add-similarity-to-haveValues-take2 (#4236)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -46,18 +46,31 @@ fun <K> haveKeys(vararg keys: K): Matcher<Map<K, Any?>> = object : Matcher<Map<K
 }
 
 fun <V> haveValue(v: V): Matcher<Map<*, V>> = object : Matcher<Map<*, V>> {
-   override fun test(value: Map<*, V>) = MatcherResult(
-      value.containsValue(v),
-      { "Map should contain value $v" },
-      { "Map should not contain value $v" })
+   override fun test(value: Map<*, V>): MatcherResult {
+      val passed = value.containsValue(v)
+      val possibleMatchesDescription = possibleMatchesForMissingElements(
+         setOf(v),
+         value.values.toSet(),
+         "value"
+      )
+      return MatcherResult(
+         passed,
+         { "Map should contain value $v$possibleMatchesDescription" },
+         { "Map should not contain value $v" })
+   }
 }
 
 fun <V> haveValues(vararg values: V): Matcher<Map<*, V>> = object : Matcher<Map<*, V>> {
    override fun test(value: Map<*, V>): MatcherResult {
       val valuesNotPresentInMap = values.filterNot { value.containsValue(it) }
+      val possibleMatchesDescription = possibleMatchesForMissingElements(
+         valuesNotPresentInMap.toSet(),
+         value.values.toSet(),
+         "values"
+      )
       return MatcherResult(
          valuesNotPresentInMap.isEmpty(),
-         { "Map did not contain the values ${values.joinToString(", ")}" },
+         { "Map did not contain the values ${valuesNotPresentInMap.joinToString(", ")}$possibleMatchesDescription" },
          { "Map should not contain the values ${values.joinToString(", ")}" }
       )
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -75,6 +75,23 @@ class MapMatchersTest : WordSpec() {
                map.shouldContainValue("c")
             }.message.shouldBe("Map should contain value c")
          }
+         "find similarities for values not found" {
+            shouldThrow<AssertionError> {
+               mapOf(
+                  1 to sweetGreenApple,
+                  2 to sweetRedApple,
+                  3 to sourYellowLemon
+               ).shouldContainValue(sweetGreenPear)
+            }.message.shouldBe("""
+            |Map should contain value Fruit(name=pear, color=green, taste=sweet)
+            |Possible matches for missing value:
+            |
+            | expected: Fruit(name=apple, color=green, taste=sweet),
+            |  but was: Fruit(name=pear, color=green, taste=sweet),
+            |  The following fields did not match:
+            |    "name" expected: <"apple">, but was: <"pear">
+            """.trimMargin())
+         }
       }
 
       "contain" should {
@@ -212,6 +229,24 @@ class MapMatchersTest : WordSpec() {
             shouldThrow<AssertionError> {
                map.shouldNotContainAnyKeysOf("a", "y")
             }
+         }
+
+         "find similarities for values not found" {
+            shouldThrow<AssertionError> {
+               mapOf(
+                  1 to sweetGreenApple,
+                  2 to sweetRedApple,
+                  3 to sourYellowLemon
+               ).shouldContainValues(sweetGreenApple, sweetGreenPear)
+            }.message.shouldBe("""
+            |Map did not contain the values Fruit(name=pear, color=green, taste=sweet)
+            |Possible matches for missing values:
+            |
+            | expected: Fruit(name=apple, color=green, taste=sweet),
+            |  but was: Fruit(name=pear, color=green, taste=sweet),
+            |  The following fields did not match:
+            |    "name" expected: <"apple">, but was: <"pear">
+            """.trimMargin())
          }
       }
 


### PR DESCRIPTION
reopening old approved PR https://github.com/kotest/kotest/pull/3931 to resolve conflicts

add search for similar elements, such as:
```
            shouldThrow<AssertionError> {
               mapOf(
                  1 to sweetGreenApple,
                  2 to sweetRedApple,
                  3 to sourYellowLemon
               ).shouldContainValue(sweetGreenPear)
            }.message.shouldBe("""
            |Map should contain value Fruit(name=pear, color=green, taste=sweet)
            |Possible matches for missing value:
            |
            | expected: Fruit(name=apple, color=green, taste=sweet),
            |  but was: Fruit(name=pear, color=green, taste=sweet),
            |  The following fields did not match:
            |    "name" expected: <"apple">, but was: <"pear">
```

