### PR TITLE
Tidy JunitXmlReporter

### DIFF
--- a/kotest-extensions/kotest-extensions-junitxml/api/kotest-extensions-junitxml.api
+++ b/kotest-extensions/kotest-extensions-junitxml/api/kotest-extensions-junitxml.api
@@ -3,10 +3,10 @@ public final class io/kotest/extensions/junitxml/JunitXmlReporter : io/kotest/co
 	public static final field BuildDirKey Ljava/lang/String;
 	public static final field Companion Lio/kotest/extensions/junitxml/JunitXmlReporter$Companion;
 	public static final field DefaultBuildDir Ljava/lang/String;
-	public fun <init> (ZZLjava/lang/String;)V
-	public synthetic fun <init> (ZZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (ZZLjava/nio/file/Path;)V
-	public synthetic fun <init> (ZZLjava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/lang/String;Ljava/time/Clock;)V
+	public synthetic fun <init> (ZZLjava/lang/String;Ljava/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZLjava/nio/file/Path;Ljava/time/Clock;)V
+	public synthetic fun <init> (ZZLjava/nio/file/Path;Ljava/time/Clock;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kotest-extensions/kotest-extensions-junitxml/src/jvmMain/kotlin/io/kotest/extensions/junitxml/JunitXmlReporter.kt
+++ b/kotest-extensions/kotest-extensions-junitxml/src/jvmMain/kotlin/io/kotest/extensions/junitxml/JunitXmlReporter.kt
@@ -1,5 +1,6 @@
 package io.kotest.extensions.junitxml
 
+import io.kotest.common.testTimeSource
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.listeners.FinalizeSpecListener
 import io.kotest.core.listeners.PrepareSpecListener
@@ -7,6 +8,7 @@ import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestType
+import io.kotest.engine.test.names.FallbackDisplayNameFormatter
 import io.kotest.engine.test.names.formatTestPath
 import io.kotest.engine.test.names.getFallbackDisplayNameFormatter
 import org.jdom2.Document
@@ -15,7 +17,6 @@ import org.jdom2.output.Format
 import org.jdom2.output.XMLOutputter
 import java.net.InetAddress
 import java.net.UnknownHostException
-import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
 import java.time.Clock
@@ -24,11 +25,11 @@ import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.bufferedWriter
 import kotlin.io.path.createParentDirectories
 import kotlin.reflect.KClass
 import kotlin.time.DurationUnit
 import kotlin.time.TimeMark
-import kotlin.time.TimeSource
 
 /**
  * A JUnit XML legacy format writer.
@@ -48,6 +49,7 @@ class JunitXmlReporter(
    private val includeContainers: Boolean = false,
    private val useTestPathAsName: Boolean = true,
    private val outputDir: Path,
+   private val clock: Clock = Clock.systemDefaultZone(),
 ) : PrepareSpecListener, FinalizeSpecListener {
 
    /**
@@ -56,58 +58,79 @@ class JunitXmlReporter(
    constructor(
       includeContainers: Boolean = false,
       useTestPathAsName: Boolean = true,
-      outputDir: String = "test-results/test"
+      outputDir: String = DefaultTestResultRelativeDir,
+      clock: Clock = Clock.systemDefaultZone(),
    ) : this(
       includeContainers = includeContainers,
       useTestPathAsName = useTestPathAsName,
+      clock = clock,
       outputDir = defaultOutputDir(outputDir),
    )
 
    companion object {
       const val DefaultBuildDir = "./build"
 
-      // sets the build directory, to which test-results will be appended
+      /**
+       * System property that provides the project's build directory.
+       *
+       * @see defaultOutputDir
+       */
       const val BuildDirKey = "gradle.build.dir"
 
       const val AttributeName = "name"
 
+      private const val DefaultTestResultRelativeDir = "test-results/test"
+
       private fun defaultOutputDir(
-         testResultsPath: String = "test-results/test",
+         testResultsPath: String = DefaultTestResultRelativeDir,
       ): Path {
          val buildDir = Path(System.getProperty(BuildDirKey) ?: DefaultBuildDir)
          return buildDir.resolve(testResultsPath).normalize().absolute()
       }
+
+      private val hostname: String? by lazy {
+         try {
+            InetAddress.getLocalHost().hostName
+         } catch (e: UnknownHostException) {
+            null
+         }
+      }
    }
 
-   private val formatter = getFallbackDisplayNameFormatter(ProjectConfiguration().registry, ProjectConfiguration())
+   private val formatter: FallbackDisplayNameFormatter =
+      getFallbackDisplayNameFormatter(ProjectConfiguration().registry, ProjectConfiguration())
 
-   private val marks = ConcurrentHashMap<KClass<out Spec>, TimeMark>()
+   /** Record the start of each spec, so the duration of each can be measured. */
+   private val marks: ConcurrentHashMap<KClass<out Spec>, TimeMark> =
+      ConcurrentHashMap()
 
    override suspend fun prepareSpec(kclass: KClass<out Spec>) {
-      marks[kclass] = TimeSource.Monotonic.markNow()
+      marks[kclass] = testTimeSource().markNow()
    }
 
-   private fun filterResults(results: Map<TestCase, TestResult>) = when (includeContainers) {
-      true -> results
-      false -> results.filter { it.key.type == TestType.Test }
-   }
+   private fun filterResults(results: Map<TestCase, TestResult>) =
+      when (includeContainers) {
+         true -> results
+         false -> results.filter { it.key.type == TestType.Test }
+      }
 
    override suspend fun finalizeSpec(kclass: KClass<out Spec>, results: Map<TestCase, TestResult>) {
-      val start = marks[kclass] ?: TimeSource.Monotonic.markNow()
+      val start = marks[kclass] ?: testTimeSource().markNow()
       val duration = start.elapsedNow()
 
       val filtered = filterResults(results)
 
       val document = Document()
-      val testSuite = Element("testsuite")
-      testSuite.setAttribute("timestamp", ISO_LOCAL_DATE_TIME.format(getCurrentDateTime()))
-      testSuite.setAttribute("time", (duration.toDouble(DurationUnit.SECONDS)).toString())
-      testSuite.setAttribute("hostname", hostname())
-      testSuite.setAttribute("errors", filtered.filter { it.value.isError }.size.toString())
-      testSuite.setAttribute("failures", filtered.filter { it.value.isFailure }.size.toString())
-      testSuite.setAttribute("skipped", filtered.filter { it.value.isIgnored }.size.toString())
-      testSuite.setAttribute("tests", filtered.size.toString())
-      testSuite.setAttribute(AttributeName, formatter.format(kclass))
+      val testSuite = Element("testsuite").apply {
+         setAttribute("timestamp", getCurrentDateTimeIsoString())
+         setAttribute("time", duration.toDouble(DurationUnit.SECONDS).toString())
+         setAttribute("hostname", hostname)
+         setAttribute("errors", filtered.count { it.value.isError }.toString())
+         setAttribute("failures", filtered.count { it.value.isFailure }.toString())
+         setAttribute("skipped", filtered.count { it.value.isIgnored }.toString())
+         setAttribute("tests", filtered.size.toString())
+         setAttribute(AttributeName, formatter.format(kclass))
+      }
       document.addContent(testSuite)
 
       filtered.map { (testcase, result) ->
@@ -124,24 +147,29 @@ class JunitXmlReporter(
 
          when (result) {
             is TestResult.Error -> {
-               val err = Element("error")
-               result.errorOrNull?.let {
-                  err.setAttribute("type", it.javaClass.name)
-                  err.setText(it.message)
-               }
-               e.addContent(err)
+               e.addContent(
+                  Element("error").apply {
+                     result.errorOrNull?.let { throwable ->
+                        setAttribute("type", throwable.javaClass.name)
+                        setText(throwable.message)
+                     }
+                  }
+               )
             }
 
             is TestResult.Failure -> {
                val failure = Element("failure")
-               result.errorOrNull?.let {
-                  failure.setAttribute("type", it.javaClass.name)
-                  failure.setText(it.message)
+               result.errorOrNull?.let { throwable ->
+                  failure.setAttribute("type", throwable.javaClass.name)
+                  failure.setText(throwable.message)
                }
                e.addContent(failure)
             }
 
-            else -> Unit
+            is TestResult.Ignored,
+            is TestResult.Success -> {
+               // Only report failures, not Ignored or Success
+            }
          }
 
          testSuite.addContent(e)
@@ -151,25 +179,18 @@ class JunitXmlReporter(
    }
 
    private fun write(kclass: KClass<*>, document: Document) {
-      val path = outputDir
+      outputDir
          .resolve("TEST-" + formatter.format(kclass) + ".xml")
          .createParentDirectories()
-      val outputter = XMLOutputter(Format.getPrettyFormat())
-      val writer = Files.newBufferedWriter(path, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)
-      outputter.output(document, writer)
-      writer.flush()
-      writer.close()
+         .bufferedWriter(options = arrayOf(StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE))
+         .use { writer ->
+            val outputter = XMLOutputter(Format.getPrettyFormat())
+            outputter.output(document, writer)
+         }
    }
 
-   private fun hostname(): String? {
-      return try {
-         InetAddress.getLocalHost().hostName
-      } catch (e: UnknownHostException) {
-         null
-      }
-   }
-
-   private fun getCurrentDateTime(): LocalDateTime {
-      return LocalDateTime.now(Clock.systemDefaultZone()).withNano(0)
-   }
+   private fun getCurrentDateTimeIsoString(): String =
+      ISO_LOCAL_DATE_TIME.format(
+         LocalDateTime.now(clock).withNano(0)
+      )
 }


### PR DESCRIPTION
- Update KDoc.
- Pass in a Clock, so the time can be customised.
- Minor tidying to make the code more Kotlin-esque (although I'll concede that's a personal opinion)

I made these refactorings while looking into #4298, and while they didn't turn out to be necessary (I wanted to pass in a clock so that I could run the JUnit XML report tests programatically), I think the refactorings are still useful.