### PR TITLE
Remove shouldHaveUpperBound, shouldHaveLowerBound Collection overloads

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -301,7 +301,6 @@ public final class io/kotest/matchers/collections/BoundsKt {
 	public static final fun haveLowerBound (Ljava/lang/Comparable;)Lio/kotest/matchers/Matcher;
 	public static final fun haveUpperBound (Ljava/lang/Comparable;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldHaveLowerBound (Ljava/lang/Iterable;Ljava/lang/Comparable;)Ljava/lang/Iterable;
-	public static final fun shouldHaveLowerBound (Ljava/util/Collection;Ljava/lang/Comparable;)Ljava/util/Collection;
 	public static final fun shouldHaveLowerBound ([BB)[B
 	public static final fun shouldHaveLowerBound ([CC)[C
 	public static final fun shouldHaveLowerBound ([DD)[D
@@ -311,7 +310,6 @@ public final class io/kotest/matchers/collections/BoundsKt {
 	public static final fun shouldHaveLowerBound ([Ljava/lang/Comparable;Ljava/lang/Comparable;)[Ljava/lang/Comparable;
 	public static final fun shouldHaveLowerBound ([SS)[S
 	public static final fun shouldHaveUpperBound (Ljava/lang/Iterable;Ljava/lang/Comparable;)Ljava/lang/Iterable;
-	public static final fun shouldHaveUpperBound (Ljava/util/Collection;Ljava/lang/Comparable;)Ljava/util/Collection;
 	public static final fun shouldHaveUpperBound ([BB)[B
 	public static final fun shouldHaveUpperBound ([CC)[C
 	public static final fun shouldHaveUpperBound ([DD)[D

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -94,16 +94,6 @@ infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(value: T): Array<T> 
  *
  * Passes if `this` is empty.
  */
-infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveUpperBound(value: T): C {
-   this should haveUpperBound(value, null)
-   return this
-}
-
-/**
- * Verifies that all elements are less than or equal to [value].
- *
- * Passes if `this` is empty.
- */
 infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(value: T): I {
    this should haveUpperBound(value, null)
    return this
@@ -208,16 +198,6 @@ infix fun DoubleArray.shouldHaveLowerBound(value: Double): DoubleArray {
  */
 infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(value: T): Array<T> {
    asList() should haveLowerBound(value, "Array")
-   return this
-}
-
-/**
- * Verifies that all elements are greater than or equal to [value].
- *
- * Passes if `this` is empty.
- */
-infix fun <T : Comparable<T>, C : Collection<T>> C.shouldHaveLowerBound(value: T): C {
-   this should haveLowerBound(value, null)
    return this
 }
 


### PR DESCRIPTION
Removes IDE autocompletion duplicates for library consumers.

See also https://github.com/kotest/kotest/pull/4367

This removal is not a breaking change. Consumer code will simply start resolving the Iterable overload.