### PR TITLE
shouldEqualJson-both-missing-and-extra-draft (#4522)

### DIFF
--- a/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
+++ b/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
@@ -130,6 +130,21 @@ public final class io/kotest/assertions/json/JsonError$NameOrderDiff : io/kotest
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/kotest/assertions/json/JsonError$ObjectExtraAndMissingKeys : io/kotest/assertions/json/JsonError {
+	public fun <init> (Ljava/util/List;Ljava/util/Set;Ljava/util/Set;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Ljava/util/Set;
+	public final fun copy (Ljava/util/List;Ljava/util/Set;Ljava/util/Set;)Lio/kotest/assertions/json/JsonError$ObjectExtraAndMissingKeys;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/JsonError$ObjectExtraAndMissingKeys;Ljava/util/List;Ljava/util/Set;Ljava/util/Set;ILjava/lang/Object;)Lio/kotest/assertions/json/JsonError$ObjectExtraAndMissingKeys;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExtra ()Ljava/util/Set;
+	public final fun getMissing ()Ljava/util/Set;
+	public fun getPath ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/kotest/assertions/json/JsonError$ObjectExtraKeys : io/kotest/assertions/json/JsonError {
 	public fun <init> (Ljava/util/List;Ljava/util/Set;)V
 	public final fun component1 ()Ljava/util/List;

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/comparisons/CompareObjects.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/comparisons/CompareObjects.kt
@@ -12,15 +12,19 @@ internal fun compareObjects(
    if (FieldComparison.Strict == options.fieldComparison) {
       val expectedKeys = expected.elements.keys
       val actualKeys = actual.elements.keys
+      val extraKeys = actualKeys - expectedKeys
+      val missingKeys = expectedKeys - actualKeys
 
-      if (actualKeys.size > expectedKeys.size) {
-         val extra = actualKeys - expectedKeys
-         return JsonError.ObjectExtraKeys(path, extra)
+      if (extraKeys.isNotEmpty() && missingKeys.isNotEmpty()) {
+         return JsonError.ObjectExtraAndMissingKeys(path, extraKeys, missingKeys)
       }
 
-      if (actualKeys.size < expectedKeys.size) {
-         val missing = expectedKeys - actualKeys
-         return JsonError.ObjectMissingKeys(path, missing)
+      if (extraKeys.isNotEmpty()) {
+         return JsonError.ObjectExtraKeys(path, extraKeys)
+      }
+
+      if (missingKeys.isNotEmpty()) {
+         return JsonError.ObjectMissingKeys(path, missingKeys)
       }
    }
 

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/errors.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/errors.kt
@@ -18,6 +18,7 @@ sealed class JsonError {
 
    data class ObjectMissingKeys(override val path: List<String>, val missing: Set<String>) : JsonError()
    data class ObjectExtraKeys(override val path: List<String>, val extra: Set<String>) : JsonError()
+   data class ObjectExtraAndMissingKeys(override val path: List<String>, val extra: Set<String>, val missing: Set<String>) : JsonError()
    data class ExpectedObject(override val path: List<String>, val b: JsonNode) : JsonError()
    data class ExpectedArray(override val path: List<String>, val b: JsonNode) : JsonError()
    data class UnequalStrings(override val path: List<String>, val a: String, val b: String) : JsonError()
@@ -40,6 +41,7 @@ fun JsonError.asString(): String {
       is JsonError.UnequalArrayLength -> "$dotpath expected array length ${this.expected} but was ${this.actual}"
       is JsonError.ObjectMissingKeys -> "$dotpath object was missing expected field(s) [${missing.joinToString(",")}]"
       is JsonError.ObjectExtraKeys -> "$dotpath object has extra field(s) [${extra.joinToString(",")}]"
+      is JsonError.ObjectExtraAndMissingKeys -> "$dotpath object has extra field(s) [${extra.joinToString(",")}] and missing field(s) [${missing.joinToString(",")}]"
       is JsonError.ExpectedObject -> "$dotpath expected object type but was ${b.type()}"
       is JsonError.ExpectedArray -> "$dotpath expected array type but was ${b.type()}"
       is JsonError.UnequalStrings -> "$dotpath expected '$a' but was '$b'"

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -22,7 +22,7 @@ import io.kotest.property.assume
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.boolean
 
-//@EnabledIf(LinuxCondition::class)
+@EnabledIf(LinuxCondition::class)
 class EqualTest : FunSpec() {
    init {
       test("compare non equal objects") {

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -22,7 +22,7 @@ import io.kotest.property.assume
 import io.kotest.property.checkAll
 import io.kotest.property.exhaustive.boolean
 
-@EnabledIf(LinuxCondition::class)
+//@EnabledIf(LinuxCondition::class)
 class EqualTest : FunSpec() {
    init {
       test("compare non equal objects") {
@@ -170,7 +170,7 @@ expected:<{
          shouldFail {
             a shouldEqualJson b
          }.shouldHaveMessage(
-            """The top level object was missing expected field(s) [c]
+            """The top level object has extra field(s) [b] and missing field(s) [c]
 
 expected:<{
   "a": "foo",


### PR DESCRIPTION
when matching Json, detect the case when both some keys are extra and some are missing:
```
The top level object has extra field(s) [b] and missing field(s) [c]
```

before this change, it was this:
```
The top level object was missing expected field(s) [c]
```
which was indistinguishable from the case when there are no extra fields