### PR TITLE
existInOrder-out-of-order-matches (#4507)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -24,9 +24,21 @@ fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> 
       if (predicates[subsequenceIndex](actualIterator.next())) subsequenceIndex += 1
    }
 
+   val passed = subsequenceIndex == predicates.size
+
+   val predicateMatchedOutOfOrderDescription = run {
+      val predicateMatchedOutOfOrderIndexes = if (passed) emptyList() else {
+         actual.mapIndexedNotNull { index, element ->
+            if (predicates[subsequenceIndex](element)) index else null
+         }
+      }
+      if (predicateMatchedOutOfOrderIndexes.isEmpty()) "" else
+         ",\nbut found element(s) matching the predicate out of order at index(es): ${predicateMatchedOutOfOrderIndexes.print().value}"
+   }
+
    MatcherResult(
-      subsequenceIndex == predicates.size,
-      { "${actual.print().value} did not match the predicates in order. Predicate at index $subsequenceIndex did not match." },
+      passed,
+      { "${actual.print().value} did not match the predicates in order. Predicate at index $subsequenceIndex did not match.$predicateMatchedOutOfOrderDescription" },
       { "${actual.print().value} should not match the predicates in order" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldExistInOrderTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldExistInOrder
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainInOrder
 
 class ShouldExistInOrderTest: WordSpec() {
    init {
@@ -20,7 +21,10 @@ class ShouldExistInOrderTest: WordSpec() {
                    { i: Int -> i < 2 },
                    { i: Int -> i < 2 }
                 )
-             }.message shouldBe "[1, 2] did not match the predicates in order. Predicate at index 1 did not match."
+             }.message.shouldContainInOrder(
+                "[1, 2] did not match the predicates in order. Predicate at index 1 did not match.",
+                "but found element(s) matching the predicate out of order at index(es): [0]",
+             )
           }
        }
    }


### PR DESCRIPTION
when `existInOrder` fails, try finding a match out of order

```kotlin
             shouldThrowAny {
                listOf(1, 2).shouldExistInOrder(
                   { i: Int -> i < 2 },
                   { i: Int -> i < 2 }
                )
             }.message.shouldContainInOrder(
                "[1, 2] did not match the predicates in order. Predicate at index 1 did not match.",
                "but found element(s) matching the predicate out of order at index(es): [0]",
             )
```
