### PR TITLE
Reuse Iterable isEmpty implementation for Sequences

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/empty.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/empty.kt
@@ -137,7 +137,7 @@ fun <T> beEmptyArray(): Matcher<Array<T>> = object : Matcher<Array<T>> {
    )
 }
 
-private fun <T> beEmpty(name: String?): Matcher<Iterable<T>> = object : Matcher<Iterable<T>> {
+internal fun <T> beEmpty(name: String?): Matcher<Iterable<T>> = object : Matcher<Iterable<T>> {
    override fun test(value: Iterable<T>): MatcherResult {
       val name = name ?: value.containerName()
       val passed: Boolean

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -6,6 +6,7 @@ import io.kotest.assertions.eq.eq
 import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.collections.beEmpty as iterableBeEmpty
 import io.kotest.matchers.collections.ContainDuplicatesMatcher
 import io.kotest.matchers.collections.duplicationReport
 import io.kotest.matchers.collections.shouldMatchEach
@@ -437,11 +438,9 @@ fun <T> containsInOrder(subsequence: Sequence<T>): Matcher<Sequence<T>?> = never
 fun <T> Sequence<T>.shouldBeEmpty() = this should beEmpty()
 fun <T> Sequence<T>.shouldNotBeEmpty() = this shouldNot beEmpty()
 fun <T> beEmpty(): Matcher<Sequence<T>> = object : Matcher<Sequence<T>> {
-   override fun test(value: Sequence<T>): MatcherResult = MatcherResult(
-      !value.iterator().hasNext(),
-      { "Sequence should be empty" },
-      { "Sequence should not be empty" }
-   )
+   private val delegate = iterableBeEmpty<T>("Sequence")
+
+   override fun test(value: Sequence<T>): MatcherResult = delegate.test(value.asIterable())
 }
 
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/sequences/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/sequences/SequenceMatchersTest.kt
@@ -79,11 +79,11 @@ class SequenceMatchersTest : StringSpec({
    "should be empty" {
       shouldThrowAny {
          sequenceOf(0).shouldBeEmpty()
-      }.message shouldBe "Sequence should be empty"
+      }.message shouldBe "Sequence should be empty but has at least one element, first being: 0"
 
       shouldThrowAny {
          sequenceOf<Int?>(null, null, null, null).shouldBeEmpty()
-      }.message shouldBe "Sequence should be empty"
+      }.message shouldBe "Sequence should be empty but has at least one element, first being: <null>"
 
       emptySequence<Int>().shouldBeEmpty()
    }


### PR DESCRIPTION
This PR deduplicates logic by delegating the Sequence check to the Iterable matcher.