### PR TITLE
inOrder-find-before (#4505)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -24,9 +24,18 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
    val mismatchDescription = if(subsequenceIndex == subsequence.size) "" else
       ", could not match element ${subsequence.elementAt(subsequenceIndex).print().value} at index $subsequenceIndex"
 
+   val foundBeforeDescription = if(subsequenceIndex == subsequence.size) "" else {
+      val foundBeforeAtIndexes = actual.take(subsequenceIndex).mapIndexedNotNull { index, value ->
+         if(value == subsequence[subsequenceIndex]) index else null
+      }
+      if (foundBeforeAtIndexes.isEmpty()) "" else {
+         "\nbut found it before at index(es) ${foundBeforeAtIndexes.print().value}"
+      }
+   }
+
    MatcherResult(
       subsequenceIndex == subsequence.size,
-      { "${actual.print().value} did not contain the elements ${subsequence.print().value} in order$mismatchDescription" },
+      { "${actual.print().value} did not contain the elements ${subsequence.print().value} in order$mismatchDescription$foundBeforeDescription" },
       { "${actual.print().value} should not contain the elements ${subsequence.print().value} in order" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.collections.containsInOrder
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class InOrderTest : WordSpec() {
@@ -51,6 +52,15 @@ class InOrderTest : WordSpec() {
          "support arrays with vararg" {
             val actual = arrayOf(1, 2, 3, 4, 5)
             actual.shouldContainInOrder(2, 3, 4)
+         }
+         "find mismatched element before" {
+            shouldThrow<AssertionError> {
+               listOf(1, 2, 3, 4, 5) should containsInOrder(3, 4, 5, 2)
+            }.message.shouldContainInOrder(
+               "did not contain the elements [3, 4, 5, 2] in order",
+               "could not match element 2 at index 3",
+               "but found it before at index(es) [1]"
+            )
          }
       }
    }


### PR DESCRIPTION
when `inOrder` fails, try finding a match in preceding elements:

```kotlin
            shouldThrow<AssertionError> {
               listOf(1, 2, 3, 4, 5) should containsInOrder(3, 4, 5, 2)
            }.message.shouldContainInOrder(
               "did not contain the elements [3, 4, 5, 2] in order",
               "could not match element 2 at index 3",
               "but found it before at index(es) [1]"
            )
```


