### PR TITLE
add-similarity-to-containAnyKeys (#4273)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -79,9 +79,14 @@ fun <V> haveValues(vararg values: V): Matcher<Map<*, V>> = object : Matcher<Map<
 fun <K> containAnyKeys(vararg keys: K): Matcher<Map<K, Any?>> = object : Matcher<Map<K, Any?>> {
    override fun test(value: Map<K, Any?>): MatcherResult {
       val passed = keys.any { value.containsKey(it) }
+      val possibleMatchesDescription = if(passed) "" else possibleMatchesForMissingElements(
+         keys.toSet(),
+         value.keys.toSet(),
+         "keys"
+      )
       return MatcherResult(
          passed,
-         { "Map did not contain any of the keys ${keys.joinToString(", ")}" },
+         { "Map did not contain any of the keys ${keys.joinToString(", ")}$possibleMatchesDescription" },
          { "Map should not contain any of the keys ${keys.joinToString(", ")}" }
       )
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldStartWith
 import java.util.LinkedList
@@ -213,6 +214,26 @@ class MapMatchersTest : WordSpec() {
          }
       }
 
+      "containValues" should {
+         "find similarities for values not found" {
+            shouldThrow<AssertionError> {
+               mapOf(
+                  1 to sweetGreenApple,
+                  2 to sweetRedApple,
+                  3 to sourYellowLemon
+               ).shouldContainValues(sweetGreenApple, sweetGreenPear)
+            }.message.shouldBe("""
+            |Map did not contain the values Fruit(name=pear, color=green, taste=sweet)
+            |Possible matches for missing values:
+            |
+            | expected: Fruit(name=apple, color=green, taste=sweet),
+            |  but was: Fruit(name=pear, color=green, taste=sweet),
+            |  The following fields did not match:
+            |    "name" expected: <"apple">, but was: <"pear">
+            """.trimMargin())
+         }
+      }
+
       "containAnyKeys" should {
          "test that a map contains any of the given keys" {
             val map = mapOf("a" to 1, "b" to 2, "c" to 3)
@@ -230,23 +251,20 @@ class MapMatchersTest : WordSpec() {
                map.shouldNotContainAnyKeysOf("a", "y")
             }
          }
-
-         "find similarities for values not found" {
+         "find similar keys if no exact matches" {
             shouldThrow<AssertionError> {
                mapOf(
-                  1 to sweetGreenApple,
-                  2 to sweetRedApple,
-                  3 to sourYellowLemon
-               ).shouldContainValues(sweetGreenApple, sweetGreenPear)
-            }.message.shouldBe("""
-            |Map did not contain the values Fruit(name=pear, color=green, taste=sweet)
-            |Possible matches for missing values:
-            |
-            | expected: Fruit(name=apple, color=green, taste=sweet),
-            |  but was: Fruit(name=pear, color=green, taste=sweet),
-            |  The following fields did not match:
-            |    "name" expected: <"apple">, but was: <"pear">
-            """.trimMargin())
+                  sweetGreenApple to 0,
+                  sweetRedApple to 1,
+                  sourYellowLemon to 2
+               ) should containAnyKeys(sweetGreenPear, bitterPurplePlum)
+            }.message.shouldContainInOrder(
+               "Possible matches for missing keys:",
+               "expected: Fruit(name=apple, color=green, taste=sweet),",
+               "but was: Fruit(name=pear, color=green, taste=sweet),",
+               "The following fields did not match:",
+               """"name" expected: <"apple">, but was: <"pear">""",
+            )
          }
       }
 


### PR DESCRIPTION
add-similarity-to-containAnyKeys, such as:
```kotlin
            shouldThrow<AssertionError> {
               mapOf(
                  sweetGreenApple to 0,
                  sweetRedApple to 1,
                  sourYellowLemon to 2
               ) should containAnyKeys(sweetGreenPear, bitterPurplePlum)
            }.message.shouldContainInOrder(
               "Possible matches for missing keys:",
               "expected: Fruit(name=apple, color=green, taste=sweet),",
               "but was: Fruit(name=pear, color=green, taste=sweet),",
               "The following fields did not match:",
               """"name" expected: <"apple">, but was: <"pear">""",
            )
```