### PR TITLE
partial-match-for-containInOrder (#4398)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -147,13 +147,25 @@ fun String?.shouldNotContainInOrder(vararg substrings: String): String? {
 fun containInOrder(vararg substrings: String) = neverNullMatcher<String> { value ->
    val matchOutcome = matchSubstrings(value, substrings.toList())
 
+   val substringFoundEarlier = if(matchOutcome is ContainInOrderOutcome.Mismatch) {
+      describePartialMatchesInString(matchOutcome.substring, value).toString()
+   } else ""
+
+   val completeMismatchDescription = joinNonEmpty(
+      "\n",
+      matchOutcome.mistmatchDescription,
+      substringFoundEarlier
+   )
+
    MatcherResult(
       matchOutcome.match,
-      { "${value.print().value} should include substrings ${substrings.print().value} in order${prefixIfNotEmpty(matchOutcome.mistmatchDescription, "\n")}" },
+      { "${value.print().value} should include substrings ${substrings.print().value} in order${prefixIfNotEmpty(completeMismatchDescription, "\n")}" },
       { "${value.print().value} should not include substrings ${substrings.print().value} in order" })
 }
 
 internal fun prefixIfNotEmpty(value: String, prefix: String) = if (value.isEmpty()) "" else "$prefix$value"
+
+internal fun joinNonEmpty(separator: String, vararg values: String) = values.filter { it.isNotEmpty() }.joinToString(separator)
 
 internal fun matchSubstrings(value: String, substrings: List<String>, depth: Int = 0): ContainInOrderOutcome = when {
    substrings.isEmpty() -> ContainInOrderOutcome.Match

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderMatcherTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.matchers.string
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FreeSpec
@@ -58,6 +59,20 @@ class ContainInOrderMatcherTest : FreeSpec() {
                   "The", "quick", "red", "fox", "jumps", "over", "the", "lazy", "dog"
                )
             }.message.shouldContain("""Did not match substring[2]: <"red">""")
+         }
+
+         "should find first mismatch before its expected place" {
+            val message = shouldThrowAny {
+               "The quick brown fox jumps over the lazy dog".shouldContainInOrder(
+                  "The", "brown", "fox", "jumps", "over", "the", "quick brown", "lazy", "dog"
+               )
+            }.message
+            assertSoftly {
+               message.shouldContain("""Did not match substring[6]: <"quick brown">""")
+               message.shouldContain("Match[0]: expected[0..10] matched actual[4..14]")
+               message.shouldContain("""Line[0] ="The quick brown fox jumps over the lazy dog"""")
+               message.shouldContain(  "Match[0]= ----+++++++++++----------------------------")
+            }
          }
       }
    }


### PR DESCRIPTION
when `containInOrder` fails, try finding a partial match in the whole string.

```
        "should find first mismatch before its expected place" {
            val message = shouldThrowAny {
               "The quick brown fox jumps over the lazy dog".shouldContainInOrder(
                  "The", "brown", "fox", "jumps", "over", "the", "quick brown", "lazy", "dog"
               )
            }.message
            assertSoftly {
               message.shouldContain("""Did not match substring[6]: <"quick brown">""")
               message.shouldContain("Match[0]: expected[0..10] matched actual[4..14]")
               message.shouldContain("""Line[0] ="The quick brown fox jumps over the lazy dog"""")
               message.shouldContain(  "Match[0]= ----+++++++++++----------------------------")
            }
         }
      }
```