### PR TITLE
fix: Print clues on any Exception thrown, #4346

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
@@ -138,7 +138,7 @@ class ClueTest : FreeSpec({
       }
 
       "should add clue when Exception is thrown" {
-         shouldThrow<Exception> {
+         shouldThrow<AssertionError> {
             withClue("some clue") {
                val list = listOf("a", "b")
                   .single { it.length == 2 }
@@ -229,7 +229,7 @@ class ClueTest : FreeSpec({
       }
 
       "should add clue when Exception is thrown" {
-         shouldThrow<Exception> {
+         shouldThrow<AssertionError> {
             "some clue".asClue {
                val list = listOf("a", "b")
                   .single { it.length == 2 }
@@ -240,6 +240,26 @@ class ClueTest : FreeSpec({
             .run {
                message.shouldContainInOrder(
                   "some clue",
+                  "Collection contains no element matching the predicate.",
+               )
+            }
+      }
+
+      "should not duplicate clue messages when Exception is thrown" {
+         shouldThrow<AssertionError> {
+            "outer clue".asClue {
+               "inner clue".asClue {
+                  val list = listOf("a", "b")
+                     .single { it.length == 2 }
+
+                  list.shouldContain("something")
+               }
+            }
+         }
+            .run {
+               message.shouldContainInOrder(
+                  "outer clue",
+                  "inner clue",
                   "Collection contains no element matching the predicate.",
                )
             }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldStartWith
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
@@ -135,6 +136,23 @@ class ClueTest : FreeSpec({
          }
          ex.message shouldBe "null\nexpected:<2> but was:<1>"
       }
+
+      "should add clue when Exception is thrown" {
+         shouldThrow<Exception> {
+            withClue("some clue") {
+               val list = listOf("a", "b")
+                  .single { it.length == 2 }
+
+               list.shouldContain("something")
+            }
+         }
+            .run {
+               message.shouldContainInOrder(
+                  "some clue",
+                  "Collection contains no element matching the predicate.",
+               )
+            }
+      }
    }
    "asClue()" - {
       "should prepend clue to message with a newline" {
@@ -208,6 +226,23 @@ class ClueTest : FreeSpec({
                null shouldBe "hello"
             }
          }.message shouldBe "A actual is null value\nExpected \"hello\" but actual was null"
+      }
+
+      "should add clue when Exception is thrown" {
+         shouldThrow<Exception> {
+            "some clue".asClue {
+               val list = listOf("a", "b")
+                  .single { it.length == 2 }
+
+               list.shouldContain("something")
+            }
+         }
+            .run {
+               message.shouldContainInOrder(
+                  "some clue",
+                  "Collection contains no element matching the predicate.",
+               )
+            }
       }
    }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/ClueTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.assertions
 
+import io.kotest.assertions.ExceptionWithClue
 import io.kotest.assertions.asClue
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.fail
@@ -138,7 +139,7 @@ class ClueTest : FreeSpec({
       }
 
       "should add clue when Exception is thrown" {
-         shouldThrow<AssertionError> {
+         shouldThrow<ExceptionWithClue> {
             withClue("some clue") {
                val list = listOf("a", "b")
                   .single { it.length == 2 }
@@ -147,6 +148,7 @@ class ClueTest : FreeSpec({
             }
          }
             .run {
+               clue shouldBe "some clue\n"
                message.shouldContainInOrder(
                   "some clue",
                   "Collection contains no element matching the predicate.",
@@ -229,7 +231,7 @@ class ClueTest : FreeSpec({
       }
 
       "should add clue when Exception is thrown" {
-         shouldThrow<AssertionError> {
+         shouldThrow<ExceptionWithClue> {
             "some clue".asClue {
                val list = listOf("a", "b")
                   .single { it.length == 2 }
@@ -238,6 +240,7 @@ class ClueTest : FreeSpec({
             }
          }
             .run {
+               clue shouldBe "some clue\n"
                message.shouldContainInOrder(
                   "some clue",
                   "Collection contains no element matching the predicate.",
@@ -246,7 +249,7 @@ class ClueTest : FreeSpec({
       }
 
       "should not duplicate clue messages when Exception is thrown" {
-         shouldThrow<AssertionError> {
+         shouldThrow<ExceptionWithClue> {
             "outer clue".asClue {
                "inner clue".asClue {
                   val list = listOf("a", "b")
@@ -257,9 +260,31 @@ class ClueTest : FreeSpec({
             }
          }
             .run {
+               clue shouldBe "outer clue\ninner clue\n"
                message.shouldContainInOrder(
                   "outer clue",
                   "inner clue",
+                  "Collection contains no element matching the predicate.",
+               )
+            }
+      }
+
+      "should not contain inner clue when Exception is thrown in outer scope" {
+         shouldThrow<ExceptionWithClue> {
+            "outer clue".asClue {
+               "inner clue".asClue {
+                  1 shouldBe 1
+               }
+               val list = listOf("a", "b")
+                  .single { it.length == 2 }
+
+               list.shouldContain("something")
+            }
+         }
+            .run {
+               clue shouldBe "outer clue\n"
+               message.shouldContainInOrder(
+                  "outer clue",
                   "Collection contains no element matching the predicate.",
                )
             }

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -164,6 +164,16 @@ public final class io/kotest/assertions/ExceptionToMessageKt {
 	public static final fun exceptionToMessage (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
+public final class io/kotest/assertions/ExceptionWithClue : java/lang/RuntimeException {
+	public static final field Companion Lio/kotest/assertions/ExceptionWithClue$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public final fun getClue ()Ljava/lang/String;
+}
+
+public final class io/kotest/assertions/ExceptionWithClue$Companion {
+	public final fun from (Ljava/lang/String;Ljava/lang/Exception;)Lio/kotest/assertions/ExceptionWithClue;
+}
+
 public final class io/kotest/assertions/Exceptions {
 	public static final field INSTANCE Lio/kotest/assertions/Exceptions;
 	public final fun createAssertionError (Ljava/lang/String;Ljava/lang/Throwable;)Ljava/lang/AssertionError;

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ExceptionWithClue.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ExceptionWithClue.kt
@@ -12,9 +12,9 @@ package io.kotest.assertions
  */
 class ExceptionWithClue(
    val clue: String,
-   override val message: String?,
-   override val cause: Throwable?,
-) : RuntimeException() {
+   message: String?,
+   cause: Throwable?,
+) : RuntimeException(message, cause) {
    companion object {
       @Suppress("ThrowableNotThrown")
       fun from(clue: String, e: Exception): ExceptionWithClue =

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ExceptionWithClue.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/ExceptionWithClue.kt
@@ -1,0 +1,27 @@
+package io.kotest.assertions
+
+/**
+ * Exception class that enhances [withClue] and [asClue] functions by capturing additional context (clue)
+ * and attaching it to the thrown exception.
+ *
+ * @property clue Additional context to enrich the assertion error message if an assertion fails.
+ * @property message The error message, combining the clue and the original exception message.
+ * @property cause The original exception that triggered this one.
+ *
+ * This class simplifies debugging by bundling relevant clues into the exception when using [withClue] and [asClue].
+ */
+class ExceptionWithClue(
+   val clue: String,
+   override val message: String?,
+   override val cause: Throwable?,
+) : RuntimeException() {
+   companion object {
+      @Suppress("ThrowableNotThrown")
+      fun from(clue: String, e: Exception): ExceptionWithClue =
+         ExceptionWithClue(
+            clue = clue,
+            message = clueContextAsString() + (e.message ?: ""),
+            cause = e,
+         )
+   }
+}

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
@@ -29,7 +29,7 @@ inline fun <R> withClue(crossinline clue: () -> Any?, thunk: () -> R): R {
    } catch (t: TimeoutCancellationException) {
       throw Exceptions.createAssertionError(clueContextAsString() + (t.message ?: ""), t)
    } catch (e: Exception) {
-      throw Exception(clueContextAsString() + (e.message ?: ""), e)
+      throw Exceptions.createAssertionError(clueContextAsString() + (e.message ?: ""), e)
    } finally {
       collector.popClue()
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
@@ -25,6 +25,7 @@ inline fun <R> withClue(crossinline clue: () -> Any?, thunk: () -> R): R {
    try {
       collector.pushClue { clue.invoke().toString() }
       return thunk()
+      // this is a special control exception used by coroutines
    } catch (t: TimeoutCancellationException) {
       throw Exceptions.createAssertionError(clueContextAsString() + (t.message ?: ""), t)
    } catch (e: ExceptionWithClue) {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
@@ -28,6 +28,8 @@ inline fun <R> withClue(crossinline clue: () -> Any?, thunk: () -> R): R {
       // this is a special control exception used by coroutines
    } catch (t: TimeoutCancellationException) {
       throw Exceptions.createAssertionError(clueContextAsString() + (t.message ?: ""), t)
+   } catch (e: Exception) {
+      throw Exception(clueContextAsString() + (e.message ?: ""), e)
    } finally {
       collector.popClue()
    }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/clues.kt
@@ -1,7 +1,5 @@
 package io.kotest.assertions
 
-import kotlinx.coroutines.TimeoutCancellationException
-
 /**
  * Add [clue] as additional info to the assertion error message in case an assertion fails.
  * Can be nested, the error message will contain all available clues.
@@ -25,9 +23,6 @@ inline fun <R> withClue(crossinline clue: () -> Any?, thunk: () -> R): R {
    try {
       collector.pushClue { clue.invoke().toString() }
       return thunk()
-      // this is a special control exception used by coroutines
-   } catch (t: TimeoutCancellationException) {
-      throw Exceptions.createAssertionError(clueContextAsString() + (t.message ?: ""), t)
    } catch (e: Exception) {
       throw Exceptions.createAssertionError(clueContextAsString() + (e.message ?: ""), e)
    } finally {


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Fixes #4346
