### PR TITLE
containIgnoringCase-detailed (#4411)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -110,10 +110,11 @@ infix fun String?.shouldNotContainIgnoringCase(substr: String): String? {
 }
 
 fun containIgnoringCase(substr: String) = neverNullMatcher<String> { value ->
+   val indexOf = value.lowercase().indexOf(substr.lowercase())
    MatcherResult(
-      value.lowercase().indexOf(substr.lowercase()) >= 0,
+      indexOf >= 0,
       { "${value.print().value} should contain the substring ${substr.print().value} (case insensitive)" },
-      { "${value.print().value} should not contain the substring ${substr.print().value} (case insensitive)" }
+      { "${value.print().value} should not contain the substring ${substr.print().value} (case insensitive), but contained it at index $indexOf" }
    )
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -281,6 +281,9 @@ class StringMatchersTest : FreeSpec() {
 
             "hello" shouldContainIgnoringCase "HEllO"
             "hello" shouldNotContainIgnoringCase "hella"
+            shouldThrow<AssertionError> {
+               "apples and oranges" shouldNotContainIgnoringCase "ORANGE"
+            }.message shouldBe "\"apples and oranges\" should not contain the substring \"ORANGE\" (case insensitive), but contained it at index 11"
          }
 
          "should fail if value is null" {


### PR DESCRIPTION
when `containIgnoringCase` fails, provide some details:
```
            shouldThrow<AssertionError> {
               "apples and oranges" shouldNotContainIgnoringCase "ORANGE"
            }.message shouldBe "\"apples and oranges\" should not contain the substring \"ORANGE\" (case insensitive), but contained it at index 11"
```
