### PR TITLE
Modernize shouldHaveUpperBound, shouldHaveLowerBound

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -305,7 +305,14 @@ public final class io/kotest/matchers/collections/BoundsKt {
 	public static final fun shouldHaveLowerBound ([Ljava/lang/Comparable;Ljava/lang/Comparable;)[Ljava/lang/Comparable;
 	public static final fun shouldHaveUpperBound (Ljava/lang/Iterable;Ljava/lang/Comparable;)Ljava/lang/Iterable;
 	public static final fun shouldHaveUpperBound (Ljava/util/Collection;Ljava/lang/Comparable;)Ljava/util/Collection;
+	public static final fun shouldHaveUpperBound ([BB)[B
+	public static final fun shouldHaveUpperBound ([CC)[C
+	public static final fun shouldHaveUpperBound ([DD)[D
+	public static final fun shouldHaveUpperBound ([FF)[F
+	public static final fun shouldHaveUpperBound ([II)[I
+	public static final fun shouldHaveUpperBound ([JJ)[J
 	public static final fun shouldHaveUpperBound ([Ljava/lang/Comparable;Ljava/lang/Comparable;)[Ljava/lang/Comparable;
+	public static final fun shouldHaveUpperBound ([SS)[S
 }
 
 public final class io/kotest/matchers/collections/CollectionMatchersKt {

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -302,7 +302,14 @@ public final class io/kotest/matchers/collections/BoundsKt {
 	public static final fun haveUpperBound (Ljava/lang/Comparable;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldHaveLowerBound (Ljava/lang/Iterable;Ljava/lang/Comparable;)Ljava/lang/Iterable;
 	public static final fun shouldHaveLowerBound (Ljava/util/Collection;Ljava/lang/Comparable;)Ljava/util/Collection;
+	public static final fun shouldHaveLowerBound ([BB)[B
+	public static final fun shouldHaveLowerBound ([CC)[C
+	public static final fun shouldHaveLowerBound ([DD)[D
+	public static final fun shouldHaveLowerBound ([FF)[F
+	public static final fun shouldHaveLowerBound ([II)[I
+	public static final fun shouldHaveLowerBound ([JJ)[J
 	public static final fun shouldHaveLowerBound ([Ljava/lang/Comparable;Ljava/lang/Comparable;)[Ljava/lang/Comparable;
+	public static final fun shouldHaveLowerBound ([SS)[S
 	public static final fun shouldHaveUpperBound (Ljava/lang/Iterable;Ljava/lang/Comparable;)Ljava/lang/Iterable;
 	public static final fun shouldHaveUpperBound (Ljava/util/Collection;Ljava/lang/Comparable;)Ljava/util/Collection;
 	public static final fun shouldHaveUpperBound ([BB)[B

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -138,18 +138,108 @@ private fun Iterable<*>.containerName(): String {
    }
 }
 
-infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(t: T): Array<T> {
-   asList() should haveLowerBound(t, "Array")
+
+// BooleanArray left out in the interest of reducing API bloat.
+// As Boolean only has 2 values, it is more natural to use
+// "shouldContain true / shouldContain false"-type assertions
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun ByteArray.shouldHaveLowerBound(value: Byte): ByteArray {
+   asList() should haveLowerBound(value, "ByteArray")
    return this
 }
 
-infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(t: T): I {
-   toList() should haveLowerBound(t, null)
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun ShortArray.shouldHaveLowerBound(value: Short): ShortArray {
+   asList() should haveLowerBound(value, "ShortArray")
    return this
 }
 
-infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveLowerBound(t: T): C {
-   this should haveLowerBound(t, null)
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun CharArray.shouldHaveLowerBound(value: Char): CharArray {
+   asList() should haveLowerBound(value, "CharArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun IntArray.shouldHaveLowerBound(value: Int): IntArray {
+   asList() should haveLowerBound(value, "IntArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun LongArray.shouldHaveLowerBound(value: Long): LongArray {
+   asList() should haveLowerBound(value, "LongArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun FloatArray.shouldHaveLowerBound(value: Float): FloatArray {
+   asList() should haveLowerBound(value, "FloatArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun DoubleArray.shouldHaveLowerBound(value: Double): DoubleArray {
+   asList() should haveLowerBound(value, "DoubleArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(value: T): Array<T> {
+   asList() should haveLowerBound(value, "Array")
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveLowerBound(value: T): C {
+   this should haveLowerBound(value, null)
+   return this
+}
+
+/**
+ * Verifies that all elements are greater than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(value: T): I {
+   this should haveLowerBound(value, null)
    return this
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -5,22 +5,116 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 
-infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(t: T): Array<T> {
-   asList() should haveUpperBound(t, "Array")
+// BooleanArray left out in the interest of reducing API bloat.
+// As Boolean only has 2 values, it is more natural to use
+// "shouldContain true / shouldContain false"-type assertions
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun ByteArray.shouldHaveUpperBound(value: Byte): ByteArray {
+   asList() should haveUpperBound(value, "ByteArray")
    return this
 }
 
-infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveUpperBound(t: T): C {
-   this should haveUpperBound(t, null)
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun ShortArray.shouldHaveUpperBound(value: Short): ShortArray {
+   asList() should haveUpperBound(value, "ShortArray")
    return this
 }
 
-infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(t: T): I {
-   this should haveUpperBound(t, null)
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun CharArray.shouldHaveUpperBound(value: Char): CharArray {
+   asList() should haveUpperBound(value, "CharArray")
    return this
 }
 
-fun <T : Comparable<T>, C : Collection<T>> haveUpperBound(t: T): Matcher<C> = haveUpperBound(t, null)
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun IntArray.shouldHaveUpperBound(value: Int): IntArray {
+   asList() should haveUpperBound(value, "IntArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun LongArray.shouldHaveUpperBound(value: Long): LongArray {
+   asList() should haveUpperBound(value, "LongArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun FloatArray.shouldHaveUpperBound(value: Float): FloatArray {
+   asList() should haveUpperBound(value, "FloatArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun DoubleArray.shouldHaveUpperBound(value: Double): DoubleArray {
+   asList() should haveUpperBound(value, "DoubleArray")
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(value: T): Array<T> {
+   asList() should haveUpperBound(value, "Array")
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveUpperBound(value: T): C {
+   this should haveUpperBound(value, null)
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(value: T): I {
+   this should haveUpperBound(value, null)
+   return this
+}
+
+/**
+ * Verifies that all elements are less than or equal to [value].
+ *
+ * Passes if `this` is empty.
+ */
+fun <T : Comparable<T>, C : Collection<T>> haveUpperBound(value: T): Matcher<C> = haveUpperBound(value, null)
 
 private fun <T : Comparable<T>, I : Iterable<T>> haveUpperBound(t: T, name: String?): Matcher<I> = object : Matcher<I> {
    override fun test(value: I): MatcherResult {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -125,40 +125,43 @@ private fun <T : Comparable<T>, I : Iterable<T>> haveUpperBound(t: T, name: Stri
          { "$name should have upper bound $t, but the following elements are above it: ${violatingElements.print().value}" },
          { "$name should not have upper bound $t" })
    }
+}
 
-   private fun Iterable<*>.containerName(): String {
-      return when (this) {
-         is List -> "List"
-         is Set -> "Set"
-         is Map<*, *> -> "Map"
-         is ClosedRange<*>, is OpenEndRange<*> -> "Range"
-         is Collection -> "Collection"
-         else -> "Iterable"
-      }
+private fun Iterable<*>.containerName(): String {
+   return when (this) {
+      is List -> "List"
+      is Set -> "Set"
+      is Map<*, *> -> "Map"
+      is ClosedRange<*>, is OpenEndRange<*> -> "Range"
+      is Collection -> "Collection"
+      else -> "Iterable"
    }
 }
 
 infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(t: T): Array<T> {
-   asList().shouldHaveLowerBound(t)
+   asList() should haveLowerBound(t, "Array")
    return this
 }
 
 infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(t: T): I {
-   toList().shouldHaveLowerBound(t)
+   toList() should haveLowerBound(t, null)
    return this
 }
 
 infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveLowerBound(t: T): C {
-   this should haveLowerBound(t)
+   this should haveLowerBound(t, null)
    return this
 }
 
-fun <T : Comparable<T>, C : Collection<T>> haveLowerBound(t: T) = object : Matcher<C> {
-   override fun test(value: C): MatcherResult {
+fun <T : Comparable<T>, C : Collection<T>> haveLowerBound(t: T): Matcher<C> = haveLowerBound(t, null)
+
+private fun <T : Comparable<T>, I : Iterable<T>> haveLowerBound(t: T, name: String?): Matcher<I> = object : Matcher<I> {
+   override fun test(value: I): MatcherResult {
+      val name = name ?: value.containerName()
       val violatingElements = value.filter { it < t }
       return MatcherResult(
          violatingElements.isEmpty(),
-         { "Collection should have lower bound $t, but the following elements are below it: ${violatingElements.print().value}" },
-         { "Collection should not have lower bound $t" })
+         { "$name should have lower bound $t, but the following elements are below it: ${violatingElements.print().value}" },
+         { "$name should not have lower bound $t" })
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -5,11 +5,6 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 
-infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(t: T): I {
-   toList().shouldHaveUpperBound(t)
-   return this
-}
-
 infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(t: T): Array<T> {
    asList().shouldHaveUpperBound(t)
    return this
@@ -17,6 +12,11 @@ infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(t: T): Array<T> {
 
 infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveUpperBound(t: T): C {
    this should haveUpperBound(t)
+   return this
+}
+
+infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(t: T): I {
+   toList().shouldHaveUpperBound(t)
    return this
 }
 
@@ -30,13 +30,13 @@ fun <T : Comparable<T>, C : Collection<T>> haveUpperBound(t: T) = object : Match
    }
 }
 
-infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(t: T): I {
-   toList().shouldHaveLowerBound(t)
+infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(t: T): Array<T> {
+   asList().shouldHaveLowerBound(t)
    return this
 }
 
-infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(t: T): Array<T> {
-   asList().shouldHaveLowerBound(t)
+infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(t: T): I {
+   toList().shouldHaveLowerBound(t)
    return this
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
@@ -122,13 +122,113 @@ class BoundsTest : WordSpec() {
 
       "haveLowerBound" should {
          "pass" {
+            byteArrayOf() shouldHaveLowerBound 3
+            byteArrayOf(3) shouldHaveLowerBound 3
+            byteArrayOf(1, 2, 3) shouldHaveLowerBound 1
+            byteArrayOf(1, 2, 3) shouldHaveLowerBound 0
+
+            shortArrayOf() shouldHaveLowerBound 3
+            shortArrayOf(3) shouldHaveLowerBound 3
+            shortArrayOf(1, 2, 3) shouldHaveLowerBound 1
+            shortArrayOf(1, 2, 3) shouldHaveLowerBound 0
+
+            charArrayOf() shouldHaveLowerBound 'c'
+            charArrayOf('c') shouldHaveLowerBound 'c'
+            charArrayOf('b', 'c', 'd') shouldHaveLowerBound 'b'
+            charArrayOf('b', 'c', 'd') shouldHaveLowerBound 'a'
+
+            intArrayOf() shouldHaveLowerBound 3
+            intArrayOf(3) shouldHaveLowerBound 3
+            intArrayOf(1, 2, 3) shouldHaveLowerBound 1
+            intArrayOf(1, 2, 3) shouldHaveLowerBound 0
+
+            longArrayOf() shouldHaveLowerBound 3
+            longArrayOf(3) shouldHaveLowerBound 3
+            longArrayOf(1, 2, 3) shouldHaveLowerBound 1
+            longArrayOf(1, 2, 3) shouldHaveLowerBound 0
+
+            floatArrayOf() shouldHaveLowerBound 0.3f
+            floatArrayOf(0.3f) shouldHaveLowerBound 0.3f
+            floatArrayOf(0.1f, 0.2f, 0.3f) shouldHaveLowerBound 0.1f
+            floatArrayOf(0.1f, 0.2f, 0.3f) shouldHaveLowerBound 0f
+
+            doubleArrayOf() shouldHaveLowerBound 0.3
+            doubleArrayOf(0.3) shouldHaveLowerBound 0.3
+            doubleArrayOf(0.1, 0.2, 0.3) shouldHaveLowerBound 0.1
+            doubleArrayOf(0.1, 0.2, 0.3) shouldHaveLowerBound 0.0
+
+            arrayOf<Int>() shouldHaveLowerBound 3
+            arrayOf(3) shouldHaveLowerBound 3
+            arrayOf(1, 2, 3) shouldHaveLowerBound 1
+            arrayOf(1, 2, 3) shouldHaveLowerBound 0
+
+            listOf<Int>() shouldHaveLowerBound 3
+            listOf(3) shouldHaveLowerBound 3
             listOf(1, 2, 3) shouldHaveLowerBound 1
             listOf(1, 2, 3) shouldHaveLowerBound 0
+
+            1..0 shouldHaveLowerBound 3
+            3..3 shouldHaveLowerBound 3
+            1..3 shouldHaveLowerBound 1
+            1..3 shouldHaveLowerBound 0
          }
-         "fail" {
-            shouldThrowAny {
-               listOf(1, 2, 3) shouldHaveLowerBound 2
-            }.shouldHaveMessage("List should have lower bound 2, but the following elements are below it: [1]")
+
+         fun msg(name: String, bound: String = "2", violation: String = "1") =
+            "$name should have lower bound $bound, but the following elements are below it: [$violation]"
+
+         "fail for ByteArray" {
+            shouldThrowAny { byteArrayOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("ByteArray"))
+         }
+
+         "fail for ShortArray" {
+            shouldThrowAny { shortArrayOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("ShortArray"))
+         }
+
+         "fail for CharArray" {
+            shouldThrowAny { charArrayOf('a', 'b', 'c') shouldHaveLowerBound 'b' }
+               .shouldHaveMessage(msg("CharArray", "b", "'a'"))
+         }
+
+         "fail for IntArray" {
+            shouldThrowAny { intArrayOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("IntArray"))
+         }
+
+         "fail for LongArray" {
+            shouldThrowAny { longArrayOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("LongArray", "2", "1L"))
+         }
+
+         "fail for FloatArray" {
+            shouldThrowAny { floatArrayOf(0.1f, 0.2f, 0.3f) shouldHaveLowerBound 0.2f }
+               .shouldHaveMessage(msg("FloatArray", "0.2", "0.1f"))
+         }
+
+         "fail for DoubleArray" {
+            shouldThrowAny { doubleArrayOf(0.1, 0.2, 0.3) shouldHaveLowerBound 0.2 }
+               .shouldHaveMessage(msg("DoubleArray", "0.2", "0.1"))
+         }
+
+         "fail for Array" {
+            shouldThrowAny { arrayOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("Array"))
+         }
+
+         "fail for List" {
+            shouldThrowAny { listOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("List"))
+         }
+
+         "fail for Set" {
+            shouldThrowAny { setOf(1, 2, 3) shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("Set"))
+         }
+
+         "fail for Range" {
+            shouldThrowAny { 1..3 shouldHaveLowerBound 2 }
+               .shouldHaveMessage(msg("Range"))
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
@@ -11,18 +11,28 @@ class BoundsTest : WordSpec() {
       "haveUpperBound" should {
          "pass" {
             listOf(1, 2, 3) shouldHaveUpperBound 3
+            listOf(1, 2, 3) shouldHaveUpperBound 4
          }
 
-         "fail" {
-            shouldThrowAny {
-               listOf(1, 2, 3) shouldHaveUpperBound 2
-            }.shouldHaveMessage("Collection should have upper bound 2, but the following elements are above it: [3]")
+         fun msg(name: String) = "$name should have upper bound 2, but the following elements are above it: [3]"
+
+         "fail for Array" {
+            shouldThrowAny { arrayOf(1, 2, 3) shouldHaveUpperBound 2 }.shouldHaveMessage(msg("Array"))
+         }
+
+         "fail for List" {
+            shouldThrowAny { listOf(1, 2, 3) shouldHaveUpperBound 2 }.shouldHaveMessage(msg("List"))
+         }
+
+         "fail for Set" {
+            shouldThrowAny { setOf(1, 2, 3) shouldHaveUpperBound 2 }.shouldHaveMessage(msg("Set"))
          }
       }
 
       "haveLowerBound" should {
          "pass" {
             listOf(1, 2, 3) shouldHaveLowerBound 1
+            listOf(1, 2, 3) shouldHaveLowerBound 0
          }
          "fail" {
             shouldThrowAny {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
@@ -10,22 +10,113 @@ class BoundsTest : WordSpec() {
    init {
       "haveUpperBound" should {
          "pass" {
+            byteArrayOf() shouldHaveUpperBound 3
+            byteArrayOf(3) shouldHaveUpperBound 3
+            byteArrayOf(1, 2, 3) shouldHaveUpperBound 3
+            byteArrayOf(1, 2, 3) shouldHaveUpperBound 4
+
+            shortArrayOf() shouldHaveUpperBound 3
+            shortArrayOf(3) shouldHaveUpperBound 3
+            shortArrayOf(1, 2, 3) shouldHaveUpperBound 3
+            shortArrayOf(1, 2, 3) shouldHaveUpperBound 4
+
+            charArrayOf() shouldHaveUpperBound 'c'
+            charArrayOf('c') shouldHaveUpperBound 'c'
+            charArrayOf('a', 'b', 'c') shouldHaveUpperBound 'c'
+            charArrayOf('a', 'b', 'c') shouldHaveUpperBound 'd'
+
+            intArrayOf() shouldHaveUpperBound 3
+            intArrayOf(3) shouldHaveUpperBound 3
+            intArrayOf(1, 2, 3) shouldHaveUpperBound 3
+            intArrayOf(1, 2, 3) shouldHaveUpperBound 4
+
+            longArrayOf() shouldHaveUpperBound 3
+            longArrayOf(3) shouldHaveUpperBound 3
+            longArrayOf(1, 2, 3) shouldHaveUpperBound 3
+            longArrayOf(1, 2, 3) shouldHaveUpperBound 4
+
+            floatArrayOf() shouldHaveUpperBound 0.3f
+            floatArrayOf(0.3f) shouldHaveUpperBound 0.3f
+            floatArrayOf(0.1f, 0.2f, 0.3f) shouldHaveUpperBound 0.3f
+            floatArrayOf(0.1f, 0.2f, 0.3f) shouldHaveUpperBound 4f
+
+            doubleArrayOf() shouldHaveUpperBound 0.3
+            doubleArrayOf(0.3) shouldHaveUpperBound 0.3
+            doubleArrayOf(0.1, 0.2, 0.3) shouldHaveUpperBound 0.3
+            doubleArrayOf(0.1, 0.2, 0.3) shouldHaveUpperBound 4.0
+
+            arrayOf<Int>() shouldHaveUpperBound 3
+            arrayOf(3) shouldHaveUpperBound 3
+            arrayOf(1, 2, 3) shouldHaveUpperBound 3
+            arrayOf(1, 2, 3) shouldHaveUpperBound 4
+
+            listOf<Int>() shouldHaveUpperBound 3
+            listOf(3) shouldHaveUpperBound 3
             listOf(1, 2, 3) shouldHaveUpperBound 3
             listOf(1, 2, 3) shouldHaveUpperBound 4
+
+            1..0 shouldHaveUpperBound 3
+            3..3 shouldHaveUpperBound 3
+            1..3 shouldHaveUpperBound 3
+            1..3 shouldHaveUpperBound 4
          }
 
-         fun msg(name: String) = "$name should have upper bound 2, but the following elements are above it: [3]"
+         fun msg(name: String, bound: String = "2", violation: String = "3") =
+            "$name should have upper bound $bound, but the following elements are above it: [$violation]"
+
+         "fail for ByteArray" {
+            shouldThrowAny { byteArrayOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("ByteArray"))
+         }
+
+         "fail for ShortArray" {
+            shouldThrowAny { shortArrayOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("ShortArray"))
+         }
+
+         "fail for CharArray" {
+            shouldThrowAny { charArrayOf('a', 'b', 'c') shouldHaveUpperBound 'b' }
+               .shouldHaveMessage(msg("CharArray", "b", "'c'"))
+         }
+
+         "fail for IntArray" {
+            shouldThrowAny { intArrayOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("IntArray"))
+         }
+
+         "fail for LongArray" {
+            shouldThrowAny { longArrayOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("LongArray", "2", "3L"))
+         }
+
+         "fail for FloatArray" {
+            shouldThrowAny { floatArrayOf(0.0f, 0.2f, 0.3f) shouldHaveUpperBound 0.2f }
+               .shouldHaveMessage(msg("FloatArray", "0.2", "0.3f"))
+         }
+
+         "fail for DoubleArray" {
+            shouldThrowAny { doubleArrayOf(0.0, 0.2, 0.3) shouldHaveUpperBound 0.2 }
+               .shouldHaveMessage(msg("DoubleArray", "0.2", "0.3"))
+         }
 
          "fail for Array" {
-            shouldThrowAny { arrayOf(1, 2, 3) shouldHaveUpperBound 2 }.shouldHaveMessage(msg("Array"))
+            shouldThrowAny { arrayOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("Array"))
          }
 
          "fail for List" {
-            shouldThrowAny { listOf(1, 2, 3) shouldHaveUpperBound 2 }.shouldHaveMessage(msg("List"))
+            shouldThrowAny { listOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("List"))
          }
 
          "fail for Set" {
-            shouldThrowAny { setOf(1, 2, 3) shouldHaveUpperBound 2 }.shouldHaveMessage(msg("Set"))
+            shouldThrowAny { setOf(1, 2, 3) shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("Set"))
+         }
+
+         "fail for Range" {
+            shouldThrowAny { 1..3 shouldHaveUpperBound 2 }
+               .shouldHaveMessage(msg("Range"))
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
@@ -128,7 +128,7 @@ class BoundsTest : WordSpec() {
          "fail" {
             shouldThrowAny {
                listOf(1, 2, 3) shouldHaveLowerBound 2
-            }.shouldHaveMessage("Collection should have lower bound 2, but the following elements are below it: [1]")
+            }.shouldHaveMessage("List should have lower bound 2, but the following elements are below it: [1]")
          }
       }
    }


### PR DESCRIPTION
Continuation of work on #4354.

- Adds `shouldHaveUpper/LowerBound` for primitive arrays except BooleanArray. BooleanArray was left out in the interest of reducing API bloat. Booleans are better served with `shouldContain true/false`.
- Matcher messages report a more precise container type
- Adds more test cases for empty / single element containers
- Removes needless allocations: Iterables were being converted to lists, then checked iterated. Now they are just iterated once.
