### PR TITLE
Correct closing parentheses in `test_factories.md` example

### DIFF
--- a/documentation/docs/framework/test_factories.md
+++ b/documentation/docs/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.2/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.2/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.3/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.3/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.4/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.4/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.5/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.5/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.6/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.6/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.7/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.7/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.8/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.8/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 

--- a/documentation/versioned_docs/version-5.9/framework/test_factories.md
+++ b/documentation/versioned_docs/version-5.9/framework/test_factories.md
@@ -83,8 +83,8 @@ And then to use this, we must include it one or more times into a spec (or sever
 
 ```kotlin
 class IndexedSeqTestSuite : WordSpec({
-   include(indexedSeqTests("vector"), Vector())
-   include(indexedSeqTests("list"), List())
+   include(indexedSeqTests("vector", Vector()))
+   include(indexedSeqTests("list", List()))
 })
 ```
 


### PR DESCRIPTION
Some closing parentheses in an example were in the wrong place. `indexedSeqTests` takes 2 arguments and `include` takes 1.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
