### PR TITLE
fix: Failing containJsonKeyValue with implicit type parameter assertion

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -27,10 +27,11 @@ inline fun <reified T> String?.shouldContainJsonKeyValue(path: String, value: T)
 inline fun <reified T> String.shouldNotContainJsonKeyValue(path: String, value: T) =
    this shouldNot containJsonKeyValue(path, value)
 
-inline fun <reified T> containJsonKeyValue(path: String, t: T) = containJsonKeyValue(path, t, T::class.java)
+inline fun <reified T> containJsonKeyValue(path: String, t: T) =
+   containJsonKeyValue(path, t, t?.let { it::class.java } ?: Nothing::class.java)
 
 @KotestInternal
-fun <T, C: Class<T>> containJsonKeyValue(path: String, t: T, tClass: C) = object : Matcher<String?> {
+fun <T, C: Class<out T>> containJsonKeyValue(path: String, t: T, tClass: C) = object : Matcher<String?> {
    private fun keyIsAbsentFailure(validSubPathDescription: String) = MatcherResult(
       false,
       { "Expected given to contain json key <'$path'> but key was not found. $validSubPathDescription" },

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/ContainJsonKeyValueTest.kt
@@ -116,4 +116,11 @@ class ContainJsonKeyValueTest : StringSpec({
          use(nullableJson)
       }
    }
+
+   "Should pass json key-value assertion for values with implicit type" {
+      """{ "value": 42 }""".shouldContainJsonKeyValue<Any>("$.value", 42L)
+      """{ "value": 0.46479126999899145 }""".shouldContainJsonKeyValue<Any>("$.value", 0.46479126999899145)
+      """{ "value": 3.14 }""".shouldContainJsonKeyValue<Any>("$.value", 3.14f)
+      """{ "value": null }""".shouldContainJsonKeyValue<Any?>("$.value", null)
+   }
 })


### PR DESCRIPTION
This PR fixes problem described in issue #4448: function `shouldContainJsonKeyValue` internally tries to cast the value read from json to type `T`, and not to the type of the variable `value`. It may shoot in specific test cases, where captured type of value is `Any`, but actuall type is more specific.

Example:

```kotlin
class Example
    @ParameterizedTest
    @EnumSource(DataType::class)
    fun `Should not fail`(type: DataType) {
        val value = randomValue(type)   // value is Any
        val json = """{ "value": ${value.wrapQuotes()} }"""
        json.shouldContainJsonKeyValue("$.value", value)    // fails randomly
    }

    private val chars = ('a'..'z') + ('A'..'Z') + (0..9)
    private fun randomValue(type: DataType) = when (type) {
        DataType.Boolean -> nextBoolean()
        DataType.Float -> nextDouble()
        DataType.Int -> nextInt()
        DataType.String -> (0..15).map { chars[nextInt(chars.size)] }.joinToString("")
    }

    private fun Any?.wrapQuotes() = if (this is String) "\"$this\"" else this
}

enum class DataType {
    Boolean,
    Float,
    Int,
    String
}
```

Suggested solution is to use type of `value` instead of type of type parameter `T`. Feel free to express criticism.
