### PR TITLE
Remove Kotlin Native repository

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,29 +18,6 @@ dependencyResolutionManagement {
          mavenContent { snapshotsOnly() }
       }
 
-      //region workaround for https://youtrack.jetbrains.com/issue/KT-51379
-      // FIXME remove when updating to Kotlin 2.0
-      ivy("https://download.jetbrains.com/kotlin/native/builds") {
-         name = "KotlinNative"
-         patternLayout {
-            listOf(
-               "macos-x86_64",
-               "macos-aarch64",
-               "osx-x86_64",
-               "osx-aarch64",
-               "linux-x86_64",
-               "windows-x86_64",
-            ).forEach { os ->
-               listOf("dev", "releases").forEach { stage ->
-                  artifact("$stage/[revision]/$os/[artifact]-[revision].[ext]")
-               }
-            }
-         }
-         content { includeModuleByRegex(".*", ".*kotlin-native-prebuilt.*") }
-         metadataSources { artifact() }
-      }
-      //endregion
-
       //region Declare the Node.js & Yarn download repositories
       // Workaround https://youtrack.jetbrains.com/issue/KT-68533/
       ivy("https://nodejs.org/dist/") {


### PR DESCRIPTION
Kotlin Native artifacts are now hosted in Maven Central, and the custom repositories can be removed.