### PR TITLE
make output of partial String matches more readable

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/StringPartialMatches.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/submatching/StringPartialMatches.kt
@@ -29,8 +29,11 @@ internal fun describePartialMatchesInString(expectedSlice: String, value: String
    val allUnderscores = getAllUnderscores(value.length, partialMatches)
    val lineIndexRanges = indexRangesOfLines(value)
    val valueAndUnderscores = lineIndexRanges.mapIndexed { index, indexRange ->
-      listOf("Line[$index] =\"${takeIndexRange(value, indexRange)}\"") + allUnderscores.mapIndexed { matchIndex, underscores ->
-         "Match[$matchIndex]= ${takeIndexRange(underscores, indexRange)}"
+      listOf("Line[$index] =\"${takeIndexRange(value, indexRange)}\"") + allUnderscores.mapIndexedNotNull { matchIndex, underscores ->
+         val underscoreLine = takeIndexRange(underscores, indexRange)
+         if(underscoreLine.contains('+'))
+            "Match[$matchIndex]= $underscoreLine"
+         else null
       }
    }.flatten().joinToString("\n")
    return PartialMatchesInCollectionDescription(partialMatchesList, valueAndUnderscores)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
@@ -76,11 +76,9 @@ class StringPartialMatchesTest : WordSpec() {
             actual.partialMatchesDescription.lines() shouldBe
                listOf(
                   "Line[0] =\"The quick brown fox\"",
-                  "Match[0]= -------------------",
                   "Match[1]= ---------++++++++++",
                   "Line[1] =\" jumps over the lazy dog\"",
                   "Match[0]= ++++++++++++------------",
-                  "Match[1]= ------------------------"
                )
          }
          "find match that takes one whole line" {
@@ -92,7 +90,6 @@ class StringPartialMatchesTest : WordSpec() {
                "Line[1] =\"The quick brown fox jumps over the lazy dog.\"",
                "Match[0]= +++++++++++++++++++++++++++++++++++++++++++-",
                "Line[2] =\"And that's it.\"",
-               "Match[0]= --------------"
             )
          }
          "find whole prefix elsewhere" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/string/StringPartialMatchesTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.submatching.PartialMatchesInCollectionDescription
-import io.kotest.submatching.describePartialMatchesInString
 import io.kotest.submatching.describePartialMatchesInStringForPrefix
 import io.kotest.submatching.describePartialMatchesInStringForSlice
 import io.kotest.submatching.describePartialMatchesInStringForSuffix
@@ -86,7 +85,6 @@ class StringPartialMatchesTest : WordSpec() {
             val actual = describePartialMatchesInStringForSlice(line, threeLines)
             actual.partialMatchesDescription.lines() shouldBe listOf(
                "Line[0] =\"What?\"",
-               "Match[0]= -----",
                "Line[1] =\"The quick brown fox jumps over the lazy dog.\"",
                "Match[0]= +++++++++++++++++++++++++++++++++++++++++++-",
                "Line[2] =\"And that's it.\"",

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/StringPartialMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/submatching/StringPartialMatchesTest.kt
@@ -1,0 +1,66 @@
+package io.kotest.submatching
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainInOrder
+import io.kotest.matchers.string.shouldNotContain
+
+class StringPartialMatchesTest: WordSpec() {
+   init {
+       "describePartialMatchesInString" should {
+          "work for no matches at all" {
+             val actual = describePartialMatchesInString(
+                "roses are red violets are blue",
+                "apples are green bananas are yellow",
+                PartialMatchType.Slice
+             )
+             actual.partialMatchesDescription shouldBe ""
+          }
+          "work for match and value on one line" {
+             val actual = describePartialMatchesInString(
+                "roses are red violets are blue",
+                "Roses are red violets are blueish",
+                PartialMatchType.Slice
+             )
+             actual.partialMatchesDescription.shouldContainInOrder(
+                """Line[0] ="Roses are red violets are blueish"""",
+                """Match[0]= -+++++++++++++++++++++++++++++---"""
+             )
+          }
+
+          "work for match on one line, value on two lines" {
+             val actual = describePartialMatchesInString(
+                "roses are red violets are blue",
+                "Roses are red violets are blue\nyes!",
+                PartialMatchType.Slice
+             )
+             actual.partialMatchesDescription.shouldContainInOrder(
+                """Line[0] ="Roses are red violets are blue"""",
+                """Match[0]= -+++++++++++++++++++++++++++++""",
+                """Line[1] ="yes!""""
+             )
+             actual.partialMatchesDescription shouldNotContain "Match[1]"
+          }
+          "work for matches spanning two lines" {
+             val line0 = "roses are red violets are blue"
+             val line1 = "apples are green bananas are yellow"
+             val actual = describePartialMatchesInString(
+                "$line0\n$line1",
+                "$line1\n$line0",
+                PartialMatchType.Slice
+             )
+             actual.partialMatchesList shouldBe
+                "Match[0]: part of slice with indexes [0..29] matched actual[36..65]\n" +
+                "Match[1]: part of slice with indexes [31..65] matched actual[0..34]"
+             actual.partialMatchesDescription.shouldContainInOrder(
+                """Line[0] ="apples are green bananas are yellow"""",
+                """Match[1]= +++++++++++++++++++++++++++++++++++""",
+                """Line[1] ="roses are red violets are blue"""",
+                """Match[0]= ++++++++++++++++++++++++++++++""",
+             )
+             actual.partialMatchesDescription shouldNotContain "Match[0]= --"
+             actual.partialMatchesDescription shouldNotContain "Match[1]= --"
+          }
+       }
+   }
+}


### PR DESCRIPTION
make description of partial match shorter, by removing some noise from the output, for instance the following output no longer contains lines that contain only `-` meaning that the slice did not have matches on this line. in the following example slice 0 does not have matches on line 0, and slice 1 does not have matches on line 1. so only slices that do have matches on the line are printed

```kotlin
         "work for matches spanning two lines" {
             val line0 = "roses are red violets are blue"
             val line1 = "apples are green bananas are yellow"
             val actual = describePartialMatchesInString(
                "$line0\n$line1",
                "$line1\n$line0",
                PartialMatchType.Slice
             )
             actual.partialMatchesList shouldBe
                "Match[0]: part of slice with indexes [0..29] matched actual[36..65]\n" +
                "Match[1]: part of slice with indexes [31..65] matched actual[0..34]"
             actual.partialMatchesDescription.shouldContainInOrder(
                """Line[0] ="apples are green bananas are yellow"""",
                """Match[1]= +++++++++++++++++++++++++++++++++++""",
                """Line[1] ="roses are red violets are blue"""",
                """Match[0]= ++++++++++++++++++++++++++++++""",
             )
             actual.partialMatchesDescription shouldNotContain "Match[0]= --"
             actual.partialMatchesDescription shouldNotContain "Match[1]= --"
          }
```
before the fix the output would be:
```kotlin
                """Line[0] ="apples are green bananas are yellow"""",
                """Match[0]= -----------------------------------""",
                """Match[1]= +++++++++++++++++++++++++++++++++++""",
                """Line[1] ="roses are red violets are blue"""",
                """Match[0]= ++++++++++++++++++++++++++++++""",
                """Match[1]= ------------------------------""",
 
```