### PR TITLE
feat: add Yaml matchers module

### DIFF
--- a/documentation/docs/assertions/yaml.md
+++ b/documentation/docs/assertions/yaml.md
@@ -1,0 +1,21 @@
+---
+title: YAML
+slug: yaml-matchers.html
+sidebar_label: YAML
+---
+
+To use these matchers add `testImplementation("io.kotest:kotest-assertions-yaml:<version>")` to your build.
+
+## Basic matchers
+
+| Matcher                | Description                                           | Targets       |
+|------------------------|-------------------------------------------------------|:--------------|
+| `shouldBeValidYaml`    | verifies that a given string parses to valid YAML     | Multiplatform |
+| `shouldNotBeValidYaml` | verifies that a given not string parses to valid YAML | Multiplatform |
+
+## Content-based matching
+
+| Matcher                                                                      | Description                                                                             | Targets       |
+|------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|:--------------|
+| `shouldEqualYaml`                                                            | Verifies that a String matches a given YAML.                                            | Multiplatform |
+| `shouldNotEqualYaml`                                                         | Verifies that a String not matches a given YAML.                             | Multiplatform |

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -94,7 +94,8 @@ module.exports = {
         "assertions/klock",
         "assertions/compiler",
         "assertions/jsoup",
-        "assertions/ranges"
+        "assertions/ranges",
+        "assertions/yaml"
       ]
     }
   ],

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ json-path = "2.9.0"
 junit4 = "4.13.2"
 junit-platform = "1.8.2"
 junit-jupiter = "5.8.2"
+kaml = "0.62.0"
 kotlin = "2.0.20"
 kotlinx-coroutines = "1.8.0"
 kotlinx-serialization = "1.6.3"
@@ -40,6 +41,7 @@ diffutils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref 
 jayway-json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "json-path" }
 jdom2 = { module = "org.jdom:jdom2", version.ref = "jdom2" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
+kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml"}
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 mockserver-netty = { module = "org.mock-server:mockserver-netty", version.ref = "mockserver-netty" }
 mordant = { module = "com.github.ajalt:mordant", version.ref = "mordant" }

--- a/kotest-assertions/kotest-assertions-yaml/api/kotest-assertions-yaml.api
+++ b/kotest-assertions/kotest-assertions-yaml/api/kotest-assertions-yaml.api
@@ -1,0 +1,9 @@
+public final class YamlMatchersKt {
+	public static final fun beValidYaml ()Lio/kotest/matchers/Matcher;
+	public static final fun equalYaml (Ljava/lang/String;)Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeValidYaml (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun shouldEqualYaml (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public static final fun shouldNotBeValidYaml (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun shouldNotEqualYaml (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+

--- a/kotest-assertions/kotest-assertions-yaml/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-yaml/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+   id("kotest-multiplatform-library-conventions")
+   alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+
+   sourceSets {
+      val commonMain by getting {
+         dependencies {
+            implementation(projects.kotestCommon)
+            implementation(libs.kaml)
+            implementation(projects.kotestAssertions.kotestAssertionsShared)
+            implementation(projects.kotestAssertions.kotestAssertionsCore)
+         }
+      }
+
+      val commonTest by getting {
+         dependencies {
+            implementation(projects.kotestFramework.kotestFrameworkApi)
+            implementation(projects.kotestFramework.kotestFrameworkEngine)
+            implementation(projects.kotestProperty)
+         }
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-yaml/src/commonMain/kotlin/io/kotest/assertions/yaml/YamlMatchers.kt
+++ b/kotest-assertions/kotest-assertions-yaml/src/commonMain/kotlin/io/kotest/assertions/yaml/YamlMatchers.kt
@@ -1,0 +1,85 @@
+import com.charleskorn.kaml.Yaml
+import com.charleskorn.kaml.YamlNode
+import io.kotest.matchers.ComparableMatcherResult
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
+
+private val yaml = Yaml.default
+
+fun String.shouldBeValidYaml(): String {
+   this should beValidYaml()
+   return this
+}
+
+fun String.shouldNotBeValidYaml(): String {
+   this shouldNot beValidYaml()
+   return this
+}
+
+fun beValidYaml() = object : Matcher<String?> {
+   override fun test(value: String?): MatcherResult {
+      return try {
+         value?.let(yaml::parseToYamlNode)
+         MatcherResult(
+            true,
+            { "expected: actual YAML to be valid YAML: $value" },
+            { "expected: actual YAML to be invalid YAML: $value" }
+         )
+      } catch (ex: Exception) {
+         MatcherResult(
+            false,
+            { "expected: actual YAML to be valid YAML: $value" },
+            { "expected: actual YAML to be invalid YAML: $value" }
+         )
+      }
+   }
+}
+
+infix fun String.shouldEqualYaml(expected: String): String {
+   this should equalYaml(expected)
+   return this
+}
+
+infix fun String.shouldNotEqualYaml(expected: String): String {
+   this shouldNot equalYaml(expected)
+   return this
+}
+
+fun equalYaml(
+   expected: String,
+): Matcher<String?> =
+   Matcher { actual ->
+      if (actual == null) {
+         MatcherResult(
+            expected == "null",
+            { "Expected value to be equal to YAML '$expected', but was: null" },
+            { "Expected value to be not equal to YAML '$expected', but was: null" }
+         )
+      } else {
+         val (expectedTree, actualTree) = parse(expected, actual)
+         equalYamlNode(expectedTree).test(actualTree)
+      }
+   }
+
+private fun equalYamlNode(
+   expected: YamlNode,
+): Matcher<YamlNode> =
+   Matcher { value ->
+      val error = expected.equivalentContentTo( value)
+
+      ComparableMatcherResult(
+         error,
+         { "$error\n" },
+         { "Expected values to not match" },
+         value.contentToString(),
+         expected.contentToString(),
+      )
+   }
+
+internal fun parse(expected: String, actual: String): Pair<YamlNode, YamlNode> {
+   val enode = yaml.parseToYamlNode(expected)
+   val anode = yaml.parseToYamlNode(actual)
+   return Pair(enode, anode)
+}

--- a/kotest-assertions/kotest-assertions-yaml/src/commonTest/kotlin/io/kotest/assertions/yaml/YamlMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-yaml/src/commonTest/kotlin/io/kotest/assertions/yaml/YamlMatchersTest.kt
@@ -1,0 +1,51 @@
+package io.kotest.assertions.yaml
+
+import io.kotest.core.spec.style.StringSpec
+import shouldBeValidYaml
+import shouldEqualYaml
+import shouldNotBeValidYaml
+import shouldNotEqualYaml
+
+class YamlMatchersTest: StringSpec() {
+   init {
+      "should be valid YAML" {
+         """
+            key: "value"
+         """.shouldBeValidYaml()
+      }
+      "should not be valid YAML" {
+         """
+            items:
+            - id: 001
+            title: A Book
+             author: Unknown
+         """.shouldNotBeValidYaml()
+      }
+      "should equal YAML without quotes" {
+         """
+            key: value
+         """ shouldEqualYaml "key: value"
+      }
+      "should equal YAML with single quotes" {
+         """
+            key: value
+         """ shouldEqualYaml "key: value"
+      }
+      "should equal YAML with double quotes" {
+         """
+            key: "value"
+         """ shouldEqualYaml "key: value"
+      }
+      "should not be equal YAML" {
+         """
+            key: "value"
+         """ shouldNotEqualYaml "value: key"
+      }
+      "should equal YAML ignoring comments" {
+         """
+            # some comment
+            key: "value"
+         """ shouldEqualYaml "key: value"
+      }
+   }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -153,3 +153,5 @@ buildCache {
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+include("kotest-assertions:kotest-assertions-yaml")
+findProject(":kotest-assertions:kotest-assertions-yaml")?.name = "kotest-assertions-yaml"


### PR DESCRIPTION
Hi everyone,
I started working on the Yaml matchers feature. In order to have a starting point for discussions/suggestions/improvements I open this PR quite early in draft mode. I had to set the Java version to 11 for now since I'm still working on upgrading KAML to Java 8 compatibility.
The 
```
   id("kotest-jvm-conventions")
   id("kotest-js-conventions")
```
can also be replaced later with the multiplatform-conversions, but this also requires a newer KAML version.
If you have ideas for additional matchers or a different file structure feel free to point it out, I'll happily adjust the code.