### PR TITLE
expose-partialMatches (#4515)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import io.kotest.submatching.PartialCollectionMatch
 import io.kotest.submatching.findPartialMatches
 
 infix fun <T> Iterable<T>.shouldStartWith(element: T) = toList().shouldStartWith(listOf(element))
@@ -73,6 +74,7 @@ internal fun<T> describePartialMatchesInCollection(expectedSlice: Collection<T>,
       partialMatchesList,
       partialMatchesDescription,
       unmatchedElementsDescription,
+      partialMatches,
       )
 }
 
@@ -80,6 +82,7 @@ internal data class PartialMatchesInCollectionDescription(
    val partialMatchesList: String,
    val partialMatchesDescription: String,
    val unmatchedElementsDescription: String,
+   val partialMatches: List<PartialCollectionMatch>,
 ) {
    override fun toString(): String = prefixIfNotEmpty(
       listOf(partialMatchesList,
@@ -90,6 +93,11 @@ internal data class PartialMatchesInCollectionDescription(
          .joinToString("\n"),
       "\n"
    )
+
+
+   companion object {
+      val Empty = PartialMatchesInCollectionDescription("", "", "", listOf())
+   }
 }
 
 private data class SliceComparison<T>(

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/DescribePartialMatchesInCollectionTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/DescribePartialMatchesInCollectionTest.kt
@@ -3,6 +3,8 @@ package io.kotest.matchers.collections
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainInOrder
+import io.kotest.submatching.MatchedCollectionElement
+import io.kotest.submatching.PartialCollectionMatch
 
 class DescribePartialMatchesInCollectionTest: WordSpec() {
    init {
@@ -13,6 +15,15 @@ class DescribePartialMatchesInCollectionTest: WordSpec() {
                  value = listOf("apple", "banana", "blueberry")
              )
              actual.unmatchedElementsDescription shouldBe ""
+             actual.partialMatches shouldContainExactly listOf(
+                PartialCollectionMatch(
+                   matchedElement= MatchedCollectionElement(
+                      startIndexInExpected=1,
+                      startIndexInValue=0
+                   ),
+                   length=3
+                )
+             )
           }
           "work when one element found in another place" {
              val actual = describePartialMatchesInCollection(
@@ -20,6 +31,14 @@ class DescribePartialMatchesInCollectionTest: WordSpec() {
                 value = listOf("apple", "banana", "blueberry", "orange")
              )
              actual.unmatchedElementsDescription shouldBe """[0] "orange" => Found At Index(es): [3]"""
+             actual.partialMatches shouldContainExactly listOf(
+                PartialCollectionMatch(
+                   matchedElement = MatchedCollectionElement(
+                      startIndexInExpected = 1,
+                      startIndexInValue = 0
+                   ), length = 3
+                )
+             )
           }
           "work when one element found in multiple places" {
              val actual = describePartialMatchesInCollection(
@@ -27,6 +46,14 @@ class DescribePartialMatchesInCollectionTest: WordSpec() {
                 value = listOf("apple", "banana", "blueberry", "orange", "lemon", "orange")
              )
              actual.unmatchedElementsDescription shouldBe """[0] "orange" => Found At Index(es): [3, 5]"""
+             actual.partialMatches shouldContainExactly listOf(
+                PartialCollectionMatch(
+                   matchedElement = MatchedCollectionElement(
+                      startIndexInExpected = 1,
+                      startIndexInValue = 0
+                   ), length = 3
+                )
+             )
           }
           "work when multiple elements found" {
              val actual = describePartialMatchesInCollection(
@@ -36,6 +63,14 @@ class DescribePartialMatchesInCollectionTest: WordSpec() {
              actual.unmatchedElementsDescription.shouldContainInOrder(
                 """[0] "orange" => Found At Index(es): [3, 5]""",
                 """[4] "lemon" => Found At Index(es): [4]""",
+             )
+             actual.partialMatches shouldContainExactly listOf(
+                PartialCollectionMatch(
+                   matchedElement = MatchedCollectionElement(
+                      startIndexInExpected = 1,
+                      startIndexInValue = 0
+                   ), length = 3
+                )
              )
           }
           "work for complete match" {


### PR DESCRIPTION
keep and expose `PartialMatchesInCollectionDescription. partialMatches` - we shall need that to search for similar strings in collections and such.

eventually we'll plug it into similarity, later