### PR TITLE
add-similarity-to-beIn 

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bein.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bein.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import io.kotest.similarity.possibleMatchesForSet
 import kotlin.jvm.JvmName
 
 /**
@@ -127,11 +128,18 @@ fun <T> beIn(collection: Collection<T>) = object : Matcher<T> {
 
       val match = value in collection
 
+      val possibleMatchesDescription = prefixIfNotEmpty(
+         possibleMatchesForSet(match, collection.toSet(), setOf(value), verifier = null),
+         "\n"
+      )
+
       return MatcherResult(
          match,
-         { "Collection should contain ${value.print().value}, but doesn't. Possible values: ${collection.print().value}" },
+         { "Collection should contain ${value.print().value}, but doesn't. Possible values: ${collection.print().value}$possibleMatchesDescription" },
          {
             "Collection should not contain ${value.print().value}, but does. Forbidden values: ${collection.print().value}"
          })
    }
 }
+
+internal fun prefixIfNotEmpty(value: String, prefix: String) = if(value.isEmpty()) "" else "$prefix$value"

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -73,6 +73,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldHave
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotHave
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class CollectionMatchersTest : WordSpec() {
@@ -1127,6 +1128,20 @@ class CollectionMatchersTest : WordSpec() {
             shouldThrow<AssertionError> {
                foo shouldBeIn list
             }.shouldHaveMessage("Asserting content on empty collection. Use Collection.shouldBeEmpty() instead.")
+         }
+
+         "fail and find similar items" {
+            shouldThrow<AssertionError> {
+               sweetGreenApple shouldBeIn listOf(
+                  sweetGreenPear, sweetRedApple
+               )
+            }.message.shouldContainInOrder(
+               "Possible matches:",
+               "expected: Fruit(name=pear, color=green, taste=sweet),",
+               "but was: Fruit(name=apple, color=green, taste=sweet),",
+               "The following fields did not match:",
+               """"name" expected: <"pear">, but was: <"apple">"""
+            )
          }
       }
 


### PR DESCRIPTION
add search for similar elements to `beIn`, for example:

```kotlin
            shouldThrow<AssertionError> {
               sweetGreenApple shouldBeIn listOf(
                  sweetGreenPear, sweetRedApple
               )
            }.message.shouldContainInOrder(
               "Possible matches:",
               "expected: Fruit(name=pear, color=green, taste=sweet),",
               "but was: Fruit(name=apple, color=green, taste=sweet),",
               "The following fields did not match:",
               """"name" expected: <"pear">, but was: <"apple">"""
            )
```
