### PR TITLE
containOnlyNulls-more-details-draft (#4323)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -24,12 +24,14 @@ For now, the documentation should mention that infinite sequences will cause the
 fun <T> Sequence<T>.shouldContainOnlyNulls() = this should containOnlyNulls()
 fun <T> Sequence<T>.shouldNotContainOnlyNulls() = this shouldNot containOnlyNulls()
 fun <T> containOnlyNulls() = object : Matcher<Sequence<T>> {
-   override fun test(value: Sequence<T>) =
-      MatcherResult(
-         value.all { it == null },
-         { "Sequence should contain only nulls" },
+   override fun test(value: Sequence<T>): MatcherResult {
+      val firstNotNull = value.mapIndexed { index, t ->  index to t}.firstOrNull { it.second != null }
+      return MatcherResult(
+         firstNotNull == null,
+         { "Sequence should contain only nulls, but had a non-null element ${firstNotNull!!.second.print().value} at index ${firstNotNull.first}" },
          { "Sequence should not contain only nulls" }
       )
+   }
 }
 
 fun <T> Sequence<T>.shouldContainNull() = this should containNull()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -40,6 +40,7 @@ import io.kotest.matchers.sequences.shouldNotContainNull
 import io.kotest.matchers.sequences.shouldNotContainOnlyNulls
 import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.throwable.shouldHaveMessage
 
@@ -315,6 +316,12 @@ class SequenceMatchersTest : WordSpec() {
 
          fail("for sparse") {
             sampleData.sparse.shouldContainOnlyNulls()
+         }
+
+         "output first element that violates the assertion" {
+            shouldThrow<AssertionError> {
+               sequenceOf(null, null, null, "apple", null).shouldContainOnlyNulls()
+            }.message shouldBe """Sequence should contain only nulls, but had a non-null element "apple" at index 3"""
          }
       }
 


### PR DESCRIPTION
when `containOnlyNulls` fails, print index and value of a non-null elelment
