### PR TITLE
haveElementAt-more-details (#4330)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -49,12 +49,19 @@ fun <T> Sequence<T>.shouldHaveElementAt(index: Int, element: T) = this should ha
 fun <T> Sequence<T>.shouldNotHaveElementAt(index: Int, element: T) = this shouldNot haveElementAt(index, element)
 
 fun <T, S : Sequence<T>> haveElementAt(index: Int, element: T) = object : Matcher<S> {
-   override fun test(value: S) =
-      MatcherResult(
-         value.elementAt(index) == element,
-         { "Sequence should contain $element at index $index" },
-         { "Sequence should not contain $element at index $index" }
+   override fun test(value: S): MatcherResult {
+      val elementAtIndex = value.take(index + 1).mapIndexed { index, t -> index to t }.lastOrNull()
+      val passed = elementAtIndex?.let { it.first == index && it.second == element } ?: false
+      val description = elementAtIndex?.let {
+         if(it.first == index) ", but the value was different: ${it.second.print().value}."
+         else ", but the sequence only had ${it.first + 1} elements"
+      } ?: ", but the sequence was empty."
+      return MatcherResult(
+         passed,
+         { "Sequence should contain ${element.print().value} at index $index$description" },
+         { "Sequence should not contain ${element.print().value} at index $index" }
       )
+   }
 }
 
 fun <T> Sequence<T>.shouldContainNoNulls() = this should containNoNulls()

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -50,12 +50,14 @@ fun <T> Sequence<T>.shouldNotHaveElementAt(index: Int, element: T) = this should
 
 fun <T, S : Sequence<T>> haveElementAt(index: Int, element: T) = object : Matcher<S> {
    override fun test(value: S): MatcherResult {
-      val elementAtIndex = value.take(index + 1).mapIndexed { index, t -> index to t }.lastOrNull()
-      val passed = elementAtIndex?.let { it.first == index && it.second == element } ?: false
-      val description = elementAtIndex?.let {
-         if(it.first == index) ", but the value was different: ${it.second.print().value}."
-         else ", but the sequence only had ${it.first + 1} elements"
-      } ?: ", but the sequence was empty."
+      val sequenceHead = value.take(index + 1).toList()
+      val elementAtIndex = sequenceHead.elementAtOrNull(index)
+      val passed = elementAtIndex == element
+      val description = when{
+         passed -> ""
+         elementAtIndex != null && elementAtIndex != element -> ", but the value was different: ${elementAtIndex.print().value}."
+         else -> ", but the sequence only had ${sequenceHead.size} elements"
+      }
       return MatcherResult(
          passed,
          { "Sequence should contain ${element.print().value} at index $index$description" },

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.matchers.collections
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
@@ -42,6 +43,7 @@ import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class SequenceMatchersTest : WordSpec() {
@@ -431,12 +433,16 @@ class SequenceMatchersTest : WordSpec() {
       }
 
       "have element at" should {
-         abort<IndexOutOfBoundsException>("for empty") {
-            sampleData.empty.shouldHaveElementAt(sampleData.empty.count(), 0)
+         "handle empty sequence" {
+            shouldThrow<AssertionError> {
+               sampleData.empty.shouldHaveElementAt(sampleData.empty.count(), 0)
+            }.message shouldContain "but the sequence was empty"
          }
 
-         abort<IndexOutOfBoundsException>("when an element after the end is requested") {
-            sampleData.nulls.shouldHaveElementAt(sampleData.nulls.count(), 0)
+         "when an element after the end is requested" {
+            shouldThrow<AssertionError> {
+               sampleData.nulls.shouldHaveElementAt(sampleData.nulls.count(), 0)
+            }.message shouldContain "but the sequence only had 4 elements"
          }
 
          succeed("when the sequence has the element") {
@@ -446,16 +452,38 @@ class SequenceMatchersTest : WordSpec() {
          fail("when the sequence doesn't have the element") {
             sampleData.countdown.shouldHaveElementAt(10, 10)
          }
+
+         "print that the sequence is empty" {
+            shouldThrow<AssertionError> {
+               sequenceOf<String>().shouldHaveElementAt(3, "banana")
+            }.message shouldBe """Sequence should contain "banana" at index 3, but the sequence was empty."""
+         }
+
+         "print that the sequence is shorter" {
+            shouldThrow<AssertionError> {
+               sequenceOf("apple", "orange", "lemon").shouldHaveElementAt(3, "banana")
+            }.message shouldBe """Sequence should contain "banana" at index 3, but the sequence only had 3 elements"""
+         }
+
+         "print that the actual element did not match" {
+            shouldThrow<AssertionError> {
+               sequenceOf("apple", "orange", "lemon").shouldHaveElementAt(2, "banana")
+            }.message shouldBe """Sequence should contain "banana" at index 2, but the value was different: "lemon"."""
+         }
       }
 
       "not have element at" should {
-         abort<IndexOutOfBoundsException>("for empty") {
-            sampleData.empty.shouldNotHaveElementAt(sampleData.empty.count(), 0)
+         "handle empty sequence" {
+            shouldNotThrowAny {
+               sampleData.empty.shouldNotHaveElementAt(sampleData.empty.count(), 0)
+            }
          }
 
-         abort<IndexOutOfBoundsException>("when an element after the end is requested") {
+      "when an element after the end is requested" {
+         shouldNotThrowAny {
             sampleData.nulls.shouldNotHaveElementAt(sampleData.nulls.count(), 0)
          }
+      }
 
          fail("when the sequence has the element") {
             sampleData.countup.shouldNotHaveElementAt(10, 10)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -436,7 +436,7 @@ class SequenceMatchersTest : WordSpec() {
          "handle empty sequence" {
             shouldThrow<AssertionError> {
                sampleData.empty.shouldHaveElementAt(sampleData.empty.count(), 0)
-            }.message shouldContain "but the sequence was empty"
+            }.message shouldContain "but the sequence only had 0 elements"
          }
 
          "when an element after the end is requested" {
@@ -456,7 +456,7 @@ class SequenceMatchersTest : WordSpec() {
          "print that the sequence is empty" {
             shouldThrow<AssertionError> {
                sequenceOf<String>().shouldHaveElementAt(3, "banana")
-            }.message shouldBe """Sequence should contain "banana" at index 3, but the sequence was empty."""
+            }.message shouldBe """Sequence should contain "banana" at index 3, but the sequence only had 0 elements"""
          }
 
          "print that the sequence is shorter" {


### PR DESCRIPTION
when `haveElementAt` fails for a `Sequence`, output more details on what exactly failed. Also make a breaking change on how empty/short sequences are handled, to make it consistent with the behavior of similar matchers for Lists, Arrays etc.

```kotlin
         "print that the sequence is empty" {
            shouldThrow<AssertionError> {
               sequenceOf<String>().shouldHaveElementAt(3, "banana")
            }.message shouldBe """Sequence should contain "banana" at index 3, but the sequence was empty."""
         }

         "print that the sequence is shorter" {
            shouldThrow<AssertionError> {
               sequenceOf("apple", "orange", "lemon").shouldHaveElementAt(3, "banana")
            }.message shouldBe """Sequence should contain "banana" at index 3, but the sequence only had 3 elements"""
         }

         "print that the actual element did not match" {
            shouldThrow<AssertionError> {
               sequenceOf("apple", "orange", "lemon").shouldHaveElementAt(2, "banana")
            }.message shouldBe """Sequence should contain "banana" at index 2, but the value was different: "lemon"."""
         }
```