### PR TITLE
endWith-submatches (#4271)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -33,20 +33,7 @@ fun <T> startWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       val comparison = SliceComparison.of(expectedSlice.toList(), value, SliceComparison.Companion.SliceType.START)
 
-      val partialMatches = findPartialMatches(expectedSlice.toList(), value, minLength = expectedSlice.size / 3)
-      val partialMatchesList = partialMatches.withIndex().joinToString("\n") { indexedValue ->
-         "Slice[${indexedValue.index}] of expected with indexes: ${indexedValue.value.rangeOfExpected} matched a slice of actual values with indexes: ${indexedValue.value.rangeOfValue}"
-      }
-      val partialMatchesDescription = value.mapIndexedNotNull{ index, element ->
-         val indexInMatches = partialMatches.withIndex().filter { match -> match.value.indexIsInValue(index) }
-         indexInMatches.takeIf { indexInMatches.isNotEmpty() }?.let {
-            val slicesList = when(indexInMatches.size) {
-               1 -> " ${indexInMatches.first().index}"
-               else -> "s: ${indexInMatches.map { it.index }}"
-            }
-            "[$index] ${element.print().value} => slice$slicesList"
-         }
-      }.joinToString("\n")
+      val (partialMatchesList, partialMatchesDescription) = describePartialMatchesInCollection(expectedSlice, value)
       return MatcherResult(
          comparison.match,
          { "List should start with ${expectedSlice.print().value} but was ${comparison.valueSlice.print().value}\n${comparison.mismatchDescription}\n$partialMatchesList\n$partialMatchesDescription" },
@@ -54,6 +41,30 @@ fun <T> startWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
       )
    }
 }
+
+internal fun<T> describePartialMatchesInCollection(expectedSlice: Collection<T>, value: List<T>): PartialMatchesInCollectionDescription {
+   val minLength = maxOf(expectedSlice.size / 3, 2)
+   val partialMatches = findPartialMatches(expectedSlice.toList(), value, minLength = minLength)
+   val partialMatchesList = partialMatches.withIndex().joinToString("\n") { indexedValue ->
+      "Slice[${indexedValue.index}] of expected with indexes: ${indexedValue.value.rangeOfExpected} matched a slice of actual values with indexes: ${indexedValue.value.rangeOfValue}"
+   }
+   val partialMatchesDescription = value.mapIndexedNotNull { index, element ->
+      val indexInMatches = partialMatches.withIndex().filter { match -> match.value.indexIsInValue(index) }
+      indexInMatches.takeIf { indexInMatches.isNotEmpty() }?.let {
+         val slicesList = when (indexInMatches.size) {
+            1 -> " ${indexInMatches.first().index}"
+            else -> "s: ${indexInMatches.map { it.index }}"
+         }
+         "[$index] ${element.print().value} => slice$slicesList"
+      }
+   }.joinToString("\n")
+   return PartialMatchesInCollectionDescription(partialMatchesList, partialMatchesDescription)
+}
+
+internal data class PartialMatchesInCollectionDescription(
+   val partialMatchesList: String,
+   val partialMatchesDescription: String
+)
 
 private data class SliceComparison<T>(
    val match: Boolean,
@@ -120,9 +131,11 @@ fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       val comparison = SliceComparison.of(expectedSlice.toList(), value, SliceComparison.Companion.SliceType.END)
 
+      val (partialMatchesList, partialMatchesDescription) = describePartialMatchesInCollection(expectedSlice, value)
+
       return MatcherResult(
          comparison.match,
-         { "List should end with ${expectedSlice.print().value} but was ${comparison.valueSlice.print().value}\n${comparison.mismatchDescription}" },
+         { "List should end with ${expectedSlice.print().value} but was ${comparison.valueSlice.print().value}\n${comparison.mismatchDescription}\n$partialMatchesList\n$partialMatchesDescription" },
          { "List should not end with ${expectedSlice.print().value}" }
       )
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.collections.startWith
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.throwable.shouldHaveMessage
 
@@ -91,14 +92,25 @@ class StartWithEndWithTest : WordSpec() {
             col.shouldNotEndWith(listOf(1, 2))
          }
          "print errors unambiguously"  {
-            shouldThrow<AssertionError> {
+            val message = shouldThrow<AssertionError> {
                listOf(1L, 2L, 3L, 4L) should endWith(listOf(1L, 3L))
-            }.shouldHaveMessage("""
+            }.message
+            message.shouldStartWith("""
                |List should end with [1L, 3L] but was [3L, 4L]
                |The following elements failed:
                |  [2] 3L => expected: <1L>, but was: <3L>
                |  [3] 4L => expected: <3L>, but was: <4L>
                """.trimMargin())
+         }
+         "find submatches"  {
+            shouldThrow<AssertionError> {
+               listOf(1L, 2L, 3L, 4L, 5L, 6L) should endWith(listOf(2L, 3L, 4L))
+            }.message.shouldContainInOrder(
+               "Slice[0] of expected with indexes: 0..2 matched a slice of actual values with indexes: 1..3",
+               "[1] 2L => slice 0",
+               "[2] 3L => slice 0",
+               "[3] 4L => slice 0",
+               )
          }
          "print errors unambiguously when the actual value is empty"  {
             shouldThrow<AssertionError> {


### PR DESCRIPTION
next step: add submatching to `endWith`

```kotlin
           shouldThrow<AssertionError> {
               listOf(1L, 2L, 3L, 4L, 5L, 6L) should endWith(listOf(2L, 3L, 4L))
            }.message.shouldContainInOrder(
               "Slice[0] of expected with indexes: 0..2 matched a slice of actual values with indexes: 1..3",
               "[1] 2L => slice 0",
               "[2] 3L => slice 0",
               "[3] 4L => slice 0",
               )
```

there will be more steps for other collection matchers
