### PR TITLE
Removed deprecated shouldBeEqualToComparingFields methods

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1294,28 +1294,16 @@ public final class io/kotest/matchers/equality/FieldsEqualityCheckConfig {
 
 public final class io/kotest/matchers/equality/ReflectionKt {
 	public static final fun beEqualComparingFields (Ljava/lang/Object;Lio/kotest/matchers/equality/FieldsEqualityCheckConfig;)Lio/kotest/matchers/Matcher;
-	public static final fun beEqualComparingFields (Ljava/lang/Object;ZLjava/util/List;ZLjava/util/List;)Lio/kotest/matchers/Matcher;
-	public static synthetic fun beEqualComparingFields$default (Ljava/lang/Object;ZLjava/util/List;ZLjava/util/List;ILjava/lang/Object;)Lio/kotest/matchers/Matcher;
 	public static final fun beEqualToIgnoringFields (Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)Lio/kotest/matchers/Matcher;
 	public static final fun beEqualToUsingFields (Ljava/lang/Object;[Lkotlin/reflect/KProperty;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeEqualToComparingFields (Ljava/lang/Object;Ljava/lang/Object;)V
 	public static final fun shouldBeEqualToComparingFields (Ljava/lang/Object;Ljava/lang/Object;Lio/kotest/matchers/equality/FieldsEqualityCheckConfig;)V
-	public static final fun shouldBeEqualToComparingFields (Ljava/lang/Object;Ljava/lang/Object;ZZLjava/util/List;)V
 	public static synthetic fun shouldBeEqualToComparingFields$default (Ljava/lang/Object;Ljava/lang/Object;Lio/kotest/matchers/equality/FieldsEqualityCheckConfig;ILjava/lang/Object;)V
-	public static synthetic fun shouldBeEqualToComparingFields$default (Ljava/lang/Object;Ljava/lang/Object;ZZLjava/util/List;ILjava/lang/Object;)V
-	public static final fun shouldBeEqualToComparingFieldsExcept (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)V
-	public static final fun shouldBeEqualToComparingFieldsExcept (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;Z)V
-	public static synthetic fun shouldBeEqualToComparingFieldsExcept$default (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)V
 	public static final fun shouldBeEqualToIgnoringFields (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)V
 	public static final fun shouldBeEqualToIgnoringFields (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)V
 	public static final fun shouldBeEqualToUsingFields (Ljava/lang/Object;Ljava/lang/Object;[Lkotlin/reflect/KProperty;)V
 	public static final fun shouldNotBeEqualToComparingFields (Ljava/lang/Object;Ljava/lang/Object;)V
 	public static final fun shouldNotBeEqualToComparingFields (Ljava/lang/Object;Ljava/lang/Object;Lio/kotest/matchers/equality/FieldsEqualityCheckConfig;)V
-	public static final fun shouldNotBeEqualToComparingFields (Ljava/lang/Object;Ljava/lang/Object;ZZ)V
-	public static synthetic fun shouldNotBeEqualToComparingFields$default (Ljava/lang/Object;Ljava/lang/Object;ZZILjava/lang/Object;)V
-	public static final fun shouldNotBeEqualToComparingFieldsExcept (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)V
-	public static final fun shouldNotBeEqualToComparingFieldsExcept (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;Z)V
-	public static synthetic fun shouldNotBeEqualToComparingFieldsExcept$default (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;ZILjava/lang/Object;)V
 	public static final fun shouldNotBeEqualToIgnoringFields (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)V
 	public static final fun shouldNotBeEqualToIgnoringFields (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/reflect/KProperty;[Lkotlin/reflect/KProperty;)V
 	public static final fun shouldNotBeEqualToUsingFields (Ljava/lang/Object;Ljava/lang/Object;[Lkotlin/reflect/KProperty;)V

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -300,42 +300,6 @@ fun <T : Any> beEqualToIgnoringFields(
 }
 
 /**
- * Matcher that compares values without using field by field comparison.
- *
- * This matcher should be used to check equality of two class for which you want to consider their fields for equality
- * instead of its `equals` method.
- *
- * This matcher recursively check equality of given values till we get a java class, kotlin class or fields for which we have
- * specified to use default shouldBe. Once we get a java class, kotlin class or specified field the equality of that fields
- * will be same as that we get with shouldBe matcher.
- *
- * @param other the other class to which equality need to be checked.
- * @param ignorePrivateFields specify whether private fields should be ignored in equality check or not, default value is true
- * @param ignoreComputedFields specify whether computed fields should be ignored in equality check or not, default value is true
- * @param useDefaultShouldBeForFields fully qualified names of data type for which we need to use default shouldBe, default empty list.
- *
- * */
-@Deprecated(
-   message = "This will be removed in Kotest 7.0",
-   replaceWith = ReplaceWith("shouldBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
-)
-fun <T : Any> T.shouldBeEqualToComparingFields(
-   other: T,
-   ignorePrivateFields: Boolean = true,
-   ignoreComputedFields: Boolean = true,
-   useDefaultShouldBeForFields: List<String> = emptyList(),
-) {
-   shouldBeEqualToComparingFields(
-      other, FieldsEqualityCheckConfig(
-         ignorePrivateFields = ignorePrivateFields,
-         ignoreComputedFields = ignoreComputedFields,
-         propertiesToExclude = emptyList(),
-         useDefaultShouldBeForFields = useDefaultShouldBeForFields
-      )
-   )
-}
-
-/**
  *  Matcher that compares values without using field by field comparison.
  *
  * This matcher should be used to check equality of two class for which you want to consider their fields for equality
@@ -379,93 +343,6 @@ fun <T : Any> T.shouldBeEqualToComparingFields(
    this should beEqualComparingFields(other, fieldsEqualityCheckConfig)
 }
 
-/**
- * Matcher that compares values without using field by field comparison.
- *
- * This matcher should be used to check equality of two class for which you want to consider there fields for equality
- * instead of its equals method.
- *
- * This matcher recursively check equality of given values till we get a java or kotlin class. Once we get a java or kotlin
- * class the equality of that fields will be same as that we get with shouldBe matcher.
- *
- * @param other the other class to which equality need to be checked.
- * @param ignorePrivateFields specify whether private fields should be ignored in equality check or not, default value is true
- * @param ignoreComputedFields specify whether computed fields should be ignored in equality check or not, default value is true
- * @param ignoreProperty fields which should be ignored during equality check
- * @param ignoreProperties fields which should be ignored during equality check
- * */
-@Deprecated(
-   message = "This will be removed in Kotest 7.0",
-   replaceWith = ReplaceWith("shouldBeEqualToComparingFields(other, fieldEqualityCheckConfig) or shouldBeEqualToIgnoringFields(other, ignoredField)")
-)
-fun <T : Any> T.shouldBeEqualToComparingFieldsExcept(
-   other: T,
-   ignorePrivateFields: Boolean,
-   ignoreProperty: KProperty<*>,
-   vararg ignoreProperties: KProperty<*>,
-   ignoreComputedFields: Boolean = true
-) {
-   shouldBeEqualToComparingFields(
-      other,
-      FieldsEqualityCheckConfig(
-         ignorePrivateFields = ignorePrivateFields,
-         ignoreComputedFields = ignoreComputedFields,
-         propertiesToExclude = listOf(ignoreProperty) + ignoreProperties,
-      )
-   )
-}
-
-@Deprecated(
-   message = "This will be removed in Kotest 7.0",
-   replaceWith = ReplaceWith("shouldNotBeEqualToComparingFields(other, fieldEqualityCheckConfig) or shouldNotBeEqualToIgnoringFields(other, ignoredField)")
-)
-fun <T : Any> T.shouldNotBeEqualToComparingFieldsExcept(
-   other: T,
-   ignorePrivateFields: Boolean,
-   ignoreProperty: KProperty<*>,
-   vararg ignoreProperties: KProperty<*>,
-   includeComputedProperties: Boolean = false
-) {
-   shouldNotBeEqualToComparingFields(
-      other,
-      FieldsEqualityCheckConfig(
-         ignorePrivateFields = ignorePrivateFields,
-         ignoreComputedFields = !includeComputedProperties,
-         propertiesToExclude = listOf(ignoreProperty) + ignoreProperties
-      )
-   )
-}
-
-@Deprecated(
-   message = "This will be removed in Kotest 7.0",
-   replaceWith = ReplaceWith("shouldBeEqualToComparingFields(other, fieldEqualityCheckConfig) or shouldBeEqualToIgnoringFields(other, ignoredField)")
-)
-fun <T : Any> T.shouldBeEqualToComparingFieldsExcept(
-   other: T,
-   ignoreProperty: KProperty<*>,
-   vararg ignoreProperties: KProperty<*>
-) {
-   shouldBeEqualToComparingFields(
-      other,
-      FieldsEqualityCheckConfig(propertiesToExclude = listOf(ignoreProperty) + ignoreProperties)
-   )
-}
-
-@Deprecated(
-   message = "This will be removed in Kotest 7.0",
-   replaceWith = ReplaceWith("shouldNotBeEqualToComparingFields(other, fieldEqualityCheckConfig) or shouldNotBeEqualToIgnoringFields(other, ignoredField)")
-)
-fun <T : Any> T.shouldNotBeEqualToComparingFieldsExcept(
-   other: T,
-   ignoreProperty: KProperty<*>,
-   vararg ignoreProperties: KProperty<*>
-) {
-   shouldNotBeEqualToComparingFields(
-      other,
-      FieldsEqualityCheckConfig(propertiesToExclude = listOf(ignoreProperty) + ignoreProperties)
-   )
-}
-
 infix fun <T : Any> T.shouldBeEqualToComparingFields(other: T) {
    shouldBeEqualToComparingFields(other, FieldsEqualityCheckConfig())
 }
@@ -480,42 +357,6 @@ fun <T : Any> T.shouldNotBeEqualToComparingFields(
 ) {
    this shouldNot beEqualComparingFields(other, fieldsEqualityCheckConfig)
 }
-
-@Deprecated(
-   message = "This will be removed in Kotest 7.0",
-   replaceWith = ReplaceWith("shouldNotBeEqualToComparingFields(other, fieldEqualityCheckConfig)")
-)
-fun <T : Any> T.shouldNotBeEqualToComparingFields(
-   other: T,
-   ignorePrivateFields: Boolean = true,
-   ignoreComputedFields: Boolean = true
-) {
-   shouldNotBeEqualToComparingFields(
-      other, FieldsEqualityCheckConfig(
-         ignorePrivateFields = ignorePrivateFields,
-         ignoreComputedFields = ignoreComputedFields
-      )
-   )
-}
-
-@Deprecated(
-   message = "This will be removed in Kotest 6.0",
-   replaceWith = ReplaceWith("beEqualComparingFields(other, fieldEqualityCheckConfig)")
-)
-fun <T : Any> beEqualComparingFields(
-   other: T,
-   ignorePrivateFields: Boolean,
-   propertiesToExclude: List<KProperty<*>>,
-   ignoreComputedFields: Boolean,
-   useDefaultShouldBeForFields: List<String> = emptyList(),
-) = beEqualComparingFields(
-   other, FieldsEqualityCheckConfig(
-      ignorePrivateFields = ignorePrivateFields,
-      ignoreComputedFields = ignoreComputedFields,
-      propertiesToExclude = propertiesToExclude,
-      useDefaultShouldBeForFields = useDefaultShouldBeForFields,
-   )
-)
 
 fun <T : Any> beEqualComparingFields(
    other: T,

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/async/timeout.jvm.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/async/timeout.jvm.kt
@@ -9,7 +9,7 @@ import kotlin.time.toKotlinDuration
  * Assert [thunk] does not complete within [duration].
  */
 @Deprecated(
-   "Updated to use Kotlin time types. This function will be removed in 6.0.",
+   "Updated to use Kotlin time types. This function will be removed in 6.1.",
    ReplaceWith(
       "shouldTimeout(duration.toKotlinDuration()) { thunk() }",
       "kotlin.time.toKotlinDuration",
@@ -22,7 +22,7 @@ suspend fun <A> shouldTimeout(duration: Duration, thunk: suspend () -> A): Unit 
  * Assert [thunk] does not complete within [timeout]/[unit].
  */
 @Deprecated(
-   "Updated to use Kotlin time types. This function will be removed in 6.0.",
+   "Updated to use Kotlin time types. This function will be removed in 6.1.",
    ReplaceWith(
       "shouldTimeout(Duration.of(timeout, unit.toChronoUnit())) { thunk() }",
       "java.time.Duration"

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/listeners/spec/instanceperleaf/AfterSpecFunctionOverrideTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/listeners/spec/instanceperleaf/AfterSpecFunctionOverrideTest.kt
@@ -51,7 +51,7 @@ class AfterSpecFunctionOverrideTestWithNested : FunSpec() {
    init {
 
       afterProject {
-         counter.get() shouldBe 5
+         counter.get() shouldBe 4
       }
 
       // this shouldn't trigger the after spec as its in an isolated instance

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/listeners/spec/instancepertest/AfterSpecInlineTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/listeners/spec/instancepertest/AfterSpecInlineTest.kt
@@ -20,7 +20,7 @@ class AfterSpecInlineTest : FunSpec() {
       }
 
       afterProject {
-         counter.get() shouldBe 5
+         counter.get() shouldBe 4
       }
 
       // this shouldn't trigger the after spec as its in an isolated instance


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
