### PR TITLE
Register OS-specific variables as test task inputs

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-base.gradle.kts
@@ -7,3 +7,12 @@ tasks.withType<AbstractArchiveTask>().configureEach {
    isPreserveFileTimestamps = false
    isReproducibleFileOrder = true
 }
+
+tasks.withType<Test>().configureEach {
+   // Register OS-specific variables as task inputs to ensure test results from another OS
+   // are not incorrectly loaded from remote Build Cache, which could prevent the tests
+   // from detecting OS-specific issues.
+   inputs.property("file.separator", providers.systemProperty("file.separator"))
+   inputs.property("line.separator", providers.systemProperty("line.separator"))
+   inputs.property("path.separator", providers.systemProperty("path.separator"))
+}


### PR DESCRIPTION
Prevent flaky tests (e.g. #4257) due to remote Build Cache loading successful results from other OSes.

Registering these properties as inputs will make sure that Gradle will re-run the tests on each OS, instead of loading a successful result from another OS.

