### PR TITLE
Remove deprecated `kotlin.wasm.stability.nowarn`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,7 +24,6 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 kotlin.native.ignoreDisabledTargets=true
 kotlin.mpp.stability.nowarn=true
-kotlin.wasm.stability.nowarn=true
 kotlin.incremental=true
 kotlin.incremental.js=true
 


### PR DESCRIPTION
This property is deprecated

```
w: The `kotlin.wasm.stability.nowarn` deprecated property is used in your build.
Please, stop using it as it is unsupported and may apply no effect to your build.
```