### PR TITLE
Submatching for collections, part 1

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -2526,3 +2526,47 @@ public final class io/kotest/similarity/PossibleMatchesKt {
 	public static final fun possibleMatchesDescription (Ljava/util/Set;Ljava/lang/Object;)Ljava/lang/String;
 }
 
+public final class io/kotest/submatching/MatchedCollectionElement {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lio/kotest/submatching/MatchedCollectionElement;
+	public static synthetic fun copy$default (Lio/kotest/submatching/MatchedCollectionElement;IIILjava/lang/Object;)Lio/kotest/submatching/MatchedCollectionElement;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStartIndexInExpected ()I
+	public final fun getStartIndexInValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/submatching/PartialCollectionMatch {
+	public static final field Companion Lio/kotest/submatching/PartialCollectionMatch$Companion;
+	public fun <init> (Lio/kotest/submatching/MatchedCollectionElement;ILjava/util/List;)V
+	public final fun component1 ()Lio/kotest/submatching/MatchedCollectionElement;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lio/kotest/submatching/MatchedCollectionElement;ILjava/util/List;)Lio/kotest/submatching/PartialCollectionMatch;
+	public static synthetic fun copy$default (Lio/kotest/submatching/PartialCollectionMatch;Lio/kotest/submatching/MatchedCollectionElement;ILjava/util/List;ILjava/lang/Object;)Lio/kotest/submatching/PartialCollectionMatch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndOfMatchAtTarget ()I
+	public final fun getLength ()I
+	public final fun getMatchedElement ()Lio/kotest/submatching/MatchedCollectionElement;
+	public final fun getPartOfValue ()Ljava/util/List;
+	public final fun getRangeOfExpected ()Lkotlin/ranges/IntRange;
+	public final fun getRangeOfValue ()Lkotlin/ranges/IntRange;
+	public final fun getValue ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun indexInExpected (I)I
+	public final fun indexIsInValue (I)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/submatching/PartialCollectionMatch$Companion {
+	public final fun rangeOfLength (II)Lkotlin/ranges/IntRange;
+}
+
+public final class io/kotest/submatching/SubmatchingKt {
+	public static final fun findPartialMatches (Ljava/util/List;Ljava/util/List;I)Ljava/util/List;
+	public static final fun findPartialMatchesInString (Ljava/lang/String;Ljava/lang/String;I)Ljava/util/List;
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/Submatching.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/Submatching.kt
@@ -1,0 +1,96 @@
+package io.kotest.submatching
+
+fun findPartialMatchesInString(expected: String, value: String, minLength: Int) =
+   findPartialMatches(expected.toList(), value.toList(), minLength)
+
+fun<T> findPartialMatches(expected: List<T>, value: List<T>, minLength: Int): List<PartialCollectionMatch<T>> {
+   val indexes = toCharIndex(value)
+   val matches = expected.asSequence().mapIndexed { index, char ->
+      index to char
+   }.filter { pair -> pair.first + minLength <= expected.size }
+      .flatMap { pair ->
+         matchedElements(indexes, pair)
+      }.mapNotNull { matchedCharacter ->
+         extendPartialMatchToRequiredLength(expected, value, matchedCharacter, minLength)
+      }.toList()
+   return removeShorterMatchesWithSameEnd(matches)
+}
+
+internal fun<T> toCharIndex(value: Collection<T>): Map<T, List<Int>> {
+   return value.mapIndexed { index, element ->
+      index to element
+   }.groupBy(keySelector = { it.second }, valueTransform = { it.first })
+}
+
+internal fun <T> matchedElements(
+   indexes: Map<T, List<Int>>,
+   elementAtIndex: Pair<Int, T>
+) = indexes[elementAtIndex.second]?.map { index ->
+   MatchedCollectionElement(
+      startIndexInExpected = elementAtIndex.first,
+      startIndexInValue = index
+   )
+} ?: listOf()
+
+internal fun <T> extendPartialMatchToRequiredLength(
+   value: List<T>,
+   target: List<T>,
+   matchedElement: MatchedCollectionElement,
+   minLength: Int
+): PartialCollectionMatch<T>? {
+   val lengthOfMatch = lengthOfMatch(value, target, matchedElement)
+   return if (lengthOfMatch >= minLength) {
+      PartialCollectionMatch(
+         matchedElement,
+         lengthOfMatch,
+         value
+      )
+   } else null
+}
+
+internal fun<T> removeShorterMatchesWithSameEnd(
+   matches: List<PartialCollectionMatch<T>>
+): List<PartialCollectionMatch<T>> {
+   val matchesGroupedByEnd = matches.groupBy {
+      it.endOfMatchAtTarget
+   }
+   return matchesGroupedByEnd.values.map { matchesWithSameEnd ->
+      matchesWithSameEnd.maxBy { it.length }
+   }
+}
+
+internal fun<T> lengthOfMatch(
+   value: List<T>, target: List<T>, matchedElement: MatchedCollectionElement
+): Int {
+   val maxLengthOfMatch = minOf(value.size - matchedElement.startIndexInExpected, target.size - matchedElement.startIndexInValue)
+   return (1..maxLengthOfMatch).takeWhile { offset ->
+      value[matchedElement.startIndexInExpected + offset - 1] == target[matchedElement.startIndexInValue + offset - 1]
+   }.lastOrNull() ?: 0
+}
+
+data class MatchedCollectionElement(
+   val startIndexInExpected: Int,
+   val startIndexInValue: Int
+)
+
+data class PartialCollectionMatch<T>(
+   val matchedElement: MatchedCollectionElement,
+   val length: Int,
+   val value: List<T>
+) {
+   val endOfMatchAtTarget: Int
+      get() = matchedElement.startIndexInValue + length - 1
+   val partOfValue: List<T>
+      get() = value.subList(matchedElement.startIndexInExpected, matchedElement.startIndexInExpected + length)
+   val rangeOfExpected: IntRange = rangeOfLength(matchedElement.startIndexInExpected, length)
+   val rangeOfValue: IntRange = rangeOfLength(matchedElement.startIndexInValue, length)
+
+   fun indexIsInValue(index: Int) = index in rangeOfValue
+   fun indexInExpected(indexInValue: Int) = matchedElement.startIndexInExpected +
+      (indexInValue - matchedElement.startIndexInValue)
+
+   companion object {
+      fun rangeOfLength(start: Int, length: Int): IntRange = (start..<start+length)
+   }
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/TopNByWithTies.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/TopNByWithTies.kt
@@ -1,0 +1,14 @@
+package io.kotest.submatching
+
+/**
+ * Return a [List] containing all the values with N highest rankings provided by [rankingTransform]
+ *
+ * If more than one element has the same ranking returned by [keySelector] their order is preserved.
+ *
+ * The operation is _stateful_ and  _terminal_.
+ */
+internal inline fun<T, R: Comparable<R>> List<T>.topNWithTiesBy(depth: Int, rankingTransform: (T) -> R ): List<T> {
+   val elementsByRank: Map<R, List<T>> = this.groupBy(rankingTransform)
+   val topRanks = elementsByRank.keys.sorted().reversed().take(depth)
+   return topRanks.flatMap { key -> elementsByRank.getOrElse(key) { listOf() } }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.matchers.collections
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.endWith
@@ -9,6 +10,9 @@ import io.kotest.matchers.collections.shouldNotStartWith
 import io.kotest.matchers.collections.shouldStartWith
 import io.kotest.matchers.collections.startWith
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class StartWithEndWithTest : WordSpec() {
@@ -25,16 +29,52 @@ class StartWithEndWithTest : WordSpec() {
          "print errors unambiguously"  {
             shouldThrow<AssertionError> {
                listOf(1L, 2L) should startWith(listOf(1L, 3L))
-            }.shouldHaveMessage("""
+            }.message shouldStartWith("""
                |List should start with [1L, 3L] but was [1L, 2L]
                |The following elements failed:
                |  [1] 2L => expected: <3L>, but was: <2L>
             """.trimMargin())
          }
+         "find one submatch".config(enabled = true) {
+            val message = shouldThrow<AssertionError> {
+               listOf(0L, 1L, 2L, 3L) should startWith(listOf(1L, 2L))
+            }.message
+            assertSoftly {
+               message shouldContain "Slice[0] of expected with indexes: 0..1 matched a slice of actual values with indexes: 1..2"
+               message shouldContain "[1] 1L => slice 0"
+               message shouldContain "[2] 2L => slice 0"
+            }
+         }
+         "find two non-overlapping submatches".config(enabled = true) {
+            val message = shouldThrow<AssertionError> {
+               listOf(0L, 1L, 2L, 3L, 4L, 5L) should startWith(listOf(1L, 2L, 4L, 5L))
+            }.message
+            assertSoftly {
+               message shouldContain "Slice[0] of expected with indexes: 0..1 matched a slice of actual values with indexes: 1..2"
+               message shouldContain "Slice[1] of expected with indexes: 2..3 matched a slice of actual values with indexes: 4..5"
+               message shouldContain "[1] 1L => slice 0"
+               message shouldContain "[2] 2L => slice 0"
+               message shouldContain "[4] 4L => slice 1"
+               message shouldContain "[5] 5L => slice 1"
+            }
+         }
+         "find two overlapping submatches".config(enabled = true) {
+            val message = shouldThrow<AssertionError> {
+               listOf(0L, 1L, 2L, 3L, 4L, 5L) should startWith(listOf(1L, 2L, 3L, 2L, 3L, 4L))
+            }.message
+            assertSoftly {
+               message shouldContain "Slice[0] of expected with indexes: 0..2 matched a slice of actual values with indexes: 1..3"
+               message shouldContain "Slice[1] of expected with indexes: 3..5 matched a slice of actual values with indexes: 2..4"
+               message shouldContain "[1] 1L => slice 0"
+               message shouldContain "[2] 2L => slices: [0, 1]"
+               message shouldContain "[3] 3L => slices: [0, 1]"
+               message shouldContain "[4] 4L => slice 1"
+            }
+         }
          "print errors unambiguously when the actual value is empty"  {
             shouldThrow<AssertionError> {
                emptyList<Long>() should startWith(listOf(1L, 3L))
-            }.shouldHaveMessage("""
+            }.message shouldStartWith("""
                |List should start with [1L, 3L] but was []
                |Actual collection is shorter than expected slice
                """.trimMargin())

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/PartialCollectionMatchTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/PartialCollectionMatchTest.kt
@@ -1,0 +1,24 @@
+package io.kotest.submatching
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class PartialCollectionMatchTest: StringSpec() {
+   private val systemToTest = PartialCollectionMatch(
+      MatchedCollectionElement(2, 3),
+      length = 4,
+      value = "buzzword".toList()
+   )
+   init {
+      "rangeOfValue" {
+         systemToTest.rangeOfExpected shouldBe 2..5
+      }
+      "rangeOfTarget" {
+         systemToTest.rangeOfValue shouldBe 3..6
+      }
+      "partOfValue" {
+         systemToTest.partOfValue.joinToString("") shouldBe "zzwo"
+      }
+   }
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/SubmatchingTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/SubmatchingTest.kt
@@ -1,0 +1,189 @@
+package io.kotest.submatching
+
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class SubmatchingTest: WordSpec() {
+   init {
+      "findPartialMatches" should {
+         "find nothing" {
+            findPartialMatchesInString("apple", "orange", minLength = 3).shouldBeEmpty()
+         }
+         "match end of one string to beginning of another" {
+            findPartialMatchesInString("broom", "roommate", minLength = 4) shouldBe listOf(
+               PartialCollectionMatch(MatchedCollectionElement(1, 0), 4, "broom".toList()))
+         }
+         "match two middles" {
+            findPartialMatchesInString("room", "boot", minLength = 2) shouldBe listOf(
+               PartialCollectionMatch(MatchedCollectionElement(1, 1), 2, "room".toList()))
+         }
+         "find common end" {
+            findPartialMatchesInString("river", "driver", minLength = 3) shouldBe listOf(
+               PartialCollectionMatch(MatchedCollectionElement(0, 1), 5, "river".toList()))
+         }
+         "find two common substrings in same order" {
+            findPartialMatchesInString("roommate", "room-mate", minLength = 3) shouldBe listOf(
+               PartialCollectionMatch(MatchedCollectionElement(0, 0), 4, "roommate".toList()),
+               PartialCollectionMatch(MatchedCollectionElement(4, 5), 4, "roommate".toList()),
+            )
+         }
+         "find two common substrings in opposite order" {
+            findPartialMatchesInString("downsize", "size down", minLength = 3) shouldBe listOf(
+               PartialCollectionMatch(MatchedCollectionElement(0, 5), 4, "downsize".toList()),
+               PartialCollectionMatch(MatchedCollectionElement(4, 0), 4, "downsize".toList()),
+            )
+         }
+         "maintain performance".config(timeout = 1.seconds) {
+            val value = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+            val expected = value.substring(5, value.length - 10)
+            val partialMatches = findPartialMatchesInString(expected, value, value.length / 2)
+            partialMatches.size shouldBe 1
+            partialMatches[0].length shouldBe value.length - 15
+         }
+         "work for Int" {
+            val expected = listOf(1, 2, 3, 4)
+            findPartialMatches (
+               expected = expected,
+               value = listOf(0, 1, 2, 3, 4, 3, 6),
+               minLength = 4
+            ) shouldBe listOf(PartialCollectionMatch(MatchedCollectionElement(0, 1), 4, expected),
+            )
+         }
+      }
+      "matchedElements" should {
+         "return empty list if element not in index" {
+            matchedElements(indexes = mapOf(
+               'p' to listOf(0, 2, 3),
+               'u' to listOf(1),
+               'y' to listOf(4)
+            ),
+               elementAtIndex = 4 to 'e'
+            ).shouldBeEmpty()
+         }
+         "return list of one element" {
+            matchedElements(indexes = mapOf(
+               'p' to listOf(0, 2, 3),
+               'u' to listOf(1),
+               'y' to listOf(4)
+            ),
+               elementAtIndex = 3 to 'u'
+            ) shouldBe listOf(MatchedCollectionElement(3, 1))
+         }
+         "return list of several elements" {
+            matchedElements(indexes = mapOf(
+               'p' to listOf(0, 2, 3),
+               'u' to listOf(1),
+               'y' to listOf(4)
+            ),
+               elementAtIndex = 1 to 'p'
+            ) shouldBe listOf(
+               MatchedCollectionElement(1, 0),
+               MatchedCollectionElement(1, 2),
+               MatchedCollectionElement(1, 3),
+            )
+         }
+      }
+      "extendPartialMatchToRequiredLength" should {
+         "return submatch if it has required length" {
+            val matchedElement = MatchedCollectionElement(0, 1)
+            val value = "table".toList()
+            extendPartialMatchToRequiredLength(
+               value = value,
+               target = "stable".toList(),
+               matchedElement = matchedElement,
+               minLength = 5
+            ) shouldBe PartialCollectionMatch(matchedElement, 5, value)
+         }
+         "return null if submatch is too short" {
+            val matchedElement = MatchedCollectionElement(0, 1)
+            val value = "rush".toList()
+            extendPartialMatchToRequiredLength(
+               value = value,
+               target = "brushes".toList(),
+               matchedElement = matchedElement,
+               minLength = 5
+            ) shouldBe null
+         }
+      }
+      "removeShorterMatchesWithSameEnd" should {
+         "leave matches as is when there is nothing to remove" {
+            val matches = listOf(
+               PartialCollectionMatch(MatchedCollectionElement(0, 5), 4, "down".toList()),
+               PartialCollectionMatch(MatchedCollectionElement(4, 0), 4, "size".toList()),
+            )
+            removeShorterMatchesWithSameEnd(matches) shouldBe matches
+         }
+         "remove shorter matches that are inside longer ones" {
+            val matches = listOf(
+               PartialCollectionMatch(MatchedCollectionElement(0, 5), 4, "down".toList()),
+               PartialCollectionMatch(MatchedCollectionElement(4, 0), 4, "size".toList()),
+               PartialCollectionMatch(MatchedCollectionElement(1, 6), 3, "own".toList()),
+               PartialCollectionMatch(MatchedCollectionElement(5, 1), 3, "ize".toList()),
+            )
+            removeShorterMatchesWithSameEnd(matches) shouldBe matches.filter { it.length == 4}
+         }
+      }
+      "toCharIndex" should {
+         "count" {
+            toCharIndex("apple".toList()) shouldBe mapOf(
+               'a' to listOf(0),
+               'p' to listOf(1, 2),
+               'l' to listOf(3),
+               'e' to listOf(4)
+            )
+         }
+      }
+      "lengthOfMatch" should {
+         "return 0 at mismatch" {
+            (0..3).forEach { start ->
+               withClue("Matching target at index $start") {
+                  lengthOfMatch(
+                     value = "bug".toList(),
+                     target = "feature".toList(),
+                     matchedElement = MatchedCollectionElement(0, start)
+                  ) shouldBe 0
+               }
+            }
+         }
+         "mismatch on first char" {
+            lengthOfMatch(
+               value = "prone".toList(),
+               target = "drone".toList(),
+               matchedElement = MatchedCollectionElement(0, 0)
+            ) shouldBe 0
+         }
+         "skip some chars at start" {
+            lengthOfMatch(
+               value = "prone".toList(),
+               target = "drone".toList(),
+               matchedElement = MatchedCollectionElement(1, 1)
+            ) shouldBe 4
+         }
+         "find common start" {
+            lengthOfMatch(
+               value = "car".toList(),
+               target = "cartoon".toList(),
+               matchedElement = MatchedCollectionElement(0, 0)
+            ) shouldBe 3
+         }
+         "stop at shorter substring in the middle of a loger one" {
+            lengthOfMatch(
+               value = "rip".toList(),
+               target = "tripod".toList(),
+               matchedElement = MatchedCollectionElement(0, 1)
+            ) shouldBe 3
+         }
+         "find common end" {
+            lengthOfMatch(
+               value = "come".toList(),
+               target = "outcome".toList(),
+               matchedElement = MatchedCollectionElement(0, 3)
+            ) shouldBe 4
+         }
+      }
+   }
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/TopNWithTiesByTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/TopNWithTiesByTest.kt
@@ -1,0 +1,17 @@
+package io.kotest.submatching
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class TopNWithTiesByTest: StringSpec() {
+   init {
+      "work without ties" {
+         listOf("apple", "banana", "pear").topNWithTiesBy(depth = 2) { it.length } shouldBe listOf("banana", "apple")
+      }
+      "work with ties" {
+         listOf("apple", "pea", "banana", "orange", "lemon", "pear")
+            .topNWithTiesBy(depth = 2) { it.length } shouldBe
+            listOf("banana",  "orange", "apple", "lemon")
+      }
+   }
+}


### PR DESCRIPTION
Start matching sub-collections when the whole thing does not match. The plan is to use this approach for the following cases:

* startWith
* endWith
* include/contain
* containExactly

I'd like to use this approach for Collection, String, and Sequence.

Find some longest sub-collections that match, For instance, if we assert that

`"I'm not coming this winter" shouldInclude "winter is coming"`

 - this algorithm finds "coming" and "winter".