### PR TITLE
Fix #4306 - fixes the order of `expected` and `but was` outout in `containAll`

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -39,7 +39,7 @@ fun <T> containAll(
          }
          val passed = missing.isEmpty()
 
-         val possibleMatchesDescription = possibleMatchesForSet(passed, value.toSet(), missing.toSet(), verifier)
+         val possibleMatchesDescription = possibleMatchesForSet(passed, missing.toSet(), value.toSet(), verifier)
 
          val failure =
             { "Collection should contain all of ${ts.print().value} but was missing ${missing.print().value}$possibleMatchesDescription" }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
@@ -127,10 +127,16 @@ class ShouldContainAllTest : WordSpec() {
                )
             }.shouldHaveMessage("""
                |Collection should contain all of [Fruit(name=apple, color=green, taste=sweet), Fruit(name=apple, color=red, taste=sweet)] but was missing [Fruit(name=apple, color=red, taste=sweet)]Possible matches:
-               | expected: Fruit(name=apple, color=green, taste=sweet),
-               |  but was: Fruit(name=apple, color=red, taste=sweet),
+               | expected: Fruit(name=apple, color=red, taste=sweet),
+               |  but was: Fruit(name=apple, color=green, taste=sweet),
                |  The following fields did not match:
-               |    "color" expected: <"green">, but was: <"red">
+               |    "color" expected: <"red">, but was: <"green">
+               |
+               | expected: Fruit(name=apple, color=red, taste=sweet),
+               |  but was: Fruit(name=pear, color=green, taste=sweet),
+               |  The following fields did not match:
+               |    "name" expected: <"apple">, but was: <"pear">
+               |        "color" expected: <"red">, but was: <"green">
     """.trimMargin())
          }
 
@@ -140,15 +146,15 @@ class ShouldContainAllTest : WordSpec() {
                   listOf(sweetGreenApple, sourYellowLemon)
                )
             }.message.shouldEndWith("""
-               | expected: Fruit(name=apple, color=red, taste=sweet),
-               |  but was: Fruit(name=apple, color=green, taste=sweet),
+               | expected: Fruit(name=apple, color=green, taste=sweet),
+               |  but was: Fruit(name=apple, color=red, taste=sweet),
                |  The following fields did not match:
-               |    "color" expected: <"red">, but was: <"green">
+               |    "color" expected: <"green">, but was: <"red">
                |
-               | expected: Fruit(name=pear, color=green, taste=sweet),
-               |  but was: Fruit(name=apple, color=green, taste=sweet),
+               | expected: Fruit(name=apple, color=green, taste=sweet),
+               |  but was: Fruit(name=pear, color=green, taste=sweet),
                |  The following fields did not match:
-               |    "name" expected: <"pear">, but was: <"apple">
+               |    "name" expected: <"apple">, but was: <"pear">
     """.trimMargin())
          }
       }


### PR DESCRIPTION
Fixes #4306 

But I think I have uncovered another bug with the fix:

The test “print one possible match for one mismatched element” should be successful in my opinion, right? Currently it fails.

Context:
```kotlin
         "print one possible match for one mismatched element" {
            shouldThrowAny {
               listOf(sweetGreenPear, sweetGreenApple, sourYellowLemon).shouldContainAll(
                  listOf(sweetGreenPear, sweetRedApple)
               )
            }.shouldHaveMessage("""
               |Collection should contain all of [Fruit(name=pear, color=green, taste=sweet), Fruit(name=apple, color=red, taste=sweet)] but was missing [Fruit(name=apple, color=red, taste=sweet)]Possible matches:
               | expected: Fruit(name=apple, color=red, taste=sweet),
               |  but was: Fruit(name=apple, color=green, taste=sweet),
               |  The following fields did not match:
               |    "color" expected: <"red">, but was: <"green">
    """.trimMargin())
         }
```

Log:
```
io.kotest.assertions.AssertionFailedError: Throwable should have message:
"Collection should contain all of [Fruit(name=pear, color=green, taste=sweet), Fruit(name=apple, color=red, taste=sweet)] but was missing [Fruit(name=apple, color=red, taste=sweet)]Possible matches:
 expected: Fruit(name=apple, color=red, taste=sweet),
  but was: Fruit(name=apple, color=green, taste=sweet),
  The following fields did not match:
    "color" expected: <"red">, but was: <"green">"

Actual was:
"Collection should contain all of [Fruit(name=pear, color=green, taste=sweet), Fruit(name=apple, color=red, taste=sweet)] but was missing [Fruit(name=apple, color=red, taste=sweet)]Possible matches:
 expected: Fruit(name=apple, color=red, taste=sweet),
  but was: Fruit(name=pear, color=green, taste=sweet),
  The following fields did not match:
    "name" expected: <"apple">, but was: <"pear">
        "color" expected: <"red">, but was: <"green">

 expected: Fruit(name=apple, color=red, taste=sweet),
  but was: Fruit(name=apple, color=green, taste=sweet),
  The following fields did not match:
    "color" expected: <"red">, but was: <"green">"

expected:<"Collection should contain all of [Fruit(name=pear, color=green, taste=sweet), Fruit(name=apple, color=red, taste=sweet)] but was missing [Fruit(name=apple, color=red, taste=sweet)]Possible matches:
 expected: Fruit(name=apple, color=red, taste=sweet),
  but was: Fruit(name=apple, color=green, taste=sweet),
  The following fields did not match:
    "color" expected: <"red">, but was: <"green">"> but was:<"Collection should contain all of [Fruit(name=pear, color=green, taste=sweet), Fruit(name=apple, color=red, taste=sweet)] but was missing [Fruit(name=apple, color=red, taste=sweet)]Possible matches:
 expected: Fruit(name=apple, color=red, taste=sweet),
  but was: Fruit(name=pear, color=green, taste=sweet),
  The following fields did not match:
    "name" expected: <"apple">, but was: <"pear">
        "color" expected: <"red">, but was: <"green">

 expected: Fruit(name=apple, color=red, taste=sweet),
  but was: Fruit(name=apple, color=green, taste=sweet),
  The following fields did not match:
    "color" expected: <"red">, but was: <"green">">
	at com.sksamuel.kotest.matchers.collections.ShouldContainAllTest$1$5.invokeSuspend(ShouldContainAllTest.kt:128)
```

I think the first entry in both lists should be successfully found and matched. The second entry is the one that should not fit. Right?