### PR TITLE
Plug in search for similar strings

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/ClosestMatches.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/ClosestMatches.kt
@@ -6,7 +6,7 @@ import java.math.BigDecimal
 internal fun<T> closestMatches(actual: Set<T>, expected: T): List<PairComparison<T>> {
    return actual.asSequence().mapNotNull { candidate ->
             val comparisonResult = VanillaDistanceCalculator.compare("", expected, candidate)
-            if (comparisonResult is MismatchByField &&
+            if (comparisonResult.canBeSimilar &&
                comparisonResult.distance.distance > maxOf(
                   Distance.COMPLETE_MISMATCH_VALUE,
                   BigDecimal(AssertionsConfig.similarityThresholdInPercent.value) * Distance.PERCENT_TO_DISTANCE,
@@ -22,5 +22,5 @@ internal fun<T> closestMatches(actual: Set<T>, expected: T): List<PairComparison
 internal data class PairComparison<T>(
    val value: T,
    val possibleMatch: T,
-   val comparisonResult: MismatchByField
+   val comparisonResult: ComparisonResult
 )

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/StringDistanceCalculator.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/StringDistanceCalculator.kt
@@ -21,7 +21,7 @@ internal fun matchNotNullStrings(field: String, expected: String, actual: String
       if(distance.aboveThresholdForStrings()) {
          StringMismatch(field, expected, actual, comparison.toString(), distance)
       } else {
-         AtomicMismatch(field, expected, actual, distance)
+         AtomicMismatch(field, expected, actual)
       }
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/VanillaDistanceCalculator.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/similarity/VanillaDistanceCalculator.kt
@@ -11,6 +11,7 @@ internal object VanillaDistanceCalculator: IDistanceCalculator {
 internal fun matchNotNull(field: String, expected: Any, actual: Any): ComparisonResult = when {
     expected == actual -> Match(field, expected)
     expected::class.isData && expected.javaClass == actual.javaClass -> matchByFields(field, expected, actual)
+    expected is String && actual is String -> matchNotNullStrings(field, expected, actual)
     else -> AtomicMismatch(field, expected, actual)
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -1020,6 +1020,19 @@ class CollectionMatchersTest : WordSpec() {
                """"color" expected: <"green">, but was: <"red">"""
             )
          }
+
+         "fail and find similar items for Strings" {
+            val message = shouldThrow<AssertionError> {
+               "sweet green fruit" shouldBeIn listOf(
+                  "sweet green pear", "sweet red apple"
+               )
+            }.message
+            message.shouldContainInOrder(
+               "Possible matches:",
+               """Line[0] ="sweet green pear"""",
+               """Match[0]= ++++++++++++----""",
+            )
+         }
       }
 
       "Be in (negative)" should {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -447,6 +447,23 @@ class ShouldContainExactlyTest : WordSpec() {
                |    "name" expected: <"pear">, but was: <"apple">
             """.trimMargin()
          }
+         "find similar element for String" {
+            val message = shouldThrow<AssertionError> {
+               listOf("sweet green apple", "sweet red apple").shouldContainExactlyInAnyOrder(
+                  listOf(
+                     "sweet green apple",
+                     "sweet red plum",
+                  )
+               )
+            }.message
+            println(message)
+            message.shouldContainInOrder(
+               "Possible matches for unexpected elements:",
+               """expected: <"sweet red plum">, found a similar value: <"sweet red apple">""",
+               """Line[0] ="sweet red apple"""",
+               """Match[0]= ++++++++++-----""",
+            )
+         }
 
          "disambiguate when using optional expected value" {
             val actual: List<String> = listOf("A", "B", "C")

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
@@ -12,6 +12,7 @@ import io.kotest.equals.types.byObjectEquality
 import io.kotest.matchers.collections.contain
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.should
+import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class ShouldContainTest : WordSpec({
@@ -55,6 +56,18 @@ class ShouldContainTest : WordSpec({
             |  The following fields did not match:
             |    "color" expected: <"red">, but was: <"green">
     """.trimMargin()
+         )
+      }
+
+      "find similar element in List<String>" {
+         val thrown = shouldThrowAny {
+            listOf("sweet green apple", "sweet red plu") shouldContain ("sweet green pear")
+         }
+         thrown.message.shouldContainInOrder(
+            "PossibleMatches:",
+            "Match[0]: part of slice with indexes [0..11] matched actual[0..11]",
+            """Line[0] ="sweet green apple"""",
+            """Match[0]= ++++++++++++-----""",
          )
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/ClosestMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/ClosestMatchesTest.kt
@@ -41,6 +41,31 @@ class ClosestMatchesTest : WordSpec() {
                actual.map { it.comparisonResult.distance.distance }.distinct() shouldBe listOf(BigDecimal("0.67"))
             }
          }
+
+         "find no matches if similarity below threshold for String" {
+            closestMatches(setOf("sweet green apple", "sweet red apple"), "sweet yellow peach").shouldBeEmpty()
+         }
+
+         "find one match for strings" {
+            val actual = closestMatches(setOf("sweet green apple", "sweet red apple"), "sweet green pear")
+            assertSoftly {
+               actual.size shouldBe 1
+               actual[0].value shouldBe "sweet green pear"
+               actual[0].possibleMatch shouldBe "sweet green apple"
+               actual[0].comparisonResult.distance.distance shouldBe BigDecimal("0.71")
+            }
+         }
+
+         "find two matches with same distance for String" {
+            val actual = closestMatches(setOf("sweet red pear", "sweet red plum"), "sweet red lime")
+            assertSoftly {
+               actual.size shouldBe 2
+               actual.map { it.value }.distinct() shouldBe listOf("sweet red lime")
+               actual.map { it.possibleMatch } shouldContainExactlyInAnyOrder listOf("sweet red pear", "sweet red plum")
+               actual.map { it.comparisonResult.distance.distance }.distinct() shouldBe listOf(BigDecimal("0.71"))
+            }
+         }
+
       }
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/FindBestMatchesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/FindBestMatchesTest.kt
@@ -1,8 +1,10 @@
 package io.kotest.similarity
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.equality.shouldBeEqualUsingFields
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
 
@@ -23,8 +25,10 @@ class FindBestMatchesTest : StringSpec() {
       }
 
       "find two closest matches" {
-         findBestMatches(oneApple, listOf(twoApples, twoOranges, oneOrange)) shouldBe listOf(
-            IndexedComparisonResult(
+         val actual = findBestMatches(oneApple, listOf(twoApples, twoOranges, oneOrange))
+         assertSoftly {
+            actual.size shouldBe 2
+            actual[0] shouldBeEqualUsingFields IndexedComparisonResult(
                0,
                MismatchByField(
                   field = "",
@@ -39,8 +43,8 @@ class FindBestMatchesTest : StringSpec() {
                   ),
                   distance = Distance(BigDecimal("0.5"))
                )
-            ),
-            IndexedComparisonResult(
+            )
+            actual[1] shouldBeEqualUsingFields IndexedComparisonResult(
                2,
                MismatchByField(
                   field = "",
@@ -56,7 +60,7 @@ class FindBestMatchesTest : StringSpec() {
                   distance = Distance(BigDecimal("0.5"))
                )
             )
-         )
+         }
       }
 
       "find nothing if complete mismatch" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/MatchNotNullStringsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/MatchNotNullStringsTest.kt
@@ -33,7 +33,7 @@ class MatchNotNullStringsTest: StringSpec() {
             actual.match shouldBe false
             actual.description() shouldBe """    "field" expected: <"0123456789abcdefghijklmnopqrstuvwxyz">, but was: <"SFGHSRGHSFDGHSFGHSDFGHSDFGHDF">"""
             actual.shouldBeInstanceOf<AtomicMismatch>()
-            (actual as AtomicMismatch).distance shouldBe Distance(BigDecimal("0.00"))
+            (actual as AtomicMismatch).distance shouldBe Distance(BigDecimal.ZERO)
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/MatchNotNullTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/MatchNotNullTest.kt
@@ -1,9 +1,13 @@
 package io.kotest.similarity
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainInOrder
+import io.kotest.matchers.types.shouldBeInstanceOf
+import java.math.BigDecimal
 
 @EnabledIf(LinuxCondition::class)
 class MatchNotNullTest : StringSpec() {
@@ -15,7 +19,8 @@ class MatchNotNullTest : StringSpec() {
       }
 
       "mismatch for primitives" {
-         matchNotNull(fieldName, "this", "another") shouldBe AtomicMismatch(fieldName, "this", "another")
+         matchNotNull(fieldName, BigDecimal.ONE, BigDecimal.TEN) shouldBe
+            AtomicMismatch(fieldName, BigDecimal.ONE, BigDecimal.TEN)
       }
 
       "match for identical data class instances" {
@@ -30,5 +35,23 @@ class MatchNotNullTest : StringSpec() {
             otherRedCircle
          )
       }
+
+
+      "mismatch for two different strings" {
+         val expectedStr = "0123456789abcdefghijklmnopqrstuvwxyz"
+         val actualStr = "$expectedStr?"
+         val actual = matchNotNull(fieldName, expectedStr, actualStr)
+         assertSoftly {
+            actual.match shouldBe false
+            actual.shouldBeInstanceOf<StringMismatch>()
+            actual.description().shouldContainInOrder(
+               "Match[0]: whole slice matched actual[0..35]",
+               """Line[0] ="0123456789abcdefghijklmnopqrstuvwxyz?"""",
+               """Match[0]= ++++++++++++++++++++++++++++++++++++-"""
+            )
+            (actual as StringMismatch).distance shouldBe Distance(BigDecimal("0.97"))
+         }
+      }
+
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/VanillaDistanceCalculatorTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/similarity/VanillaDistanceCalculatorTest.kt
@@ -1,9 +1,12 @@
 package io.kotest.similarity
 
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.assertions.assertSoftly
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainInOrder
 
 @EnabledIf(LinuxCondition::class)
 class VanillaDistanceCalculatorTest : StringSpec() {
@@ -22,11 +25,26 @@ class VanillaDistanceCalculatorTest : StringSpec() {
             AtomicMismatch(fieldName, 42, null)
       }
 
-      "different not nulls" {
+      "different not null data classes" {
          VanillaDistanceCalculator.compare(fieldName, 41, 42) shouldBe
             AtomicMismatch(fieldName, 41, 42)
          VanillaDistanceCalculator.compare(fieldName, redCircle, otherRedCircle) shouldBe
             AtomicMismatch(fieldName, redCircle, otherRedCircle)
+      }
+
+      "different not null Strings" {
+         val actual = VanillaDistanceCalculator.compare(fieldName, "Perpetuum mobile", "perpetuum mobile")
+         assertSoftly {
+            actual.shouldBeInstanceOf<StringMismatch>()
+            actual.field shouldBe fieldName
+            actual.expected shouldBe "Perpetuum mobile"
+            actual.actual shouldBe "perpetuum mobile"
+            actual.mismatchDescription.shouldContainInOrder(
+               "Match[0]: part of slice with indexes [1..15] matched actual[1..15]",
+               """Line[0] ="perpetuum mobile"""",
+               """Match[0]= -+++++++++++++++"""
+            )
+         }
       }
    }
 }


### PR DESCRIPTION
Plug in search for similar strings everywhere we search for similar instances of data classes. For instance:

```kotlin
            val message = shouldThrow<AssertionError> {
               "sweet green fruit" shouldBeIn listOf(
                  "sweet green pear", "sweet red apple"
               )
            }.message
            message.shouldContainInOrder(
               "Possible matches:",
               """Line[0] ="sweet green pear"""",
               """Match[0]= ++++++++++++----""",
            )
```

