### PR TITLE
Generate at most one element in sequence isEmpty matcher

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -12,7 +12,6 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldHave
 import io.kotest.matchers.shouldNot
-import kotlin.collections.indexOfFirst
 
 /*
 How should infinite sequences be detected, and how should they be dealt with?
@@ -26,7 +25,7 @@ fun <T> Sequence<T>.shouldContainOnlyNulls() = this should containOnlyNulls()
 fun <T> Sequence<T>.shouldNotContainOnlyNulls() = this shouldNot containOnlyNulls()
 fun <T> containOnlyNulls() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
-      val firstNotNull = value.mapIndexed { index, t ->  index to t}.firstOrNull { it.second != null }
+      val firstNotNull = value.mapIndexed { index, t -> index to t }.firstOrNull { it.second != null }
       return MatcherResult(
          firstNotNull == null,
          { "Sequence should contain only nulls, but had a non-null element ${firstNotNull!!.second.print().value} at index ${firstNotNull.first}" },
@@ -56,7 +55,7 @@ fun <T, S : Sequence<T>> haveElementAt(index: Int, element: T) = object : Matche
       val sequenceHead = value.take(index + 1).toList()
       val elementAtIndex = sequenceHead.elementAtOrNull(index)
       val passed = elementAtIndex == element
-      val description = when{
+      val description = when {
          passed -> ""
          elementAtIndex != null && elementAtIndex != element -> ", but the value was different: ${elementAtIndex.print().value}."
          else -> ", but the sequence only had ${sequenceHead.size} elements"
@@ -443,7 +442,7 @@ fun <T> Sequence<T>.shouldBeEmpty() = this should beEmpty()
 fun <T> Sequence<T>.shouldNotBeEmpty() = this shouldNot beEmpty()
 fun <T> beEmpty(): Matcher<Sequence<T>> = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult = MatcherResult(
-      value.count() == 0,
+      !value.iterator().hasNext(),
       { "Sequence should be empty" },
       { "Sequence should not be empty" }
    )

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/sequences/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/sequences/SequenceMatchersTest.kt
@@ -4,11 +4,17 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.sequences.shouldContainExactly
 import io.kotest.matchers.sequences.shouldHaveSingleElement
+import io.kotest.matchers.sequences.shouldNotBeEmpty
 import io.kotest.matchers.sequences.shouldNotContainExactly
 import io.kotest.matchers.sequences.shouldNotHaveSingleElement
 import io.kotest.matchers.shouldBe
 
 class SequenceMatchersTest : StringSpec({
+
+   "beEmpty consumes at most 1 element" {
+      val atMostOne = sequence { yield(1); throw Exception("Should not consume a second element") }
+      atMostOne.shouldNotBeEmpty()
+   }
 
    "contain exactly" {
       sequenceOf(1, 2, 3).shouldContainExactly(1, 2, 3)


### PR DESCRIPTION
Closes #4364 

The previous implementation used `Sequence.count()` which generates the entire sequence. Checking if a Sequence is empty only needs the first element to determine whether it is in fact empty.

Also ran autoformatter, so there are several whitespace adjustments