### PR TITLE
Fix kotest-tests-spec-parallelism

### DIFF
--- a/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
+++ b/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
@@ -6,10 +6,14 @@ kotlin {
    jvm()
 
    sourceSets {
-      val jvmTest by getting {
+      jvmTest {
          dependencies {
             implementation(projects.kotestRunner.kotestRunnerJunit5)
          }
       }
    }
+}
+
+tasks.withType<Test>().configureEach {
+   systemProperty("kotest.framework.config.fqn", "com.sksamuel.kotest.parallelism.ProjectConfig")
 }


### PR DESCRIPTION
Currently the tests run, but the ProjectConfig is not loaded, so the tests aren't tested!

- Set `kotest.framework.config.fqn`
- Fix `statuses.shouldForAll {}` assertion.
- Verify `beforeProject()` is only called once.
