### PR TITLE
Fix deletion of files with unmappable characters

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempdir.kt
@@ -2,12 +2,18 @@ package io.kotest.engine.spec
 
 import io.kotest.core.TestConfiguration
 import java.io.File
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.deleteRecursively
 
+@OptIn(ExperimentalPathApi::class)
 fun TestConfiguration.tempdir(prefix: String? = null, suffix: String? = null): File {
    val dir = kotlin.io.path.createTempDirectory((prefix ?: javaClass.name) + (suffix ?: "")).toFile()
    afterSpec {
-      if (!dir.deleteRecursively())
+      runCatching {
+         dir.toPath().deleteRecursively()
+      }.onFailure {
          throw TempDirDeletionException(dir)
+      }
    }
    return dir
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempfile.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/tempfile.kt
@@ -2,13 +2,16 @@ package io.kotest.engine.spec
 
 import io.kotest.core.TestConfiguration
 import java.io.File
+import kotlin.io.path.deleteExisting
 
 fun TestConfiguration.tempfile(prefix: String? = null, suffix: String? = null): File {
-  
    val file = kotlin.io.path.createTempFile(prefix ?: javaClass.name, suffix).toFile()
    afterSpec {
-      if (!file.delete())
+      runCatching {
+         file.toPath().deleteExisting()
+      }.onFailure {
          throw TempFileDeletionException(file)
+      }
    }
    return file
 }


### PR DESCRIPTION
In contrast to the File's extension function, the Path's one can delete files with unmappable characters like the one at [1].

[1]: https://github.com/fshost/node-dir/tree/a57c3b1b571dd91f464ae398090ba40f64ba38a2/test/fixtures/testdir5
