### PR TITLE
Removed @KotestInternal from funcs/classes that can simply be internal

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/NullTests.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/NullTests.kt
@@ -1,7 +1,6 @@
 package com.sksamuel.kotest
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.common.nonConstantTrue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.WordSpec

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/InspectorSizeTests.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/inspectors/InspectorSizeTests.kt
@@ -1,8 +1,8 @@
 package com.sksamuel.kotest.inspectors
 
+import com.sksamuel.kotest.nonConstantTrue
 import io.kotest.assertions.shouldFail
 import io.kotest.assertions.throwables.shouldThrowAny
-import io.kotest.common.nonConstantTrue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/nonConstantResults.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/nonConstantResults.kt
@@ -1,9 +1,7 @@
-package io.kotest.common
+package com.sksamuel.kotest
 
 /** returns `true` while preventing the compiler from optimizing it away. */
-@KotestInternal
 fun nonConstantTrue() = System.currentTimeMillis() > 0L
 
 /** returns `false` while preventing the compiler from optimizing it away. */
-@KotestInternal
 fun nonConstantFalse() = System.currentTimeMillis() == 0L

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/UntilTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/UntilTest.kt
@@ -1,6 +1,6 @@
 package io.kotest.assertions.nondeterministic
 
-import io.kotest.common.nonConstantTrue
+import com.sksamuel.kotest.nonConstantTrue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FunSpec

--- a/kotest-common/api/kotest-common.api
+++ b/kotest-common/api/kotest-common.api
@@ -10,11 +10,6 @@ public abstract interface annotation class io/kotest/common/JVMOnly : java/lang/
 public abstract interface annotation class io/kotest/common/KotestInternal : java/lang/annotation/Annotation {
 }
 
-public final class io/kotest/common/NonConstantResultsKt {
-	public static final fun nonConstantFalse ()Z
-	public static final fun nonConstantTrue ()Z
-}
-
 public final class io/kotest/common/NonDeterministicTestVirtualTimeEnabled : kotlin/coroutines/CoroutineContext$Element, kotlin/coroutines/CoroutineContext$Key {
 	public static final field INSTANCE Lio/kotest/common/NonDeterministicTestVirtualTimeEnabled;
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3827,19 +3827,6 @@ public final class io/kotest/engine/listener/CollectingTestEngineListener$TestCa
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/kotest/engine/listener/CompositeTestEngineListener : io/kotest/engine/listener/TestEngineListener {
-	public fun <init> (Ljava/util/List;)V
-	public fun engineFinished (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun engineInitialized (Lio/kotest/engine/interceptors/EngineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun engineStarted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specFinished (Lkotlin/reflect/KClass;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specIgnored (Lkotlin/reflect/KClass;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specStarted (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testFinished (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testIgnored (Lio/kotest/core/test/TestCase;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testStarted (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class io/kotest/engine/listener/EnhancedConsoleTestEngineListener : io/kotest/engine/listener/AbstractTestEngineListener {
 	public fun <init> (Lcom/github/ajalt/mordant/TermColors;)V
 	public fun engineFinished (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -4265,15 +4252,6 @@ public final class io/kotest/engine/test/interceptors/BlockedThreadTestTimeoutEx
 	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
-public abstract interface class io/kotest/engine/test/interceptors/NextTestExecutionInterceptor {
-	public abstract fun invoke (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/kotest/engine/test/interceptors/TestDispatcherInterceptor : io/kotest/engine/test/interceptors/TestExecutionInterceptor {
-	public fun <init> ()V
-	public fun intercept (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestScope;Lio/kotest/engine/test/interceptors/NextTestExecutionInterceptor;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/kotest/engine/test/interceptors/TestTimeoutException : java/lang/Exception {

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3827,26 +3827,6 @@ public final class io/kotest/engine/listener/CollectingTestEngineListener$TestCa
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/kotest/engine/listener/EnhancedConsoleTestEngineListener : io/kotest/engine/listener/AbstractTestEngineListener {
-	public fun <init> (Lcom/github/ajalt/mordant/TermColors;)V
-	public fun engineFinished (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun engineInitialized (Lio/kotest/engine/interceptors/EngineContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specFinished (Lkotlin/reflect/KClass;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specStarted (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testFinished (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testIgnored (Lio/kotest/core/test/TestCase;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testStarted (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/kotest/engine/listener/LoggingTestEngineListener : io/kotest/engine/listener/AbstractTestEngineListener {
-	public static final field INSTANCE Lio/kotest/engine/listener/LoggingTestEngineListener;
-	public fun engineFinished (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specFinished (Lkotlin/reflect/KClass;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun specStarted (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testFinished (Lio/kotest/core/test/TestCase;Lio/kotest/core/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun testStarted (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public final class io/kotest/engine/listener/PinnedSpecTestEngineListener : io/kotest/engine/listener/TestEngineListener {
 	public fun <init> (Lio/kotest/engine/listener/TestEngineListener;)V
 	public fun engineFinished (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ContainerScope.kt
@@ -33,7 +33,7 @@ private val outOfOrderCallbacksException =
    InvalidDslException("Cannot register callbacks after a test has been defined. To disable this behavior set the global configuration value allowOutOfOrderCallbacks to true but be aware this can lead to subtle bugs in your tests.")
 
 /**
- * Extends a [TestScope] with convenience methods for registering tests and listeners.
+ * Extends a [TestScope] with convenience methods for registering tests and callbacks.
  */
 @KotestTestScope
 interface ContainerScope : TestScope {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CompositeTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CompositeTestEngineListener.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
  * A [TestEngineListener] that wraps one or more other test engine listeners,
  * forwarding calls to all listeners.
  */
-class CompositeTestEngineListener(private val listeners: List<TestEngineListener>) : TestEngineListener {
+internal class CompositeTestEngineListener(private val listeners: List<TestEngineListener>) : TestEngineListener {
 
    init {
       require(listeners.isNotEmpty())

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/LoggingTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/LoggingTestEngineListener.kt
@@ -7,7 +7,7 @@ import io.kotest.core.Logger
 import io.kotest.mpp.bestName
 import kotlin.reflect.KClass
 
-object LoggingTestEngineListener : AbstractTestEngineListener() {
+internal object LoggingTestEngineListener : AbstractTestEngineListener() {
 
    private val logger = Logger(SpecExecutorDelegate::class)
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestExecutionInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TestExecutionInterceptor.kt
@@ -1,6 +1,5 @@
 package io.kotest.engine.test.interceptors
 
-import io.kotest.common.KotestInternal
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
 import io.kotest.core.test.TestScope
@@ -23,7 +22,6 @@ internal interface TestExecutionInterceptor {
  *
  * With a normal lambda type, each call adds three lines to the stacktrace, but an interface only adds one line.
  */
-@KotestInternal
-fun interface NextTestExecutionInterceptor {
+internal fun interface NextTestExecutionInterceptor {
    suspend operator fun invoke(testCase: TestCase, scope: TestScope): TestResult
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/interceptors.kt
@@ -1,6 +1,5 @@
 package io.kotest.engine
 
-import io.kotest.common.KotestInternal
 import io.kotest.engine.interceptors.DumpConfigInterceptor
 import io.kotest.engine.interceptors.EmptyTestSuiteInterceptor
 import io.kotest.engine.interceptors.EngineInterceptor
@@ -15,7 +14,6 @@ import io.kotest.engine.interceptors.TestEngineStartedFinishedInterceptor
 import io.kotest.engine.interceptors.WriteFailuresInterceptor
 import io.kotest.engine.test.interceptors.TestExecutionInterceptor
 
-@KotestInternal
 actual fun testEngineInterceptors(): List<EngineInterceptor> {
    return listOfNotNull(
       TestEngineStartedFinishedInterceptor,
@@ -31,6 +29,5 @@ actual fun testEngineInterceptors(): List<EngineInterceptor> {
    )
 }
 
-@KotestInternal
 internal actual fun testInterceptorsForPlatform(): List<TestExecutionInterceptor> =
    listOf(MarkAbortedExceptionsAsSkippedTestInterceptor)

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/listener/EnhancedConsoleTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/listener/EnhancedConsoleTestEngineListener.kt
@@ -19,7 +19,8 @@ import kotlin.time.TimeSource
 /**
  * Generates test output to the console in an enhanced, formatted, coloured, way.
  */
-class EnhancedConsoleTestEngineListener(private val term: TermColors) : AbstractTestEngineListener() {
+@Suppress("SameParameterValue")
+internal class EnhancedConsoleTestEngineListener(private val term: TermColors) : AbstractTestEngineListener() {
 
    private var errors = 0
    private var start = TimeSource.Monotonic.markNow()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/TestDispatcherInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/test/interceptors/TestDispatcherInterceptor.kt
@@ -20,8 +20,7 @@ import kotlin.coroutines.coroutineContext
  * If the current dispatcher is already a [TestDispatcher] then this interceptor is a no-op.
  */
 @ExperimentalCoroutinesApi
-@ExperimentalStdlibApi
-class TestDispatcherInterceptor : TestExecutionInterceptor {
+internal class TestDispatcherInterceptor : TestExecutionInterceptor {
 
    private val logger = Logger(TestDispatcherInterceptor::class)
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/nonConstantResults.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/nonConstantResults.kt
@@ -1,0 +1,7 @@
+package com.sksamuel.kotest.engine
+
+/** returns `true` while preventing the compiler from optimizing it away. */
+fun nonConstantTrue() = System.currentTimeMillis() > 0L
+
+/** returns `false` while preventing the compiler from optimizing it away. */
+fun nonConstantFalse() = System.currentTimeMillis() == 0L

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/DescribeSpecConfigSyntaxTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/DescribeSpecConfigSyntaxTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.engine.spec.config
 
-import io.kotest.common.nonConstantFalse
+import com.sksamuel.kotest.engine.nonConstantFalse
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.DescribeSpec

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/FunSpecConfigSyntaxTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/FunSpecConfigSyntaxTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.engine.spec.config
 
-import io.kotest.common.nonConstantFalse
+import com.sksamuel.kotest.engine.nonConstantFalse
 import io.kotest.core.Tag
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/ShouldSpecConfigSyntaxTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/config/ShouldSpecConfigSyntaxTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.engine.spec.config
 
-import io.kotest.common.nonConstantFalse
+import com.sksamuel.kotest.engine.nonConstantFalse
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.ShouldSpec

--- a/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/FeatureSpecEngineKitTest.kt
+++ b/kotest-runner/kotest-runner-junit5/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/FeatureSpecEngineKitTest.kt
@@ -1,6 +1,5 @@
 package com.sksamuel.kotest.runner.junit5
 
-import io.kotest.common.nonConstantFalse
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.enabledif.LinuxCondition
 import io.kotest.core.spec.style.FeatureSpec
@@ -157,6 +156,8 @@ private class FeatureSpecHappyPathSample : FeatureSpec() {
    }
 }
 
+/** returns `false` while preventing the compiler from optimizing it away. */
+fun nonConstantFalse() = System.currentTimeMillis() == 0L
 
 private class FeatureSpecSample : FeatureSpec() {
    init {


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
