### PR TITLE
Add SpringExtension that combines existing into a single extension

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/api/kotest-extensions-spring.api
+++ b/kotest-extensions/kotest-extensions-spring/api/kotest-extensions-spring.api
@@ -8,6 +8,17 @@ public final class io/kotest/extensions/spring/SpringAutowireConstructorExtensio
 	public fun instantiate (Lkotlin/reflect/KClass;)Lio/kotest/core/spec/Spec;
 }
 
+public final class io/kotest/extensions/spring/SpringExtension : io/kotest/core/extensions/ConstructorExtension, io/kotest/core/extensions/SpecExtension, io/kotest/core/extensions/TestCaseExtension {
+	public fun <init> ()V
+	public fun <init> (Lio/kotest/extensions/spring/SpringTestLifecycleMode;)V
+	public synthetic fun <init> (Lio/kotest/extensions/spring/SpringTestLifecycleMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getIgnoreSpringListenerOnFinalClassWarning ()Z
+	public fun instantiate (Lkotlin/reflect/KClass;)Lio/kotest/core/spec/Spec;
+	public fun intercept (Lio/kotest/core/spec/Spec;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun intercept (Lio/kotest/core/test/TestCase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setIgnoreSpringListenerOnFinalClassWarning (Z)V
+}
+
 public final class io/kotest/extensions/spring/SpringTestContextCoroutineContextElement : kotlin/coroutines/AbstractCoroutineContextElement {
 	public static final field Key Lio/kotest/extensions/spring/SpringTestContextCoroutineContextElement$Key;
 	public fun <init> (Lorg/springframework/test/context/TestContextManager;)V
@@ -28,7 +39,6 @@ public final class io/kotest/extensions/spring/SpringTestExtension : io/kotest/c
 }
 
 public final class io/kotest/extensions/spring/SpringTestExtensionKt {
-	public static final fun getSpringExtension ()Lio/kotest/extensions/spring/SpringTestExtension;
 	public static final fun testContextManager (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringAutowireConstructorExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringAutowireConstructorExtension.kt
@@ -1,7 +1,7 @@
 package io.kotest.extensions.spring
 
-import io.kotest.core.spec.Spec
 import io.kotest.core.extensions.ConstructorExtension
+import io.kotest.core.spec.Spec
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory
 import org.springframework.test.context.TestContextManager
 import kotlin.reflect.KClass
@@ -13,7 +13,9 @@ import kotlin.reflect.full.primaryConstructor
  *
  * The extension will delegate to spring's [TestContextManager] to autowire the constructors.
  */
+@Deprecated("Use SpringExtension which combines this and SpringTestExtension. Deprecated since 6.0")
 object SpringAutowireConstructorExtension : ConstructorExtension {
+
    override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
       // we only instantiate via spring if there's actually parameters in the constructor
       // otherwise there's nothing to inject there

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/ActiveProfileSpringTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/ActiveProfileSpringTest.kt
@@ -9,7 +9,7 @@ import org.springframework.test.context.ActiveProfiles
 
 @SpringBootTest(classes = [Components::class])
 @ActiveProfiles("test-profile")
-@ApplyExtension(SpringTestExtension::class)
+@ApplyExtension(SpringExtension::class)
 class ActiveProfileSpringTest : FunSpec() {
 
     @Value("\${test-foo}")

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/IsolationModeTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/IsolationModeTest.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 
 @ContextConfiguration(classes = [(Components::class)])
-@ApplyExtension(SpringTestExtension::class)
+@ApplyExtension(SpringExtension::class)
 class IsolationModeTest : WordSpec() {
 
    override fun isolationMode() = IsolationMode.InstancePerTest

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringBootTestTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringBootTestTest.kt
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest
 @SpringBootTest(classes = [Components::class])
 class SpringBootTestTest : FunSpec() {
 
-   override fun extensions() = listOf(SpringExtension)
+   override fun extensions() = listOf(SpringExtension())
 
     @Autowired
     lateinit var userService: UserService

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionConstructorTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionConstructorTest.kt
@@ -1,0 +1,18 @@
+package io.kotest.extensions.spring
+
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [(Components::class)])
+@ApplyExtension(SpringExtension::class)
+class SpringExtensionConstructorTest(service: UserService) : WordSpec() {
+  init {
+    "SpringListener" should {
+      "have autowired the service" {
+        service.repository.findUser().name shouldBe "system_user"
+      }
+    }
+  }
+}

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTest.kt
@@ -16,7 +16,7 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(classes = [Components::class])
 class SpringExtensionTest : WordSpec() {
 
-   override fun extensions() = listOf(SpringExtension)
+   override fun extensions() = listOf(SpringExtension())
 
    @Autowired
    private lateinit var service: UserService
@@ -30,7 +30,7 @@ class SpringExtensionTest : WordSpec() {
             testContextManager().shouldNotBeNull()
          }
          "generate applicable method name for a root test" {
-            SpringExtension.methodName(
+            SpringExtension().methodName(
                TestCase(
                   descriptor = SpringExtensionTest::class.toDescriptor()
                      .append("0foo__!!55@#woo"),
@@ -43,7 +43,7 @@ class SpringExtensionTest : WordSpec() {
             ) shouldStartWith "_0foo____55__woo"
          }
          "generate applicable method name for a nested test" {
-            SpringExtension.methodName(
+            SpringExtension().methodName(
                TestCase(
                   descriptor = SpringExtensionTest::class.toDescriptor()
                      .append("0foo__!!55@#woo")

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringRootLifecycleModeTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringRootLifecycleModeTest.kt
@@ -10,7 +10,7 @@ import org.springframework.test.context.TestExecutionListeners
 class SpringRootLifecycleModeTest : DescribeSpec() {
    init {
 
-      extension(SpringTestExtension(SpringTestLifecycleMode.Root))
+      extension(SpringExtension(SpringTestLifecycleMode.Root))
 
       beforeSpec {
          before shouldBe 0

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringTestExecutionListenerTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringTestExecutionListenerTest.kt
@@ -19,7 +19,7 @@ class SpringTestExecutionListenerTest : FunSpec() {
    @Autowired
    lateinit var userService: UserService
 
-   override fun extensions() = listOf(SpringExtension)
+   override fun extensions() = listOf(SpringExtension())
 
    init {
       test("Should autowire with spring listeners") {

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringTestLifecycleModeTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringTestLifecycleModeTest.kt
@@ -10,7 +10,7 @@ import org.springframework.test.context.TestExecutionListeners
 class SpringTestLifecycleModeTest : DescribeSpec() {
    init {
 
-      extensions(SpringTestExtension(SpringTestLifecycleMode.Test))
+      extensions(SpringExtension(SpringTestLifecycleMode.Test))
 
       beforeSpec {
          before shouldBe 0

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/org/example/myproject/import/SoftKeywordTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/org/example/myproject/import/SoftKeywordTest.kt
@@ -17,7 +17,7 @@ class IllegalPackageNameTest : FunSpec() {
       test("should throw clear error on illegal package name") {
          @Suppress("MaxLineLength")
          shouldThrowAny {
-            SpringExtension.intercept(this@IllegalPackageNameTest) {}
+            SpringExtension().intercept(this@IllegalPackageNameTest) {}
          }.message shouldBe "Spec package name cannot contain a java keyword: import,finally,catch,const,final,inner,protected,private,public"
       }
    }
@@ -29,7 +29,7 @@ class IllegalPackageNameTest : FunSpec() {
 private class SoftKeywordTest(
    @Suppress("UNUSED_PARAMETER") service: UserService
 ) : StringSpec({
-   extensions(SpringExtension)
+   extensions(SpringExtension())
    "empty test should always be green" {
    }
 })


### PR DESCRIPTION
Now that @ApplyExtension supports test case extensions and constructor extensions we can have a single easy to use spring extension