### PR TITLE
speed-up-increasing-decreasing-draft

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/decreasing.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/decreasing.kt
@@ -153,7 +153,11 @@ fun <T> monotonicallyDecreasingWith(comparator: Comparator<in T>): Matcher<List<
 }
 
 private fun <T> testMonotonicallyDecreasingWith(value: List<T>, comparator: Comparator<in T>): MatcherResult {
-   val failure = value.zipWithNext().withIndex().find { (_, pair) -> comparator.compare(pair.first, pair.second) < 0 }
+   val failure = value
+      .asSequence()
+      .zipWithNext()
+      .withIndex()
+      .find { (_, pair) -> comparator.compare(pair.first, pair.second) < 0 }
    val snippet = value.print().value
    val elementMessage = when (failure) {
       null -> ""
@@ -184,7 +188,11 @@ fun <T> strictlyDecreasingWith(comparator: Comparator<in T>): Matcher<List<T>> =
 }
 
 private fun <T> testStrictlyDecreasingWith(value: List<T>, comparator: Comparator<in T>): MatcherResult {
-   val failure = value.zipWithNext().withIndex().find { (_, pair) -> comparator.compare(pair.first, pair.second) <= 0 }
+   val failure = value
+      .asSequence()
+      .zipWithNext()
+      .withIndex()
+      .find { (_, pair) -> comparator.compare(pair.first, pair.second) <= 0 }
    val snippet = value.print().value
    val elementMessage = when (failure) {
       null -> ""

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/increasing.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/increasing.kt
@@ -182,7 +182,11 @@ fun <T> strictlyIncreasingWith(comparator: Comparator<in T>): Matcher<List<T>> =
 }
 
 private fun <T> testStrictlyIncreasingWith(value: List<T>, comparator: Comparator<in T>): MatcherResult {
-   val failure = value.zipWithNext().withIndex().find { (_, pair) -> comparator.compare(pair.first, pair.second) >= 0 }
+   val failure = value
+      .asSequence()
+      .zipWithNext()
+      .withIndex()
+      .find { (_, pair) -> comparator.compare(pair.first, pair.second) >= 0 }
    val snippet = value.print().value
    val elementMessage = when (failure) {
       null -> ""
@@ -212,7 +216,11 @@ fun <T> monotonicallyIncreasingWith(comparator: Comparator<in T>): Matcher<List<
 }
 
 private fun <T> testMonotonicallyIncreasingWith(value: List<T>, comparator: Comparator<in T>): MatcherResult {
-   val failure = value.zipWithNext().withIndex().find { (_, pair) -> comparator.compare(pair.first, pair.second) > 0 }
+   val failure = value
+      .asSequence()
+      .zipWithNext()
+      .withIndex()
+      .find { (_, pair) -> comparator.compare(pair.first, pair.second) > 0 }
    val snippet = value.print().value
    val elementMessage = when (failure) {
       null -> ""


### PR DESCRIPTION
performance optimization - by using `asSequence` we no longer materialize intermediate steps into `List`, which is faster