### PR TITLE
add-submatching-to-containExactly (#4290)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -220,7 +220,7 @@ internal fun<T> StringBuilder.appendPossibleMatches(missing: Collection<T>, expe
    }
 }
 
-internal fun <T> StringBuilder.appendSubmatches(actual: Collection<T>, expected: Collection<T>) {
+private fun <T> StringBuilder.appendSubmatches(actual: Collection<T>, expected: Collection<T>) {
    val (partialMatchesList, partialMatchesDescription) = describePartialMatchesInCollection(expected, actual.toList())
    if (partialMatchesList.isNotEmpty()) {
       appendLine()

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -105,7 +105,7 @@ fun <T, C : Collection<T>> containExactly(
          appendLine()
          appendPossibleMatches(missing, expected)
 
-         if(!passed && !failureReason.isDisallowedIterableComparisonFailure() && verifier == null) {
+         if (!passed && !failureReason.isDisallowedIterableComparisonFailure() && verifier == null) {
             appendSubmatches(actual, expected)
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -104,6 +104,10 @@ fun <T, C : Collection<T>> containExactly(
          appendMissingAndExtra(missing, extra)
          appendLine()
          appendPossibleMatches(missing, expected)
+
+         if(!passed && !failureReason.isDisallowedIterableComparisonFailure() && verifier == null) {
+            appendSubmatches(actual, expected)
+         }
       }
    }
 
@@ -213,5 +217,14 @@ internal fun<T> StringBuilder.appendPossibleMatches(missing: Collection<T>, expe
    }
    if(AssertionsConfig.maxSimilarityPrintSize.value < possibleMatches.size) {
       append("\nPrinted first ${AssertionsConfig.maxSimilarityPrintSize.value} similarities out of ${possibleMatches.size}, (set the 'kotest.assertions.similarity.print.size' JVM property to see full output for similarity)\n")
+   }
+}
+
+internal fun<T> StringBuilder.appendSubmatches(actual: Collection<T>, expected: Collection<T>) {
+   val (partialMatchesList, partialMatchesDescription) = describePartialMatchesInCollection(expected, actual.toList())
+   if(partialMatchesList.isNotEmpty()) {
+      appendLine()
+      appendLine(partialMatchesList)
+      appendLine(partialMatchesDescription)
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -220,9 +220,9 @@ internal fun<T> StringBuilder.appendPossibleMatches(missing: Collection<T>, expe
    }
 }
 
-internal fun<T> StringBuilder.appendSubmatches(actual: Collection<T>, expected: Collection<T>) {
+internal fun <T> StringBuilder.appendSubmatches(actual: Collection<T>, expected: Collection<T>) {
    val (partialMatchesList, partialMatchesDescription) = describePartialMatchesInCollection(expected, actual.toList())
-   if(partialMatchesList.isNotEmpty()) {
+   if (partialMatchesList.isNotEmpty()) {
       appendLine()
       appendLine(partialMatchesList)
       appendLine(partialMatchesDescription)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.containInOrder
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldEndWith
 import io.kotest.matchers.string.shouldStartWith
 import io.kotest.matchers.throwable.shouldHaveMessage
@@ -180,20 +181,14 @@ class ShouldContainExactlyTest : WordSpec() {
                )
             }.message?.trim()
 
-            message shouldStartWith
-               """
-                  |Collection should contain exactly: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]
-                  |Some elements were unexpected: [Blonde(a=goo, b=true, c=51984, p=$expectedPath)]
-               """.trimMargin()
-
-            message shouldContain """
-               |Slice[0] of expected with indexes: 0..1 matched a slice of actual values with indexes: 0..1
-               |[0] Blonde(a=foo, b=true, c=23423, p=a/b/c) => slice 0
-               |[1] Blonde(a=woo, b=true, c=97821, p=a/b/c) => slice 0
-            """.trimMargin()
-
-            message shouldEndWith
-               """expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]>"""
+            message.shouldContainInOrder(
+               "Collection should contain exactly: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]",
+               "Some elements were unexpected: [Blonde(a=goo, b=true, c=51984, p=$expectedPath)]",
+               "Slice[0] of expected with indexes: 0..1 matched a slice of actual values with indexes: 0..1",
+               "[0] Blonde(a=foo, b=true, c=23423, p=a/b/c) => slice 0",
+               "[1] Blonde(a=woo, b=true, c=97821, p=a/b/c) => slice 0",
+               """expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]>""",
+            )
          }
 
          "include extras when too many" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -170,6 +170,7 @@ class ShouldContainExactlyTest : WordSpec() {
          }
 
          "print dataclasses" {
+            
             val message = shouldThrow<AssertionError> {
                listOf(
                   Blonde("foo", true, 23423, inputPath),

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -185,8 +185,8 @@ class ShouldContainExactlyTest : WordSpec() {
                "Collection should contain exactly: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)] but was: [Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]",
                "Some elements were unexpected: [Blonde(a=goo, b=true, c=51984, p=$expectedPath)]",
                "Slice[0] of expected with indexes: 0..1 matched a slice of actual values with indexes: 0..1",
-               "[0] Blonde(a=foo, b=true, c=23423, p=a/b/c) => slice 0",
-               "[1] Blonde(a=woo, b=true, c=97821, p=a/b/c) => slice 0",
+               "[0] Blonde(a=foo, b=true, c=23423, p=$expectedPath) => slice 0",
+               "[1] Blonde(a=woo, b=true, c=97821, p=$expectedPath) => slice 0",
                """expected:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath)]> but was:<[Blonde(a=foo, b=true, c=23423, p=$expectedPath), Blonde(a=woo, b=true, c=97821, p=$expectedPath), Blonde(a=goo, b=true, c=51984, p=$expectedPath)]>""",
             )
          }

--- a/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/test/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePluginSpec.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-gradle/src/test/kotlin/io/kotest/framework/multiplatform/gradle/KotestMultiplatformCompilerGradlePluginSpec.kt
@@ -3,6 +3,7 @@
 package io.kotest.framework.multiplatform.gradle
 
 import io.kotest.assertions.withClue
+import io.kotest.core.annotation.DoNotParallelize
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
@@ -25,6 +26,7 @@ import kotlin.io.path.name
 // Why don't we use Gradle's TestKit here?
 // It embeds a particular version of Kotlin, which causes all kinds of pain.
 // See https://youtrack.jetbrains.com/issue/KT-24327 for one example.
+@DoNotParallelize
 class KotestMultiplatformCompilerGradlePluginSpec : ShouldSpec({
    setOf(
       "2.0.20-RC",


### PR DESCRIPTION
find partial matches if `containExactly` fails, such as:

```kotlin
        "find matching slices" {
            val message = shouldThrow<AssertionError> {
               listOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9) shouldContainExactly listOf(5, 6, 7, 8, 9, 0, 1, 2, 3, 4,)
            }.message
            message should containInOrder(
               "Slice[0] of expected with indexes: 0..4 matched a slice of actual values with indexes: 5..9",
               "Slice[1] of expected with indexes: 5..9 matched a slice of actual values with indexes: 0..4",
               "[0] 0 => slice 1",
               "[1] 1 => slice 1",
               "[2] 2 => slice 1",
               "[3] 3 => slice 1",
               "[4] 4 => slice 1",
               "[5] 5 => slice 0",
               "[6] 6 => slice 0",
               "[7] 7 => slice 0",
               "[8] 8 => slice 0",
               "[9] 9 => slice 0",
            )
         }
```