### PR TITLE
fix: Stacktrace is lost with one assertion in AssertSoftly, #4171

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTest.kt
@@ -156,7 +156,10 @@ class AssertSoftlyTest : FreeSpec({
       }
 
 
-      "Should not loose stacktrace with only one assertion" {
+      "Should not lose stacktrace with only one assertion" {
+         val expectedLineNumber = Exception().stackTrace
+            .first { it.className.contains("AssertSoftlyTest") }.lineNumber + 5
+
          shouldThrow<AssertionError> {
             assertSoftly {
                null should beEmpty()
@@ -165,7 +168,7 @@ class AssertSoftlyTest : FreeSpec({
             message.shouldContainInOrder(
                "The following assertion failed:",
                "1) Expecting actual not to be null",
-               "   at com.sksamuel.kotest.matchers.AssertSoftlyTest${'$'}1${'$'}1${'$'}9.invokeSuspend(AssertSoftlyTest.kt:162)"
+               "   at com.sksamuel.kotest.matchers.AssertSoftlyTest${'$'}1${'$'}1${'$'}9.invokeSuspend(AssertSoftlyTest.kt:$expectedLineNumber)"
             )
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTest.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.beEmpty
 import io.kotest.matchers.string.contain
 import io.kotest.matchers.string.endWith
 import io.kotest.matchers.string.shouldContain
@@ -151,6 +152,21 @@ class AssertSoftlyTest : FreeSpec({
             assertSoftly {
                it shouldBe person // it being person verifies assertSoftly does not have any receiver
             }
+         }
+      }
+
+
+      "Should not loose stacktrace with only one assertion" {
+         shouldThrow<AssertionError> {
+            assertSoftly {
+               null should beEmpty()
+            }
+         }.run {
+            message.shouldContainInOrder(
+               "The following assertion failed:",
+               "1) Expecting actual not to be null",
+               "   at com.sksamuel.kotest.matchers.AssertSoftlyTest${'$'}1${'$'}1${'$'}9.invokeSuspend(AssertSoftlyTest.kt:162)"
+            )
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -596,7 +596,11 @@ private fun matchMapTests(contextName: String) = wordSpec {
                mapOf("key" to "hi") should matcher("key" to { it shouldHaveLength 4 })
             }
          }.also {
-            it.message shouldBe """Expected map to match all assertions. Missing keys were=[], Mismatched values were=[(key, "hi" should have length 4, but instead was 2)], Unexpected keys were []."""
+            it.message.shouldContainInOrder(
+               "The following assertion failed:",
+               "1) Expected map to match all assertions. Missing keys were=[], Mismatched values were=[(key, \"hi\" should have length 4, but instead was 2)], Unexpected keys were [].",
+               "   at com.sksamuel.kotest.matchers.maps.MapMatchersTestKt${'$'}matchMapTests${'$'}1${'$'}1${'$'}3.invokeSuspend(MapMatchersTest.kt:596)",
+            )
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -591,6 +591,9 @@ private fun matchMapTests(contextName: String) = wordSpec {
       }
 
       "works correctly within assertSoftly" {
+         val expectedLineNumber = Exception().stackTrace
+            .first { it.className.contains("MapMatchersTest") }.lineNumber + 5
+
          shouldFail {
             assertSoftly {
                mapOf("key" to "hi") should matcher("key" to { it shouldHaveLength 4 })
@@ -599,7 +602,7 @@ private fun matchMapTests(contextName: String) = wordSpec {
             it.message.shouldContainInOrder(
                "The following assertion failed:",
                "1) Expected map to match all assertions. Missing keys were=[], Mismatched values were=[(key, \"hi\" should have length 4, but instead was 2)], Unexpected keys were [].",
-               "   at com.sksamuel.kotest.matchers.maps.MapMatchersTestKt${'$'}matchMapTests${'$'}1${'$'}1${'$'}3.invokeSuspend(MapMatchersTest.kt:596)",
+               "   at com.sksamuel.kotest.matchers.maps.MapMatchersTestKt${'$'}matchMapTests${'$'}1${'$'}1${'$'}3.invokeSuspend(MapMatchersTest.kt:$expectedLineNumber)",
             )
          }
       }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ErrorCollector.kt
@@ -176,8 +176,6 @@ inline fun <reified T> ErrorCollector.runWithMode(mode: ErrorCollectionMode, blo
 internal fun List<Throwable>.toAssertionError(depth: Int, subject: Printed?): AssertionError? {
    return when {
       isEmpty() -> null
-      size == 1 && subject != null -> AssertionError("The following assertion for ${subject.value} failed:\n" + this[0].message)
-      size == 1 && subject == null -> AssertionError(this[0].message)
       else -> MultiAssertionError(this, depth, subject)
    }?.let {
       stacktraces.cleanStackTrace(it)

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
@@ -6,7 +6,6 @@ import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainInOrder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -46,14 +45,15 @@ class AssertSoftlyTests : FunSpec({
       )
    }
    test("adds an Exception to an empty collection of assertion failures") {
-      val thrown = shouldThrowExactly<AssertionError> {
+      val thrown = shouldThrowExactly<MultiAssertionError> {
          assertSoftly {
             bespokeDivision(1, 0) shouldBe 1
             "first assertion" shouldBe "First Assertion"
          }
       }
-      thrown.message.shouldContain(
-         "/ by zero"
+      thrown.message.shouldContainInOrder(
+         "The following assertion failed:",
+         "1) / by zero",
       )
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/io/kotest/assertions/AssertSoftlyTests.kt
@@ -7,6 +7,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainInOrder
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -55,6 +56,7 @@ class AssertSoftlyTests : FunSpec({
          "The following assertion failed:",
          "1) / by zero",
       )
+      thrown.message.shouldNotContain("""expected:<"First Assertion"> but was:<"first assertion">""")
    }
 })
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
It looks like `MultiAssertionError` factory method already handles properly following cases:
 - `size == 1 && subject != null`
 - `size == 1 && subject == null `
 
So the easiest fix is to use `MultiAssertionError` even though there is just one assertion error - this way we don't loose the stacktrace. I provided appropriate test which covers the case presented in issue #4171 