### PR TITLE
Adjust spec ref interceptor to reduce the size of stack traces

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -483,11 +483,6 @@ public final class io/kotest/engine/project/ProjectExtensions {
 	public final fun beforeProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor : io/kotest/engine/spec/interceptor/SpecRefInterceptor {
-	public fun <init> (Lio/kotest/engine/interceptors/EngineContext;)V
-	public fun intercept-0E7RQCE (Lio/kotest/core/spec/SpecRef;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class io/kotest/engine/spec/InstantiateSpecKt {
 	public static final fun createAndInitializeSpec (Lkotlin/reflect/KClass;Lio/kotest/core/config/ExtensionRegistry;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExecutor.kt
@@ -12,6 +12,7 @@ import io.kotest.engine.concurrency.NoopCoroutineDispatcherFactory
 import io.kotest.engine.interceptors.EngineContext
 import io.kotest.engine.spec.interceptor.SpecRefInterceptorPipeline
 import io.kotest.core.Logger
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.mpp.bestName
 import kotlin.reflect.KClass
 
@@ -36,8 +37,10 @@ internal class SpecExecutor(
 
    suspend fun execute(ref: SpecRef) {
       logger.log { Pair(ref.kclass.bestName(), "Received $ref") }
-      val innerExecute: suspend (SpecRef) -> Result<Map<TestCase, TestResult>> = {
-         createInstance(ref).flatMap { executeInDelegate(it) }
+      val innerExecute = object : NextSpecRefInterceptor {
+         override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+            return createInstance(ref).flatMap { executeInDelegate(it) }
+         }
       }
       pipeline.execute(ref, innerExecute)
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptor.kt
@@ -19,6 +19,6 @@ internal interface SpecRefInterceptor {
  *
  * This is a functional interface to reduce the size of stack traces - type-erased lambda types add excess stack lines.
  */
-internal fun interface NextSpecRefInterceptor {
+internal interface NextSpecRefInterceptor {
    suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>>
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptor.kt
@@ -10,7 +10,15 @@ import io.kotest.core.test.TestResult
 internal interface SpecRefInterceptor {
    suspend fun intercept(
       ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>,
+      next: NextSpecRefInterceptor,
    ): Result<Map<TestCase, TestResult>>
 }
 
+/**
+ * Callback for invoking the next SpecRefInterceptor.
+ *
+ * This is a functional interface to reduce the size of stack traces - type-erased lambda types add excess stack lines.
+ */
+internal fun interface NextSpecRefInterceptor {
+   suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>>
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/ApplyExtensionsInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/ApplyExtensionsInterceptor.kt
@@ -10,6 +10,7 @@ import io.kotest.core.test.TestResult
 import io.kotest.engine.extensions.SpecWrapperExtension
 import io.kotest.engine.flatMap
 import io.kotest.engine.newInstanceNoArgConstructorOrObjectInstance
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import io.kotest.mpp.annotation
 
@@ -23,10 +24,7 @@ import io.kotest.mpp.annotation
  */
 internal class ApplyExtensionsInterceptor(private val registry: ExtensionRegistry) : SpecRefInterceptor {
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       return runCatching {
          ref.kclass.annotation<ApplyExtension>()?.wrapper?.map { extensionClass ->
             val extension = extensionClass.newInstanceNoArgConstructorOrObjectInstance()
@@ -34,7 +32,7 @@ internal class ApplyExtensionsInterceptor(private val registry: ExtensionRegistr
          } ?: emptyList()
       }.flatMap { exts ->
          exts.forEach { registry.add(it) }
-         fn(ref).apply {
+         next.invoke(ref).apply {
             exts.forEach { registry.remove(it) }
          }
       }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/BeforeSpecStateInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/BeforeSpecStateInterceptor.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.interceptors.EngineContext
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import io.kotest.engine.test.interceptors.BeforeSpecListenerInterceptor
 import io.kotest.mpp.bestName
@@ -16,13 +17,10 @@ import kotlin.reflect.KClass
  * when the first test in a spec is executed.
  */
 internal class BeforeSpecStateInterceptor(private val context: EngineContext) : SpecRefInterceptor {
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       val state = BeforeSpecState(mutableListOf(), mutableSetOf(), mutableSetOf())
       context.state[ref.kclass.beforeSpecStateKey()] = state
-      return fn(ref)
+      return next.invoke(ref)
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/FinalizeSpecInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/FinalizeSpecInterceptor.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.spec.SpecExtensions
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 
 /**
@@ -17,11 +18,8 @@ internal class FinalizeSpecInterceptor(
 
    private val extensions = SpecExtensions(registry)
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
-      return fn(ref)
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
+      return next.invoke(ref)
          .onSuccess { extensions.finalizeSpec(ref.kclass, it, null) }
          .onFailure { extensions.finalizeSpec(ref.kclass, emptyMap(), it) }
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/IgnoredSpecInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/IgnoredSpecInterceptor.kt
@@ -10,6 +10,7 @@ import io.kotest.engine.listener.TestEngineListener
 import io.kotest.engine.spec.SpecExtensions
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import io.kotest.core.Logger
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.mpp.annotation
 import io.kotest.mpp.bestName
 import io.kotest.mpp.hasAnnotation
@@ -28,10 +29,7 @@ internal class IgnoredSpecInterceptor(
    private val logger = Logger(IgnoredSpecInterceptor::class)
    private val extensions = SpecExtensions(registry)
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
 
       val isIgnored = ref.kclass.hasAnnotation<Ignored>()
       logger.log { Pair(ref.kclass.bestName(), "@Ignored == $isIgnored") }
@@ -48,7 +46,7 @@ internal class IgnoredSpecInterceptor(
             .flatMap { extensions.ignored(ref.kclass, reason) }
             .map { emptyMap() }
       } else {
-         fn(ref)
+         next.invoke(ref)
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/PrepareSpecInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/PrepareSpecInterceptor.kt
@@ -7,6 +7,7 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.spec.SpecExtensions
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 
 /**
@@ -16,12 +17,9 @@ internal class PrepareSpecInterceptor(registry: ExtensionRegistry) : SpecRefInte
 
    private val extensions = SpecExtensions(registry)
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>,
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       return extensions
          .prepareSpec(ref.kclass)
-         .flatMap { fn(ref) }
+         .flatMap { next.invoke(ref) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/SpecFinishedInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/SpecFinishedInterceptor.kt
@@ -4,6 +4,7 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.TestEngineListener
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import kotlin.time.measureTimedValue
 
@@ -13,12 +14,9 @@ import kotlin.time.measureTimedValue
  */
 internal class SpecFinishedInterceptor(private val listener: TestEngineListener) : SpecRefInterceptor {
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       val (value, duration) = measureTimedValue {
-         fn(ref)
+         next.invoke(ref)
       }
       return value
          .onSuccess { listener.specFinished(ref.kclass, TestResult.Success(duration)) }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/SpecStartedInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/SpecStartedInterceptor.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.TestEngineListener
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 
 /**
@@ -12,12 +13,9 @@ import io.kotest.engine.spec.interceptor.SpecRefInterceptor
  */
 internal class SpecStartedInterceptor(private val listener: TestEngineListener) : SpecRefInterceptor {
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       return runCatching { listener.specStarted(ref.kclass) }
-         .flatMap { fn(ref) }
+         .flatMap { next.invoke(ref) }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/SystemPropertySpecFilterInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/SystemPropertySpecFilterInterceptor.kt
@@ -12,6 +12,7 @@ import io.kotest.engine.listener.TestEngineListener
 import io.kotest.engine.spec.SpecExtensions
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import io.kotest.core.Logger
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.mpp.bestName
 import io.kotest.mpp.syspropOrEnv
 import kotlin.reflect.KClass
@@ -30,10 +31,7 @@ internal class SystemPropertySpecFilterInterceptor(
    private val logger = Logger(SystemPropertySpecFilterInterceptor::class)
    private val extensions = SpecExtensions(registry)
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       val filter = syspropOrEnv(KotestEngineProperties.filterSpecs) ?: ""
       logger.log { Pair(ref.kclass.bestName(), "Filter specs syspropOrEnv=$filter") }
 
@@ -45,7 +43,7 @@ internal class SystemPropertySpecFilterInterceptor(
       logger.log { Pair(ref.kclass.bestName(), "included = $included") }
 
       return if (included) {
-         fn(ref)
+         next.invoke(ref)
       } else {
          runCatching {
             listener.specIgnored(

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
@@ -5,21 +5,19 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.interceptors.EngineContext
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import kotlin.reflect.KVisibility
 
 /**
  * A [SpecRefInterceptor] which will ignore private specs when the configuration values are set.
  */
-class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : SpecRefInterceptor {
+internal class ClassVisibilitySpecRefInterceptor(private val context: EngineContext) : SpecRefInterceptor {
 
-   override suspend fun intercept(
-      ref: SpecRef,
-      fn: suspend (SpecRef) -> Result<Map<TestCase, TestResult>>
-   ): Result<Map<TestCase, TestResult>> {
+   override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       return when {
          ref.kclass.visibility == KVisibility.PRIVATE && ignorePrivate() -> Result.success(emptyMap())
-         else -> fn(ref)
+         else -> next.invoke(ref)
       }
    }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/SpecFilterInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/SpecFilterInterceptorTest.kt
@@ -5,7 +5,10 @@ import io.kotest.core.filter.SpecFilter
 import io.kotest.core.filter.SpecFilterResult
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.ref.SpecFilterInterceptor
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -21,16 +24,26 @@ class SpecFilterInterceptorTest : FunSpec() {
             }
          })
          var fired = false
-         SpecFilterInterceptor(NoopTestEngineListener, c.registry).intercept(SpecRef.Reference(FooSpec::class)) {
-            fired = true
-            Result.success(emptyMap())
-         }
+         SpecFilterInterceptor(NoopTestEngineListener, c.registry)
+            .intercept(
+               SpecRef.Reference(FooSpec::class),
+               object : NextSpecRefInterceptor {
+                  override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                     fired = true
+                     return Result.success(emptyMap())
+                  }
+               })
          fired.shouldBeFalse()
 
-         SpecFilterInterceptor(NoopTestEngineListener, c.registry).intercept(SpecRef.Reference(BarSpec::class)) {
-            fired = true
-            Result.success(emptyMap())
-         }
+         SpecFilterInterceptor(NoopTestEngineListener, c.registry)
+            .intercept(
+               SpecRef.Reference(BarSpec::class),
+               object : NextSpecRefInterceptor {
+                  override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                     fired = true
+                     return Result.success(emptyMap())
+                  }
+               })
          fired.shouldBeTrue()
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/ApplyExtensionsInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/ApplyExtensionsInterceptorTest.kt
@@ -5,7 +5,10 @@ import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.engine.extensions.SpecWrapperExtension
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.ref.ApplyExtensionsInterceptor
 import io.kotest.matchers.types.shouldBeInstanceOf
 
@@ -15,21 +18,25 @@ class ApplyExtensionsInterceptorTest : FunSpec() {
       test("ApplyExtensionsInterceptor should apply extensions") {
          val registry = DefaultExtensionRegistry()
          ApplyExtensionsInterceptor(registry)
-            .intercept(SpecRef.Reference(MyAnnotatedSpec::class)) {
-               val wrapper = registry.all().single() as SpecWrapperExtension
-               wrapper.delegate.shouldBeInstanceOf<Foo>()
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(MyAnnotatedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  val wrapper = registry.all().single() as SpecWrapperExtension
+                  wrapper.delegate.shouldBeInstanceOf<Foo>()
+                  return Result.success(emptyMap())
+               }
+            })
       }
 
       test("ApplyExtensionsInterceptor should apply extensions where the primary constructor is not no-args") {
          val registry = DefaultExtensionRegistry()
          ApplyExtensionsInterceptor(registry)
-            .intercept(SpecRef.Reference(MyAnnotatedSpec2::class)) {
-               val wrapper = registry.all().single() as SpecWrapperExtension
-               wrapper.delegate.shouldBeInstanceOf<Bar>()
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(MyAnnotatedSpec2::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  val wrapper = registry.all().single() as SpecWrapperExtension
+                  wrapper.delegate.shouldBeInstanceOf<Bar>()
+                  return Result.success(emptyMap())
+               }
+            })
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/IgnoredSpecInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/IgnoredSpecInterceptorTest.kt
@@ -7,7 +7,10 @@ import io.kotest.core.config.FixedExtensionRegistry
 import io.kotest.core.listeners.IgnoredSpecListener
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.ref.IgnoredSpecInterceptor
 import io.kotest.matchers.booleans.shouldBeTrue
 import kotlin.reflect.KClass
@@ -18,16 +21,22 @@ class IgnoredSpecInterceptorTest : FunSpec({
    test("IgnoredSpecInterceptor should pass any class not annotated with @Ignored") {
       var fired = false
       IgnoredSpecInterceptor(NoopTestEngineListener, EmptyExtensionRegistry)
-         .intercept(SpecRef.Reference(NotIgnoredSpec::class)) {
-            fired = true
-            Result.success(emptyMap())
-         }
+         .intercept(SpecRef.Reference(NotIgnoredSpec::class), object : NextSpecRefInterceptor {
+            override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+               fired = true
+               return Result.success(emptyMap())
+            }
+         })
       fired.shouldBeTrue()
    }
 
    test("IgnoredSpecInterceptor should skip any spec annotated with @Ignored") {
       IgnoredSpecInterceptor(NoopTestEngineListener, EmptyExtensionRegistry)
-         .intercept(SpecRef.Reference(MyIgnoredSpec::class)) { error("boom") }
+         .intercept(SpecRef.Reference(MyIgnoredSpec::class), object : NextSpecRefInterceptor {
+            override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+               error("boom")
+            }
+         })
    }
 
    test("IgnoredSpecInterceptor should fire listeners on skip") {
@@ -38,7 +47,11 @@ class IgnoredSpecInterceptorTest : FunSpec({
          }
       }
       IgnoredSpecInterceptor(NoopTestEngineListener, FixedExtensionRegistry(ext))
-         .intercept(SpecRef.Reference(MyIgnoredSpec::class)) { error("boom") }
+         .intercept(SpecRef.Reference(MyIgnoredSpec::class), object : NextSpecRefInterceptor {
+            override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+               error("boom")
+            }
+         })
       fired.shouldBeTrue()
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/SpecStartedFinishedInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/SpecStartedFinishedInterceptorTest.kt
@@ -2,8 +2,10 @@ package com.sksamuel.kotest.engine.spec.interceptor
 
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.engine.listener.AbstractTestEngineListener
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.ref.SpecFinishedInterceptor
 import io.kotest.engine.spec.interceptor.ref.SpecStartedInterceptor
 import io.kotest.matchers.shouldBe
@@ -20,10 +22,12 @@ class SpecStartedFinishedInterceptorTest : FunSpec() {
             }
          }
          SpecStartedInterceptor(listener)
-            .intercept(SpecRef.Reference(FooSpec::class)) {
-               result += "b"
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(FooSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  result += "b"
+                  return Result.success(emptyMap())
+               }
+            })
          result shouldBe "ab"
       }
 
@@ -35,10 +39,12 @@ class SpecStartedFinishedInterceptorTest : FunSpec() {
             }
          }
          SpecFinishedInterceptor(listener)
-            .intercept(SpecRef.Reference(FooSpec::class)) {
-               r += "b"
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(FooSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  r += "b"
+                  return Result.success(emptyMap())
+               }
+            })
          r shouldBe "ba"
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/TagsExcludedDiscoveryExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/TagsExcludedDiscoveryExtensionTest.kt
@@ -8,8 +8,11 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.engine.extensions.SpecifiedTagsTagExtension
 import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.ref.TagsInterceptor
 import io.kotest.matchers.booleans.shouldBeTrue
 
@@ -25,24 +28,32 @@ class TagsExcludedDiscoveryExtensionTest : FunSpec() {
 
          // will be excluded explicitly
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(ExcludedSpec::class)) { error("foo") }
+            .intercept(SpecRef.Reference(ExcludedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  error("foo")
+               }
+            })
 
          // will be included as includes are ignored at the class level
          var executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(IncludedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(IncludedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
 
          // will be included as we must check the spec itself later to see if the test themselves have the include or exclude
          executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(UntaggedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(UntaggedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
       }
 
@@ -54,26 +65,32 @@ class TagsExcludedDiscoveryExtensionTest : FunSpec() {
 
          var executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(ExcludedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(ExcludedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
 
          executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(IncludedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(IncludedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
 
          executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(UntaggedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(UntaggedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
       }
 
@@ -84,24 +101,30 @@ class TagsExcludedDiscoveryExtensionTest : FunSpec() {
          conf.registry.add(SpecifiedTagsTagExtension(tags))
 
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(ExcludedSpec::class)) {
-               error("foo")
-            }
+            .intercept(SpecRef.Reference(ExcludedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  error("foo")
+               }
+            })
 
          var executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(IncludedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(IncludedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
 
          executed = false
          TagsInterceptor(NoopTestEngineListener, conf)
-            .intercept(SpecRef.Reference(UntaggedSpec::class)) {
-               executed = true
-               Result.success(emptyMap())
-            }
+            .intercept(SpecRef.Reference(UntaggedSpec::class), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  executed = true
+                  return Result.success(emptyMap())
+               }
+            })
          executed.shouldBeTrue()
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/IgnoredSpecInterceptorTests.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/spec/interceptor/IgnoredSpecInterceptorTests.kt
@@ -8,6 +8,8 @@ import io.kotest.core.config.EmptyExtensionRegistry
 import io.kotest.core.spec.Isolate
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
 import io.kotest.datatest.withData
 import io.kotest.engine.listener.AbstractTestEngineListener
 import io.kotest.engine.spec.interceptor.ref.IgnoredSpecInterceptor
@@ -18,14 +20,19 @@ import kotlin.reflect.KClass
 @Isolate
 class IgnoredSpecInterceptorTests : FunSpec({
    context("IgnoredSpecInterceptor should report appropriate reasons when a class is ignored by @Ignored") {
-      withData(nameFn = { "Interceptor reports: $it" },
+      withData(
+         nameFn = { "Interceptor reports: $it" },
          "Disabled by @Ignored" to DefaultIgnoredSpec::class,
          """Disabled by @Ignored(reason="it's a good reason!")""" to ReasonIgnoredSpec::class,
       ) { (expected, kclass) ->
 
          val listener = TestIgnoredSpecListener()
          IgnoredSpecInterceptor(listener, EmptyExtensionRegistry)
-            .intercept(SpecRef.Reference(kclass)) { error("boom") }
+            .intercept(SpecRef.Reference(kclass), object : NextSpecRefInterceptor {
+               override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
+                  error("boom")
+               }
+            })
 
          all(listener) {
             name shouldBe kclass.simpleName


### PR DESCRIPTION
Trying to split up https://github.com/kotest/kotest/pull/4312 to get it over the line (part 2)