### PR TITLE
StringPartialMatches.kt

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.print.print
 import io.kotest.matchers.*
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.string.UUIDVersion.ANY
+import io.kotest.submatching.describePartialMatchesInString
 import kotlin.contracts.contract
 import kotlin.text.RegexOption.IGNORE_CASE
 
@@ -202,9 +203,16 @@ infix fun String?.shouldNotInclude(substr: String): String? {
 }
 
 fun include(substr: String) = neverNullMatcher<String> { value ->
+   val passed = value.contains(substr)
+   val differencesDescription = listOf(
+      "${value.print().value} should include substring ${substr.print().value}",
+      describePartialMatchesInString(substr, value).toString(),
+   )
    MatcherResult(
-      value.contains(substr),
-      { "${value.print().value} should include substring ${substr.print().value}" },
+      passed,
+      {
+         differencesDescription.filter { it.isNotEmpty() }.joinToString("\n")
+      },
       { "${value.print().value} should not include substring ${substr.print().value}" })
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/StringPartialMatches.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/StringPartialMatches.kt
@@ -1,0 +1,92 @@
+package io.kotest.submatching
+
+import io.kotest.assertions.AssertionsConfig
+
+internal fun describePartialMatchesInString(expectedSlice: String, value: String): PartialMatchesInCollectionDescription {
+   if(!AssertionsConfig.enabledSubmatchesInStrings.value ||
+         substringNotEligibleForSubmatching(expectedSlice) ||
+         valueNotEligibleForSubmatching(value)
+      ) {
+      return PartialMatchesInCollectionDescription("", "")
+   }
+   val minLength = maxOf(expectedSlice.length / 3, 2)
+   val partialMatches = findPartialMatches(expectedSlice.toList(), value.toList(), minLength = minLength).take(9)
+   if(partialMatches.isEmpty()) {
+      return PartialMatchesInCollectionDescription("", "")
+   }
+   val partialMatchesList = partialMatches.withIndex().joinToString("\n") { indexedValue ->
+      "Match[${indexedValue.index}]: expected[${indexedValue.value.rangeOfExpected}] matched actual[${indexedValue.value.rangeOfValue}]"
+   }
+   val allUnderscores = getAllUnderscores(value.length, partialMatches)
+   val lineIndexRanges = indexRangesOfLines(value)
+   val valueAndUnderscores = lineIndexRanges.mapIndexed { index, indexRange ->
+      listOf("Line[$index] =\"${takeIndexRange(value, indexRange)}\"") + allUnderscores.mapIndexed { matchIndex, underscores ->
+         "Match[$matchIndex]= ${takeIndexRange(underscores, indexRange)}"
+      }
+   }.flatten().joinToString("\n")
+   return PartialMatchesInCollectionDescription(partialMatchesList, valueAndUnderscores)
+}
+
+private fun substringNotEligibleForSubmatching(value: String) =
+   AssertionsConfig.minSubtringSubmatchingSize.value > value.length ||
+      value.length > AssertionsConfig.maxSubtringSubmatchingSize.value
+
+
+private fun valueNotEligibleForSubmatching(value: String) =
+   AssertionsConfig.minValueSubmatchingSize.value > value.length ||
+      value.length > AssertionsConfig.maxValueSubmatchingSize.value
+
+internal fun getAllUnderscores(valueLength: Int, partialMatches: List<PartialCollectionMatch<Char>>): List<String> {
+   return partialMatches.map { underscoreSubstring(valueLength, it.rangeOfValue.first, it.rangeOfValue.last) }
+}
+
+internal data class PartialMatchesInCollectionDescription(
+   val partialMatchesList: String,
+   val partialMatchesDescription: String
+) {
+   override fun toString(): String = listOf(partialMatchesList, partialMatchesDescription)
+      .filter { it.isNotEmpty() }.joinToString("\n")
+}
+
+internal fun underscoreSubstring(
+   valueLength: Int,
+   fromIndex: Int,
+   toIndex: Int
+): String {
+   val indexRange = fromIndex .. toIndex
+   return (0 until valueLength).map { index ->
+      if(index in indexRange) "+" else "-"
+   }.joinToString("")
+}
+
+internal data class IndexRange(
+   val fromIndex: Int,
+   val toIndex: Int,
+)
+
+internal fun indexRangesOfLines(value: String): Sequence<IndexRange> {
+   var fromIndex: Int? = null
+   return sequence {
+      "$value\n".forEachIndexed { index, c ->
+         if(c in listOf('\r', '\n')) {
+            if(fromIndex != null) {
+               yield(IndexRange(fromIndex!!, index - 1))
+               fromIndex = null
+            }
+         } else {
+            fromIndex = fromIndex ?: index
+         }
+      }
+    }
+}
+
+internal fun splitByIndexRanges(value: String, indexRanges: List<IndexRange>): List<String> {
+   val lastRange = indexRanges.lastOrNull() ?: return listOf()
+   require(lastRange.toIndex < value.length) {
+      "Last range: $lastRange exceeds value length: ${value.length}"
+   }
+   return indexRanges.map { takeIndexRange(value, it) }
+}
+
+private fun takeIndexRange(value: String, it: IndexRange) =
+   value.substring(it.fromIndex, it.toIndex + 1)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/IncludeMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/IncludeMatcherTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.string.shouldInclude
 import io.kotest.matchers.string.shouldNotInclude
 import io.kotest.matchers.string.include
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldNotContain
 
 class IncludeMatcherTest : FreeSpec() {
@@ -36,6 +37,18 @@ class IncludeMatcherTest : FreeSpec() {
             shouldThrow<AssertionError> {
                "hello" shouldInclude "qwe"
             }.message shouldBe "\"hello\" should include substring \"qwe\""
+         }
+
+         "should find a submatch for reasonably long value and substring" {
+            val line = "The quick brown fox jumps over the lazy dog"
+            shouldThrow<AssertionError> {
+               line shouldInclude "The coyote jumps over the lazy dog"
+            }.message.shouldContainInOrder(
+               """"The quick brown fox jumps over the lazy dog" should include substring "The coyote jumps over the lazy dog"""",
+               """Match[0]: expected[10..33] matched actual[19..42]""",
+               """Line[0] ="The quick brown fox jumps over the lazy dog"""",
+               """Match[0]= -------------------++++++++++++++++++++++++"""
+            )
          }
 
          "should fail if value is null" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
@@ -1,0 +1,83 @@
+package io.kotest.matchers.string
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.submatching.PartialMatchesInCollectionDescription
+import io.kotest.submatching.describePartialMatchesInString
+import io.kotest.submatching.underscoreSubstring
+
+class StringPartialMatchesTest: WordSpec() {
+   val value = "0123456789"
+   val text = """The quick brown fox
+            |jumps over
+            |the lazy dog""".trimMargin()
+   val line = "The quick brown fox jumps over the lazy dog"
+   init {
+       "underscoreSubstring" should {
+          "underscore start" {
+             underscoreSubstring(10, 0, 3) shouldBe "++++------"
+          }
+          "underscore middle" {
+             underscoreSubstring(10, 3, 7) shouldBe "---+++++--"
+          }
+          "underscore end" {
+             underscoreSubstring(10, 7, 10) shouldBe "-------+++"
+          }
+       }
+      "describePartialMatchesInString" should {
+         "return empty if no matches" {
+            describePartialMatchesInString("hawk", text) shouldBe PartialMatchesInCollectionDescription("", "")
+         }
+         "find one match in one line" {
+            val actual = describePartialMatchesInString("brown fox jumps over", line)
+            actual.partialMatchesList shouldBe "Match[0]: expected[0..19] matched actual[10..29]"
+            actual.partialMatchesDescription shouldBe
+               """Line[0] ="The quick brown fox jumps over the lazy dog"
+                 |Match[0]= ----------++++++++++++++++++++-------------""".trimMargin()
+         }
+         "find one match spanning two lines" {
+            val twoLines = "The quick brown fox\n jumps over the lazy dog"
+            val actual = describePartialMatchesInString("brown fox\n jumps over", twoLines)
+            actual.partialMatchesList.shouldContainInOrder(
+               "Match[0]: expected[0..20] matched actual[10..30]",
+            )
+            actual.partialMatchesDescription.lines() shouldBe
+               listOf(
+                  "Line[0] =\"The quick brown fox\"",
+                  "Match[0]= ----------+++++++++",
+                  "Line[1] =\" jumps over the lazy dog\"",
+                  "Match[0]= +++++++++++-------------"
+               )
+         }
+         "find two matches on separate lines" {
+            val twoLines = "The quick brown fox\n jumps over the lazy dog"
+            val actual = describePartialMatchesInString("Rabbit jumps over brown fox", twoLines)
+            actual.partialMatchesList.shouldContainInOrder(
+               "Match[0]: expected[6..17] matched actual[20..31]",
+               "Match[1]: expected[17..26] matched actual[9..18]"
+            )
+            actual.partialMatchesDescription.lines() shouldBe
+               listOf(
+                  "Line[0] =\"The quick brown fox\"",
+                  "Match[0]= -------------------",
+                  "Match[1]= ---------++++++++++",
+                  "Line[1] =\" jumps over the lazy dog\"",
+                  "Match[0]= ++++++++++++------------",
+                  "Match[1]= ------------------------"
+            )
+         }
+         "find match that takes one whole line" {
+            val threeLines = "What?\nThe quick brown fox jumps over the lazy dog.\nAnd that's it."
+            val actual = describePartialMatchesInString(line, threeLines)
+            actual.partialMatchesDescription.lines() shouldBe listOf(
+               "Line[0] =\"What?\"",
+               "Match[0]= -----",
+               "Line[1] =\"The quick brown fox jumps over the lazy dog.\"",
+               "Match[0]= +++++++++++++++++++++++++++++++++++++++++++-",
+               "Line[2] =\"And that's it.\"",
+               "Match[0]= --------------"
+            )
+         }
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/IndexRangesOfLinesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/IndexRangesOfLinesTest.kt
@@ -1,0 +1,37 @@
+package io.kotest.submatching
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class IndexRangesOfLinesTest: StringSpec() {
+   init {
+      "handle single line" {
+         val line = "The quick brown fox jumps over the lazy dog"
+         indexRangesOfLines(line).toList() shouldBe listOf(IndexRange(0, line.length - 1))
+      }
+      "empty line" {
+         indexRangesOfLines("").toList() shouldBe listOf()
+      }
+      "no non empty lines" {
+         indexRangesOfLines("\r\n\n").toList() shouldBe listOf()
+      }
+      "handle two lines with one separator" {
+         indexRangesOfLines("The quick brown fox\njumps over the lazy dog").toList() shouldBe listOf(
+            IndexRange(0, 18),
+            IndexRange(20, 42)
+         )
+      }
+      "handle two lines with multiple separators" {
+         indexRangesOfLines("The quick brown fox\n\njumps over the lazy dog").toList() shouldBe listOf(
+            IndexRange(0, 18),
+            IndexRange(21, 43)
+         )
+      }
+      "handle two lines with one separator in the middle and one at the end" {
+         indexRangesOfLines("The quick brown fox\njumps over the lazy dog\n").toList() shouldBe listOf(
+            IndexRange(0, 18),
+            IndexRange(20, 42)
+         )
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/SplitByIndexRangesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/SplitByIndexRangesTest.kt
@@ -1,0 +1,26 @@
+package io.kotest.submatching
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SplitByIndexRangesTest: StringSpec() {
+   init {
+       "handle one line" {
+          val line = "The quick brown fox jumps over the lazy dog"
+          splitByIndexRanges(
+             line,
+             listOf(IndexRange(0, 42))
+          ) shouldBe listOf(line)
+       }
+      "handle multiple lines" {
+         val line0 = "The quick brown fox"
+         val line1 = "jumps over the lazy dog"
+         splitByIndexRanges(
+            "$line0\n$line1",
+            listOf( IndexRange(0, 18),
+               IndexRange(20, 42)
+            )
+         ) shouldBe listOf(line0, line1)
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -34,6 +34,22 @@ object AssertionsConfig {
 
    val maxSimilarityPrintSize: ConfigValue<Int> =
       EnvironmentConfigValue<Int>("kotest.assertions.similarity.print.size", 5, String::toInt)
+
+   val minSubtringSubmatchingSize: ConfigValue<Int> =
+      EnvironmentConfigValue<Int>("kotest.assertions.string.submatching.min.substring.size", 8, String::toInt)
+
+   val maxSubtringSubmatchingSize: ConfigValue<Int> =
+      EnvironmentConfigValue<Int>("kotest.assertions.string.submatching.max.substring.size", 1024, String::toInt)
+
+   val minValueSubmatchingSize: ConfigValue<Int> =
+      EnvironmentConfigValue<Int>("kotest.assertions.string.submatching.min.value.size", 8, String::toInt)
+
+   val maxValueSubmatchingSize: ConfigValue<Int> =
+      EnvironmentConfigValue<Int>("kotest.assertions.string.submatching.max.value.size", 1024, String::toInt)
+
+   val enabledSubmatchesInStrings: ConfigValue<Boolean> =
+      EnvironmentConfigValue<Boolean>("kotest.assertions.string.submatching.enabled", true, String::toBoolean)
+
 }
 
 interface ConfigValue<T> {


### PR DESCRIPTION
add more detailed description when `shouldInclude` fails, but we can find a substring than matches, such as:

```kotlin
         "should find a submatch for reasonably long value and substring" {
            val line = "The quick brown fox jumps over the lazy dog"
            shouldThrow<AssertionError> {
               line shouldInclude "The coyote jumps over the lazy dog"
            }.message.shouldContainInOrder(
               """"The quick brown fox jumps over the lazy dog" should include substring "The coyote jumps over the lazy dog"""",
               """Match[0]: expected[10..33] matched actual[19..42]""",
               """Line[0] ="The quick brown fox jumps over the lazy dog"""",
               """Match[0]= -------------------++++++++++++++++++++++++"""
            )
         }
```

I know we have a matcher for multi-line strings, but it does not seem to be very helpful.

The plan is to extend this approach to many other places where strings are matched, and also look for similar strings in `similarity` package, like how we search for similar data classes.

