### PR TITLE
Add system properties for default shrinking mode

### DIFF
--- a/documentation/docs/proptest/shrinking.md
+++ b/documentation/docs/proptest/shrinking.md
@@ -70,6 +70,20 @@ Arb.positiveInt().checkAll(PropTestConfig(shrinkingMode = ShrinkingMode.Unbounde
 }
 ```
 
+If you want to configure the behaviour globally, then either modify the value of `PropertyTesting.defaultShrinkingMode` or use the following system properties as in this example:
+
+```
+# If you want to disable shrinking:
+kotest.proptest.default.shrinking.mode=off
+
+# If you want to continue shrinking without bounds:
+kotest.proptest.default.shrinking.mode=unbounded
+
+# If you want to shrink a bounded number of times (e.g. 500):
+kotest.proptest.default.shrinking.mode=bounded
+kotest.proptest.default.shrinking.bound=500
+```
+
 ## Shrinking for custom generators
 [Custom generators](customgens.md) do not have a Shrinker defined by Kotest.
 Instead, custom Shrinkers can be implemented.

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -29,7 +29,12 @@ object PropertyTesting {
 
    var defaultIterationCount: Int = sysprop("kotest.proptest.default.iteration.count", 1000)
 
-   var defaultShrinkingMode: ShrinkingMode = ShrinkingMode.Bounded(1000)
+   var defaultShrinkingMode: ShrinkingMode = when(val mode = sysprop("kotest.proptest.default.shrinking.mode", "bounded")) {
+      "off" -> ShrinkingMode.Off
+      "bounded" -> ShrinkingMode.Bounded(sysprop("kotest.proptest.default.shrinking.bound", 1000))
+      "unbounded" -> ShrinkingMode.Unbounded
+      else -> error("Invalid shrinking mode: $mode")
+   }
 
    var defaultListeners: List<PropTestListener> = listOf()
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
I thought it'd be a good idea to have system properties to globally configure shrinking. The concept should be relatively straightforward:

- `kotest.property.default.shrinking.mode`: can be set to `off`, `bounded` or `unbounded`, and throws an error with any other value
- `kotest.property.default.shrinking.bound`: if the mode is `bounded`, sets the bound