### PR TITLE
add-shouldNotMatch-Regex

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -2420,6 +2420,7 @@ public final class io/kotest/matchers/string/MatchKt {
 	public static final fun shouldMatch (Ljava/lang/CharSequence;Ljava/lang/String;)Ljava/lang/CharSequence;
 	public static final fun shouldMatch (Ljava/lang/CharSequence;Lkotlin/text/Regex;)Ljava/lang/CharSequence;
 	public static final fun shouldNotMatch (Ljava/lang/CharSequence;Ljava/lang/String;)Ljava/lang/CharSequence;
+	public static final fun shouldNotMatch (Ljava/lang/CharSequence;Lkotlin/text/Regex;)Ljava/lang/CharSequence;
 }
 
 public final class io/kotest/matchers/string/MatchersKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/match.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/match.kt
@@ -22,6 +22,11 @@ infix fun <A : CharSequence> A?.shouldNotMatch(regex: String): A {
    return this!!
 }
 
+infix fun <A : CharSequence> A?.shouldNotMatch(regex: Regex): A {
+   this shouldNot match(regex)
+   return this!!
+}
+
 fun match(regex: Regex): Matcher<CharSequence?> = neverNullMatcher { value ->
    MatcherResult(
       value.matches(regex),

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -372,6 +372,11 @@ class StringMatchersTest : FreeSpec() {
             "foo" shouldMatch "f.."
             "boo" shouldNotMatch "foo"
             "boo" shouldNotMatch "f.."
+            "123" shouldMatch Regex("\\d\\{3}")
+         }
+         "string should not match Regex" {
+            "123" shouldNotMatch Regex("\\d\\{2}")
+            "123" shouldNotMatch Regex("\\d\\{4}")
          }
          "should fail if value is null" {
             shouldThrow<AssertionError> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/StringMatchersTest.kt
@@ -372,11 +372,11 @@ class StringMatchersTest : FreeSpec() {
             "foo" shouldMatch "f.."
             "boo" shouldNotMatch "foo"
             "boo" shouldNotMatch "f.."
-            "123" shouldMatch Regex("\\d\\{3}")
+            "123" shouldMatch Regex("\\d{3}")
          }
          "string should not match Regex" {
-            "123" shouldNotMatch Regex("\\d\\{2}")
-            "123" shouldNotMatch Regex("\\d\\{4}")
+            "123" shouldNotMatch Regex("\\d{2}")
+            "123" shouldNotMatch Regex("\\d{4}")
          }
          "should fail if value is null" {
             shouldThrow<AssertionError> {


### PR DESCRIPTION
Fix for https://github.com/kotest/kotest/issues/4531

add `infix fun <A : CharSequence> A?.shouldNotMatch(regex: Regex)` - it seems to be just missing, I don't see a reason why it should not be there.

Please correct me if I am wrong.


