### PR TITLE
containOnlyDigits-detailed (#4402)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -23,9 +23,10 @@ fun String?.shouldNotContainOnlyDigits(): String? {
 }
 
 fun containOnlyDigits() = neverNullMatcher<String> { value ->
+   val firstNonDigit = value.toCharArray().withIndex().firstOrNull { it.value !in '0'..'9'}
    MatcherResult(
-      value.toCharArray().all { it in '0'..'9' },
-      { "${value.print().value} should contain only digits" },
+      firstNonDigit == null,
+      { "${value.print().value} should contain only digits, but contained ${firstNonDigit?.let { it.value.print().value }} at index ${firstNonDigit?.index}" },
       { "${value.print().value} should not contain only digits" })
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -314,6 +314,11 @@ class StringMatchersTest : FreeSpec() {
             "qweqwe".shouldNotContainOnlyDigits()
             "123a".shouldNotContainOnlyDigits()
          }
+         "should print first non-digit" {
+            shouldThrow<AssertionError> {
+               "123a234e".shouldContainOnlyDigits()
+            }.message shouldBe """"123a234e" should contain only digits, but contained 'a' at index 3"""
+         }
       }
 
 


### PR DESCRIPTION
tell what exactly failed the test, in this example "but contained 'a' at index 3":
```
         "should print first non-digit" {
            shouldThrow<AssertionError> {
               "123a234e".shouldContainOnlyDigits()
            }.message shouldBe """"123a234e" should contain only digits, but contained 'a' at index 3"""
         }
```
