### PR TITLE
Use task-specific report directory for JUnit XML reporter test

### DIFF
--- a/kotest-extensions/kotest-extensions-junitxml/api/kotest-extensions-junitxml.api
+++ b/kotest-extensions/kotest-extensions-junitxml/api/kotest-extensions-junitxml.api
@@ -3,9 +3,10 @@ public final class io/kotest/extensions/junitxml/JunitXmlReporter : io/kotest/co
 	public static final field BuildDirKey Ljava/lang/String;
 	public static final field Companion Lio/kotest/extensions/junitxml/JunitXmlReporter$Companion;
 	public static final field DefaultBuildDir Ljava/lang/String;
-	public fun <init> ()V
 	public fun <init> (ZZLjava/lang/String;)V
 	public synthetic fun <init> (ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/nio/file/Path;)V
+	public synthetic fun <init> (ZZLjava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kotest-extensions/kotest-extensions-junitxml/src/jvmMain/kotlin/io/kotest/extensions/junitxml/JunitXmlReporter.kt
+++ b/kotest-extensions/kotest-extensions-junitxml/src/jvmMain/kotlin/io/kotest/extensions/junitxml/JunitXmlReporter.kt
@@ -80,7 +80,8 @@ class JunitXmlReporter(
    }
 
    private val formatter = getFallbackDisplayNameFormatter(ProjectConfiguration().registry, ProjectConfiguration())
-   private var marks = ConcurrentHashMap<KClass<out Spec>, TimeMark>()
+
+   private val marks = ConcurrentHashMap<KClass<out Spec>, TimeMark>()
 
    override suspend fun prepareSpec(kclass: KClass<out Spec>) {
       marks[kclass] = TimeSource.Monotonic.markNow()

--- a/kotest-extensions/kotest-extensions-junitxml/src/jvmMain/kotlin/io/kotest/extensions/junitxml/JunitXmlReporter.kt
+++ b/kotest-extensions/kotest-extensions-junitxml/src/jvmMain/kotlin/io/kotest/extensions/junitxml/JunitXmlReporter.kt
@@ -31,15 +31,18 @@ import kotlin.time.TimeMark
 import kotlin.time.TimeSource
 
 /**
- * A JUnit xml legacy format writer.
+ * A JUnit XML legacy format writer.
  *
- * This implementation handles nesting, whereas the junit implementation will only output for leaf tests.
+ * This implementation handles nesting, whereas the JUnit implementation will only output for leaf tests.
  *
- * @param includeContainers when true, all intermediate tests are included in the report as
- * tests in their own right. Defaults to false.
+ * @param includeContainers when `true`, all intermediate tests are included in the report as
+ * tests in their own right.
+ * Defaults to `false`.
  *
- * @param useTestPathAsName when true, the full test path will be used as the name. In other
- * words the name will include the name of any parent tests as a single string.
+ * @param useTestPathAsName when `true`, the full test path will be used as the name.
+ * In other words the name will include the name of any parent tests as a single string.
+ *
+ * @param outputDir The directory to write reports.
  */
 class JunitXmlReporter(
    private val includeContainers: Boolean = false,
@@ -47,6 +50,9 @@ class JunitXmlReporter(
    private val outputDir: Path,
 ) : PrepareSpecListener, FinalizeSpecListener {
 
+   /**
+    * @param outputDir Path of the output directory, relative to the build directory.
+    */
    constructor(
       includeContainers: Boolean = false,
       useTestPathAsName: Boolean = true,

--- a/kotest-tests/kotest-tests-junitxml/build.gradle.kts
+++ b/kotest-tests/kotest-tests-junitxml/build.gradle.kts
@@ -15,3 +15,20 @@ kotlin {
       }
    }
 }
+
+val testResultsDir = layout.buildDirectory.dir("test-results").get()
+
+tasks.withType<Test>().configureEach {
+   systemProperty("kotest.framework.config.fqn", "com.sksamuel.kotest.ProjectConfig")
+
+   // There are multiple TestRuns (for separate JDKs), so use a separate report directory for each test.
+   // Don't register the value as a task input because the directory doesn't affect the result of the test.
+   val taskTestResultsDir = testResultsDir.dir(name)
+
+   systemProperty("taskTestResultsDir", taskTestResultsDir.asFile.invariantSeparatorsPath)
+
+   doFirst {
+      // First clean old results, to prevent results from previous tests interfering with the current test.
+      taskTestResultsDir.asFile.deleteRecursively()
+   }
+}

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/JunitXmlReporterTest.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/JunitXmlReporterTest.kt
@@ -19,7 +19,7 @@ class JunitXmlReporterTest : WordSpec() {
       private fun loadTestFile(filename: String): Element {
          val path = taskTestResultsDir.resolve(filename)
          val builder = SAXBuilder()
-         val doc = builder.build(path)
+         val doc = builder.build(path.toFile())
          return doc.rootElement
       }
    }

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/JunitXmlReporterTest.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/JunitXmlReporterTest.kt
@@ -1,8 +1,11 @@
 package com.sksamuel.kotest
 
+import com.sksamuel.kotest.ProjectConfig.Companion.taskTestResultsDir
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.shouldForAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.jdom2.Element
 import org.jdom2.input.SAXBuilder
@@ -12,11 +15,13 @@ import org.jdom2.input.SAXBuilder
 @Order(1)
 class JunitXmlReporterTest : WordSpec() {
 
-   private fun loadTestFile(filename: String): Element {
-      val path = "./build/test-results/$filename"
-      val builder = SAXBuilder()
-      val doc = builder.build(path)
-      return doc.rootElement
+   companion object {
+      private fun loadTestFile(filename: String): Element {
+         val path = taskTestResultsDir.resolve(filename)
+         val builder = SAXBuilder()
+         val doc = builder.build(path)
+         return doc.rootElement
+      }
    }
 
    init {
@@ -26,18 +31,19 @@ class JunitXmlReporterTest : WordSpec() {
          "include all tests" {
             val root = loadTestFile("with_containers/TEST-com.sksamuel.kotest.DummyBehaviorSpecTest.xml")
             assertSoftly {
-               root.getAttributeValue("name").shouldBe("com.sksamuel.kotest.DummyBehaviorSpecTest")
-               root.getAttributeValue("tests").shouldBe("6")
-               root.getAttributeValue("skipped").shouldBe("0")
-               root.getAttributeValue("errors").shouldBe("0")
-               root.getAttributeValue("failures").shouldBe("0")
+               root.getAttributeValue("name") shouldBe "com.sksamuel.kotest.DummyBehaviorSpecTest"
+               root.getAttributeValue("tests") shouldBe "6"
+               root.getAttributeValue("skipped") shouldBe "0"
+               root.getAttributeValue("errors") shouldBe "0"
+               root.getAttributeValue("failures") shouldBe "0"
             }
          }
 
          "include test names" {
             val root = loadTestFile("with_containers/TEST-com.sksamuel.kotest.DummyBehaviorSpecTest.xml")
-            root.getChildren("testcase").map { it.getAttributeValue("name") }.toSet() shouldBe
-               setOf(
+            root.getChildren("testcase")
+               .map { it.getAttributeValue("name") }
+               .shouldContainExactlyInAnyOrder(
                   "When: another when",
                   "When: a when",
                   "Then: a final then",
@@ -45,8 +51,9 @@ class JunitXmlReporterTest : WordSpec() {
                   "Then: a then",
                   "Then: another then"
                )
-            root.getChildren("testcase").map { it.getAttributeValue("classname") }.toSet()
-               .shouldBe(setOf("com.sksamuel.kotest.DummyBehaviorSpecTest"))
+            root.getChildren("testcase").shouldForAll {
+               it.getAttributeValue("classname") shouldBe "com.sksamuel.kotest.DummyBehaviorSpecTest"
+            }
          }
       }
 
@@ -55,38 +62,40 @@ class JunitXmlReporterTest : WordSpec() {
          "only include leaf tests" {
             val root = loadTestFile("without_containers/TEST-com.sksamuel.kotest.DummyBehaviorSpecTest.xml")
             assertSoftly {
-               root.getAttributeValue("name").shouldBe("com.sksamuel.kotest.DummyBehaviorSpecTest")
-               root.getAttributeValue("tests").shouldBe("3")
-               root.getAttributeValue("skipped").shouldBe("0")
-               root.getAttributeValue("errors").shouldBe("0")
-               root.getAttributeValue("failures").shouldBe("0")
+               root.getAttributeValue("name") shouldBe "com.sksamuel.kotest.DummyBehaviorSpecTest"
+               root.getAttributeValue("tests") shouldBe "3"
+               root.getAttributeValue("skipped") shouldBe "0"
+               root.getAttributeValue("errors") shouldBe "0"
+               root.getAttributeValue("failures") shouldBe "0"
             }
          }
 
          "!include test names" {
             val root = loadTestFile("without_containers/TEST-com.sksamuel.kotest.DummyBehaviorSpecTest.xml")
-            root.getChildren("testcase").map { it.getAttributeValue("name") }.toSet() shouldBe
-               setOf(
+            root.getChildren("testcase")
+               .map { it.getAttributeValue("name") }
+               .shouldContainExactlyInAnyOrder(
                   "Given: a given When: a when Then: a then",
                   "Given: a given When: another when Then: a final then",
                   "Given: a given When: a when Then: another then"
                )
-            root.getChildren("testcase").map { it.getAttributeValue("classname") }.toSet()
-               .shouldBe(setOf("com.sksamuel.kotest.DummyBehaviorSpecTest"))
+            root.getChildren("testcase").shouldForAll {
+               it.getAttributeValue("classname") shouldBe "com.sksamuel.kotest.DummyBehaviorSpecTest"
+            }
          }
 
          "include the full path of deeply nested tests" {
             val root = loadTestFile("without_containers/TEST-com.sksamuel.kotest.DummyFreeSpecTest.xml")
-            root.getChildren("testcase").map { it.getAttributeValue("name") }.toSet() shouldBe
-               setOf(
+            root.getChildren("testcase")
+               .map { it.getAttributeValue("name") }
+               .shouldContainExactlyInAnyOrder(
                   "1 -- 2 -- 3",
                   "1 -- 2 -- 4 -- 5 -- 6",
                )
-            root.getChildren("testcase").map { it.getAttributeValue("classname") }.toSet()
-               .shouldBe(setOf("com.sksamuel.kotest.DummyFreeSpecTest"))
-
+            root.getChildren("testcase").shouldForAll {
+               it.getAttributeValue("classname") shouldBe "com.sksamuel.kotest.DummyFreeSpecTest"
+            }
          }
       }
    }
-
 }

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
@@ -16,12 +16,12 @@ class ProjectConfig : AbstractProjectConfig() {
          JunitXmlReporter(
             includeContainers = false,
             useTestPathAsName = true,
-            outputDir = taskTestResultsDir,
+            outputDir = taskTestResultsDir.resolve("without_containers"),
          ),
          JunitXmlReporter(
             includeContainers = true,
             useTestPathAsName = false,
-            outputDir = taskTestResultsDir,
+            outputDir = taskTestResultsDir.resolve("with_containers"),
          )
       )
    }

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
@@ -6,34 +6,27 @@ import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.extensions.junitxml.JunitXmlReporter
 import java.nio.file.Path
 import kotlin.io.path.Path
-import kotlin.io.path.absolute
-import kotlin.io.path.invariantSeparatorsPathString
-import kotlin.io.path.relativeTo
 
 class ProjectConfig : AbstractProjectConfig() {
 
    override val specExecutionOrder = SpecExecutionOrder.Annotated
 
    override fun extensions(): List<Extension> {
-      val outputDir = taskTestResultsDir.relativeTo(buildDir).invariantSeparatorsPathString
-
       return listOf(
          JunitXmlReporter(
             includeContainers = false,
             useTestPathAsName = true,
-            outputDir = "$outputDir/without_containers",
+            outputDir = taskTestResultsDir,
          ),
          JunitXmlReporter(
             includeContainers = true,
             useTestPathAsName = false,
-            outputDir = "$outputDir/with_containers",
+            outputDir = taskTestResultsDir,
          )
       )
    }
 
    companion object {
-      private val buildDir = Path("./build").absolute().normalize()
-
       internal val taskTestResultsDir: Path by lazy {
          System.getProperty("taskTestResultsDir")
             ?.let { Path(it) }

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
@@ -4,31 +4,39 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.extensions.junitxml.JunitXmlReporter
-import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
+import kotlin.io.path.invariantSeparatorsPathString
+import kotlin.io.path.relativeTo
 
 class ProjectConfig : AbstractProjectConfig() {
 
    override val specExecutionOrder = SpecExecutionOrder.Annotated
 
    override fun extensions(): List<Extension> {
+      val outputDir = taskTestResultsDir.relativeTo(buildDir).invariantSeparatorsPathString
+
       return listOf(
          JunitXmlReporter(
             includeContainers = false,
             useTestPathAsName = true,
-            outputDir = taskTestResultsDir.resolve("without_containers").invariantSeparatorsPath,
+            outputDir = "$outputDir/without_containers",
          ),
          JunitXmlReporter(
             includeContainers = true,
             useTestPathAsName = false,
-            outputDir = taskTestResultsDir.resolve("with_containers").invariantSeparatorsPath,
+            outputDir = "$outputDir/with_containers",
          )
       )
    }
 
    companion object {
-      internal val taskTestResultsDir: File by lazy {
+      private val buildDir = Path("./build").absolute().normalize()
+
+      internal val taskTestResultsDir: Path by lazy {
          System.getProperty("taskTestResultsDir")
-            ?.let { File(it) }
+            ?.let { Path(it) }
             ?: error("Missing system property 'taskTestResultsDir'")
       }
    }

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/ProjectConfig.kt
@@ -4,6 +4,7 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.SpecExecutionOrder
 import io.kotest.extensions.junitxml.JunitXmlReporter
+import java.io.File
 
 class ProjectConfig : AbstractProjectConfig() {
 
@@ -14,13 +15,21 @@ class ProjectConfig : AbstractProjectConfig() {
          JunitXmlReporter(
             includeContainers = false,
             useTestPathAsName = true,
-            outputDir = "test-results/without_containers"
+            outputDir = taskTestResultsDir.resolve("without_containers").invariantSeparatorsPath,
          ),
          JunitXmlReporter(
             includeContainers = true,
             useTestPathAsName = false,
-            outputDir = "test-results/with_containers"
+            outputDir = taskTestResultsDir.resolve("with_containers").invariantSeparatorsPath,
          )
       )
+   }
+
+   companion object {
+      internal val taskTestResultsDir: File by lazy {
+         System.getProperty("taskTestResultsDir")
+            ?.let { File(it) }
+            ?: error("Missing system property 'taskTestResultsDir'")
+      }
    }
 }


### PR DESCRIPTION
Kotest has multiple JVM test runs, meaning multiple Gradle JVM test tasks. By default Kotest uses the same report directory for all tasks, which means the tests overwrite each other's reports.

This commit passes a system property with a distinct directory for each test, and wipes the directory before each test.

Additionally, I tidied up the assertions in JunitXmlReporterTest.

Partial fix for #4297 - but I think probably Kotest should have a 'test report' configuration property, or some other mechanism that is more robust and can be more easily applied in other projects.

