### PR TITLE
Reduce the size of stack traces

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -287,7 +287,11 @@ public final class io/kotest/engine/interceptors/EngineContext$Companion {
 }
 
 public abstract interface class io/kotest/engine/interceptors/EngineInterceptor {
-	public abstract fun intercept (Lio/kotest/engine/interceptors/EngineContext;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun intercept (Lio/kotest/engine/interceptors/EngineContext;Lio/kotest/engine/interceptors/NextEngineInterceptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/kotest/engine/interceptors/NextEngineInterceptor {
+	public abstract fun invoke (Lio/kotest/engine/interceptors/EngineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/engine/interceptors/ProjectTimeoutException : java/lang/Exception {
@@ -784,14 +788,18 @@ public final class io/kotest/engine/test/interceptors/BlockedThreadTestTimeoutEx
 	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public abstract interface class io/kotest/engine/test/interceptors/NextTestExecutionInterceptor {
+	public abstract fun invoke (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/kotest/engine/test/interceptors/TestCoroutineInterceptor : io/kotest/engine/test/interceptors/TestExecutionInterceptor {
 	public fun <init> ()V
-	public fun intercept (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun intercept (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lio/kotest/engine/test/interceptors/NextTestExecutionInterceptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/engine/test/interceptors/TestDispatcherInterceptor : io/kotest/engine/test/interceptors/TestExecutionInterceptor {
 	public fun <init> ()V
-	public fun intercept (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun intercept (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lio/kotest/engine/test/interceptors/NextTestExecutionInterceptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/kotest/engine/test/interceptors/TestTimeoutException : java/lang/Exception {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/DumpConfigInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/DumpConfigInterceptor.kt
@@ -13,7 +13,7 @@ internal object DumpConfigInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
       if (syspropEnabled()) {
          context.configuration.dumpProjectConfig()

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/EmptyTestSuiteInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/EmptyTestSuiteInterceptor.kt
@@ -12,7 +12,7 @@ internal object EmptyTestSuiteInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
 
       return when (context.configuration.failOnEmptyTestSuite) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/EngineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/EngineInterceptor.kt
@@ -19,7 +19,17 @@ import io.kotest.engine.listener.TestEngineListener
  */
 @KotestInternal
 interface EngineInterceptor {
-   suspend fun intercept(context: EngineContext, execute: suspend (EngineContext) -> EngineResult): EngineResult
+   suspend fun intercept(context: EngineContext, execute: NextEngineInterceptor): EngineResult
+}
+
+/**
+ * A functional interface for the interceptor callback, to reduce the size of stack traces.
+ *
+ * With a normal lambda type, each call adds three lines to the stacktrace, but an interface only adds one line.
+ */
+@KotestInternal
+fun interface NextEngineInterceptor {
+   suspend operator fun invoke(context: EngineContext): EngineResult
 }
 
 @KotestInternal

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/ProjectExtensionEngineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/ProjectExtensionEngineInterceptor.kt
@@ -15,7 +15,7 @@ internal object ProjectExtensionEngineInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
 
       var result: EngineResult = EngineResult.empty

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/ProjectListenerEngineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/ProjectListenerEngineInterceptor.kt
@@ -10,7 +10,7 @@ internal object ProjectListenerEngineInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
 
       val extensions = ProjectExtensions(context.configuration.registry)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/ProjectTimeoutEngineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/ProjectTimeoutEngineInterceptor.kt
@@ -9,7 +9,7 @@ internal object ProjectTimeoutEngineInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
       return when (val timeout = context.configuration.projectTimeout) {
          null -> execute(context)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/SpecSortEngineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/SpecSortEngineInterceptor.kt
@@ -16,7 +16,7 @@ internal object SpecSortEngineInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
 
       // spec classes are ordered using SpecExecutionOrderExtension extensions

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/TestDslStateInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/TestDslStateInterceptor.kt
@@ -1,6 +1,5 @@
 package io.kotest.engine.interceptors
 
-import io.kotest.common.KotestInternal
 import io.kotest.core.spec.style.scopes.TestDslState
 import io.kotest.engine.EngineResult
 
@@ -10,7 +9,7 @@ import io.kotest.engine.EngineResult
 internal object TestDslStateInterceptor : EngineInterceptor {
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
       val result = execute(context)
       return runCatching { TestDslState.checkState() }.fold(

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/TestEngineInitializedInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/TestEngineInitializedInterceptor.kt
@@ -10,7 +10,7 @@ internal object TestEngineInitializedInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
       context.listener.engineInitialized(context)
       return execute(context)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/TestEngineStartedFinishedInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/interceptors/TestEngineStartedFinishedInterceptor.kt
@@ -14,7 +14,7 @@ internal object TestEngineStartedFinishedInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
 
       context.listener.engineStarted()

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestCaseExecutor.kt
@@ -17,6 +17,7 @@ import io.kotest.engine.test.interceptors.ExpectExceptionTestInterceptor
 import io.kotest.engine.test.interceptors.InvocationCountCheckInterceptor
 import io.kotest.engine.test.interceptors.InvocationTimeoutInterceptor
 import io.kotest.engine.test.interceptors.LifecycleInterceptor
+import io.kotest.engine.test.interceptors.NextTestExecutionInterceptor
 import io.kotest.engine.test.interceptors.SoftAssertInterceptor
 import io.kotest.engine.test.interceptors.SupervisorScopeInterceptor
 import io.kotest.engine.test.interceptors.TestCaseExtensionInterceptor
@@ -91,7 +92,7 @@ internal class TestCaseExecutor(
          CoroutineDebugProbeInterceptor,
       )
 
-      val innerExecute: suspend (TestCase, TestScope) -> TestResult = { tc, scope ->
+      val innerExecute = NextTestExecutionInterceptor { tc, scope ->
          logger.log { Pair(testCase.name.testName, "Executing test") }
          tc.test(scope)
          try {
@@ -102,7 +103,7 @@ internal class TestCaseExecutor(
       }
 
       return interceptors.foldRight(innerExecute) { ext, fn ->
-         { tc, sc -> ext.intercept(tc, sc, fn) }
+         NextTestExecutionInterceptor { tc, sc -> ext.intercept(tc, sc, fn) }
       }.invoke(testCase, testScope)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestExtensions.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestExtensions.kt
@@ -21,6 +21,7 @@ import io.kotest.engine.collect
 import io.kotest.engine.extensions.ExtensionException
 import io.kotest.engine.extensions.MultipleExceptions
 import io.kotest.engine.mapError
+import io.kotest.engine.test.interceptors.NextTestExecutionInterceptor
 import io.kotest.engine.test.logging.LogExtension
 import io.kotest.engine.test.scopes.withCoroutineContext
 import kotlin.coroutines.coroutineContext
@@ -131,12 +132,12 @@ internal class TestExtensions(private val registry: ExtensionRegistry) {
    suspend fun intercept(
       testCase: TestCase,
       context: TestScope,
-      inner: suspend (TestCase, TestScope) -> TestResult,
+      inner: NextTestExecutionInterceptor,
    ): TestResult {
 
       val execute = extensions(testCase).filterIsInstance<TestCaseExtension>()
          .foldRight(inner) { extension, execute ->
-            { tc, ctx ->
+            NextTestExecutionInterceptor { tc, ctx ->
                extension.intercept(tc) {
                   // the user's intercept method is free to change the context of the coroutine
                   // to support this, we should switch the context used by the test case context

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/AssertionModeInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/AssertionModeInterceptor.kt
@@ -18,7 +18,7 @@ internal object AssertionModeInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       if (testCase.type != TestType.Test) return test(testCase, scope)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/BeforeSpecListenerInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/BeforeSpecListenerInterceptor.kt
@@ -32,7 +32,7 @@ internal class BeforeSpecListenerInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult,
+      test: NextTestExecutionInterceptor,
    ): TestResult {
       // check if we need to run beforeSpec and if so do inside the mutex to avoid race conditions
       // the actual test invocation should be outside of the lock

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/CoroutineDebugProbeInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/CoroutineDebugProbeInterceptor.kt
@@ -17,7 +17,7 @@ internal object CoroutineDebugProbeInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       return if (testCase.config.coroutineDebugProbes) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/CoroutineLoggingInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/CoroutineLoggingInterceptor.kt
@@ -21,7 +21,7 @@ internal class CoroutineLoggingInterceptor(private val configuration: ProjectCon
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       val extensions = TestExtensions(configuration.registry).logExtensions(testCase)
       return when {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/ExceptionCapturingInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/ExceptionCapturingInterceptor.kt
@@ -19,7 +19,7 @@ internal class ExceptionCapturingInterceptor(private val timeMark: TimeMark) : T
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return try {
          test(testCase, scope)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/ExpectExceptionTestInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/ExpectExceptionTestInterceptor.kt
@@ -13,7 +13,7 @@ internal object ExpectExceptionTestInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       val result = test(testCase, scope)
       return when (result) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationCountCheckInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationCountCheckInterceptor.kt
@@ -17,7 +17,7 @@ internal object InvocationCountCheckInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       logger.log { Pair(testCase.name.testName, "Checking that invocation count is 1 for containers") }
       return when {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
@@ -21,7 +21,7 @@ internal object InvocationTimeoutInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       return if (testCase.type == TestType.Container) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/LifecycleInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/LifecycleInterceptor.kt
@@ -38,7 +38,7 @@ internal class LifecycleInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       logger.log { Pair(testCase.name.testName, "Notifying listener test started") }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/SoftAssertInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/SoftAssertInterceptor.kt
@@ -20,7 +20,7 @@ internal class SoftAssertInterceptor() : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       if (testCase.type != TestType.Test) return test(testCase, scope)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/SupervisorScopeInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/SupervisorScopeInterceptor.kt
@@ -16,7 +16,7 @@ internal object SupervisorScopeInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       // a timeout in a parent test will still cause this to fail
       return supervisorScope {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCaseExtensionInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCaseExtensionInterceptor.kt
@@ -19,7 +19,7 @@ internal class TestCaseExtensionInterceptor(registry: ExtensionRegistry) : TestE
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return extensions.intercept(testCase, scope) { tc, s -> test(tc, s) }
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestCoroutineInterceptor.kt
@@ -24,7 +24,7 @@ class TestCoroutineInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       var result: TestResult = TestResult.Ignored()
       logger.log { Pair(testCase.name.testName, "Switching context to coroutines runTest") }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestEnabledCheckInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestEnabledCheckInterceptor.kt
@@ -22,7 +22,7 @@ internal class TestEnabledCheckInterceptor(private val configuration: ProjectCon
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       val enabled = testCase.isEnabled(configuration)
       return when (enabled.isEnabled) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestExecutionInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestExecutionInterceptor.kt
@@ -1,5 +1,6 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.common.KotestInternal
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
@@ -13,6 +14,16 @@ internal interface TestExecutionInterceptor {
    suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult
+}
+
+/**
+ * A functional interface for the interceptor callback, to reduce the size of stack traces.
+ *
+ * With a normal lambda type, each call adds three lines to the stacktrace, but an interface only adds one line.
+ */
+@KotestInternal
+fun interface NextTestExecutionInterceptor {
+   suspend operator fun invoke(testCase: TestCase, scope: TestScope): TestResult
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestFinishedInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestFinishedInterceptor.kt
@@ -20,7 +20,7 @@ internal class TestFinishedInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       val result = test(testCase, scope)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestPathContextInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestPathContextInterceptor.kt
@@ -14,7 +14,7 @@ internal object TestPathContextInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return withContext(TestPathContextElement(testCase.descriptor.path(true))) {
          test(testCase, scope)
@@ -29,7 +29,7 @@ internal object TestNameContextInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return withContext(TestNameContextElement(testCase.name.testName)) {
          test(testCase, scope)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
@@ -21,7 +21,7 @@ internal class TimeoutInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       // this timeout applies to the test itself. If the test has multiple invocations then

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/MarkAbortedExceptionsAsSkippedTestInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/MarkAbortedExceptionsAsSkippedTestInterceptor.kt
@@ -4,6 +4,7 @@ import io.kotest.common.JVMOnly
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
+import io.kotest.engine.test.interceptors.NextTestExecutionInterceptor
 import io.kotest.engine.test.interceptors.TestExecutionInterceptor
 import org.opentest4j.TestAbortedException
 
@@ -18,7 +19,7 @@ internal object MarkAbortedExceptionsAsSkippedTestInterceptor : TestExecutionInt
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return test(testCase, scope).let { testResult ->
          if (testResult.errorOrNull is TestAbortedException) {

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/WriteFailuresInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors/WriteFailuresInterceptor.kt
@@ -19,7 +19,7 @@ internal object WriteFailuresInterceptor : EngineInterceptor {
 
    override suspend fun intercept(
       context: EngineContext,
-      execute: suspend (EngineContext) -> EngineResult
+      execute: NextEngineInterceptor
    ): EngineResult {
       return if (context.configuration.writeSpecFailureFile) {
          val collector = CollectingTestEngineListener()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/BlockedThreadTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/BlockedThreadTimeoutInterceptor.kt
@@ -44,7 +44,7 @@ internal class BlockedThreadTimeoutInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return if (testCase.config.blockingTest) {
          // we must switch execution onto a throwaway thread so an interruption

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/CoroutineErrorCollectorInterceptor.kt
@@ -24,7 +24,7 @@ internal object CoroutineErrorCollectorInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       logger.log {
          Pair(

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/TestDispatcherInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/TestDispatcherInterceptor.kt
@@ -28,7 +28,7 @@ class TestDispatcherInterceptor : TestExecutionInterceptor {
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
       return when (coroutineContext[CoroutineDispatcher]) {
          is TestDispatcher -> test(testCase, scope)

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/coroutineDispatcherFactoryInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/coroutineDispatcherFactoryInterceptor.kt
@@ -33,7 +33,7 @@ internal class CoroutineDispatcherFactoryInterceptor(
    override suspend fun intercept(
       testCase: TestCase,
       scope: TestScope,
-      test: suspend (TestCase, TestScope) -> TestResult
+      test: NextTestExecutionInterceptor
    ): TestResult {
 
       val currentDispatcher = coroutineContext[CoroutineDispatcher]


### PR DESCRIPTION
Kotest stack traces are quite large right now. While intellij does collapse them, I still run into them when seeing test runs on a terminal, like in Github Actions, and it would be nice if they were a bit shorter to make it easier to find my own code in the trace.

I noticed that currently there's three stack trace lines between each interceptor invocation. This is down to them using lambdas via a generic lambda type like `suspend (EngineContext) -> EngineResult`, where, due to type-erasure, the compiler has to generate some extra synthetic methods in between. If we instead define dedicated interfaces for each of those lambda types, the extra synthetic methods go away, reducing the stacktraces to only one extra line between each interceptor.

See the change in the example stack traces below: each lambda call goes from being `invoke()` + `invoke()` + `invokeSuspend()`, to just `invoke()`.

<details>
<summary><b>Stack trace before</b> (53 lines)</summary>
<pre>
**snip**
	at io.kotest.engine.ConcurrentTestSuiteScheduler.schedule(ConcurrentTestSuiteScheduler.kt:41)
	at io.kotest.engine.TestEngine$execute$innerExecute$1.invokeSuspend(TestEngine.kt:65)
	at io.kotest.engine.TestEngine$execute$innerExecute$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$innerExecute$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.TestEngineInitializedInterceptor.intercept(TestEngineInitializedInterceptor.kt:16)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.DumpConfigInterceptor.intercept(DumpConfigInterceptor.kt:21)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.WriteFailuresInterceptor.intercept(WriteFailuresInterceptor.kt:34)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.EmptyTestSuiteInterceptor.intercept(EmptyTestSuiteInterceptor.kt:27)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.ProjectTimeoutEngineInterceptor.intercept(ProjectTimeoutEngineInterceptor.kt:15)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.ProjectListenerEngineInterceptor.intercept(ProjectListenerEngineInterceptor.kt:23)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor$intercept$initial$1.invokeSuspend(ProjectExtensionEngineInterceptor.kt:22)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor$intercept$initial$1.invoke(ProjectExtensionEngineInterceptor.kt)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor$intercept$initial$1.invoke(ProjectExtensionEngineInterceptor.kt)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor.intercept(ProjectExtensionEngineInterceptor.kt:34)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.SpecSortEngineInterceptor.intercept(SpecSortEngineInterceptor.kt:29)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.TestDslStateInterceptor.intercept(TestDslStateInterceptor.kt:15)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.interceptors.TestEngineStartedFinishedInterceptor.intercept(TestEngineStartedFinishedInterceptor.kt:21)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invokeSuspend(TestEngine.kt:71)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt)
	at io.kotest.engine.TestEngine.execute$kotest_framework_engine(TestEngine.kt:77)
	at io.kotest.engine.TestEngineLauncher.async(TestEngineLauncher.kt:234)
	at io.kotest.engine.launcher.MainKt$main$1.invokeSuspend(main.kt:36)
	at io.kotest.engine.launcher.MainKt$main$1.invoke(main.kt)
	at io.kotest.engine.launcher.MainKt$main$1.invoke(main.kt)
	at io.kotest.engine.RunBlockingKt$runBlocking$1.invokeSuspend(runBlocking.kt:3)
**snip**
</pre>
</details>


<details>
<summary><b>Stack trace after</b> (31 lines)</summary>
<pre>
**snip**
	at io.kotest.engine.ConcurrentTestSuiteScheduler.schedule(ConcurrentTestSuiteScheduler.kt:41)
	at io.kotest.engine.TestEngine$execute$innerExecute$1.invoke(TestEngine.kt:66)
	at io.kotest.engine.interceptors.TestEngineInitializedInterceptor.intercept(TestEngineInitializedInterceptor.kt:16)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.DumpConfigInterceptor.intercept(DumpConfigInterceptor.kt:21)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.WriteFailuresInterceptor.intercept(WriteFailuresInterceptor.kt:34)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.EmptyTestSuiteInterceptor.intercept(EmptyTestSuiteInterceptor.kt:27)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.ProjectTimeoutEngineInterceptor.intercept(ProjectTimeoutEngineInterceptor.kt:15)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.ProjectListenerEngineInterceptor.intercept(ProjectListenerEngineInterceptor.kt:23)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor$intercept$initial$1.invokeSuspend(ProjectExtensionEngineInterceptor.kt:22)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor$intercept$initial$1.invoke(ProjectExtensionEngineInterceptor.kt)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor$intercept$initial$1.invoke(ProjectExtensionEngineInterceptor.kt)
	at io.kotest.engine.interceptors.ProjectExtensionEngineInterceptor.intercept(ProjectExtensionEngineInterceptor.kt:34)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.SpecSortEngineInterceptor.intercept(SpecSortEngineInterceptor.kt:29)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.TestDslStateInterceptor.intercept(TestDslStateInterceptor.kt:15)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.interceptors.TestEngineStartedFinishedInterceptor.intercept(TestEngineStartedFinishedInterceptor.kt:21)
	at io.kotest.engine.TestEngine$execute$execute$1$1.invoke(TestEngine.kt:72)
	at io.kotest.engine.TestEngine.execute$kotest_framework_engine(TestEngine.kt:78)
	at io.kotest.engine.TestEngineLauncher.async(TestEngineLauncher.kt:234)
	at io.kotest.engine.launcher.MainKt$main$1.invokeSuspend(main.kt:36)
	at io.kotest.engine.launcher.MainKt$main$1.invoke(main.kt)
	at io.kotest.engine.launcher.MainKt$main$1.invoke(main.kt)
	at io.kotest.engine.RunBlockingKt$runBlocking$1.invokeSuspend(runBlocking.kt:3)
**snip**
</pre>
</details>

I've only done `EngineInterceptor` and `TestExecutionInterceptor` so far, but if you're happy with the PR, I can add `SpecInterceptor` and `SpecRefInterceptor` too.