### PR TITLE
Report indexes of duplicated elements in failed shouldNotContainDuplicates messages

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
@@ -7,129 +7,144 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 fun BooleanArray.shouldContainDuplicates(): BooleanArray {
-   asList() should containDuplicates("BooleanArray")
+   asList() should ContainDuplicatesMatcher("BooleanArray")
    return this
 }
 
 fun BooleanArray.shouldNotContainDuplicates(): BooleanArray {
-   asList() shouldNot containDuplicates("BooleanArray")
+   asList() shouldNot ContainDuplicatesMatcher("BooleanArray")
    return this
 }
 
 fun ByteArray.shouldContainDuplicates(): ByteArray {
-   asList() should containDuplicates("ByteArray")
+   asList() should ContainDuplicatesMatcher("ByteArray")
    return this
 }
 
 fun ByteArray.shouldNotContainDuplicates(): ByteArray {
-   asList() shouldNot containDuplicates("ByteArray")
+   asList() shouldNot ContainDuplicatesMatcher("ByteArray")
    return this
 }
 
 fun ShortArray.shouldContainDuplicates(): ShortArray {
-   asList() should containDuplicates("ShortArray")
+   asList() should ContainDuplicatesMatcher("ShortArray")
    return this
 }
 
 fun ShortArray.shouldNotContainDuplicates(): ShortArray {
-   asList() shouldNot containDuplicates("ShortArray")
+   asList() shouldNot ContainDuplicatesMatcher("ShortArray")
    return this
 }
 
 fun CharArray.shouldContainDuplicates(): CharArray {
-   asList() should containDuplicates("CharArray")
+   asList() should ContainDuplicatesMatcher("CharArray")
    return this
 }
 
 fun CharArray.shouldNotContainDuplicates(): CharArray {
-   asList() shouldNot containDuplicates("CharArray")
+   asList() shouldNot ContainDuplicatesMatcher("CharArray")
    return this
 }
 
 fun IntArray.shouldContainDuplicates(): IntArray {
-   asList() should containDuplicates("IntArray")
+   asList() should ContainDuplicatesMatcher("IntArray")
    return this
 }
 
 fun IntArray.shouldNotContainDuplicates(): IntArray {
-   asList() shouldNot containDuplicates("IntArray")
+   asList() shouldNot ContainDuplicatesMatcher("IntArray")
    return this
 }
 
 fun LongArray.shouldContainDuplicates(): LongArray {
-   asList() should containDuplicates("LongArray")
+   asList() should ContainDuplicatesMatcher("LongArray")
    return this
 }
 
 fun LongArray.shouldNotContainDuplicates(): LongArray {
-   asList() shouldNot containDuplicates("LongArray")
+   asList() shouldNot ContainDuplicatesMatcher("LongArray")
    return this
 }
 
 fun FloatArray.shouldContainDuplicates(): FloatArray {
-   asList() should containDuplicates("FloatArray")
+   asList() should ContainDuplicatesMatcher("FloatArray")
    return this
 }
 
 fun FloatArray.shouldNotContainDuplicates(): FloatArray {
-   asList() shouldNot containDuplicates("FloatArray")
+   asList() shouldNot ContainDuplicatesMatcher("FloatArray")
    return this
 }
 
 fun DoubleArray.shouldContainDuplicates(): DoubleArray {
-   asList() should containDuplicates("DoubleArray")
+   asList() should ContainDuplicatesMatcher("DoubleArray")
    return this
 }
 
 fun DoubleArray.shouldNotContainDuplicates(): DoubleArray {
-   asList() shouldNot containDuplicates("DoubleArray")
+   asList() shouldNot ContainDuplicatesMatcher("DoubleArray")
    return this
 }
 
 fun <T> Array<T>.shouldContainDuplicates(): Array<T> {
-   asList() should containDuplicates("Array")
+   asList() should ContainDuplicatesMatcher("Array")
    return this
 }
 
 fun <T> Array<T>.shouldNotContainDuplicates(): Array<T> {
-   asList() shouldNot containDuplicates("Array")
+   asList() shouldNot ContainDuplicatesMatcher("Array")
    return this
 }
 
 fun <T, C : Collection<T>> C.shouldContainDuplicates(): C {
-   this should containDuplicates(null)
+   this should ContainDuplicatesMatcher(null)
    return this
 }
 
 fun <T, C : Collection<T>> C.shouldNotContainDuplicates(): C {
-   this shouldNot containDuplicates(null)
+   this shouldNot ContainDuplicatesMatcher(null)
    return this
 }
 
 fun <T, I : Iterable<T>> I.shouldContainDuplicates(): I {
-   this should containDuplicates(null)
+   this should ContainDuplicatesMatcher(null)
    return this
 }
 
 fun <T, I : Iterable<T>> I.shouldNotContainDuplicates(): I {
-   this shouldNot containDuplicates(null)
+   this shouldNot ContainDuplicatesMatcher(null)
    return this
 }
 
-fun <T> containDuplicates(): Matcher<Iterable<T>> = containDuplicates(null)
+fun <T> containDuplicates(): Matcher<Iterable<T>> = ContainDuplicatesMatcher(null)
 
-internal fun <T> containDuplicates(name: String?) = object : Matcher<Iterable<T>> {
+internal class ContainDuplicatesMatcher<T>(private val name: String?) : Matcher<Iterable<T>> {
    override fun test(value: Iterable<T>): MatcherResult {
       val name = name ?: value.containerName()
-      val duplicates = value.duplicates()
+      val report = value.duplicationReport()
       return MatcherResult(
-         duplicates.isNotEmpty(),
+         report.hasDuplicates(),
          { "$name should contain duplicates" },
-         { "$name should not contain duplicates, but has some: ${duplicates.print().value}" })
+         { "$name should not contain duplicates, but has:\n${report.standardMessage()}" }
+      )
    }
 }
 
-internal fun <T> Iterable<T>.duplicates(): List<T> = this.groupingBy { it }
-   .eachCount().entries
-   .filter { it.value > 1 }
-   .map { it.key }
+internal class DuplicationReport<T>(iterable: Iterable<T>) {
+   val duplicates: Map<T, List<Int>> = iterable.withIndex()
+      .groupingBy { it.value }
+      .fold<IndexedValue<T>, T, MutableList<Int>>({ _, _ -> mutableListOf() }) { _, acc, indexedValue ->
+         acc.apply { add(indexedValue.index) }
+      }
+      .filter { (_, indexes) -> indexes.size > 1 }
+
+   fun hasDuplicates(): Boolean = duplicates.isNotEmpty()
+
+   fun standardMessage(): String {
+      return duplicates.entries.joinToString(separator = "\n") { dupe ->
+         "${dupe.key.print().value} at indexes: ${dupe.value}"
+      }
+   }
+}
+
+internal fun <T> Iterable<T>.duplicationReport(): DuplicationReport<T> = DuplicationReport(this)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -6,7 +6,8 @@ import io.kotest.assertions.eq.eq
 import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
-import io.kotest.matchers.collections.duplicates
+import io.kotest.matchers.collections.ContainDuplicatesMatcher
+import io.kotest.matchers.collections.duplicationReport
 import io.kotest.matchers.collections.shouldMatchEach
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
@@ -216,10 +217,10 @@ fun <T> Sequence<T>.shouldBeUnique() = this should beUnique()
 fun <T> Sequence<T>.shouldNotBeUnique() = this shouldNot beUnique()
 fun <T> beUnique() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
-      val duplicates = value.toList().duplicates()
+      val report = value.asIterable().duplicationReport()
       return MatcherResult(
-         duplicates.isEmpty(),
-         { "Sequence should be Unique, but has duplicates: ${duplicates.print().value}" },
+         !report.hasDuplicates(),
+         { "Sequence should be Unique, but has duplicates:\n${report.standardMessage()}" },
          { "Sequence should contain at least one duplicate element" }
       )
    }
@@ -229,12 +230,7 @@ fun <T> Sequence<T>.shouldContainDuplicates() = this should containDuplicates()
 fun <T> Sequence<T>.shouldNotContainDuplicates() = this shouldNot containDuplicates()
 fun <T> containDuplicates() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
-      val duplicates = value.toList().duplicates()
-      return MatcherResult(
-         duplicates.isNotEmpty(),
-         { "Sequence should contain duplicates" },
-         { "Sequence should not contain duplicates, but has some: ${duplicates.print().value}" }
-      )
+      return ContainDuplicatesMatcher<T>("Sequence").test(value.asIterable())
    }
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/DuplicatesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/DuplicatesTest.kt
@@ -2,30 +2,31 @@ package com.sksamuel.kotest.matchers.collections
 
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.duplicates
-import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.collections.duplicationReport
 import io.kotest.matchers.collections.shouldContainDuplicates
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContainDuplicates
+import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
 class DuplicatesTest : WordSpec({
    "duplicates" should {
       "be empty for unique values" {
-         listOf(1, 2, 3, 4, null).duplicates().shouldBeEmpty()
+         listOf(1, 2, 3, 4, null).duplicationReport().hasDuplicates().shouldBeFalse()
       }
 
       "return not null duplicates" {
-         listOf(1, 2, 3, 4, 3, 2).duplicates() shouldContainExactlyInAnyOrder listOf(2, 3)
+         listOf(1, 2, 3, 4, 3, 2).duplicationReport().duplicates
+            .shouldContainExactly(mapOf(2 to listOf(1, 5), 3 to listOf(2, 4)))
       }
 
       "return null duplicates" {
-         listOf(1, 2, 3, null, 4, 3, null, 2).duplicates() shouldContainExactlyInAnyOrder listOf(2, 3, null)
+         listOf(null, 2, 3, null, 2).duplicationReport().duplicates
+            .shouldContainExactly(mapOf(null to listOf(0, 3), 2 to listOf(1, 4)))
       }
 
       "return null duplicates" {
-         listOf<Unit?>(null, null).duplicates().shouldContainExactly(null)
+         listOf(null, null).duplicationReport().duplicates.shouldContainExactly(mapOf(null to listOf(0, 1)))
       }
    }
 
@@ -328,77 +329,80 @@ class DuplicatesTest : WordSpec({
       "fail for non unique BooleanArray" {
          shouldThrowAny {
             booleanArrayOf(true, false, true, false).shouldNotContainDuplicates()
-         }.message shouldBe "BooleanArray should not contain duplicates, but has some: [true, false]"
+         }.message shouldBe "BooleanArray should not contain duplicates, but has:\ntrue at indexes: [0, 2]\nfalse at indexes: [1, 3]"
       }
 
       "fail for non unique ByteArray" {
          shouldThrowAny {
             byteArrayOf(1, 1).shouldNotContainDuplicates()
-         }.message shouldBe "ByteArray should not contain duplicates, but has some: [1]"
+         }.message shouldBe "ByteArray should not contain duplicates, but has:\n1 at indexes: [0, 1]"
       }
 
       "fail for non unique ShortArray" {
          shouldThrowAny {
             shortArrayOf(1, 1).shouldNotContainDuplicates()
-         }.message shouldBe "ShortArray should not contain duplicates, but has some: [1]"
+         }.message shouldBe "ShortArray should not contain duplicates, but has:\n1 at indexes: [0, 1]"
       }
 
       "fail for non unique CharArray" {
          shouldThrowAny {
             charArrayOf('1', '1').shouldNotContainDuplicates()
-         }.message shouldBe "CharArray should not contain duplicates, but has some: ['1']"
+         }.message shouldBe "CharArray should not contain duplicates, but has:\n'1' at indexes: [0, 1]"
       }
 
       "fail for non unique IntArray" {
          shouldThrowAny {
             intArrayOf(1, 1).shouldNotContainDuplicates()
-         }.message shouldBe "IntArray should not contain duplicates, but has some: [1]"
+         }.message shouldBe "IntArray should not contain duplicates, but has:\n1 at indexes: [0, 1]"
       }
 
       "fail for non unique LongArray" {
          shouldThrowAny {
             longArrayOf(1, 1).shouldNotContainDuplicates()
-         }.message shouldBe "LongArray should not contain duplicates, but has some: [1L]"
+         }.message shouldBe "LongArray should not contain duplicates, but has:\n1L at indexes: [0, 1]"
       }
 
       "fail for non unique FloatArray" {
          shouldThrowAny {
             floatArrayOf(0.1f, 0.1f).shouldNotContainDuplicates()
-         }.message shouldBe "FloatArray should not contain duplicates, but has some: [0.1f]"
+         }.message shouldBe "FloatArray should not contain duplicates, but has:\n0.1f at indexes: [0, 1]"
       }
 
       "fail for non unique DoubleArray" {
          shouldThrowAny {
-            doubleArrayOf(0.000000000000000000000000000000000000001, 0.000000000000000000000000000000000000001).shouldNotContainDuplicates()
-         }.message shouldBe "DoubleArray should not contain duplicates, but has some: [1.0E-39]"
+            doubleArrayOf(
+               0.000000000000000000000000000000000000001,
+               0.000000000000000000000000000000000000001
+            ).shouldNotContainDuplicates()
+         }.message shouldBe "DoubleArray should not contain duplicates, but has:\n1.0E-39 at indexes: [0, 1]"
 
          shouldThrowAny {
             doubleArrayOf(1234.056789, 1234.056789).shouldNotContainDuplicates()
-         }.message shouldBe "DoubleArray should not contain duplicates, but has some: [1234.056789]"
+         }.message shouldBe "DoubleArray should not contain duplicates, but has:\n1234.056789 at indexes: [0, 1]"
       }
 
       "fail for non unique Array" {
          shouldThrowAny {
             arrayOf(1, 2, 3, null, null, 3, 2).shouldNotContainDuplicates()
-         }.message shouldBe "Array should not contain duplicates, but has some: [2, 3, <null>]"
+         }.message shouldBe "Array should not contain duplicates, but has:\n2 at indexes: [1, 6]\n3 at indexes: [2, 5]\n<null> at indexes: [3, 4]"
       }
 
       "fail for non unique List" {
          shouldThrowAny {
             listOf(1, 2, 3, null, null, 3, 2).shouldNotContainDuplicates()
-         }.message shouldBe "List should not contain duplicates, but has some: [2, 3, <null>]"
+         }.message shouldBe "List should not contain duplicates, but has:\n2 at indexes: [1, 6]\n3 at indexes: [2, 5]\n<null> at indexes: [3, 4]"
       }
 
       "fail for arbitrary non unique Iterable" {
          shouldThrowAny {
             Game("Risk", listOf("p1", "p2", "p3", "p1")).shouldNotContainDuplicates()
-         }.message shouldBe "Iterable should not contain duplicates, but has some: [\"p1\"]"
+         }.message shouldBe "Iterable should not contain duplicates, but has:\n\"p1\" at indexes: [0, 3]"
       }
 
       "fail for misbehaving set" {
          shouldThrowAny {
             (NonUniqueSet() as Set<Int>).shouldNotContainDuplicates()
-         }.message shouldBe "Set should not contain duplicates, but has some: [1]"
+         }.message shouldBe "Set should not contain duplicates, but has:\n1 at indexes: [0, 1]"
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -43,7 +43,6 @@ import io.kotest.matchers.sequences.shouldNotHaveCount
 import io.kotest.matchers.sequences.shouldNotHaveElementAt
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class SequenceMatchersTest : WordSpec() {
@@ -886,13 +885,13 @@ class SequenceMatchersTest : WordSpec() {
          "fail with repeated nulls" {
             shouldThrowAny {
                sampleData.sparse.shouldBeUnique()
-            }.shouldHaveMessage("Sequence should be Unique, but has duplicates: [<null>]")
+            }.shouldHaveMessage("Sequence should be Unique, but has duplicates:\n<null> at indexes: [0, 1, 2]")
          }
 
          "fail with repeats" {
             shouldThrowAny {
                sampleData.repeating.shouldBeUnique()
-            }.shouldHaveMessage("Sequence should be Unique, but has duplicates: [1, 2, 3]")
+            }.shouldHaveMessage("Sequence should be Unique, but has duplicates:\n1 at indexes: [0, 3]\n2 at indexes: [1, 4]\n3 at indexes: [2, 5]")
          }
 
          succeed("for multiple unique") {
@@ -946,7 +945,7 @@ class SequenceMatchersTest : WordSpec() {
          "fail with repeats" {
             shouldThrowAny {
                sampleData.repeating.shouldNotContainDuplicates()
-            }.shouldHaveMessage("Sequence should not contain duplicates, but has some: [1, 2, 3]")
+            }.shouldHaveMessage("Sequence should not contain duplicates, but has:\n1 at indexes: [0, 3]\n2 at indexes: [1, 4]\n3 at indexes: [2, 5]")
          }
       }
 

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ArraySchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ArraySchemaTest.kt
@@ -98,9 +98,8 @@ class ArraySchemaTest : FunSpec(
             array(uniqueItems = true) { number() }
          }
          array shouldNotMatchSchema uniqueArray
-         shouldFail { array shouldMatchSchema uniqueArray }.message shouldBe """
-            $ => Sequence should be Unique, but has duplicates: [NumberNode(content=1)]
-         """.trimIndent()
+         shouldFail { array shouldMatchSchema uniqueArray }
+            .message shouldBe "$ => Sequence should be Unique, but has duplicates:\nNumberNode(content=1) at indexes: [0, 1]"
       }
 
       test("Array not contains string") {


### PR DESCRIPTION
This PR builds upon #4369 and adds the indexes of violating elements to the assertion messages.

`listOf(1, 2, 3, null, null, 3, 2).shouldNotContainDuplicates()`

Before:
```
List should not contain duplicates, but has some: [2, 3, <null>]
```

After:
```
List should not contain duplicates, but has:
2 at indexes: [1, 6]
3 at indexes: [2, 5]
<null> at indexes: [3, 4]
```

Affected matchers/assertions:
1) All `shouldNotContainDuplicates`
2) `Sequence.shouldBeUnique` - this assertion was and remains to be implemented via "contains duplicates"

