### PR TITLE
shouldNotContain-more-details (#4332)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -71,11 +71,14 @@ fun <T> containNoNulls() = object : Matcher<Sequence<T>> {
 infix fun <T, C : Sequence<T>> C.shouldContain(t: T) = this should contain(t)
 infix fun <T, C : Sequence<T>> C.shouldNotContain(t: T) = this shouldNot contain(t)
 fun <T, C : Sequence<T>> contain(t: T) = object : Matcher<C> {
-   override fun test(value: C) = MatcherResult(
-      value.contains(t),
-      { "Sequence should contain element $t" },
-      { "Sequence should not contain element $t" }
-   )
+   override fun test(value: C): MatcherResult {
+      val indexOfElement = value.indexOfFirst { it == t }
+      return MatcherResult(
+         indexOfElement >= 0,
+         { "Sequence should contain element $t" },
+         { "Sequence should not contain element ${t.print().value}, but contained it at index $indexOfElement" }
+      )
+   }
 }
 
 infix fun <T, C : Sequence<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -492,6 +492,12 @@ class SequenceMatchersTest : WordSpec() {
          succeed("when the sequence doesn't contain the value") {
             sampleData.sparse.shouldNotContain(2)
          }
+
+         "print the index of element" {
+            shouldThrow<AssertionError> {
+               sequenceOf("apple", "orange", "lemon").shouldNotContain("orange")
+            }.message shouldBe """Sequence should not contain element "orange", but contained it at index 1"""
+         }
       }
 
       /** multiple-value */


### PR DESCRIPTION
output more information when `shouldNotContain` fails:

```kotlin
         "print the index of element" {
            shouldThrow<AssertionError> {
               sequenceOf("apple", "orange", "lemon").shouldNotContain("orange")
            }.message shouldBe """Sequence should not contain element "orange", but contained it at index 1"""
         }
```