### PR TITLE
containOnlyOnce-details

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -57,9 +57,17 @@ infix fun String?.shouldNotContainOnlyOnce(substr: String): String? {
 }
 
 fun containOnlyOnce(substring: String) = neverNullMatcher<String> { value ->
+   val firstIndexOf = value.indexOf(substring)
+   val lastIndexOf = value.lastIndexOf(substring)
+   val passed = firstIndexOf >= 0 && firstIndexOf == lastIndexOf
+   val failureDescription = when {
+      passed -> ""
+      firstIndexOf == -1 -> ", but did not contain it"
+      else -> ", but contained it at least at indexes $firstIndexOf and $lastIndexOf"
+   }
    MatcherResult(
-      value.indexOf(substring) >= 0 && value.indexOf(substring) == value.lastIndexOf(substring),
-      { "${value.print().value} should contain the substring ${substring.print().value} exactly once" },
+      passed,
+      { "${value.print().value} should contain the substring ${substring.print().value} exactly once$failureDescription" },
       { "${value.print().value} should not contain the substring ${substring.print().value} exactly once" })
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -91,7 +91,11 @@ class StringMatchersTest : FreeSpec() {
 
          shouldThrow<AssertionError> {
             "la" should containOnlyOnce("tour")
-         }.message shouldBe """"la" should contain the substring "tour" exactly once"""
+         }.message shouldBe """"la" should contain the substring "tour" exactly once, but did not contain it"""
+
+         shouldThrow<AssertionError> {
+            "Run, Forrest, Run" should containOnlyOnce("Run")
+         }.message shouldBe """"Run, Forrest, Run" should contain the substring "Run" exactly once, but contained it at least at indexes 0 and 14"""
 
          shouldThrow<AssertionError> {
             null shouldNot containOnlyOnce("tour")


### PR DESCRIPTION
should `containOnlyOnce` fail, give some details, such as "but did not contain it" and ", but contained it at least at indexes 0 and 14":

```kotlin
        shouldThrow<AssertionError> {
            "la" should containOnlyOnce("tour")
         }.message shouldBe """"la" should contain the substring "tour" exactly once, but did not contain it"""

         shouldThrow<AssertionError> {
            "Run, Forrest, Run" should containOnlyOnce("Run")
         }.message shouldBe """"Run, Forrest, Run" should contain the substring "Run" exactly once, but contained it at least at indexes 0 and 14"""
```