### PR TITLE
Alex/big decimal tolerance  

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -184,6 +184,7 @@ Collections: also see [inspectors](inspectors.md) which are useful ways to test 
 | `bigDecimal.shouldBeGreaterThanOrEquals(n)` | Asserts that the bigDecimal is greater than or equals to the given value n |
 | `bigDecimal.shouldBeInRange(r)`             | Asserts that the bigDecimal is in the given range                          |
 | `bigDecimal.shouldBeEqualIgnoringScale(r)`  | Asserts that the bigDecimal is equal to the given value n ignoring scale   |
+| `bigDecimal.shouldBe(value plusOrMinus(tolerance))` | Asserts that the bigDecimal is equal to the given value within a tolerance range. |
 
 | Channels                                          ||
 |---------------------------------------------------| ---- |

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -222,6 +222,14 @@ public final class io/kotest/matchers/atomic/AtomicBooleanMatchersKt {
 	public static final fun shouldNotBeTrue (Ljava/util/concurrent/atomic/AtomicBoolean;)Z
 }
 
+public final class io/kotest/matchers/bigdecimal/BigDecimalToleranceKt {
+	public static final fun beWithinPercentageOf (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lio/kotest/matchers/Matcher;
+	public static final fun plusOrMinus (Ljava/math/BigDecimal;Lio/kotest/matchers/doubles/Percentage;)Lio/kotest/matchers/bigdecimal/ToleranceMatcher;
+	public static final fun plusOrMinus (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Lio/kotest/matchers/bigdecimal/ToleranceMatcher;
+	public static final fun shouldBeWithinPercentageOf (Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)V
+	public static final fun shouldNotBeWithinPercentageOf (Ljava/math/BigDecimal;Ljava/math/BigDecimal;Ljava/math/BigDecimal;)V
+}
+
 public final class io/kotest/matchers/bigdecimal/MatchersKt {
 	public static final fun beEqualIgnoringScale (Ljava/math/BigDecimal;)Lio/kotest/matchers/Matcher;
 	public static final fun beInClosedRange (Lkotlin/ranges/ClosedRange;)Lio/kotest/matchers/Matcher;
@@ -245,6 +253,15 @@ public final class io/kotest/matchers/bigdecimal/MatchersKt {
 	public static final fun shouldNotBeNegative (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBePositive (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotHaveScale (Ljava/math/BigDecimal;I)I
+}
+
+public final class io/kotest/matchers/bigdecimal/ToleranceMatcher : io/kotest/matchers/Matcher {
+	public fun <init> (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)V
+	public fun contramap (Lkotlin/jvm/functions/Function1;)Lio/kotest/matchers/Matcher;
+	public fun invert ()Lio/kotest/matchers/Matcher;
+	public fun invertIf (Lio/kotest/matchers/Matcher;Z)Lio/kotest/matchers/Matcher;
+	public synthetic fun test (Ljava/lang/Object;)Lio/kotest/matchers/MatcherResult;
+	public fun test (Ljava/math/BigDecimal;)Lio/kotest/matchers/MatcherResult;
 }
 
 public final class io/kotest/matchers/booleans/BooleanMatchersKt {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/BigDecimalTolerance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/BigDecimalTolerance.kt
@@ -1,0 +1,106 @@
+package io.kotest.matchers.bigdecimal
+
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.doubles.Percentage
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
+import java.math.BigDecimal
+
+
+/**
+ * Creates a matcher for the interval [[this] - [tolerance] , [this] + [tolerance]]
+ *
+ *
+ * ```
+ * BigDecimal("0.1") shouldBe (BigDecimal("0.4") plusOrMinus BigDecimal("0.5"))   // Assertion passes
+ * BigDecimal("0.1") shouldBe (BigDecimal("0.4") plusOrMinus BigDecimal("0.2"))   // Assertion fails
+ * ```
+ */
+infix fun BigDecimal.plusOrMinus(tolerance: BigDecimal): ToleranceMatcher {
+   require(tolerance >= BigDecimal.ZERO) { "tolerance must be non-negative, was: $tolerance" }
+   return ToleranceMatcher(this, tolerance)
+}
+
+
+/**
+ * Creates a matcher for the interval [[this] - [tolerance] , [this] + [tolerance]]
+ *
+ *
+ * ```
+ * BigDecimal("1.5") shouldBe (BigDecimal("1.0") plusOrMinus 50.percent )   // Assertion passes
+ * BigDecimal("1.5:) shouldBe (BigDecimal("1.0") plusOrMinus 10.percent)   // Assertion fails
+ * ```
+ */
+infix fun BigDecimal.plusOrMinus(tolerance: Percentage): ToleranceMatcher {
+   val realValue = (this * BigDecimal(tolerance.value) / BigDecimal(100)).abs()
+   return ToleranceMatcher(this, realValue)
+}
+
+class ToleranceMatcher(private val expected: BigDecimal?, private val tolerance: BigDecimal) : Matcher<BigDecimal?> {
+
+  override fun test(value: BigDecimal?): MatcherResult {
+    return if (value == null || expected == null ) {
+       MatcherResult(
+          value == expected,
+          { "$value should be equal to $expected" },
+          {
+             "$value should not be equal to $expected"
+          })
+    } else {
+       if (tolerance == BigDecimal.ZERO)
+          println("[WARN] When comparing doubles consider using tolerance, eg: a shouldBe (b plusOrMinus c)")
+       val diff = (value - expected).abs()
+
+       val passed = diff <= tolerance
+       val low = expected - tolerance
+       val high = expected + tolerance
+       val msg = when (tolerance) {
+          BigDecimal.ZERO -> "$value should be equal to $expected"
+          else -> "$value should be equal to $expected within tolerance of $tolerance (lowest acceptable value is $low; highest acceptable value is $high)"
+       }
+       MatcherResult(
+          passed,
+          { msg },
+          { "$value should not be equal to $expected" })
+    }
+  }
+}
+
+/**
+ * Verifies that this double is within [percentage]% of [other]
+ *
+ * BigDecimal("90.0").shouldBeWithinPercentageOf(BigDecimal("100.0"), 10.0)  // Passes
+ * BigDecimal("50.0").shouldBeWithinPercentageOf(BigDecimal("100.0"), 50.0)  // Passes
+ * BigDecimal("30.0").shouldBeWithinPercentageOf(BigDecimal("100.0:), 10.0)  // Fail
+ *
+ */
+fun BigDecimal.shouldBeWithinPercentageOf(other: BigDecimal, percentage: BigDecimal) {
+   require(percentage > BigDecimal.ZERO) { "Percentage must be > 0.0" }
+   this should beWithinPercentageOf(other, percentage)
+}
+
+/**
+ * Verifies that this double is NOT within [percentage]% of [other]
+ *
+ * BigDecimal("90.0").shouldNotBeWithinPercentageOf(BigDecimal("100.0"), 10.0)  // Fail
+ * BigDecimal("50.0").shouldNotBeWithinPercentageOf(BigDecimal("100.0,") 50.0)  // Fail
+ * BigDecimal("30.0").shouldNotBeWithinPercentageOf(BigDecimal("100.0"), 10.0)  // Passes
+ *
+ */
+fun BigDecimal.shouldNotBeWithinPercentageOf(other: BigDecimal, percentage: BigDecimal) {
+   require(percentage > BigDecimal.ZERO) { "Percentage must be > 0, was: $percentage" }
+   this shouldNot beWithinPercentageOf(other, percentage)
+}
+
+fun beWithinPercentageOf(other: BigDecimal, percentage: BigDecimal) = object : Matcher<BigDecimal> {
+   private val tolerance = other.times(percentage / BigDecimal(100)).abs()
+   private val range = (other - tolerance)..(other + tolerance)
+
+   override fun test(value: BigDecimal) = MatcherResult(
+      value in range,
+      { "$value should be in $range" },
+      {
+         "$value should not be in $range"
+      })
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/bigdecimal/BigDecimalToleranceTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/bigdecimal/BigDecimalToleranceTest.kt
@@ -1,0 +1,55 @@
+package com.sksamuel.kotest.matchers.bigdecimal
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.bigdecimal.plusOrMinus
+import io.kotest.matchers.doubles.percent
+import io.kotest.matchers.bigdecimal.shouldBeWithinPercentageOf
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.bigDecimal
+import io.kotest.property.checkAll
+import java.math.BigDecimal
+
+class BigDecimalToleranceTest : FunSpec({
+
+   test("double with tolerance should include tolerance in error message") {
+      shouldThrowAny {
+         BigDecimal("1.0") shouldBe (BigDecimal("1.5") plusOrMinus BigDecimal("0.4"))
+      }.message shouldBe "1.0 should be equal to 1.5 within tolerance of 0.4 (lowest acceptable value is 1.1; highest acceptable value is 1.9)"
+   }
+
+   test("Allow for percentage tolerance") {
+      BigDecimal("1.5") shouldBe (BigDecimal("1.0") plusOrMinus 50.percent)
+      BigDecimal("1.5") shouldNotBe (BigDecimal("2.0") plusOrMinus 10.percent)
+
+      BigDecimal("-1.5") shouldBe (BigDecimal("-1.0") plusOrMinus 50.percent)
+      BigDecimal("-1.5") shouldNotBe (BigDecimal("-2.0") plusOrMinus 10.percent)
+   }
+
+   context("Percentage") {
+
+      test("Match equal numbers") {
+         checkAll(Arb.bigDecimal(), Arb.bigDecimal(BigDecimal("0.00001"), BigDecimal("5.0"))) { value, percentage ->
+            value.shouldBeWithinPercentageOf(value, percentage)
+         }
+      }
+
+      test("Refuse negative percentage") {
+         shouldThrow<IllegalArgumentException> {
+            BigDecimal("1.0").shouldBeWithinPercentageOf(BigDecimal("1.0"), BigDecimal("-0.1"))
+         }
+      }
+
+      test("Match close enough numbers") {
+         checkAll(Arb.bigDecimal(), Arb.bigDecimal(BigDecimal("0.00001"), BigDecimal("5.0"))) { value, percentage ->
+            val delta = value.times(percentage / BigDecimal("100"))
+            (value + delta).shouldBeWithinPercentageOf(value, percentage)
+            (value - delta).shouldBeWithinPercentageOf(value, percentage)
+         }
+      }
+   }
+})
+


### PR DESCRIPTION
add tolerance matching for `BigDecimal`:
```kotlin
        BigDecimal("1.0") shouldBe (BigDecimal("1.5") plusOrMinus BigDecimal("0.4"))
       BigDecimal("-1.5") shouldBe (BigDecimal("-1.0") plusOrMinus 50.percent)
```
