### PR TITLE
Increase the number of arguments in forAll to 10

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -722,6 +722,15 @@ public final class io/kotest/data/ErrorsKt {
 	public static final fun forNoneError (Ljava/util/List;Ljava/util/List;)Ljava/lang/Throwable;
 }
 
+public final class io/kotest/data/ForAll10Kt {
+	public static final fun forAll (Lio/kotest/data/Table10;Lkotlin/jvm/functions/Function10;)V
+	public static final fun forAll ([Lio/kotest/data/Row10;Lkotlin/jvm/functions/Function11;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun forNone (Lio/kotest/data/Table10;Lkotlin/jvm/functions/Function10;)V
+	public static final fun forNone ([Lio/kotest/data/Row10;Lkotlin/jvm/functions/Function11;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun forall8 (Lio/kotest/data/Table10;Lkotlin/jvm/functions/Function10;)V
+	public static final fun fornone8 (Lio/kotest/data/Table10;Lkotlin/jvm/functions/Function10;)V
+}
+
 public final class io/kotest/data/ForAll1Kt {
 	public static final fun forAll (Lio/kotest/data/Table1;Lkotlin/jvm/functions/Function1;)V
 	public static final fun forAll ([Lio/kotest/data/Row1;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2657,6 +2666,11 @@ public final class io/kotest/data/TablesKt {
 	public static synthetic fun toTable$default (Ljava/util/Map;Lio/kotest/data/Headers2;ILjava/lang/Object;)Lio/kotest/data/Table2;
 }
 
+public final class io/kotest/data/blocking/ForAll10Kt {
+	public static final fun forAll ([Lio/kotest/data/Row10;Lkotlin/jvm/functions/Function10;)V
+	public static final fun forNone ([Lio/kotest/data/Row10;Lkotlin/jvm/functions/Function10;)V
+}
+
 public final class io/kotest/data/blocking/ForAll1Kt {
 	public static final fun forAll ([Lio/kotest/data/Row1;Lkotlin/jvm/functions/Function1;)V
 	public static final fun forNone ([Lio/kotest/data/Row1;Lkotlin/jvm/functions/Function1;)V
@@ -2690,6 +2704,16 @@ public final class io/kotest/data/blocking/ForAll6Kt {
 public final class io/kotest/data/blocking/ForAll7Kt {
 	public static final fun forAll ([Lio/kotest/data/Row7;Lkotlin/jvm/functions/Function7;)V
 	public static final fun forNone ([Lio/kotest/data/Row7;Lkotlin/jvm/functions/Function7;)V
+}
+
+public final class io/kotest/data/blocking/ForAll8Kt {
+	public static final fun forAll ([Lio/kotest/data/Row8;Lkotlin/jvm/functions/Function8;)V
+	public static final fun forNone ([Lio/kotest/data/Row8;Lkotlin/jvm/functions/Function8;)V
+}
+
+public final class io/kotest/data/blocking/ForAll9Kt {
+	public static final fun forAll ([Lio/kotest/data/Row9;Lkotlin/jvm/functions/Function9;)V
+	public static final fun forNone ([Lio/kotest/data/Row9;Lkotlin/jvm/functions/Function9;)V
 }
 
 public final class io/kotest/equals/CommutativeEquality : io/kotest/equals/Equality {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll10.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll10.kt
@@ -1,15 +1,15 @@
 package io.kotest.data.blocking
 
-import io.kotest.data.Row9
+import io.kotest.data.Row10
 import io.kotest.data.forAll
 import io.kotest.data.forNone
 import io.kotest.data.headers
 import io.kotest.data.table
 import io.kotest.mpp.reflection
 
-fun <A, B, C, D, E, F, G, H, I> forAll(
-   vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
-   testfn: (A, B, C, D, E, F, G, H, I) -> Unit
+fun <A, B, C, D, E, F, G, H, I, J> forAll(
+   vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
+   testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit
 ) {
    val params = reflection.paramNames(testfn) ?: emptyList<String>()
    val paramA = params.getOrElse(0) { "a" }
@@ -21,12 +21,13 @@ fun <A, B, C, D, E, F, G, H, I> forAll(
    val paramG = params.getOrElse(6) { "g" }
    val paramH = params.getOrElse(7) { "h" }
    val paramI = params.getOrElse(8) { "i" }
-   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI), *rows).forAll(testfn)
+   val paramJ = params.getOrElse(9) { "j" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ), *rows).forAll(testfn)
 }
 
-fun <A, B, C, D, E, F, G, H, I> forNone(
-   vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
-   testfn: (A, B, C, D, E, F, G, H, I) -> Unit
+fun <A, B, C, D, E, F, G, H, I, J> forNone(
+   vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
+   testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit
 ) {
    val params = reflection.paramNames(testfn) ?: emptyList<String>()
    val paramA = params.getOrElse(0) { "a" }
@@ -38,5 +39,6 @@ fun <A, B, C, D, E, F, G, H, I> forNone(
    val paramG = params.getOrElse(6) { "g" }
    val paramH = params.getOrElse(7) { "h" }
    val paramI = params.getOrElse(8) { "i" }
-   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI), *rows).forNone(testfn)
+   val paramJ = params.getOrElse(9) { "j" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ), *rows).forNone(testfn)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll8.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll8.kt
@@ -1,0 +1,40 @@
+package io.kotest.data.blocking
+
+import io.kotest.data.Row8
+import io.kotest.data.forAll
+import io.kotest.data.forNone
+import io.kotest.data.headers
+import io.kotest.data.table
+import io.kotest.mpp.reflection
+
+fun <A, B, C, D, E, F, G, H> forAll(
+   vararg rows: Row8<A, B, C, D, E, F, G, H>,
+   testfn: (A, B, C, D, E, F, G, H) -> Unit
+) {
+   val params = reflection.paramNames(testfn) ?: emptyList<String>()
+   val paramA = params.getOrElse(0) { "a" }
+   val paramB = params.getOrElse(1) { "b" }
+   val paramC = params.getOrElse(2) { "c" }
+   val paramD = params.getOrElse(3) { "d" }
+   val paramE = params.getOrElse(4) { "e" }
+   val paramF = params.getOrElse(5) { "f" }
+   val paramG = params.getOrElse(6) { "g" }
+   val paramH = params.getOrElse(7) { "h" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH), *rows).forAll(testfn)
+}
+
+fun <A, B, C, D, E, F, G, H> forNone(
+   vararg rows: Row8<A, B, C, D, E, F, G, H>,
+   testfn: (A, B, C, D, E, F, G, H) -> Unit
+) {
+   val params = reflection.paramNames(testfn) ?: emptyList<String>()
+   val paramA = params.getOrElse(0) { "a" }
+   val paramB = params.getOrElse(1) { "b" }
+   val paramC = params.getOrElse(2) { "c" }
+   val paramD = params.getOrElse(3) { "d" }
+   val paramE = params.getOrElse(4) { "e" }
+   val paramF = params.getOrElse(5) { "f" }
+   val paramG = params.getOrElse(6) { "g" }
+   val paramH = params.getOrElse(7) { "h" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH), *rows).forNone(testfn)
+}

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll9.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/blocking/forAll9.kt
@@ -1,0 +1,42 @@
+package io.kotest.data.blocking
+
+import io.kotest.data.Row9
+import io.kotest.data.forAll
+import io.kotest.data.forNone
+import io.kotest.data.headers
+import io.kotest.data.table
+import io.kotest.mpp.reflection
+
+fun <A, B, C, D, E, F, G, H, I> forAll(
+   vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
+   testfn: (A, B, C, D, E, F, G, H, I) -> Unit
+) {
+   val params = reflection.paramNames(testfn) ?: emptyList<String>()
+   val paramA = params.getOrElse(0) { "a" }
+   val paramB = params.getOrElse(1) { "b" }
+   val paramC = params.getOrElse(2) { "c" }
+   val paramD = params.getOrElse(3) { "d" }
+   val paramE = params.getOrElse(4) { "e" }
+   val paramF = params.getOrElse(5) { "f" }
+   val paramG = params.getOrElse(6) { "g" }
+   val paramH = params.getOrElse(7) { "h" }
+   val paramI = params.getOrElse(8) { "i" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI), *rows).forAll(testfn)
+}
+
+fun <A, B, C, D, E, F, G, H, I forNone(
+   vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
+   testfn: (A, B, C, D, E, F, G, H, I) -> Unit
+) {
+   val params = reflection.paramNames(testfn) ?: emptyList<String>()
+   val paramA = params.getOrElse(0) { "a" }
+   val paramB = params.getOrElse(1) { "b" }
+   val paramC = params.getOrElse(2) { "c" }
+   val paramD = params.getOrElse(3) { "d" }
+   val paramE = params.getOrElse(4) { "e" }
+   val paramF = params.getOrElse(5) { "f" }
+   val paramG = params.getOrElse(6) { "g" }
+   val paramH = params.getOrElse(7) { "h" }
+   val paramI = params.getOrElse(8) { "i" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI), *rows).forNone(testfn)
+}

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/forAll10.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/data/forAll10.kt
@@ -1,0 +1,75 @@
+package io.kotest.data
+
+import io.kotest.mpp.reflection
+import kotlin.jvm.JvmName
+
+suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
+   vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
+   testfn: suspend (A, B, C, D, E, F, G, H, I, J) -> Unit
+) {
+   val params = reflection.paramNames(testfn) ?: emptyList<String>()
+   val paramA = params.getOrElse(0) { "a" }
+   val paramB = params.getOrElse(1) { "b" }
+   val paramC = params.getOrElse(2) { "c" }
+   val paramD = params.getOrElse(3) { "d" }
+   val paramE = params.getOrElse(4) { "e" }
+   val paramF = params.getOrElse(5) { "f" }
+   val paramG = params.getOrElse(6) { "g" }
+   val paramH = params.getOrElse(7) { "h" }
+   val paramI = params.getOrElse(8) { "i" }
+   val paramJ = params.getOrElse(9) { "j" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ), *rows).forAll { A, B, C, D, E, F, G, H, I, J ->
+      testfn(A, B, C, D, E, F, G, H, I, J)
+   }
+}
+
+@JvmName("forall8")
+inline fun <A, B, C, D, E, F, G, H, I, J> forAll(table: Table10<A, B, C, D, E, F, G, H, I, J>, testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit) =
+   table.forAll(testfn)
+
+inline fun <A, B, C, D, E, F, G, H, I, J> Table10<A, B, C, D, E, F, G, H, I, J>.forAll(fn: (A, B, C, D, E, F, G, H, I, J) -> Unit) {
+   val collector = ErrorCollector()
+   for (row in rows) {
+      try {
+         fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j)
+      } catch (e: Throwable) {
+         collector.append(error(e, headers.values(), row.values()))
+      }
+   }
+   collector.assertAll()
+}
+
+suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
+   vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
+   testfn: suspend (A, B, C, D, E, F, G, H, I, J) -> Unit
+) {
+   val params = reflection.paramNames(testfn) ?: emptyList<String>()
+   val paramA = params.getOrElse(0) { "a" }
+   val paramB = params.getOrElse(1) { "b" }
+   val paramC = params.getOrElse(2) { "c" }
+   val paramD = params.getOrElse(3) { "d" }
+   val paramE = params.getOrElse(4) { "e" }
+   val paramF = params.getOrElse(5) { "f" }
+   val paramG = params.getOrElse(6) { "g" }
+   val paramH = params.getOrElse(7) { "h" }
+   val paramI = params.getOrElse(8) { "i" }
+   val paramJ = params.getOrElse(9) { "j" }
+   table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ), *rows).forNone { A, B, C, D, E, F, G, H, I, J ->
+      testfn(A, B, C, D, E, F, G, H, I, J)
+   }
+}
+
+@JvmName("fornone8")
+inline fun <A, B, C, D, E, F, G, H, I, J> forNone(table: Table10<A, B, C, D, E, F, G, H, I, J>, testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit) =
+   table.forNone(testfn)
+
+inline fun <A, B, C, D, E, F, G, H, I, J> Table10<A, B, C, D, E, F, G, H, I, J>.forNone(fn: (A, B, C, D, E, F, G, H, I, J) -> Unit) {
+   for (row in rows) {
+      try {
+         fn(row.a, row.b, row.c, row.d, row.e, row.f, row.g, row.h, row.i, row.j)
+      } catch (e: AssertionError) {
+         continue
+      }
+      throw forNoneError(headers.values(), row.values())
+   }
+}


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

To migrate from kotlintest to kotest, I have changed the number of arguments in forAll to 10.

I am doing a kotest migration from kotlintest v3.3.2
I am replacing as shown below, an error occurred due to an insufficient number of arguments in forAll.
- `io.kotlintest.data.forall` -> `io.kotest.data.blocking.forAll`
- `io.kotlintest.data.suspend.forall` -> `io.kotest.data.forAll`


In kotlintest it accepts up to 10 arguments
`io.kotlintest.data.forall`
https://github.com/kotest/kotest/blob/3.3.2/kotlintest-assertions/src/main/kotlin/io/kotlintest/data/DataDrivenTesting.kt
`io.kotlintest.data.suspend.forall`
https://github.com/kotest/kotest/blob/3.3.2/kotlintest-assertions/src/main/kotlin/io/kotlintest/data/suspend/DataDrivenTesting.kt