### PR TITLE
Add inline keyword and support for suspend functions in InspectorAliases

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/InspectorAliasTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/InspectorAliasTest.kt
@@ -4,16 +4,7 @@ import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.inspectors.shouldForAll
-import io.kotest.inspectors.shouldForAny
-import io.kotest.inspectors.shouldForAtLeast
-import io.kotest.inspectors.shouldForAtLeastOne
-import io.kotest.inspectors.shouldForAtMost
-import io.kotest.inspectors.shouldForAtMostOne
-import io.kotest.inspectors.shouldForExactly
-import io.kotest.inspectors.shouldForNone
-import io.kotest.inspectors.shouldForOne
-import io.kotest.inspectors.shouldForSome
+import io.kotest.inspectors.*
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
@@ -25,8 +16,11 @@ class InspectorAliasTest : FunSpec({
    val list = listOf(1, 2, 3)
    val sequence = sequenceOf(1, 2, 3)
 
+   suspend fun dummySuspendFunction(x: Int) = x
+
    context("forAll") {
       fun block(x: Int) = x shouldBeGreaterThan 0
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 0
 
       test("array") {
          array.shouldForAll {
@@ -39,6 +33,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("array with suspend function") {
+         array.shouldForAll { suspendBlock(it) }
+      }
+
       test("list") {
          list.shouldForAll(::block)
          shouldThrowAny {
@@ -46,6 +44,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 3
             }
          }
+      }
+
+      test("list with suspend function") {
+         list.shouldForAll { suspendBlock(it) }
       }
 
       test("sequence") {
@@ -56,10 +58,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForAll { suspendBlock(it) }
+      }
    }
 
    context("forOne") {
       fun block(x: Int) = x shouldBe 2
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBe 2
 
       test("array") {
          array.shouldForOne(::block)
@@ -68,6 +75,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 1
             }
          }
+      }
+
+      test("array with suspend function") {
+         array.shouldForOne { suspendBlock(it) }
       }
 
       test("list") {
@@ -79,6 +90,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("list with suspend function") {
+         list.shouldForOne { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForOne(::block)
          shouldThrowAny {
@@ -87,10 +102,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForOne { suspendBlock(it) }
+      }
    }
 
    context("forExactly") {
       fun block(x: Int) = x shouldBeGreaterThan 1
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 1
       val n = 2
 
       test("array") {
@@ -102,6 +122,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("array with suspend function") {
+         array.shouldForExactly(n) { suspendBlock(it) }
+      }
+
       test("list") {
          list.shouldForExactly(n, ::block)
          shouldThrowAny {
@@ -109,6 +133,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 1
             }
          }
+      }
+
+      test("list with suspend function") {
+         list.shouldForExactly(n) { suspendBlock(it) }
       }
 
       test("sequence") {
@@ -119,10 +147,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForExactly(n) { suspendBlock(it) }
+      }
    }
 
    context("forSome") {
       fun block(x: Int) = x shouldBeGreaterThan 2
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 2
 
       test("array") {
          array.shouldForSome(::block)
@@ -131,6 +164,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 1
             }
          }
+      }
+
+      test("array with suspend function") {
+         array.shouldForSome { suspendBlock(it) }
       }
 
       test("list") {
@@ -142,6 +179,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("list with suspend function") {
+         list.shouldForSome { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForSome(::block)
          shouldThrowAny {
@@ -150,10 +191,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForSome { suspendBlock(it) }
+      }
    }
 
    context("forAny") {
       fun block(x: Int) = x shouldBeGreaterThan 0
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 0
 
       test("array") {
          array.shouldForAny(::block)
@@ -162,6 +208,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 1
             }
          }
+      }
+
+      test("array with suspend function") {
+         array.shouldForAny { suspendBlock(it) }
       }
 
       test("list") {
@@ -173,6 +223,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("list with suspend function") {
+         list.shouldForAny { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForAny(::block)
          shouldThrowAny {
@@ -181,10 +235,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForAny { suspendBlock(it) }
+      }
    }
 
    context("forAtLeast") {
       fun block(x: Int) = x shouldBeGreaterThan 0
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 0
       val n = 3
 
       test("array") {
@@ -196,6 +255,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("array with suspend function") {
+         array.shouldForAtLeast(n) { suspendBlock(it) }
+      }
+
       test("list") {
          list.shouldForAtLeast(n, ::block)
          shouldThrowAny {
@@ -203,6 +266,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 3
             }
          }
+      }
+
+      test("list with suspend function") {
+         list.shouldForAtLeast(n) { suspendBlock(it) }
       }
 
       test("sequence") {
@@ -213,10 +280,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForAtLeast(n) { suspendBlock(it) }
+      }
    }
 
    context("forAtLeastOne") {
       fun block(x: Int) = x shouldBeGreaterThan 0
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 0
 
       test("array") {
          array.shouldForAtLeastOne(::block)
@@ -225,6 +297,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 1
             }
          }
+      }
+
+      test("array with suspend function") {
+         array.shouldForAtLeastOne { suspendBlock(it) }
       }
 
       test("list") {
@@ -236,6 +312,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("list with suspend function") {
+         list.shouldForAtLeastOne { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForAtLeastOne(::block)
          shouldThrowAny {
@@ -244,10 +324,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForAtLeastOne { suspendBlock(it) }
+      }
    }
 
    context("forAtMost") {
       fun block(x: Int) = x shouldBeGreaterThan 0
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeGreaterThan 0
 
       test("array") {
          val arr = arrayOf(0, 0, 1)
@@ -257,6 +342,11 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 3
             }
          }
+      }
+
+      test("array with suspend function") {
+         val arr = arrayOf(0, 0, 1)
+         arr.shouldForAtMost(1) { suspendBlock(it) }
       }
 
       test("list") {
@@ -269,6 +359,11 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("list with suspend function") {
+         val l = listOf(0, 1, 1)
+         l.shouldForAtMost(2) { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForAtMost(3, ::block)
          shouldThrowAny {
@@ -277,10 +372,15 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForAtMost(3) { suspendBlock(it) }
+      }
    }
 
    context("forNone") {
       fun block(x: Int) = x shouldBeLessThan 1
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBeLessThan 1
 
       test("array") {
          array.shouldForNone(::block)
@@ -289,6 +389,10 @@ class InspectorAliasTest : FunSpec({
                it shouldBeLessThan 4
             }
          }
+      }
+
+      test("array with suspend function") {
+         array.shouldForNone { suspendBlock(it) }
       }
 
       test("list") {
@@ -300,6 +404,10 @@ class InspectorAliasTest : FunSpec({
          }
       }
 
+      test("list with suspend function") {
+         list.shouldForNone { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForNone(::block)
          shouldThrowAny {
@@ -308,21 +416,38 @@ class InspectorAliasTest : FunSpec({
             }
          }
       }
+
+      test("sequence with suspend function") {
+         sequence.shouldForNone { suspendBlock(it) }
+      }
    }
 
    context("forAtMostOne") {
       fun block(x: Int) = x shouldBe 1
+      suspend fun suspendBlock(x: Int) = dummySuspendFunction(x) shouldBe 1
 
       test("array") {
          array.shouldForAtMostOne(::block)
+      }
+
+      test("array with suspend function") {
+         array.shouldForAtMostOne { suspendBlock(it) }
       }
 
       test("list") {
          list.shouldForAtMostOne(::block)
       }
 
+      test("list with suspend function") {
+         list.shouldForAtMostOne { suspendBlock(it) }
+      }
+
       test("sequence") {
          sequence.shouldForAtMostOne(::block)
+      }
+
+      test("sequence with suspend function") {
+         sequence.shouldForAtMostOne { suspendBlock(it) }
       }
    }
 })

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/InspectorAliases.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/inspectors/InspectorAliases.kt
@@ -1,79 +1,100 @@
 package io.kotest.inspectors
 
 /** Alias for [Sequence.forAll] */
-fun <T> Sequence<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
+inline fun <T> Sequence<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
+
 /** Alias for [Array.forAll] */
-fun <T> Array<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
+inline fun <T> Array<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
+
 /** Alias for [Collection.forAll] */
-fun <T> Collection<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
+inline fun <T> Collection<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
 
 
 /** Alias for [Sequence.forOne] */
-fun <T> Sequence<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
+inline fun <T> Sequence<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
+
 /** Alias for [Array.forOne] */
-fun <T> Array<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
+inline fun <T> Array<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
+
 /** Alias for [Collection.forOne] */
-fun <T> Collection<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
+inline fun <T> Collection<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
 
 
 /** Alias for [Sequence.forExactly] */
-fun <T> Sequence<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
+inline fun <T> Sequence<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
+
 /** Alias for [Array.forExactly] */
-fun <T> Array<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
+inline fun <T> Array<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
+
 /** Alias for [Collection.forExactly] */
-fun <T> Collection<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
+inline fun <T> Collection<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
 
 
 /** Alias for [Sequence.forSome] */
-fun <T> Sequence<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
+inline fun <T> Sequence<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
+
 /** Alias for [Array.forSome] */
-fun <T> Array<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
+inline fun <T> Array<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
+
 /** Alias for [Collection.forSome] */
-fun <T> Collection<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
+inline fun <T> Collection<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
 
 
 /** Alias for [Sequence.forAny] */
-fun <T> Sequence<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
+inline fun <T> Sequence<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
+
 /** Alias for [Array.forAny] */
-fun <T> Array<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
+inline fun <T> Array<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
+
 /** Alias for [Collection.forAny] */
-fun <T> Collection<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
+inline fun <T> Collection<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
 
 
 /** Alias for [Sequence.forAtLeastOne] */
-fun <T> Sequence<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
+inline fun <T> Sequence<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
+
 /** Alias for [Array.forAtLeastOne] */
-fun <T> Array<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
+inline fun <T> Array<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
+
 /** Alias for [Collection.forAtLeastOne] */
-fun <T> Collection<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
+inline fun <T> Collection<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
 
 
 /** Alias for [Sequence.forAtLeast] */
-fun <T> Sequence<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
+inline fun <T> Sequence<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
+
 /** Alias for [Array.forAtLeast] */
-fun <T> Array<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
+inline fun <T> Array<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
+
 /** Alias for [Collection.forAtLeast] */
-fun <T> Collection<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
+inline fun <T> Collection<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
 
 
 /** Alias for [Sequence.forAtMostOne] */
-fun <T> Sequence<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
+inline fun <T> Sequence<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
+
 /** Alias for [Array.forAtMostOne] */
-fun <T> Array<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
+inline fun <T> Array<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
+
 /** Alias for [Collection.forAtMostOne] */
-fun <T> Collection<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
+inline fun <T> Collection<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
 
 
 /** Alias for [Sequence.forAtMost] */
-fun <T> Sequence<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
+inline fun <T> Sequence<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
+
 /** Alias for [Array.forAtMost] */
-fun <T> Array<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
+inline fun <T> Array<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
+
 /** Alias for [Collection.forAtMost] */
-fun <T> Collection<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
+inline fun <T> Collection<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
+
 
 /** Alias for [Sequence.forNone] */
-fun <T> Sequence<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
+inline fun <T> Sequence<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
+
 /** Alias for [Array.forNone] */
-fun <T> Array<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
+inline fun <T> Array<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
+
 /** Alias for [Collection.forNone] */
-fun <T> Collection<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
+inline fun <T> Collection<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)


### PR DESCRIPTION
Introduced the inline keyword to all alias functions in InspectorAliases . Added tests to support suspend functions in InspectorAliasTest for better flexibility in async scenarios.

Fixes #4462
