### PR TITLE
improve-partial-match-descriptions (#4417)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/end.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/end.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.kotest.submatching.describePartialMatchesInString
+import io.kotest.submatching.describePartialMatchesInStringForSuffix
 
 infix fun <A : CharSequence> A?.shouldEndWith(suffix: CharSequence): A {
    this should endWith(suffix)
@@ -21,7 +22,7 @@ infix fun <A : CharSequence> A?.shouldNotEndWith(suffix: CharSequence): A {
 fun endWith(suffix: CharSequence): Matcher<CharSequence?> = neverNullMatcher { value ->
    val passed = value.endsWith(suffix)
    val shortMessage = "${value.print().value} should end with ${suffix.print().value}"
-   val possibleSubmatches = if(passed) "" else describePartialMatchesInString(suffix.toString(), value.toString()).toString()
+   val possibleSubmatches = if(passed) "" else describePartialMatchesInStringForSuffix(suffix.toString(), value.toString()).toString()
    val message = listOf(shortMessage, possibleSubmatches).filter { it.isNotEmpty() }.joinToString("\n")
    MatcherResult(
       passed,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.UUIDVersion.ANY
 import io.kotest.submatching.describePartialMatchesInString
+import io.kotest.submatching.describePartialMatchesInStringForSlice
 import kotlin.contracts.contract
 import kotlin.text.RegexOption.IGNORE_CASE
 
@@ -158,7 +159,7 @@ fun containInOrder(vararg substrings: String) = neverNullMatcher<String> { value
    val matchOutcome = matchSubstrings(value, substrings.toList())
 
    val substringFoundEarlier = if(matchOutcome is ContainInOrderOutcome.Mismatch) {
-      describePartialMatchesInString(matchOutcome.substring, value).toString()
+      describePartialMatchesInStringForSlice(matchOutcome.substring, value).toString()
    } else ""
 
    val completeMismatchDescription = joinNonEmpty(
@@ -231,7 +232,7 @@ fun include(substr: String) = neverNullMatcher<String> { value ->
    val passed = value.contains(substr)
    val differencesDescription = listOf(
       "${value.print().value} should include substring ${substr.print().value}",
-      describePartialMatchesInString(substr, value).toString(),
+      describePartialMatchesInStringForSlice(substr, value).toString(),
    )
    MatcherResult(
       passed,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import io.kotest.submatching.describePartialMatchesInString
+import io.kotest.submatching.describePartialMatchesInStringForPrefix
 import kotlin.math.min
 
 infix fun <A : CharSequence?> A.shouldStartWith(prefix: CharSequence): A {
@@ -30,7 +31,7 @@ fun startWith(prefix: CharSequence): Matcher<CharSequence?> = neverNullMatcher {
             break
          }
       }
-      val partialMismatches = describePartialMatchesInString(prefix.toString(), value.toString()).toString()
+      val partialMismatches = describePartialMatchesInStringForPrefix(prefix.toString(), value.toString()).toString()
       if (partialMismatches.isNotEmpty()) {
          msg = "$msg\n$partialMismatches"
       }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/StringPartialMatches.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/StringPartialMatches.kt
@@ -2,7 +2,16 @@ package io.kotest.submatching
 
 import io.kotest.assertions.AssertionsConfig
 
-internal fun describePartialMatchesInString(expectedSlice: String, value: String): PartialMatchesInCollectionDescription {
+internal fun describePartialMatchesInStringForSlice(expectedSlice: String, value: String) =
+   describePartialMatchesInString(expectedSlice, value, PartialMatchType.Slice)
+
+internal fun describePartialMatchesInStringForSuffix(expectedSlice: String, value: String) =
+   describePartialMatchesInString(expectedSlice, value, PartialMatchType.Suffix)
+
+internal fun describePartialMatchesInStringForPrefix(expectedSlice: String, value: String) =
+   describePartialMatchesInString(expectedSlice, value, PartialMatchType.Prefix)
+
+internal fun describePartialMatchesInString(expectedSlice: String, value: String, type: PartialMatchType): PartialMatchesInCollectionDescription {
    if(!AssertionsConfig.enabledSubmatchesInStrings.value ||
          substringNotEligibleForSubmatching(expectedSlice) ||
          valueNotEligibleForSubmatching(value)
@@ -15,7 +24,7 @@ internal fun describePartialMatchesInString(expectedSlice: String, value: String
       return PartialMatchesInCollectionDescription("", "")
    }
    val partialMatchesList = partialMatches.withIndex().joinToString("\n") { indexedValue ->
-      "Match[${indexedValue.index}]: expected[${indexedValue.value.rangeOfExpected}] matched actual[${indexedValue.value.rangeOfValue}]"
+      "Match[${indexedValue.index}]: ${describeMatchedSlice(expectedSlice, indexedValue.value.rangeOfExpected, type)} matched actual[${indexedValue.value.rangeOfValue}]"
    }
    val allUnderscores = getAllUnderscores(value.length, partialMatches)
    val lineIndexRanges = indexRangesOfLines(value)
@@ -25,6 +34,29 @@ internal fun describePartialMatchesInString(expectedSlice: String, value: String
       }
    }.flatten().joinToString("\n")
    return PartialMatchesInCollectionDescription(partialMatchesList, valueAndUnderscores)
+}
+
+internal fun describeMatchedSlice(expectedSlice: String, range: IntRange, type: PartialMatchType): String {
+   return when {
+      range == expectedSlice.indices -> "whole ${type.description}"
+      else -> "part of ${type.description} with indexes [$range]"
+   }
+}
+
+internal sealed interface PartialMatchType {
+   val description: String
+
+   data object Prefix: PartialMatchType {
+      override val description: String = "prefix"
+   }
+
+   data object Suffix: PartialMatchType {
+      override val description: String = "suffix"
+   }
+
+   data object Slice: PartialMatchType {
+      override val description: String = "slice"
+   }
 }
 
 private fun substringNotEligibleForSubmatching(value: String) =

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderMatcherTest.kt
@@ -69,7 +69,7 @@ class ContainInOrderMatcherTest : FreeSpec() {
             }.message
             assertSoftly {
                message.shouldContain("""Did not match substring[6]: <"quick brown">""")
-               message.shouldContain("Match[0]: expected[0..10] matched actual[4..14]")
+               message.shouldContain("Match[0]: whole slice matched actual[4..14]")
                message.shouldContain("""Line[0] ="The quick brown fox jumps over the lazy dog"""")
                message.shouldContain(  "Match[0]= ----+++++++++++----------------------------")
             }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/EndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/EndWithTest.kt
@@ -43,7 +43,7 @@ class EndWithTest : FreeSpec() {
                "The quick brown fox jumps over the lazy dog" should endWith("fox jumps over the lazy cat")
             }.message
             message.shouldContainInOrder(
-               "Match[0]: expected[0..23] matched actual[16..39]",
+               "Match[0]: part of suffix with indexes [0..23] matched actual[16..39]",
                """Line[0] ="The quick brown fox jumps over the lazy dog"""",
                """Match[0]= ----------------++++++++++++++++++++++++---"""
             )

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/IncludeMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/IncludeMatcherTest.kt
@@ -45,7 +45,7 @@ class IncludeMatcherTest : FreeSpec() {
                line shouldInclude "The coyote jumps over the lazy dog"
             }.message.shouldContainInOrder(
                """"The quick brown fox jumps over the lazy dog" should include substring "The coyote jumps over the lazy dog"""",
-               """Match[0]: expected[10..33] matched actual[19..42]""",
+               """Match[0]: part of slice with indexes [10..33] matched actual[19..42]""",
                """Line[0] ="The quick brown fox jumps over the lazy dog"""",
                """Match[0]= -------------------++++++++++++++++++++++++"""
             )

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StartWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StartWithTest.kt
@@ -61,7 +61,7 @@ class StartWithTest : FreeSpec() {
             assertSoftly {
                message shouldStartWith "\"la tour eiffel\" should start with \"la tour tower london\" (diverged at index 8)"
                message.shouldContainInOrder(
-                  "Match[0]: expected[0..7] matched actual[0..7]",
+                  "Match[0]: part of prefix with indexes [0..7] matched actual[0..7]",
                   """Line[0] ="la tour eiffel"""",
                   """Match[0]= ++++++++------"""
                )
@@ -74,7 +74,7 @@ class StartWithTest : FreeSpec() {
             assertSoftly {
                message shouldStartWith """"The quick brown fox jumps over the lazy dog" should start with "quick brown fox jumps" (diverged at index 0)"""
                message.shouldContainInOrder(
-                  "Match[0]: expected[0..20] matched actual[4..24]",
+                  "Match[0]: whole prefix matched actual[4..24]",
                   """Line[0] ="The quick brown fox jumps over the lazy dog"""",
                   """Match[0]= ----+++++++++++++++++++++------------------"""
                )

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
@@ -6,6 +6,9 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.submatching.PartialMatchesInCollectionDescription
 import io.kotest.submatching.describePartialMatchesInString
+import io.kotest.submatching.describePartialMatchesInStringForPrefix
+import io.kotest.submatching.describePartialMatchesInStringForSlice
+import io.kotest.submatching.describePartialMatchesInStringForSuffix
 import io.kotest.submatching.underscoreSubstring
 
 @EnabledIf(LinuxCondition::class)
@@ -30,30 +33,30 @@ class StringPartialMatchesTest : WordSpec() {
       }
       "describePartialMatchesInString" should {
          "return empty if no matches" {
-            describePartialMatchesInString("hawk", text) shouldBe PartialMatchesInCollectionDescription("", "")
+            describePartialMatchesInStringForSlice("hawk", text) shouldBe PartialMatchesInCollectionDescription("", "")
          }
          "handle empty slice" {
-            val actual = describePartialMatchesInString("", text)
+            val actual = describePartialMatchesInStringForSlice("", text)
             actual.partialMatchesList shouldBe ""
             actual.partialMatchesDescription shouldBe ""
          }
          "handle empty text" {
-            val actual = describePartialMatchesInString("something", "")
+            val actual = describePartialMatchesInStringForSlice("something", "")
             actual.partialMatchesList shouldBe ""
             actual.partialMatchesDescription shouldBe ""
          }
          "find one match in one line" {
-            val actual = describePartialMatchesInString("brown fox jumps over", line)
-            actual.partialMatchesList shouldBe "Match[0]: expected[0..19] matched actual[10..29]"
+            val actual = describePartialMatchesInStringForSlice("brown fox jumps over", line)
+            actual.partialMatchesList shouldBe "Match[0]: whole slice matched actual[10..29]"
             actual.partialMatchesDescription shouldBe
                """Line[0] ="The quick brown fox jumps over the lazy dog"
                  |Match[0]= ----------++++++++++++++++++++-------------""".trimMargin()
          }
          "find one match spanning two lines" {
             val twoLines = "The quick brown fox\n jumps over the lazy dog"
-            val actual = describePartialMatchesInString("brown fox\n jumps over", twoLines)
+            val actual = describePartialMatchesInStringForSlice("brown fox\n jumps over", twoLines)
             actual.partialMatchesList.shouldContainInOrder(
-               "Match[0]: expected[0..20] matched actual[10..30]",
+               "Match[0]: whole slice matched actual[10..30]",
             )
             actual.partialMatchesDescription.lines() shouldBe
                listOf(
@@ -65,10 +68,10 @@ class StringPartialMatchesTest : WordSpec() {
          }
          "find two matches on separate lines" {
             val twoLines = "The quick brown fox\n jumps over the lazy dog"
-            val actual = describePartialMatchesInString("Rabbit jumps over brown fox", twoLines)
+            val actual = describePartialMatchesInStringForSlice("Rabbit jumps over brown fox", twoLines)
             actual.partialMatchesList.shouldContainInOrder(
-               "Match[0]: expected[6..17] matched actual[20..31]",
-               "Match[1]: expected[17..26] matched actual[9..18]"
+               "Match[0]: part of slice with indexes [6..17] matched actual[20..31]",
+               "Match[1]: part of slice with indexes [17..26] matched actual[9..18]"
             )
             actual.partialMatchesDescription.lines() shouldBe
                listOf(
@@ -82,7 +85,7 @@ class StringPartialMatchesTest : WordSpec() {
          }
          "find match that takes one whole line" {
             val threeLines = "What?\nThe quick brown fox jumps over the lazy dog.\nAnd that's it."
-            val actual = describePartialMatchesInString(line, threeLines)
+            val actual = describePartialMatchesInStringForSlice(line, threeLines)
             actual.partialMatchesDescription.lines() shouldBe listOf(
                "Line[0] =\"What?\"",
                "Match[0]= -----",
@@ -91,6 +94,42 @@ class StringPartialMatchesTest : WordSpec() {
                "Line[2] =\"And that's it.\"",
                "Match[0]= --------------"
             )
+         }
+         "find whole prefix elsewhere" {
+            val actual = describePartialMatchesInStringForPrefix("quick brown fox jumps", line)
+            actual.partialMatchesList shouldBe "Match[0]: whole prefix matched actual[4..24]"
+            actual.partialMatchesDescription.lines() shouldBe
+               listOf(
+                 """Line[0] ="The quick brown fox jumps over the lazy dog"""",
+                  """Match[0]= ----+++++++++++++++++++++------------------"""
+               )
+         }
+         "find partial prefix elsewhere" {
+            val actual = describePartialMatchesInStringForPrefix("quick brown fox runs", line)
+            actual.partialMatchesList shouldBe "Match[0]: part of prefix with indexes [0..15] matched actual[4..19]"
+            actual.partialMatchesDescription.lines() shouldBe
+               listOf(
+                  """Line[0] ="The quick brown fox jumps over the lazy dog"""",
+                  """Match[0]= ----++++++++++++++++-----------------------"""
+               )
+         }
+         "find whole suffix elsewhere" {
+            val actual = describePartialMatchesInStringForSuffix("jumps over the lazy", line)
+            actual.partialMatchesList shouldBe "Match[0]: whole suffix matched actual[20..38]"
+            actual.partialMatchesDescription.lines() shouldBe
+               listOf(
+                  """Line[0] ="The quick brown fox jumps over the lazy dog"""",
+                  """Match[0]= --------------------+++++++++++++++++++----"""
+               )
+         }
+         "find partial suffix elsewhere" {
+            val actual = describePartialMatchesInStringForSuffix("jumps over the lazy cat", line)
+            actual.partialMatchesList shouldBe "Match[0]: part of suffix with indexes [0..19] matched actual[20..39]"
+            actual.partialMatchesDescription.lines() shouldBe
+               listOf(
+                  """Line[0] ="The quick brown fox jumps over the lazy dog"""",
+                  """Match[0]= --------------------++++++++++++++++++++---"""
+               )
          }
       }
    }


### PR DESCRIPTION
Improve messages for partial String matches, as suggested by @LeoColman :

* describe whether it's a prefix, a suffix, or a slice
* tell if the whole thing matched, or only a substring
