### PR TITLE
replace-shouldPass-with-shouldNotThrowAny

### DIFF
--- a/documentation/docs/assertions/soft_assertions.md
+++ b/documentation/docs/assertions/soft_assertions.md
@@ -33,7 +33,7 @@ assertSoftly(foo) {
 
 We can configure assert softly to be implicitly added to every test via [project config](../framework/project_config.md).
 
-**Note:** only Kotest's own assertions can be asserted softly. To be compatible with `assertSoftly`, assertions from other libraries must be wrapped in `shouldPass`, which is described leter in this section. If any other checks fail and throw an `AssertionError`, it will not respect `assertSoftly` and bubble up, erasing the results of previous assertions. This includes Kotest's own `fail()` function, so when the following code runs, we won't know if the first assertion `foo shouldBe bar` succeeded or failed:
+**Note:** only Kotest's own assertions can be asserted softly. To be compatible with `assertSoftly`, assertions from other libraries must be wrapped in `shouldNotThrowAny`, which is described later in this section. If any other checks fail and throw an `AssertionError`, it will not respect `assertSoftly` and bubble up, erasing the results of previous assertions. This includes Kotest's own `fail()` function, so when the following code runs, we won't know if the first assertion `foo shouldBe bar` succeeded or failed:
 
 ```kotlin
 assertSoftly {
@@ -56,7 +56,7 @@ In the following example both `verify` and the second assertion can fail, and we
 
 ```kotlin
 assertSoftly {
-  shouldPass {
+  shouldNotThrowAny {
     verify(exactly = 1) { myClass.myMethod(any()) }
   }
   foo shouldBe bar
@@ -69,7 +69,7 @@ Likewise, in the following example the failure of `verify` will not be ignored, 
 ```kotlin
 assertSoftly {
   (2+2) shouldBe 5
-  shouldPass {
+  shouldNotThrowAny {
     verify(exactly = 1) { myClass.myMethod(any()) }
   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/CovariantThrowableHandlingTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/CovariantThrowableHandlingTest.kt
@@ -5,9 +5,7 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldNotThrowUnit
-import io.kotest.assertions.throwables.shouldPass
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.assertions.throwables.shouldThrowUnit
 import io.kotest.assertions.throwables.shouldThrowUnitWithMessage
 import io.kotest.assertions.throwables.shouldThrowWithMessage
@@ -189,60 +187,6 @@ class CovariantThrowableHandlingTest : FreeSpec() {
             }
                .exceptionOrNull() shouldBe AssertionError("Expected exception java.lang.RuntimeException but a Exception was thrown instead.")
          }
-      }
-
-      "shouldPass" - {
-         "pass when no exception thrown and other assertion passed" {
-            shouldNotThrowAny {
-               assertSoftly {
-                  shouldPass {
-                     mimicPossibleAssertionError(fail = false)
-                  }
-                  (2 + 2) shouldBe 4
-               }
-            }
-         }
-         "fail when no exception thrown and other assertion failed" {
-            shouldThrow<AssertionError> {
-               assertSoftly {
-                  shouldPass {
-                     mimicPossibleAssertionError(fail = false)
-                  }
-                  (2 + 2) shouldBe 5
-               }
-            }.message shouldBe """expected:<5> but was:<4>"""
-         }
-         "fail both assertions" {
-            shouldThrow<AssertionError> {
-               assertSoftly {
-                  shouldPass {
-                     mimicPossibleAssertionError(fail = true)
-                  }
-                  (2 + 2) shouldBe 5
-               }
-            }.message.shouldContainInOrder(
-               """The following 2 assertions failed:""",
-               """Assertion Failed!""",
-               """expected:<5> but was:<4>"""
-            )
-         }
-         "does not trap any other Throwable that is not AssertionError" {
-            val exception = Exception("Non-Assertion Failure!")
-            val thrown = shouldThrow<MultiAssertionError> {
-                  assertSoftly {
-                     (2 + 2) shouldBe 5
-                     shouldPass {
-                        throw exception
-                     }
-                  }
-               }
-            thrown.message.shouldContainInOrder(
-               """The following 2 assertions failed:""",
-               """1) expected:<5> but was:<4>""",
-               """Unexpected Exception was thrown with the following message: "Non-Assertion Failure!""",
-            )
-         }
-
       }
    }
 

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -698,7 +698,6 @@ public final class io/kotest/assertions/throwables/AnyThrowableHandlingKt {
 }
 
 public final class io/kotest/assertions/throwables/CovariantThrowableHandlingKt {
-	public static final fun shouldPass (Lkotlin/jvm/functions/Function0;)V
 	public static final fun tryRunning (Lkotlin/jvm/functions/Function0;)Ljava/lang/Throwable;
 }
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
@@ -252,30 +252,6 @@ inline fun <reified T : Throwable> shouldNotThrow(block: () -> Any?) {
    throw thrown
 }
 
-/**
- * Verifies if a block of code will either throw an [AssertionError] or no exception at all. It can only be invoked inside [assertSoftly] blocks.
- *
- * Use this function to wrap a block of code that might throw an [AssertionError]. Use it to wrap invocations of non-kotest functions
- * such as `verify` from mockk library, so that they can be invoked inside [assertSoftly] blocks, and
- * errors are only thrown at the end of the block, rather than immediately. Therefore, the signature cannot return
- * the throwable type, as in the case of a failure, there would be neither an immediate throws, nor a type to return.
- */
-inline fun shouldPass(block: () -> Any?) {
-   require(errorCollector.getCollectionMode() == ErrorCollectionMode.Soft)
-
-   assertionCounter.inc()
-   val thrownThrowable = tryRunning(block)
-
-   if (thrownThrowable is AssertionError) {
-      errorCollector.collectOrThrow(thrownThrowable)
-   } else {
-      thrownThrowable?.let {
-         val failure = failure("Unexpected ${it::class.simpleName} was thrown with the following message: \"${it.message}\".", it)
-         errorCollector.collectOrThrow(failure)
-      }
-   }
-}
-
 inline fun tryRunning(block: () -> Any?): Throwable? {
    val thrownThrowable = try {
       block()


### PR DESCRIPTION
replace `shouldPass` with `shouldNotThrowAny`, because now it is compatible with `assertSoftly`. we can just delete `shouldPass` because it has never been released
