### PR TITLE
feat: Output Hex for Unprintable characters, #4152

### DIFF
--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -133,8 +133,8 @@ public final class io/kotest/property/MaxDiscardPercentageException : java/lang/
 
 public final class io/kotest/property/PropTest {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;)V
-	public synthetic fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;Z)V
+	public synthetic fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Long;
 	public final fun component2 ()I
 	public final fun component3 ()I
@@ -143,8 +143,9 @@ public final class io/kotest/property/PropTest {
 	public final fun component6 ()Ljava/util/List;
 	public final fun component7 ()Lio/kotest/property/EdgeConfig;
 	public final fun component8 ()Lio/kotest/property/Constraints;
-	public final fun copy (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;)Lio/kotest/property/PropTest;
-	public static synthetic fun copy$default (Lio/kotest/property/PropTest;Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;ILjava/lang/Object;)Lio/kotest/property/PropTest;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;Z)Lio/kotest/property/PropTest;
+	public static synthetic fun copy$default (Lio/kotest/property/PropTest;Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;Lio/kotest/property/Constraints;ZILjava/lang/Object;)Lio/kotest/property/PropTest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConstraints ()Lio/kotest/property/Constraints;
 	public final fun getEdgeConfig ()Lio/kotest/property/EdgeConfig;
@@ -152,6 +153,7 @@ public final class io/kotest/property/PropTest {
 	public final fun getListeners ()Ljava/util/List;
 	public final fun getMaxFailure ()I
 	public final fun getMinSuccess ()I
+	public final fun getOutputHexForUnprintableChars ()Z
 	public final fun getSeed ()Ljava/lang/Long;
 	public final fun getShrinkingMode ()Lio/kotest/property/ShrinkingMode;
 	public fun hashCode ()I
@@ -160,12 +162,13 @@ public final class io/kotest/property/PropTest {
 
 public final class io/kotest/property/PropTestConfig {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;II)V
-	public synthetic fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;IIZ)V
+	public synthetic fun <init> (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;IIZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Long;
 	public final fun component10 ()Lio/kotest/property/Constraints;
 	public final fun component11 ()I
 	public final fun component12 ()I
+	public final fun component13 ()Z
 	public final fun component2 ()I
 	public final fun component3 ()I
 	public final fun component4 ()Lio/kotest/property/ShrinkingMode;
@@ -174,8 +177,8 @@ public final class io/kotest/property/PropTestConfig {
 	public final fun component7 ()Lio/kotest/property/EdgeConfig;
 	public final fun component8 ()Z
 	public final fun component9 ()Lio/kotest/property/classifications/LabelsReporter;
-	public final fun copy (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;II)Lio/kotest/property/PropTestConfig;
-	public static synthetic fun copy$default (Lio/kotest/property/PropTestConfig;Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;IIILjava/lang/Object;)Lio/kotest/property/PropTestConfig;
+	public final fun copy (Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;IIZ)Lio/kotest/property/PropTestConfig;
+	public static synthetic fun copy$default (Lio/kotest/property/PropTestConfig;Ljava/lang/Long;IILio/kotest/property/ShrinkingMode;Ljava/lang/Integer;Ljava/util/List;Lio/kotest/property/EdgeConfig;ZLio/kotest/property/classifications/LabelsReporter;Lio/kotest/property/Constraints;IIZILjava/lang/Object;)Lio/kotest/property/PropTestConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getConstraints ()Lio/kotest/property/Constraints;
 	public final fun getEdgeConfig ()Lio/kotest/property/EdgeConfig;
@@ -186,6 +189,7 @@ public final class io/kotest/property/PropTestConfig {
 	public final fun getMaxFailure ()I
 	public final fun getMinSuccess ()I
 	public final fun getOutputClassifications ()Z
+	public final fun getOutputHexForUnprintableChars ()Z
 	public final fun getSeed ()Ljava/lang/Long;
 	public final fun getShrinkingMode ()Lio/kotest/property/ShrinkingMode;
 	public final fun getSkipTo ()I
@@ -552,6 +556,7 @@ public final class io/kotest/property/PropertyTesting {
 	public final fun getDefaultMaxFailure ()I
 	public final fun getDefaultMinSuccess ()I
 	public final fun getDefaultOutputClassifications ()Z
+	public final fun getDefaultOutputHexForUnprintableChars ()Z
 	public final fun getDefaultSeed ()Ljava/lang/Long;
 	public final fun getDefaultShrinkingMode ()Lio/kotest/property/ShrinkingMode;
 	public final fun getEdgecasesBindDeterminism ()D
@@ -569,6 +574,7 @@ public final class io/kotest/property/PropertyTesting {
 	public final fun setDefaultMaxFailure (I)V
 	public final fun setDefaultMinSuccess (I)V
 	public final fun setDefaultOutputClassifications (Z)V
+	public final fun setDefaultOutputHexForUnprintableChars (Z)V
 	public final fun setDefaultSeed (Ljava/lang/Long;)V
 	public final fun setDefaultShrinkingMode (Lio/kotest/property/ShrinkingMode;)V
 	public final fun setEdgecasesBindDeterminism (D)V
@@ -1418,6 +1424,10 @@ public final class io/kotest/property/internal/Counter {
 	public final fun getCount ()I
 	public final fun inc ()I
 	public final fun setCount (I)V
+}
+
+public final class io/kotest/property/internal/EscapeUnprintableKt {
+	public static final fun escapeUnprintable (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class io/kotest/property/internal/ProptestKt {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -54,6 +54,9 @@ object PropertyTesting {
 
    @ExperimentalKotest
    var statisticsReportMode: StatisticsReportMode = StatisticsReportMode.ON
+
+   var defaultOutputHexForUnprintableChars: Boolean =
+      sysprop("kotest.proptest.arb.string.output-hex-for-unprintable-chars", false)
 }
 
 enum class LabelOrder {
@@ -74,6 +77,7 @@ data class PropTest(
    val listeners: List<PropTestListener> = PropertyTesting.defaultListeners,
    val edgeConfig: EdgeConfig = EdgeConfig.default(),
    val constraints: Constraints? = null,
+   val outputHexForUnprintableChars: Boolean = PropertyTesting.defaultOutputHexForUnprintableChars
 )
 
 fun PropTest.toPropTestConfig() =
@@ -84,7 +88,8 @@ fun PropTest.toPropTestConfig() =
       iterations = iterations,
       shrinkingMode = shrinkingMode,
       listeners = listeners,
-      edgeConfig = edgeConfig
+      edgeConfig = edgeConfig,
+      outputHexForUnprintableChars = outputHexForUnprintableChars,
    )
 
 /**
@@ -109,7 +114,8 @@ data class PropTestConfig(
    val labelsReporter: LabelsReporter = StandardLabelsReporter,
    val constraints: Constraints? = null,
    val maxDiscardPercentage: Int = 20,
-   val skipTo: Int = 0
+   val skipTo: Int = 0,
+   val outputHexForUnprintableChars: Boolean = PropertyTesting.defaultOutputHexForUnprintableChars,
 )
 
 interface PropTestListener {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/errors.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/errors.kt
@@ -9,8 +9,8 @@ import io.kotest.assertions.print.print
 internal fun throwPropertyTestAssertionError(
    e: Throwable, // the underlying failure reason,
    attempts: Int,
-   seed: Long
-): Unit = throw propertyAssertionError(e, attempts, seed, emptyList())
+   seed: Long,
+): Unit = throw propertyAssertionError(e, attempts, seed, emptyList(), false)
 
 /**
  * Generates an [AssertionError] for a property test with arg details and then throws it.
@@ -23,9 +23,10 @@ internal fun throwPropertyTestAssertionError(
    results: List<ShrinkResult<Any?>>,
    e: Throwable,
    attempts: Int,
-   seed: Long
+   seed: Long,
+   outputHexForUnprintableChars: Boolean,
 ) {
-   throw propertyAssertionError(e, attempts, seed, results)
+   throw propertyAssertionError(e, attempts, seed, results, outputHexForUnprintableChars)
 }
 
 /**
@@ -39,9 +40,10 @@ internal fun propertyAssertionError(
    e: Throwable,
    attempt: Int,
    seed: Long,
-   results: List<ShrinkResult<Any?>>
+   results: List<ShrinkResult<Any?>>,
+   outputHexForUnprintableChars: Boolean,
 ): Throwable {
-   return failure(propertyTestFailureMessage(attempt, results, seed, e), e)
+   return failure(propertyTestFailureMessage(attempt, results, seed, e, outputHexForUnprintableChars), e)
 }
 
 /**
@@ -52,17 +54,25 @@ internal fun propertyTestFailureMessage(
    attempt: Int,
    results: List<ShrinkResult<Any?>>,
    seed: Long,
-   cause: Throwable
+   cause: Throwable,
+   outputHexForUnprintableChars: Boolean,
 ): String {
    val sb = StringBuilder()
    sb.append("Property failed after $attempt attempts\n")
    if (results.isNotEmpty()) {
       sb.append("\n")
       results.withIndex().forEach { (index, result) ->
-         val input = if (result.initial == result.shrink) {
-            "\tArg ${index}: ${result.initial.print().value}"
+         val initialPrintable = result.initial.print().value.let {
+            if (outputHexForUnprintableChars) it.escapeUnprintable() else it
+         }
+         val shrinkPrintable = result.shrink.print().value.let {
+            if (outputHexForUnprintableChars) it.escapeUnprintable() else it
+         }
+
+         val input: String = if (result.initial == result.shrink) {
+            "\tArg ${index}: $initialPrintable"
          } else {
-            "\tArg ${index}: ${result.shrink.print().value} (shrunk from ${result.initial})"
+            "\tArg ${index}: $shrinkPrintable (shrunk from $initialPrintable)"
          }
          sb.append(input)
          sb.append("\n")

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/escapeUnprintable.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/escapeUnprintable.kt
@@ -1,0 +1,33 @@
+package io.kotest.property.internal
+
+/**
+ * Escapes non-printable (ISO control) characters in the string by converting them into their
+ * Unicode notation (`U+xxxx` for BMP characters and `U+xxxxxxxx` for supplementary characters).
+ * Printable characters remain unchanged.
+ *
+ * This is useful for displaying strings that may contain unprintable characters, such as control
+ * characters, in a more readable and standardized form by replacing those characters with their
+ * corresponding Unicode code points.
+ *
+ * Example:
+ * ```
+ * val input = "Hello\u0007World"
+ * val escaped = input.escapeUnprintable()  // Returns "HelloU+0007World"
+ * ```
+ *
+ * @receiver String The string in which unprintable characters will be escaped.
+ * @return A new string with non-printable characters replaced by their Unicode code points.
+ */
+fun String.escapeUnprintable(): String = buildString {
+   this@escapeUnprintable.forEach { c ->
+      if (c.isISOControl()) {
+         append(
+            "U+${
+               c.code.toString(16).uppercase().padStart(4, '0')
+            }"
+         )
+      } else {
+         append(c)
+      }
+   }
+}

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/test.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/test.kt
@@ -78,10 +78,10 @@ internal suspend fun handleException(
    writeFailedSeed(seed)
    if (config.maxFailure == 0) {
       printFailureMessage(context, inputs, e)
-      throwPropertyTestAssertionError(shrinkfn(), e, context.attempts(), seed)
+      throwPropertyTestAssertionError(shrinkfn(), e, context.attempts(), seed, config.outputHexForUnprintableChars)
    } else if (context.failures() > config.maxFailure) {
       val error = buildMaxFailureErrorMessage(context, config, inputs)
-      throwPropertyTestAssertionError(shrinkfn(), AssertionError(error), context.attempts(), seed)
+      throwPropertyTestAssertionError(shrinkfn(), AssertionError(error), context.attempts(), seed, config.outputHexForUnprintableChars)
    }
 }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
@@ -119,7 +119,7 @@ Caused by: Property passed 8 times (minSuccess rate was 9)"""
       }.message shouldBe """Property failed after 1 attempts
 
 	Arg 0: 1 (shrunk from 2)
-	Arg 1: "r" (shrunk from rDi)
+	Arg 1: "r" (shrunk from "rDi")
 
 Repeat this test by using seed 1234
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/OutputHexForUnprintableCharsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/OutputHexForUnprintableCharsTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.kotest.property.arbitrary
+
+import io.kotest.assertions.AssertionFailedError
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.ExperimentalKotest
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.property.Arb
+import io.kotest.property.PropTestConfig
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.ascii
+import io.kotest.property.arbitrary.printableAscii
+import io.kotest.property.arbitrary.string
+import io.kotest.property.checkAll
+import io.kotest.property.internal.escapeUnprintable
+
+@OptIn(ExperimentalKotest::class)
+class OutputHexForUnprintableCharsTest : StringSpec({
+
+   "should handle unprintable characters in failure messages" {
+      checkAll(
+         PropTestConfig(outputHexForUnprintableChars = true, seed = -5556043119863981334),
+         Arb.string(1..127, codepoints = Codepoint.ascii())
+      ) { str ->
+         val message = shouldThrow<AssertionFailedError> { str shouldBe "expectedString" }.message
+
+         val escapedMessage = message?.escapeUnprintable()
+
+         val expectedEscapedString = str.escapeUnprintable()
+         escapedMessage shouldContain expectedEscapedString
+         escapedMessage shouldContain "expectedString"
+      }
+   }
+
+   "should handle printable characters without escaping" {
+      checkAll(
+         PropTestConfig(outputHexForUnprintableChars = true, seed = -5556043119863981334),
+         Arb.string(1..127, codepoints = Codepoint.printableAscii())
+      ) { str ->
+         val message = shouldThrow<AssertionFailedError> { str shouldBe "expectedString" }.message
+         message?.escapeUnprintable() shouldBe message
+      }
+   }
+})

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/OutputHexForUnprintableCharsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/OutputHexForUnprintableCharsTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.AssertionFailedError
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.property.Arb
@@ -19,18 +20,23 @@ import io.kotest.property.internal.escapeUnprintable
 class OutputHexForUnprintableCharsTest : StringSpec({
 
    "should handle unprintable characters in failure messages" {
+      var unprintableCount = 0
+
       checkAll(
          PropTestConfig(outputHexForUnprintableChars = true, seed = -5556043119863981334),
          Arb.string(1..127, codepoints = Codepoint.ascii())
       ) { str ->
          val message = shouldThrow<AssertionFailedError> { str shouldBe "expectedString" }.message
-
          val escapedMessage = message?.escapeUnprintable()
+
+         if (message != escapedMessage) unprintableCount++
 
          val expectedEscapedString = str.escapeUnprintable()
          escapedMessage shouldContain expectedEscapedString
          escapedMessage shouldContain "expectedString"
       }
+
+      unprintableCount.shouldBeGreaterThan(0)
    }
 
    "should handle printable characters without escaping" {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/internal/EscapeUnprintableTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/internal/EscapeUnprintableTest.kt
@@ -1,0 +1,50 @@
+package com.sksamuel.kotest.property.internal
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.internal.escapeUnprintable
+
+class EscapeUnprintableTest : StringSpec({
+
+   "should leave printable characters unchanged" {
+      val input = "Hello, World!"
+      val result = input.escapeUnprintable()
+      result shouldBe "Hello, World!"
+   }
+
+   "should escape a single control character" {
+      val input = "\u0007"
+      val result = input.escapeUnprintable()
+      result shouldBe "U+0007"
+   }
+
+   "should escape multiple control characters" {
+      val input = "\u0007\u0008"
+      val result = input.escapeUnprintable()
+      result shouldBe "U+0007U+0008"
+   }
+
+   "should escape control characters mixed with printable characters" {
+      val input = "Hello\u0007World"
+      val result = input.escapeUnprintable()
+      result shouldBe "HelloU+0007World"
+   }
+
+   "should handle empty string" {
+      val input = ""
+      val result = input.escapeUnprintable()
+      result shouldBe ""
+   }
+
+   "should escape multiple control characters at various positions" {
+      val input = "\u0007Hello\u0008World\u001B"
+      val result = input.escapeUnprintable()
+      result shouldBe "U+0007HelloU+0008WorldU+001B"
+   }
+
+   "should escape non-ASCII control characters" {
+      val input = "\u009F"
+      val result = input.escapeUnprintable()
+      result shouldBe "U+009F"
+   }
+})


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
Implements #4152. 

This PR introduces the feature to handle unprintable characters in failure messages by escaping them to a standardized Unicode notation (U+xxxx).

Once the overall approach is approved, I will update the documentation accordingly.