### PR TITLE
Modernize shouldBeUnique collection assertions

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -875,11 +875,27 @@ public final class io/kotest/matchers/collections/UniqueKt {
 	public static final fun beUnique (Ljava/util/Comparator;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeUnique (Ljava/lang/Iterable;)Ljava/lang/Iterable;
 	public static final fun shouldBeUnique (Ljava/lang/Iterable;Ljava/util/Comparator;)Ljava/lang/Iterable;
+	public static final fun shouldBeUnique ([B)[B
+	public static final fun shouldBeUnique ([C)[C
+	public static final fun shouldBeUnique ([D)[D
+	public static final fun shouldBeUnique ([F)[F
+	public static final fun shouldBeUnique ([I)[I
+	public static final fun shouldBeUnique ([J)[J
 	public static final fun shouldBeUnique ([Ljava/lang/Object;)[Ljava/lang/Object;
 	public static final fun shouldBeUnique ([Ljava/lang/Object;Ljava/util/Comparator;)[Ljava/lang/Object;
+	public static final fun shouldBeUnique ([S)[S
+	public static final fun shouldBeUnique ([Z)[Z
 	public static final fun shouldNotBeUnique (Ljava/lang/Iterable;)Ljava/lang/Iterable;
 	public static final fun shouldNotBeUnique (Ljava/util/Collection;)Ljava/util/Collection;
+	public static final fun shouldNotBeUnique ([B)[B
+	public static final fun shouldNotBeUnique ([C)[C
+	public static final fun shouldNotBeUnique ([D)[D
+	public static final fun shouldNotBeUnique ([F)[F
+	public static final fun shouldNotBeUnique ([I)[I
+	public static final fun shouldNotBeUnique ([J)[J
 	public static final fun shouldNotBeUnique ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun shouldNotBeUnique ([S)[S
+	public static final fun shouldNotBeUnique ([Z)[Z
 }
 
 public final class io/kotest/matchers/comparables/ComparableMatchersKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/unique.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/unique.kt
@@ -5,25 +5,83 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
-/**
- * Asserts that the given [Iterable] contains no duplicate elements using the equality
- * method of the elements themselves.
- *
- * @return the input instance is returned for chaining, maintaining the input type
- */
-fun <E, T : Iterable<E>> T.shouldBeUnique(): T {
-   toList() should beUnique()
+fun BooleanArray.shouldBeUnique(): BooleanArray {
+   asList() should beUniqueByEquals("BooleanArray")
    return this
 }
 
-/**
- * Asserts that the given [Iterable] contains no duplicate elements using the given
- * [comparator] for equality.
- *
- * @return the input instance is returned for chaining, maintaining the input type
- */
-fun <E, T : Iterable<E>> T.shouldBeUnique(comparator: Comparator<E>): T {
-   toList() should beUnique(comparator)
+fun BooleanArray.shouldNotBeUnique(): BooleanArray {
+   asList() shouldNot beUniqueByEquals("BooleanArray")
+   return this
+}
+
+fun ByteArray.shouldBeUnique(): ByteArray {
+   asList() should beUniqueByEquals("ByteArray")
+   return this
+}
+
+fun ByteArray.shouldNotBeUnique(): ByteArray {
+   asList() shouldNot beUniqueByEquals("ByteArray")
+   return this
+}
+
+fun ShortArray.shouldBeUnique(): ShortArray {
+   asList() should beUniqueByEquals("ShortArray")
+   return this
+}
+
+fun ShortArray.shouldNotBeUnique(): ShortArray {
+   asList() shouldNot beUniqueByEquals("ShortArray")
+   return this
+}
+
+fun CharArray.shouldBeUnique(): CharArray {
+   asList() should beUniqueByEquals("CharArray")
+   return this
+}
+
+fun CharArray.shouldNotBeUnique(): CharArray {
+   asList() shouldNot beUniqueByEquals("CharArray")
+   return this
+}
+
+fun IntArray.shouldBeUnique(): IntArray {
+   asList() should beUniqueByEquals("IntArray")
+   return this
+}
+
+fun IntArray.shouldNotBeUnique(): IntArray {
+   asList() shouldNot beUniqueByEquals("IntArray")
+   return this
+}
+
+fun LongArray.shouldBeUnique(): LongArray {
+   asList() should beUniqueByEquals("LongArray")
+   return this
+}
+
+fun LongArray.shouldNotBeUnique(): LongArray {
+   asList() shouldNot beUniqueByEquals("LongArray")
+   return this
+}
+
+fun FloatArray.shouldBeUnique(): FloatArray {
+   asList() should beUniqueByEquals("FloatArray")
+   return this
+}
+
+fun FloatArray.shouldNotBeUnique(): FloatArray {
+   asList() shouldNot beUniqueByEquals("FloatArray")
+   return this
+}
+
+fun DoubleArray.shouldBeUnique(): DoubleArray {
+   asList() should beUniqueByEquals("DoubleArray")
+   return this
+}
+
+fun DoubleArray.shouldNotBeUnique(): DoubleArray {
+   asList() shouldNot beUniqueByEquals("DoubleArray")
    return this
 }
 
@@ -34,7 +92,7 @@ fun <E, T : Iterable<E>> T.shouldBeUnique(comparator: Comparator<E>): T {
  * @return the input instance is returned for chaining
  */
 fun <T> Array<T>.shouldBeUnique(): Array<T> {
-   asList().shouldBeUnique()
+   asList() should beUniqueByEquals("Array")
    return this
 }
 
@@ -45,50 +103,74 @@ fun <T> Array<T>.shouldBeUnique(): Array<T> {
  * @return the input instance is returned for chaining
  */
 fun <T> Array<T>.shouldBeUnique(comparator: Comparator<T>): Array<T> {
-   asList().shouldBeUnique(comparator)
-   return this
-}
-
-fun <T, I : Iterable<T>> I.shouldNotBeUnique(): I {
-   toList().shouldNotBeUnique()
+   asList() should beUniqueByCompare("Array", comparator)
    return this
 }
 
 fun <T> Array<T>.shouldNotBeUnique(): Array<T> {
-   asList().shouldNotBeUnique()
+   asList() shouldNot beUniqueByEquals("Array")
    return this
 }
 
 fun <T, C : Collection<T>> C.shouldNotBeUnique(): C {
-   this shouldNot beUnique()
+   this shouldNot beUniqueByEquals(null)
    return this
 }
 
-fun <T> beUnique() = object : Matcher<Collection<T>> {
-   override fun test(value: Collection<T>): MatcherResult {
+/**
+ * Asserts that the given [Iterable] contains no duplicate elements using the equality
+ * method of the elements themselves.
+ *
+ * @return the input instance is returned for chaining, maintaining the input type
+ */
+fun <T, I : Iterable<T>> I.shouldBeUnique(): I {
+   this should beUniqueByEquals(null)
+   return this
+}
 
-      val list = value.toMutableList()
-      list.toSet().forEach { list.remove(it) }
-      val duplicates = list.toList().distinct()
+/**
+ * Asserts that the given [Iterable] contains no duplicate elements using the given
+ * [comparator] for equality.
+ *
+ * @return the input instance is returned for chaining, maintaining the input type
+ */
+fun <T, I : Iterable<T>> I.shouldBeUnique(comparator: Comparator<T>): I {
+   this should beUniqueByCompare(null, comparator)
+   return this
+}
 
+fun <T, I : Iterable<T>> I.shouldNotBeUnique(): I {
+   this shouldNot beUniqueByEquals(null)
+   return this
+}
+
+fun <T> beUnique(): Matcher<Iterable<T>> = beUniqueByEquals(null)
+
+fun <T> beUnique(comparator: Comparator<T>): Matcher<Iterable<T>> = beUniqueByCompare(null, comparator)
+
+internal fun <T> beUniqueByEquals(name: String?): Matcher<Iterable<T>> = object : Matcher<Iterable<T>> {
+   override fun test(value: Iterable<T>): MatcherResult {
+      val name = name ?: value.containerName()
+      val report = value.duplicationByEqualsReport()
       return MatcherResult(
-         duplicates.isEmpty(),
-         { "Collection should be unique but contained duplicates of ${duplicates.joinToString(", ")}" },
-         { "Collection should contain at least one duplicate element" })
+         !report.hasDuplicates(),
+         { "$name should be unique, but has:\n${report.standardMessage()}" },
+         { "$name should contain duplicates, but all elements are unique" }
+      )
    }
 }
 
-fun <T> beUnique(comparator: Comparator<T>) = object : Matcher<Collection<T>> {
-   override fun test(value: Collection<T>): MatcherResult {
-
-      val duplicates = value.toList()
-         .sortedWith(comparator)
-         .windowed(2)
-         .find { comparator.compare(it.first(), it.last()) == 0 }
-
+internal fun <T> beUniqueByCompare(
+   name: String?,
+   comparator: Comparator<T>
+): Matcher<Iterable<T>> = object : Matcher<Iterable<T>> {
+   override fun test(value: Iterable<T>): MatcherResult {
+      val name = name ?: value.containerName()
+      val report = value.duplicationByCompareReportWith(comparator)
       return MatcherResult(
-         duplicates == null,
-         { "Collection should be unique but contained duplicates of ${duplicates?.first()}" },
-         { "Collection should contain at least one duplicate element" })
+         !report.hasDuplicates(),
+         { "$name should be unique by comparison, but has:\n${report.standardMessage()}" },
+         { "$name should contain duplicates elements by comparison, but all elements are unique" }
+      )
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -7,8 +7,8 @@ import io.kotest.assertions.print.print
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.collections.beEmpty as iterableBeEmpty
+import io.kotest.matchers.collections.beUniqueByEquals
 import io.kotest.matchers.collections.ContainDuplicatesMatcher
-import io.kotest.matchers.collections.duplicationReport
 import io.kotest.matchers.collections.shouldMatchEach
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
@@ -217,14 +217,9 @@ fun <T : Comparable<T>, C : Sequence<T>> haveLowerBound(t: T) = object : Matcher
 fun <T> Sequence<T>.shouldBeUnique() = this should beUnique()
 fun <T> Sequence<T>.shouldNotBeUnique() = this shouldNot beUnique()
 fun <T> beUnique() = object : Matcher<Sequence<T>> {
-   override fun test(value: Sequence<T>): MatcherResult {
-      val report = value.asIterable().duplicationReport()
-      return MatcherResult(
-         !report.hasDuplicates(),
-         { "Sequence should be Unique, but has duplicates:\n${report.standardMessage()}" },
-         { "Sequence should contain at least one duplicate element" }
-      )
-   }
+   val delegate = beUniqueByEquals<T>("Sequence")
+
+   override fun test(value: Sequence<T>): MatcherResult = delegate.test(value.asIterable())
 }
 
 fun <T> Sequence<T>.shouldContainDuplicates() = this should containDuplicates()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SequenceMatchersTest.kt
@@ -885,13 +885,13 @@ class SequenceMatchersTest : WordSpec() {
          "fail with repeated nulls" {
             shouldThrowAny {
                sampleData.sparse.shouldBeUnique()
-            }.shouldHaveMessage("Sequence should be Unique, but has duplicates:\n<null> at indexes: [0, 1, 2]")
+            }.shouldHaveMessage("Sequence should be unique, but has:\n<null> at indexes: [0, 1, 2]")
          }
 
          "fail with repeats" {
             shouldThrowAny {
                sampleData.repeating.shouldBeUnique()
-            }.shouldHaveMessage("Sequence should be Unique, but has duplicates:\n1 at indexes: [0, 3]\n2 at indexes: [1, 4]\n3 at indexes: [2, 5]")
+            }.shouldHaveMessage("Sequence should be unique, but has:\n1 at indexes: [0, 3]\n2 at indexes: [1, 4]\n3 at indexes: [2, 5]")
          }
 
          succeed("for multiple unique") {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/TestData.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/TestData.kt
@@ -23,3 +23,43 @@ class InfiniteIterable : Iterable<Long> {
       override fun next(): Long = 1
    }
 }
+
+/**
+ * This class implements `equals` and `hashCode` by [equalsDelegate] and Comparable by [comparableDelegate].
+ */
+class ConfigurableEquality(
+   val equalsDelegate: String,
+   val comparableDelegate: String,
+) : Comparable<ConfigurableEquality> {
+
+   override fun compareTo(other: ConfigurableEquality): Int = comparableDelegate.compareTo(other.comparableDelegate)
+
+   override fun equals(other: Any?): Boolean {
+      if (this === other) return true
+      if (other !is ConfigurableEquality) return false
+
+      if (equalsDelegate != other.equalsDelegate) return false
+
+      return true
+   }
+
+   override fun hashCode(): Int {
+      return equalsDelegate.hashCode()
+   }
+
+   override fun toString(): String = "($equalsDelegate, $comparableDelegate)"
+}
+
+internal class NonUniqueSet : Set<Int> {
+   private val elements = listOf(1, 1)
+
+   override val size: Int = elements.size
+
+   override fun contains(element: Int): Boolean = elements.contains(element)
+
+   override fun containsAll(elements: Collection<Int>): Boolean = elements.containsAll(elements)
+
+   override fun isEmpty(): Boolean = false
+
+   override fun iterator(): Iterator<Int> = elements.iterator()
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/UniqueTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/UniqueTest.kt
@@ -1,61 +1,283 @@
 package com.sksamuel.kotest.matchers.collections
 
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.assertions.throwables.shouldThrowWithMessage
-import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.collections.shouldNotBeUnique
+import io.kotest.matchers.shouldBe
 
-class UniqueTest : FunSpec() {
-   init {
+class UniqueTest : WordSpec({
 
-      test("List.shouldBeUnique") {
-         shouldThrowWithMessage<AssertionError>("Collection should be unique but contained duplicates of 1") {
-            listOf(1, 1, 2).shouldBeUnique()
-         }
-         listOf(1, 2, 3).shouldBeUnique()
+   "shouldBeUnique" should {
+      "succeed for unique BooleanArray" {
+         booleanArrayOf().shouldBeUnique()
+         booleanArrayOf(true).shouldBeUnique()
+         booleanArrayOf(true, false).shouldBeUnique()
       }
 
-      test("List.shouldNotBeUnique") {
-         listOf(1, 1, 2).shouldNotBeUnique()
-         shouldThrowWithMessage<AssertionError>("Collection should contain at least one duplicate element") {
-            listOf(1, 2, 3).shouldNotBeUnique()
-         }
+      "succeed for unique ByteArray" {
+         byteArrayOf().shouldBeUnique()
+         byteArrayOf(1).shouldBeUnique()
+         byteArrayOf(1, 2).shouldBeUnique()
       }
 
-      test("Array.shouldBeUnique") {
-         shouldThrowWithMessage<AssertionError>("Collection should be unique but contained duplicates of 1") {
-            arrayOf(1, 1, 2).shouldBeUnique()
-         }
-         arrayOf(1, 2, 3).shouldBeUnique()
+      "succeed for unique ShortArray" {
+         shortArrayOf().shouldBeUnique()
+         shortArrayOf(1).shouldBeUnique()
+         shortArrayOf(1, 2).shouldBeUnique()
       }
 
-      test("Array.shouldNotBeUnique") {
-         arrayOf(1, 1, 2).shouldNotBeUnique()
-         shouldThrowWithMessage<AssertionError>("Collection should contain at least one duplicate element") {
-            arrayOf(1, 2, 3).shouldNotBeUnique()
-         }
+      "succeed for unique CharArray" {
+         charArrayOf().shouldBeUnique()
+         charArrayOf('1').shouldBeUnique()
+         charArrayOf('1', '2').shouldBeUnique()
       }
 
-      test("List.shouldBeUnique with comparator") {
-         shouldThrowWithMessage<AssertionError>("Collection should be unique but contained duplicates of 1") {
-            listOf(1, 1, 2).shouldBeUnique(compareBy { it })
-         }
-         listOf(1, 1, 1).shouldBeUnique(object : Comparator<Int> {
-            override fun compare(p0: Int?, p1: Int?): Int {
-               return 1
-            }
-         })
+      "succeed for unique IntArray" {
+         intArrayOf().shouldBeUnique()
+         intArrayOf(1).shouldBeUnique()
+         intArrayOf(1, 2).shouldBeUnique()
       }
 
-      test("Array.shouldBeUnique with comparator") {
-         shouldThrowWithMessage<AssertionError>("Collection should be unique but contained duplicates of 1") {
-            arrayOf(1, 1, 2).shouldBeUnique(compareBy { it })
-         }
-         arrayOf(1, 1, 1).shouldBeUnique(object : Comparator<Int> {
-            override fun compare(p0: Int?, p1: Int?): Int {
-               return 1
-            }
-         })
+      "succeed for unique LongArray" {
+         longArrayOf().shouldBeUnique()
+         longArrayOf(1).shouldBeUnique()
+         longArrayOf(1, 2).shouldBeUnique()
+      }
+
+      "succeed for unique FloatArray" {
+         floatArrayOf().shouldBeUnique()
+         floatArrayOf(1f).shouldBeUnique()
+         floatArrayOf(1f, 2f).shouldBeUnique()
+      }
+
+      "succeed for unique DoubleArray" {
+         doubleArrayOf().shouldBeUnique()
+         doubleArrayOf(0.0).shouldBeUnique()
+         doubleArrayOf(0.1, 0.2).shouldBeUnique()
+      }
+
+      "succeed for unique Array" {
+         arrayOf<Int>().shouldBeUnique()
+         arrayOf(1).shouldBeUnique()
+         arrayOf<Int?>(null).shouldBeUnique()
+         arrayOf(1, 2, null).shouldBeUnique()
+         arrayOf(1, 2, 3, 4).shouldBeUnique()
+      }
+      "succeed for unique List" {
+         listOf<Int>().shouldBeUnique()
+         listOf(1).shouldBeUnique()
+         listOf<Int?>(null).shouldBeUnique()
+         listOf(1, 2, null).shouldBeUnique()
+         listOf(1, 2, 3, 4).shouldBeUnique()
+      }
+
+      fun msg(name: String) = "$name should be unique, but has:\n1 at indexes: [0, 2]\n2 at indexes: [1, 3]"
+
+      "fail for non unique BooleanArray" {
+         shouldThrowAny {
+            booleanArrayOf(true, false, true, false).shouldBeUnique()
+         }.message shouldBe "BooleanArray should be unique, but has:\ntrue at indexes: [0, 2]\nfalse at indexes: [1, 3]"
+      }
+
+      "fail for non unique ByteArray" {
+         shouldThrowAny { byteArrayOf(1, 2, 1, 2, 3).shouldBeUnique() }.message shouldBe msg("ByteArray")
+      }
+
+      "fail for non unique ShortArray" {
+         shouldThrowAny { shortArrayOf(1, 2, 1, 2, 3).shouldBeUnique() }.message shouldBe msg("ShortArray")
+      }
+
+      "fail for non unique CharArray" {
+         shouldThrowAny {
+            charArrayOf('1', '1').shouldBeUnique()
+         }.message shouldBe "CharArray should be unique, but has:\n'1' at indexes: [0, 1]"
+      }
+
+      "fail for non unique IntArray" {
+         shouldThrowAny { intArrayOf(1, 2, 1, 2, 3).shouldBeUnique() }.message shouldBe msg("IntArray")
+      }
+
+      "fail for non unique LongArray" {
+         shouldThrowAny {
+            longArrayOf(1, 2, 1, 2, 3).shouldBeUnique()
+         }.message shouldBe "LongArray should be unique, but has:\n1L at indexes: [0, 2]\n2L at indexes: [1, 3]"
+      }
+
+      "fail for non unique FloatArray" {
+         shouldThrowAny {
+            floatArrayOf(0.1f, 0.1f).shouldBeUnique()
+         }.message shouldBe "FloatArray should be unique, but has:\n0.1f at indexes: [0, 1]"
+      }
+
+      "fail for non unique DoubleArray" {
+         shouldThrowAny {
+            doubleArrayOf(
+               0.000000000000000000000000000000000000001,
+               0.000000000000000000000000000000000000001
+            ).shouldBeUnique()
+         }.message shouldBe "DoubleArray should be unique, but has:\n1.0E-39 at indexes: [0, 1]"
+
+         shouldThrowAny {
+            doubleArrayOf(1234.056789, 1234.056789).shouldBeUnique()
+         }.message shouldBe "DoubleArray should be unique, but has:\n1234.056789 at indexes: [0, 1]"
+      }
+
+      fun nullMsg(name: String) =
+         "$name should be unique, but has:\n2 at indexes: [1, 6]\n3 at indexes: [2, 5]\n<null> at indexes: [3, 4]"
+
+      "fail for non unique Array" {
+         shouldThrowAny { arrayOf(1, 2, 3, null, null, 3, 2).shouldBeUnique() }.message shouldBe nullMsg("Array")
+      }
+
+      "fail for non unique List" {
+         shouldThrowAny { listOf(1, 2, 3, null, null, 3, 2).shouldBeUnique() }.message shouldBe nullMsg("List")
       }
    }
-}
+
+   "shouldNotBeUnique" should {
+      fun msg(name: String) = "$name should contain duplicates, but all elements are unique"
+
+      "fail for unique BooleanArray" {
+         shouldThrowAny { booleanArrayOf().shouldNotBeUnique() }.message shouldBe msg("BooleanArray")
+         shouldThrowAny { booleanArrayOf(true).shouldNotBeUnique() }.message shouldBe msg("BooleanArray")
+         shouldThrowAny { booleanArrayOf(false, true).shouldNotBeUnique() }.message shouldBe msg("BooleanArray")
+      }
+
+      "fail for unique ByteArray" {
+         shouldThrowAny { byteArrayOf().shouldNotBeUnique() }.message shouldBe msg("ByteArray")
+         shouldThrowAny { byteArrayOf(1).shouldNotBeUnique() }.message shouldBe msg("ByteArray")
+         shouldThrowAny { byteArrayOf(1, 2).shouldNotBeUnique() }.message shouldBe msg("ByteArray")
+      }
+
+      "fail for unique ShortArray" {
+         shouldThrowAny { shortArrayOf().shouldNotBeUnique() }.message shouldBe msg("ShortArray")
+         shouldThrowAny { shortArrayOf(1).shouldNotBeUnique() }.message shouldBe msg("ShortArray")
+         shouldThrowAny { shortArrayOf(1, 2).shouldNotBeUnique() }.message shouldBe msg("ShortArray")
+      }
+
+      "fail for unique CharArray" {
+         shouldThrowAny { charArrayOf().shouldNotBeUnique() }.message shouldBe msg("CharArray")
+         shouldThrowAny { charArrayOf('a').shouldNotBeUnique() }.message shouldBe msg("CharArray")
+         shouldThrowAny { charArrayOf('a', 'b').shouldNotBeUnique() }.message shouldBe msg("CharArray")
+      }
+
+      "fail for unique IntArray" {
+         shouldThrowAny { intArrayOf().shouldNotBeUnique() }.message shouldBe msg("IntArray")
+         shouldThrowAny { intArrayOf(1).shouldNotBeUnique() }.message shouldBe msg("IntArray")
+         shouldThrowAny { intArrayOf(1, 2).shouldNotBeUnique() }.message shouldBe msg("IntArray")
+      }
+
+      "fail for unique LongArray" {
+         shouldThrowAny { longArrayOf().shouldNotBeUnique() }.message shouldBe msg("LongArray")
+         shouldThrowAny { longArrayOf(1).shouldNotBeUnique() }.message shouldBe msg("LongArray")
+         shouldThrowAny { longArrayOf(1, 2).shouldNotBeUnique() }.message shouldBe msg("LongArray")
+      }
+
+      "fail for unique FloatArray" {
+         shouldThrowAny { floatArrayOf().shouldNotBeUnique() }.message shouldBe msg("FloatArray")
+         shouldThrowAny { floatArrayOf(1.00001f).shouldNotBeUnique() }.message shouldBe msg("FloatArray")
+         shouldThrowAny { floatArrayOf(1.00001f, 1.000001f).shouldNotBeUnique() }.message shouldBe msg("FloatArray")
+      }
+
+      "fail for unique DoubleArray" {
+         shouldThrowAny { doubleArrayOf().shouldNotBeUnique() }.message shouldBe msg("DoubleArray")
+         shouldThrowAny { doubleArrayOf(1.0000001).shouldNotBeUnique() }.message shouldBe msg("DoubleArray")
+         shouldThrowAny { doubleArrayOf(1.0000001, 1.00000001).shouldNotBeUnique() }.message shouldBe msg("DoubleArray")
+      }
+
+      "fail for unique Array" {
+         shouldThrowAny { arrayOf<Int>().shouldNotBeUnique() }.message shouldBe msg("Array")
+         shouldThrowAny { arrayOf(1).shouldNotBeUnique() }.message shouldBe msg("Array")
+         shouldThrowAny { arrayOf<Int?>(null).shouldNotBeUnique() }.message shouldBe msg("Array")
+         shouldThrowAny { arrayOf(1, 2, 3, 4, null).shouldNotBeUnique() }.message shouldBe msg("Array")
+      }
+
+      "fail for unique List" {
+         shouldThrowAny { listOf<Int>().shouldNotBeUnique() }.message shouldBe msg("List")
+         shouldThrowAny { listOf(1).shouldNotBeUnique() }.message shouldBe msg("List")
+         shouldThrowAny { listOf<Int?>(null).shouldNotBeUnique() }.message shouldBe msg("List")
+         shouldThrowAny { listOf(1, 2, 3, 4, null).shouldNotBeUnique() }.message shouldBe msg("List")
+      }
+
+      "fail for any Set" {
+         shouldThrowAny { setOf<Int>().shouldNotBeUnique() }.message shouldBe msg("Set")
+         shouldThrowAny { setOf(1, 2, 3, 4, null).shouldNotBeUnique() }.message shouldBe msg("Set")
+         shouldThrowAny { setOf(8, 9, 1, 1, null).shouldNotBeUnique() }.message shouldBe msg("Set")
+         shouldThrowAny { setOf<Int?>(null, null).shouldNotBeUnique() }.message shouldBe msg("Set")
+      }
+
+      "succeed for non unique BooleanArray" {
+         booleanArrayOf(true, false, true).shouldNotBeUnique()
+      }
+
+      "succeed for non unique ByteArray" {
+         byteArrayOf(1, 1).shouldNotBeUnique()
+      }
+
+      "succeed for non unique ShortArray" {
+         shortArrayOf(1, 1).shouldNotBeUnique()
+      }
+
+      "succeed for non unique CharArray" {
+         charArrayOf('a', 'a').shouldNotBeUnique()
+      }
+
+      "succeed for non unique IntArray" {
+         intArrayOf(1, 1).shouldNotBeUnique()
+      }
+
+      "succeed for non unique LongArray" {
+         longArrayOf(1, 1).shouldNotBeUnique()
+      }
+
+      "succeed for non unique FloatArray" {
+         floatArrayOf(1.0000001f, 1.0000001f).shouldNotBeUnique()
+      }
+
+      "succeed for non unique DoubleArray" {
+         doubleArrayOf(1.000000000000001, 1.000000000000001).shouldNotBeUnique()
+      }
+
+      "succeed for non unique Array" {
+         arrayOf<Int?>(null, null).shouldNotBeUnique()
+         arrayOf(1, 2, 3, null, null, 3, 2).shouldNotBeUnique()
+      }
+
+      "succeed for non unique List" {
+         listOf<Int?>(null, null).shouldNotBeUnique()
+         listOf(1, 2, 3, null, null, 3, 2).shouldNotBeUnique()
+      }
+
+      "succeed for misbehaving Set" {
+         NonUniqueSet().shouldNotBeUnique()
+      }
+   }
+
+   "shouldBeUnique using COMPARATOR" should {
+      "succeed for unique Array" {
+         listOf(1, 1, 1).shouldBeUnique(Comparator { _, _ -> 1 })
+      }
+      "succeed for unique List" {
+         listOf(1, 1, 1).shouldBeUnique(Comparator { _, _ -> 1 })
+      }
+
+      "fail for non unique Array" {
+         shouldThrowWithMessage<AssertionError>("Array should be unique by comparison, but has:\n1 at indexes: [0, 1]") {
+            arrayOf(1, 1, 2).shouldBeUnique(compareBy { it })
+         }
+         shouldThrowWithMessage<AssertionError>("Array should be unique by comparison, but has:\n<null> at indexes: [0, 1]") {
+            arrayOf<Int?>(null, null).shouldBeUnique(compareBy { it })
+         }
+      }
+      "fail for non unique List" {
+         shouldThrowWithMessage<AssertionError>("List should be unique by comparison, but has:\n1 at indexes: [0, 1]") {
+            listOf(1, 1, 2).shouldBeUnique(compareBy { it })
+         }
+         shouldThrowWithMessage<AssertionError>("List should be unique by comparison, but has:\n<null> at indexes: [0, 1]") {
+            listOf<Int?>(null, null).shouldBeUnique(compareBy { it })
+         }
+      }
+   }
+})

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ArraySchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ArraySchemaTest.kt
@@ -99,7 +99,7 @@ class ArraySchemaTest : FunSpec(
          }
          array shouldNotMatchSchema uniqueArray
          shouldFail { array shouldMatchSchema uniqueArray }
-            .message shouldBe "$ => Sequence should be Unique, but has duplicates:\nNumberNode(content=1) at indexes: [0, 1]"
+            .message shouldBe "$ => Sequence should be unique, but has:\nNumberNode(content=1) at indexes: [0, 1]"
       }
 
       test("Array not contains string") {


### PR DESCRIPTION
- Adds shouldBeUnique for primitive arrays
- Prints indexes of duplicated elements
- Sequence.shouldBeUnique delegates to the Iterable matcher

As before, the removal of any leftover Collection overloads will be performed in a followup PR.

#4369 introduced a helper class `DuplicationReport` for finding indexed duplicates in a container using `equals`. This helper can be used for implementing `shouldBeUnique` as well. `shouldBeUnique` offers two variants: checking for uniqueness by equals and by using a comparator. Therefore, `DuplicationReport` was renamed to `DuplicationByEqualsReport` and a sibling helper, `DuplicationByCompareReport`, was introduced.