### PR TITLE
DoNotInterceptErrorsTest.kt (#4604)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
@@ -239,6 +239,11 @@ private class EventuallyControl(
          return true
       }
 
+      // do not intercept Error unless it's an AssertionError
+      if (e is Error && e !is AssertionError) {
+         return true
+      }
+
       return !config.expectedExceptionsFn(e)
    }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/DoNotInterceptErrorsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/DoNotInterceptErrorsTest.kt
@@ -1,0 +1,32 @@
+package io.kotest.assertions.nondeterministic
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlin.time.Duration.Companion.seconds
+
+class DoNotInterceptErrorsTest: StringSpec() {
+   init {
+      "does not retry after Error" {
+         mapOf(
+            "OutOfMemoryError" to OutOfMemoryError(),
+            "StackOverflowError" to StackOverflowError(),
+         ).entries.forEach {  (name, error) ->
+            var count = 0
+            val thrown = shouldThrow<Error> {
+               eventually(1.seconds) {
+                  count++
+                  throw error
+               }
+            }
+            assertSoftly {
+               thrown::class shouldBe AssertionError::class
+               thrown.message shouldContain name
+               count shouldBe 1
+            }
+         }
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyTest.kt
@@ -197,6 +197,26 @@ class EventuallyTest : FunSpec() {
          }
       }
 
+      test("do not retry after OutOfMemoryError and StackOverflowError") {
+         mapOf(
+            "OutOfMemoryError" to OutOfMemoryError(),
+            "StackOverflowError" to StackOverflowError(),
+         ).entries.forEach { (name, error) ->
+            var count = 0
+            val thrown = shouldThrow<Error> {
+               testEventually(1.seconds) {
+                  count++
+                  throw error
+               }
+            }
+            assertSoftly {
+               thrown::class shouldBe AssertionError::class
+               thrown.message shouldContain name
+               count shouldBe 1
+            }
+         }
+      }
+
       test("display the first and last underlying failures") {
          var count = 0
          val message = shouldFail {


### PR DESCRIPTION
make sure `eventually` does not retry after critical errors such as `OutOfMemoryError`


