### PR TITLE
For comparing string to boolean with TypeCoercion.Enabled didn't check "false" value for JSON in jsTest

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/jsTest/kotlin/io/kotest/assertions/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jsTest/kotlin/io/kotest/assertions/json/EqualTest.kt
@@ -299,9 +299,9 @@ actual:
 
          val c = """ { "a" : "foo", "b" : "false" } """
          val d = """ { "a" : "foo", "b" : false } """
-         a.shouldEqualJson {
+         c.shouldEqualJson {
             typeCoercion = TypeCoercion.Enabled
-            b
+            d
          }
       }
 


### PR DESCRIPTION
It's my first PR and it can be wrong :) 

I've found, that boolean  `false` wasn't tested. 

This typo was done [in this PR](https://github.com/kotest/kotest/commit/acb1ccf80ed17baa8e466f1af8d6cc7558f551b7#diff-92e4c81158966a6dfb5d99bc92b5a2bd271862818d5a7ec2fdd863ccfd3bd943R302)
