### PR TITLE
containAnyOf-more-detail 

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -133,12 +133,19 @@ infix fun <T> Collection<T>.shouldNotContainAnyOf(ts: Collection<T>) = this shou
 fun <T> containAnyOf(ts: Collection<T>) = object : Matcher<Collection<T>> {
    override fun test(value: Collection<T>): MatcherResult {
       if (ts.isEmpty()) throwEmptyCollectionError()
+      val elementsInValue = ts.mapIndexedNotNull { index, t -> if(value.contains(t)) IndexedValue(index, t) else null }
       return MatcherResult(
-         ts.any { it in value },
+         elementsInValue.isNotEmpty(),
          { "Collection ${value.print().value} should contain any of ${ts.print().value}" },
-         { "Collection ${value.print().value} should not contain any of ${ts.print().value}" }
+         { "Collection ${value.print().value} should not contain any of ${ts.print().value}${describeForbiddenElementsInCollection(elementsInValue)}" }
       )
    }
+}
+
+internal fun<T> describeForbiddenElementsInCollection(indexedElements: List<IndexedValue<T>>): String {
+   return "\nForbidden elements found in collection:\n${indexedElements.joinToString("\n") {
+      indexedValue -> "[${indexedValue.index}] => ${indexedValue.value.print().value}"
+   } }"
 }
 
 internal fun throwEmptyCollectionError(): Nothing {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -133,7 +133,7 @@ infix fun <T> Collection<T>.shouldNotContainAnyOf(ts: Collection<T>) = this shou
 fun <T> containAnyOf(ts: Collection<T>) = object : Matcher<Collection<T>> {
    override fun test(value: Collection<T>): MatcherResult {
       if (ts.isEmpty()) throwEmptyCollectionError()
-      val elementsInValue = ts.mapIndexedNotNull { index, t -> if(value.contains(t)) IndexedValue(index, t) else null }
+      val elementsInValue = value.mapIndexedNotNull { index, t -> if(ts.contains(t)) IndexedValue(index, t) else null }
       return MatcherResult(
          elementsInValue.isNotEmpty(),
          { "Collection ${value.print().value} should contain any of ${ts.print().value}" },

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -924,25 +924,43 @@ class CollectionMatchersTest : WordSpec() {
          "Fail when one element is in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldNotContainAnyOf(1)
-            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
+            }.message.shouldContainInOrder(
+               "Collection [1, 2, 3] should not contain any of [1]",
+               "Forbidden elements found in collection:",
+               "[0] => 1",
+               )
          }
 
          "Fail when one element is in the iterable" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).asIterable().shouldNotContainAnyOf(1)
-            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
+            }.message.shouldContainInOrder(
+               "Collection [1, 2, 3] should not contain any of [1]",
+               "Forbidden elements found in collection:",
+               "[0] => 1",
+            )
          }
 
          "Fail when one element is in the array" {
             shouldThrow<AssertionError> {
                arrayOf(1, 2, 3).shouldNotContainAnyOf(1)
-            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1]")
+            }.message.shouldContainInOrder(
+               "Collection [1, 2, 3] should not contain any of [1]",
+               "Forbidden elements found in collection:",
+               "[0] => 1",
+               )
          }
 
          "Fail when all elements are in the list" {
             shouldThrow<AssertionError> {
                listOf(1, 2, 3).shouldNotContainAnyOf(1, 2, 3)
-            }.shouldHaveMessage("Collection [1, 2, 3] should not contain any of [1, 2, 3]")
+            }.message.shouldContainInOrder(
+               "Collection [1, 2, 3] should not contain any of [1, 2, 3]",
+               "Forbidden elements found in collection:",
+               "[0] => 1",
+               "[1] => 2",
+               "[2] => 3",
+               )
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -953,9 +953,9 @@ class CollectionMatchersTest : WordSpec() {
 
          "Fail when all elements are in the list" {
             shouldThrow<AssertionError> {
-               listOf(1, 2, 3).shouldNotContainAnyOf(1, 2, 3)
+               listOf(1, 2, 3).shouldNotContainAnyOf(3, 2, 1)
             }.message.shouldContainInOrder(
-               "Collection [1, 2, 3] should not contain any of [1, 2, 3]",
+               "Collection [1, 2, 3] should not contain any of [3, 2, 1]",
                "Forbidden elements found in collection:",
                "[0] => 1",
                "[1] => 2",


### PR DESCRIPTION
when `shouldNotContainAnyOf` fails, provide detailed information:

```kotlin
            shouldThrow<AssertionError> {
               listOf(1, 2, 3).shouldNotContainAnyOf(1, 2, 3)
            }.message.shouldContainInOrder(
               "Collection [1, 2, 3] should not contain any of [1, 2, 3]",
               "Forbidden elements found in collection:",
               "[0] => 1",
               "[1] => 2",
               "[2] => 3",
               )
```