### PR TITLE
fix: make private the launcher preventing the warning in kotlin 2.1.0

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/NativeTransformer.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/NativeTransformer.kt
@@ -3,6 +3,7 @@ package io.kotest.framework.multiplatform.embeddablecompiler
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.ir.UNDEFINED_OFFSET
 import org.jetbrains.kotlin.ir.builders.IrSingleStatementBuilder
 import org.jetbrains.kotlin.ir.builders.Scope
@@ -33,6 +34,7 @@ class NativeTransformer(messageCollector: MessageCollector, pluginContext: IrPlu
    ): IrDeclaration {
       val launcher = pluginContext.irFactory.buildProperty {
          name = Name.identifier(EntryPoint.LauncherValName)
+         visibility = DescriptorVisibilities.PRIVATE
       }.apply {
          parent = declarationParent
          annotations += IrSingleStatementBuilder(


### PR DESCRIPTION
This PR closes #4521 preventing the warning in Kotlin 2.1.0

```
...
FIELD name:launcher type:kotlin.Unit visibility:public [final,static]
  inside PROPERTY name:launcher visibility:public modality:FINAL [val]
...
```

I could not test against `2.1.0` in  `KotestMultiplatformCompilerGradlePluginSpec` since no XML report is generated when the `wasmJsBrowser` task is executed and the test fails.
