### PR TITLE
Add system property key for displayFullTestPath

### DIFF
--- a/documentation/docs/framework/output.md
+++ b/documentation/docs/framework/output.md
@@ -10,7 +10,8 @@ will notice that only the leaf test name is included in output and test reports.
 which is designed around class.method test frameworks.
 
 Until such time that Gradle improves their test integration so that tests can be arbitrarily nested, Kotest
-offers a workaround by allowing you to specify `displayFullTestPath` in [project configuration](project_config.md).
+offers a workaround by allowing you to specify `displayFullTestPath` in [project configuration](project_config.md)
+or the [system property](config_props.md) `kotest.framework.testname.display.full.path`.
 
 When this setting is enabled, the test names will be the concatenation of the entire test path. So a test like this:
 

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3398,7 +3398,7 @@ public final class io/kotest/engine/KotestEngineProperties {
 	public static final field disableSourceRef Ljava/lang/String;
 	public static final field disableTestNestedJarScanning Ljava/lang/String;
 	public static final field discoveryClasspathFallbackEnabled Ljava/lang/String;
-   public static final field displayFullTestPath Ljava/lang/String;
+	public static final field displayFullTestPath Ljava/lang/String;
 	public static final field dumpConfig Ljava/lang/String;
 	public static final field duplicateTestNameMode Ljava/lang/String;
 	public static final field excludeTags Ljava/lang/String;

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3398,6 +3398,7 @@ public final class io/kotest/engine/KotestEngineProperties {
 	public static final field disableSourceRef Ljava/lang/String;
 	public static final field disableTestNestedJarScanning Ljava/lang/String;
 	public static final field discoveryClasspathFallbackEnabled Ljava/lang/String;
+   public static final field displayFullTestPath Ljava/lang/String;
 	public static final field dumpConfig Ljava/lang/String;
 	public static final field duplicateTestNameMode Ljava/lang/String;
 	public static final field excludeTags Ljava/lang/String;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -282,7 +282,7 @@ class ProjectConfiguration {
     */
    var duplicateTestNameMode: DuplicateTestNameMode = Defaults.duplicateTestNameMode
 
-   var displayFullTestPath: Boolean = Defaults.displayFullTestPath
+   var displayFullTestPath: Boolean = sysprop(KotestEngineProperties.displayFullTestPath, Defaults.displayFullTestPath)
 
    var allowOutOfOrderCallbacks: Boolean = Defaults.allowOutOfOrderCallbacks
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/ProjectConfiguration.kt
@@ -11,9 +11,11 @@ import io.kotest.core.test.EnabledOrReasonIf
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestCaseOrder
 import io.kotest.core.test.TestCaseSeverityLevel
+import io.kotest.engine.KotestEngineProperties
 import io.kotest.engine.concurrency.SpecExecutionMode
 import io.kotest.engine.concurrency.TestExecutionMode
 import io.kotest.engine.coroutines.CoroutineDispatcherFactory
+import io.kotest.mpp.sysprop
 import kotlin.time.Duration
 
 /**

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/KotestEngineProperties.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/KotestEngineProperties.kt
@@ -76,6 +76,8 @@ object KotestEngineProperties {
 
    const val disableTestNestedJarScanning = "kotest.framework.disable.test.nested.jar.scanning"
 
+   const val displayFullTestPath = "kotest.framework.testname.display.full.path"
+
    /**
     * Specify a fully qualified name to use for project config.
     * This class will be instantiated via reflection.


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Added another system property key, `kotest.framework.testname.display.full.path`, used to configure the option to display the full test paths in reports. This is a nice-to-have for my use case where I want to upload my test results for CI and have to use this setting, but currently I can only use an `AbstractProjectConfig`.