### PR TITLE
Remove a bunch of tests from running on mac-os

### DIFF
--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -879,32 +879,32 @@ public final class io/kotest/core/annotation/displayname/WrapperKt {
 }
 
 public final class io/kotest/core/annotation/enabledif/LinuxCondition : io/kotest/core/annotation/EnabledCondition {
-	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/LinuxCondition;
+	public fun <init> ()V
 	public fun enabled (Lkotlin/reflect/KClass;)Z
 }
 
 public final class io/kotest/core/annotation/enabledif/MacCondition : io/kotest/core/annotation/EnabledCondition {
-	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/MacCondition;
+	public fun <init> ()V
 	public fun enabled (Lkotlin/reflect/KClass;)Z
 }
 
 public final class io/kotest/core/annotation/enabledif/NotLinuxCondition : io/kotest/core/annotation/EnabledCondition {
-	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/NotLinuxCondition;
+	public fun <init> ()V
 	public fun enabled (Lkotlin/reflect/KClass;)Z
 }
 
 public final class io/kotest/core/annotation/enabledif/NotMacCondition : io/kotest/core/annotation/EnabledCondition {
-	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/NotMacCondition;
+	public fun <init> ()V
 	public fun enabled (Lkotlin/reflect/KClass;)Z
 }
 
 public final class io/kotest/core/annotation/enabledif/NotWindowsCondition : io/kotest/core/annotation/EnabledCondition {
-	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/NotWindowsCondition;
+	public fun <init> ()V
 	public fun enabled (Lkotlin/reflect/KClass;)Z
 }
 
 public final class io/kotest/core/annotation/enabledif/WindowsCondition : io/kotest/core/annotation/EnabledCondition {
-	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/WindowsCondition;
+	public fun <init> ()V
 	public fun enabled (Lkotlin/reflect/KClass;)Z
 }
 

--- a/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
+++ b/kotest-framework/kotest-framework-api/api/kotest-framework-api.api
@@ -878,6 +878,36 @@ public final class io/kotest/core/annotation/displayname/WrapperKt {
 	public static final fun getWrapper (Lio/kotest/core/annotation/DisplayName;)Ljava/lang/String;
 }
 
+public final class io/kotest/core/annotation/enabledif/LinuxCondition : io/kotest/core/annotation/EnabledCondition {
+	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/LinuxCondition;
+	public fun enabled (Lkotlin/reflect/KClass;)Z
+}
+
+public final class io/kotest/core/annotation/enabledif/MacCondition : io/kotest/core/annotation/EnabledCondition {
+	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/MacCondition;
+	public fun enabled (Lkotlin/reflect/KClass;)Z
+}
+
+public final class io/kotest/core/annotation/enabledif/NotLinuxCondition : io/kotest/core/annotation/EnabledCondition {
+	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/NotLinuxCondition;
+	public fun enabled (Lkotlin/reflect/KClass;)Z
+}
+
+public final class io/kotest/core/annotation/enabledif/NotMacCondition : io/kotest/core/annotation/EnabledCondition {
+	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/NotMacCondition;
+	public fun enabled (Lkotlin/reflect/KClass;)Z
+}
+
+public final class io/kotest/core/annotation/enabledif/NotWindowsCondition : io/kotest/core/annotation/EnabledCondition {
+	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/NotWindowsCondition;
+	public fun enabled (Lkotlin/reflect/KClass;)Z
+}
+
+public final class io/kotest/core/annotation/enabledif/WindowsCondition : io/kotest/core/annotation/EnabledCondition {
+	public static final field INSTANCE Lio/kotest/core/annotation/enabledif/WindowsCondition;
+	public fun enabled (Lkotlin/reflect/KClass;)Z
+}
+
 public final class io/kotest/core/annotation/enabledif/WrapperKt {
 	public static final fun getWrapper (Lio/kotest/core/annotation/EnabledIf;)Lkotlin/reflect/KClass;
 }

--- a/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/EnabledIf.kt
+++ b/kotest-framework/kotest-framework-api/src/commonMain/kotlin/io/kotest/core/annotation/EnabledIf.kt
@@ -7,7 +7,8 @@ import kotlin.reflect.KClass
  * Attach to a [io.kotest.core.spec.Spec], and the referenced [EnabledCondition] will be
  * instantiated and the [enabledIf] function invoked.
  *
- * Implementations must contain a no-arg constructor as it will be created via reflection.
+ * Implementations of [EnabledCondition] must contain a no-arg constructor as they will
+ * be created via reflection.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/kotest-framework/kotest-framework-api/src/jvmMain/kotlin/io/kotest/core/annotation/enabledif/os.kt
+++ b/kotest-framework/kotest-framework-api/src/jvmMain/kotlin/io/kotest/core/annotation/enabledif/os.kt
@@ -4,26 +4,26 @@ import io.kotest.core.annotation.EnabledCondition
 import io.kotest.core.spec.Spec
 import kotlin.reflect.KClass
 
-object NotMacCondition : EnabledCondition {
+class NotMacCondition : EnabledCondition {
    override fun enabled(kclass: KClass<out Spec>): Boolean = !System.getProperty("os.name").lowercase().contains("mac")
 }
 
-object MacCondition : EnabledCondition {
+class MacCondition : EnabledCondition {
    override fun enabled(kclass: KClass<out Spec>): Boolean = System.getProperty("os.name").lowercase().contains("mac")
 }
 
-object LinuxCondition : EnabledCondition {
+class LinuxCondition : EnabledCondition {
    override fun enabled(kclass: KClass<out Spec>): Boolean = System.getProperty("os.name").lowercase().contains("linux")
 }
 
-object NotLinuxCondition : EnabledCondition {
+class NotLinuxCondition : EnabledCondition {
    override fun enabled(kclass: KClass<out Spec>): Boolean = !System.getProperty("os.name").lowercase().contains("linux")
 }
 
-object WindowsCondition : EnabledCondition {
+class WindowsCondition : EnabledCondition {
    override fun enabled(kclass: KClass<out Spec>): Boolean = System.getProperty("os.name").lowercase().contains("windows")
 }
 
-object NotWindowsCondition : EnabledCondition {
+class NotWindowsCondition : EnabledCondition {
    override fun enabled(kclass: KClass<out Spec>): Boolean = !System.getProperty("os.name").lowercase().contains("windows")
 }

--- a/kotest-framework/kotest-framework-api/src/jvmMain/kotlin/io/kotest/core/annotation/enabledif/os.kt
+++ b/kotest-framework/kotest-framework-api/src/jvmMain/kotlin/io/kotest/core/annotation/enabledif/os.kt
@@ -1,0 +1,29 @@
+package io.kotest.core.annotation.enabledif
+
+import io.kotest.core.annotation.EnabledCondition
+import io.kotest.core.spec.Spec
+import kotlin.reflect.KClass
+
+object NotMacCondition : EnabledCondition {
+   override fun enabled(kclass: KClass<out Spec>): Boolean = !System.getProperty("os.name").lowercase().contains("mac")
+}
+
+object MacCondition : EnabledCondition {
+   override fun enabled(kclass: KClass<out Spec>): Boolean = System.getProperty("os.name").lowercase().contains("mac")
+}
+
+object LinuxCondition : EnabledCondition {
+   override fun enabled(kclass: KClass<out Spec>): Boolean = System.getProperty("os.name").lowercase().contains("linux")
+}
+
+object NotLinuxCondition : EnabledCondition {
+   override fun enabled(kclass: KClass<out Spec>): Boolean = !System.getProperty("os.name").lowercase().contains("linux")
+}
+
+object WindowsCondition : EnabledCondition {
+   override fun enabled(kclass: KClass<out Spec>): Boolean = System.getProperty("os.name").lowercase().contains("windows")
+}
+
+object NotWindowsCondition : EnabledCondition {
+   override fun enabled(kclass: KClass<out Spec>): Boolean = !System.getProperty("os.name").lowercase().contains("windows")
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvalidTestNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvalidTestNameTest.kt
@@ -1,9 +1,12 @@
 package com.sksamuel.kotest.engine
 
 import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class InvalidTestNameTest : FunSpec({
 
    test("empty test name should error") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvocationThreadErrorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvocationThreadErrorTest.kt
@@ -1,11 +1,14 @@
 package com.sksamuel.kotest.engine
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class InvocationThreadErrorTest : FunSpec({
 
    test("invocation errors should be propagated") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/IsolatedAnnotationTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/IsolatedAnnotationTest.kt
@@ -1,15 +1,16 @@
 package com.sksamuel.kotest.engine
 
-import io.kotest.common.KotestInternal
-import io.kotest.core.descriptors.DescriptorId
+import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
+import io.kotest.core.annotation.enabledif.LinuxCondition
+import io.kotest.core.descriptors.DescriptorId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.shouldBe
 
-@KotestInternal
+@EnabledIf(LinuxCondition::class)
 class IsolatedAnnotationTest : FunSpec() {
    init {
       test("classes annotated with @Isolate should run") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/NoClassDefFoundTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/NoClassDefFoundTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -8,6 +10,7 @@ import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 // tests that a java.lang.NoClassDefFoundError is caught
+@EnabledIf(LinuxCondition::class)
 class NoClassDefFoundTest : FunSpec() {
    init {
       test("java.lang.NoClassDefFoundError should be caught") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
@@ -13,6 +15,7 @@ private var includeTest = false
 /**
  * Tests that private classes can be ignored when the option is set
  */
+@EnabledIf(LinuxCondition::class)
 class PrivateClassesIngoreOptionTest : FunSpec() {
    init {
       test("private class should be ignore") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/SpecInstantiationErrorCapturedTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/SpecInstantiationErrorCapturedTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -7,6 +9,7 @@ import io.kotest.engine.spec.SpecInstantiationException
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.types.shouldBeInstanceOf
 
+@EnabledIf(LinuxCondition::class)
 class SpecInstantiationErrorCapturedTest : FunSpec() {
    init {
       test("spec instantiation errors should be captured and reported") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/teamcity/LocationsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/teamcity/LocationsTest.kt
@@ -1,10 +1,13 @@
 package com.sksamuel.kotest.engine.teamcity
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.source.SourceRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.teamcity.Locations
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class LocationsTest : FunSpec({
 
    test("ClassSource hint") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/FailFastTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/FailFastTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
@@ -8,6 +10,7 @@ import io.kotest.matchers.maps.shouldNotContainKey
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class FailFastTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/DescribeSpecBlockingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/DescribeSpecBlockingTest.kt
@@ -1,9 +1,12 @@
 package com.sksamuel.kotest.engine.test.blocking
 
 import io.kotest.assertions.withClue
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class DescribeSpecBlockingTest : DescribeSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/ExpectSpecBlockingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/ExpectSpecBlockingTest.kt
@@ -1,8 +1,11 @@
 package com.sksamuel.kotest.engine.test.blocking
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class ExpectSpecBlockingTest : ExpectSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/FeatureSpecBlockingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/FeatureSpecBlockingTest.kt
@@ -1,8 +1,11 @@
 package com.sksamuel.kotest.engine.test.blocking
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class FeatureSpecBlockingTest : FeatureSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/FreeSpecBlockingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/FreeSpecBlockingTest.kt
@@ -1,8 +1,11 @@
 package com.sksamuel.kotest.engine.test.blocking
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class FreeSpecBlockingTest : FreeSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/FunSpecBlockingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/FunSpecBlockingTest.kt
@@ -1,8 +1,11 @@
 package com.sksamuel.kotest.engine.test.blocking
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class FunSpecBlockingTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/ShouldSpecBlockingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/blocking/ShouldSpecBlockingTest.kt
@@ -1,9 +1,12 @@
 package com.sksamuel.kotest.engine.test.blocking
 
 import io.kotest.assertions.withClue
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class ShouldSpecBlockingTest : ShouldSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.assertions.asClue
 import io.kotest.common.testTimeSource
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -12,6 +14,7 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 
+@EnabledIf(LinuxCondition::class)
 class ContainerTimeoutTest : FunSpec() {
    init {
       coroutineTestScope = true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/CoroutinesTimeoutTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
@@ -7,6 +9,7 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 
+@EnabledIf(LinuxCondition::class)
 class CoroutinesTimeoutTest : FunSpec() {
 
    init {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.assertions.asClue
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -10,6 +12,7 @@ import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
 
+@EnabledIf(LinuxCondition::class)
 class EngineTimeoutTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/FunctionOverrideInvocationTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/FunctionOverrideInvocationTimeoutTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
 import kotlinx.coroutines.delay
@@ -11,6 +13,7 @@ private val factory = funSpec {
    }
 }
 
+@EnabledIf(LinuxCondition::class)
 class FunctionOverrideInvocationTimeoutTest : FunSpec() {
 
    override fun invocationTimeout(): Long {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.assertions.asClue
 import io.kotest.common.testTimeSource
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
@@ -14,6 +16,7 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.measureTime
 
+@EnabledIf(LinuxCondition::class)
 class GlobalTimeoutTest : FunSpec() {
    init {
       coroutineTestScope = true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/MultipleTestTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/MultipleTestTimeoutTest.kt
@@ -1,8 +1,11 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FreeSpec
 
 @Suppress("BlockingMethodInNonBlockingContext")
+@EnabledIf(LinuxCondition::class)
 class MultipleTestTimeoutTest : FreeSpec() {
 
    /*

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ShouldSpecTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ShouldSpecTimeoutTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
-import io.kotest.common.ExperimentalKotest
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.core.test.TestResult
 import io.kotest.engine.test.toTestResult
@@ -9,7 +10,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
-@ExperimentalKotest
+@EnabledIf(LinuxCondition::class)
 class ShouldSpecTimeoutTest : ShouldSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInlineInvocationTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInlineInvocationTimeoutTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
 import kotlinx.coroutines.delay
@@ -14,6 +16,7 @@ private val factory = funSpec {
 /**
  * Tests `invocationTimeout` at the spec level using inline assignment.
  */
+@EnabledIf(LinuxCondition::class)
 class SpecInlineInvocationTimeoutTest : FunSpec() {
    init {
       extension(expectFailureExtension)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInvocationTimeoutMessageExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInvocationTimeoutMessageExceptionTest.kt
@@ -1,14 +1,15 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.ExperimentalTime
 
 // tests that the values in the timeout exception are populated correctly
-@ExperimentalTime
+@EnabledIf(LinuxCondition::class)
 class SpecInvocationTimeoutMessageExceptionTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInvocationTimeoutShouldNotApplyToContainersTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecInvocationTimeoutShouldNotApplyToContainersTest.kt
@@ -1,10 +1,13 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FreeSpec
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
+@EnabledIf(LinuxCondition::class)
 class SpecInvocationTimeoutShouldNotApplyToContainersTest : FreeSpec({
 
    timeout = 4.minutes.inWholeMilliseconds

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutExceptionMessageTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutExceptionMessageTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
@@ -7,6 +9,7 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
 // tests that the values in the timeout exception are populated correctly
+@EnabledIf(LinuxCondition::class)
 class SpecTimeoutExceptionMessageTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutFunctionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutFunctionTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
 import kotlinx.coroutines.delay
@@ -15,6 +17,7 @@ private val factory = funSpec {
 /**
  * Tests timeouts at the spec level (by function override) should be applied.
  */
+@EnabledIf(LinuxCondition::class)
 class SpecTimeoutFunctionTest : FunSpec() {
 
    override fun timeout(): Long = 10.milliseconds.inWholeMilliseconds

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutInlineTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/SpecTimeoutInlineTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.funSpec
 import kotlinx.coroutines.delay
@@ -15,6 +17,7 @@ private val factory = funSpec {
 /**
  * Tests timeouts at the spec level using inline assignment should be applied.
  */
+@EnabledIf(LinuxCondition::class)
 class SpecTimeoutInlineTest : FunSpec() {
    init {
       extension(expectFailureExtension)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceptionMessageTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceptionMessageTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
@@ -9,6 +11,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
 // tests that the values in the timeout exception are populated correctly
+@EnabledIf(LinuxCondition::class)
 class TestInvocationTimeoutExceptionMessageTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecFunctionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecFunctionTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.hours
@@ -8,6 +10,7 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Tests invocation timeouts at the spec level using inline assignment.
  */
+@EnabledIf(LinuxCondition::class)
 class TestInvocationTimeoutOverridesSpecFunctionTest : FunSpec() {
 
    override fun invocationTimeout(): Long {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecInlineTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutOverridesSpecInlineTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.hours
@@ -8,6 +10,7 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Tests that a test case `invocationTimeout` overrides spec level `invocationTimeout`.
  */
+@EnabledIf(LinuxCondition::class)
 class TestInvocationTimeoutOverridesSpecInlineTest : FunSpec() {
    init {
       extension(expectFailureExtension)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutAfterTestListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutAfterTestListenerTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.core.Platform
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.descriptors.append
 import io.kotest.core.descriptors.toDescriptor
@@ -18,15 +20,14 @@ import io.kotest.engine.test.NoopTestCaseExecutionListener
 import io.kotest.engine.test.TestCaseExecutor
 import io.kotest.engine.test.scopes.NoopTestScope
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.milliseconds
 
-@DelicateCoroutinesApi
 @Suppress("BlockingMethodInNonBlockingContext")
+@EnabledIf(LinuxCondition::class)
 class TestTimeoutAfterTestListenerTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutExceptionTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
@@ -7,6 +9,7 @@ import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
 // tests that the values in the timeout exception are populated correctly
+@EnabledIf(LinuxCondition::class)
 class TestTimeoutExceptionTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutOverridesSpecFunctionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutOverridesSpecFunctionTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
@@ -7,6 +9,7 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Tests that the timeout in a test case should take precedence over the timeout at a spec level.
  */
+@EnabledIf(LinuxCondition::class)
 class TestTimeoutOverridesSpecFunctionTest : FunSpec() {
 
    override fun timeout(): Long = 1.milliseconds.inWholeMilliseconds

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutOverridesSpecInlineTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutOverridesSpecInlineTest.kt
@@ -1,9 +1,12 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
+@EnabledIf(LinuxCondition::class)
 class TestTimeoutOverridesSpecInlineTest : FunSpec() {
    init {
       timeout = 1

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutTest.kt
@@ -1,6 +1,8 @@
 package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.core.Platform
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.config.ProjectConfiguration
 import io.kotest.core.descriptors.append
 import io.kotest.core.descriptors.toDescriptor
@@ -15,13 +17,12 @@ import io.kotest.engine.interceptors.EngineContext
 import io.kotest.engine.test.NoopTestCaseExecutionListener
 import io.kotest.engine.test.TestCaseExecutor
 import io.kotest.engine.test.scopes.NoopTestScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 
-@DelicateCoroutinesApi
+@EnabledIf(LinuxCondition::class)
 @Suppress("BlockingMethodInNonBlockingContext")
 class TestTimeoutTest : FunSpec() {
    init {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/WithTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/WithTimeoutTest.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -8,9 +10,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
 
-@ExperimentalTime
+@EnabledIf(LinuxCondition::class)
 class WithTimeoutTest : FunSpec() {
    init {
       test("a users withTimeout should not be caught by InvocationTimeoutInterceptor") {
@@ -25,7 +26,6 @@ class WithTimeoutTest : FunSpec() {
    }
 }
 
-@ExperimentalTime
 private class WithTimeoutSpec : FunSpec() {
    init {
       test("a") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/EnumValueInDataClassNamingTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/EnumValueInDataClassNamingTest.kt
@@ -1,11 +1,14 @@
 package io.kotest.datatest
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class EnumValueInDataClassNamingTest : FunSpec() {
 
    private val names = mutableListOf<String>()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/StableTestNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/StableTestNameTest.kt
@@ -1,10 +1,13 @@
 package io.kotest.datatest
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.mpp.isStable
 import java.util.UUID
 
+@EnabledIf(LinuxCondition::class)
 class StableTestNameTest : FunSpec() {
    init {
       test("UUIDs should be stable on JVM") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/UnstableTestNameWithLeafIsolationTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/UnstableTestNameWithLeafIsolationTest.kt
@@ -1,7 +1,9 @@
 package io.kotest.datatest
 
 import io.kotest.common.ExperimentalKotest
+import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
@@ -15,6 +17,7 @@ import io.kotest.matchers.shouldNotBe
 
 @ExperimentalKotest
 @Isolate // sets global values via configuration so must be isolated
+@EnabledIf(LinuxCondition::class)
 class UnstableTestNameWithLeafIsolationTest : FunSpec() {
    init {
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/concurrency/ConcurrencyKtTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/concurrency/ConcurrencyKtTest.kt
@@ -1,6 +1,8 @@
 package io.kotest.engine.concurrency
 
+import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
@@ -18,6 +20,7 @@ private abstract class Baz
 
 private class Qux : Baz()
 
+@EnabledIf(LinuxCondition::class)
 class ConcurrencyKtTest : FreeSpec({
 
    "isIsolate should return true for class that directly marked by Isolate" {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/concurrency/TimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/concurrency/TimeoutTest.kt
@@ -1,12 +1,15 @@
 package io.kotest.engine.concurrency
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 
+@EnabledIf(LinuxCondition::class)
 class TimeoutTest : FunSpec({
    test("detection with blocking job") {
       shouldThrow<TimeoutCancellationException> {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/BeforeSpecRunsExactlyOnce.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/BeforeSpecRunsExactlyOnce.kt
@@ -1,11 +1,14 @@
 package io.kotest.engine.spec.interceptor
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.delay
 import java.util.concurrent.atomic.AtomicBoolean
 
+@EnabledIf(LinuxCondition::class)
 class BeforeSpecRunsExactlyOnce : FunSpec() {
    companion object {
       private val beforeSpecRan = AtomicBoolean()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/EscapeStringFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/EscapeStringFilterTest.kt
@@ -1,30 +1,33 @@
 package io.kotest.engine.spec.interceptor
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 
+@EnabledIf(LinuxCondition::class)
 class EscapeStringFilterTest : DescribeSpec({ // 🟢
 
 
-    describe("include escape string \\n"){ // ⚪
-        context("something..."){ // ⚪
-            it("something..."){ // ⚪
-                true shouldBe true
-            }
-        }
-    }
+   describe("include escape string \\n") { // ⚪
+      context("something...") { // ⚪
+         it("something...") { // ⚪
+            true shouldBe true
+         }
+      }
+   }
 
-    describe("something..."){ // 🟢
-        context("include escape string \\n"){ // ⚪
-            it("something true"){ // ⚪
-                true shouldBe true
-            }
-        }
+   describe("something...") { // 🟢
+      context("include escape string \\n") { // ⚪
+         it("something true") { // ⚪
+            true shouldBe true
+         }
+      }
 
-        context("something ..."){  // 🟢
-            it("include escape string \\n"){  // 🟢
-                true shouldBe true
-            }
-        }
-    }
+      context("something ...") {  // 🟢
+         it("include escape string \\n") {  // 🟢
+            true shouldBe true
+         }
+      }
+   }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/IgnoredSpecInterceptorTests.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/IgnoredSpecInterceptorTests.kt
@@ -2,8 +2,9 @@ package io.kotest.engine.spec.interceptor
 
 import io.kotest.assertions.all
 import io.kotest.assertions.fail
-import io.kotest.common.ExperimentalKotest
+import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Ignored
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.config.EmptyExtensionRegistry
 import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.SpecRef
@@ -14,8 +15,8 @@ import io.kotest.engine.spec.interceptor.ref.IgnoredSpecInterceptor
 import io.kotest.matchers.shouldBe
 import kotlin.reflect.KClass
 
-@OptIn(ExperimentalKotest::class)
 @Isolate
+@EnabledIf(LinuxCondition::class)
 class IgnoredSpecInterceptorTests : FunSpec({
    context("IgnoredSpecInterceptor should report appropriate reasons when a class is ignored by @Ignored") {
       withData(nameFn = { "Interceptor reports: $it" },

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/DummyBehaviorSpecTest.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/DummyBehaviorSpecTest.kt
@@ -1,11 +1,14 @@
 package com.sksamuel.kotest
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 
 // this is used to generate some data for the xml report
 @Order(0)
+@EnabledIf(LinuxCondition::class)
 class DummyBehaviorSpecTest : BehaviorSpec() {
    init {
       given("a given") {

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/DummyFreeSpecTest.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/DummyFreeSpecTest.kt
@@ -1,11 +1,14 @@
 package com.sksamuel.kotest
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 
 // this is used to generate some data for the xml report
 @Order(0)
+@EnabledIf(LinuxCondition::class)
 class DummyFreeSpecTest : FreeSpec() {
    init {
       "1" - {

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/DummyFunSpecTest.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/DummyFunSpecTest.kt
@@ -1,11 +1,14 @@
 package com.sksamuel.kotest
 
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 // this is used to generate some data for the xml report
 @Order(0)
+@EnabledIf(LinuxCondition::class)
 class DummyFunSpecTest : FunSpec() {
    init {
       context("context") {

--- a/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/JunitXmlReporterTest.kt
+++ b/kotest-tests/kotest-tests-junitxml/src/jvmTest/kotlin/com/sksamuel/kotest/JunitXmlReporterTest.kt
@@ -2,6 +2,8 @@ package com.sksamuel.kotest
 
 import com.sksamuel.kotest.ProjectConfig.Companion.taskTestResultsDir
 import io.kotest.assertions.assertSoftly
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.Order
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.shouldForAll
@@ -13,6 +15,7 @@ import org.jdom2.input.SAXBuilder
 // this must have a higher order number than the dummy tests
 // so that when we get to this test, we already have written some data
 @Order(1)
+@EnabledIf(LinuxCondition::class)
 class JunitXmlReporterTest : WordSpec() {
 
    companion object {


### PR DESCRIPTION
Will keep adding to this.
JVM tests don't need to run on all platforms, we can assume the JDK is solid across platforms :)
So removing from macos (where we are limited to 2 runners) will hopefully stop the build slowness.