### PR TITLE
Rework larger.kt matchers

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -595,9 +595,25 @@ public final class io/kotest/matchers/collections/InorderKt {
 public final class io/kotest/matchers/collections/LargerKt {
 	public static final fun beLargerThan (Ljava/lang/Iterable;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeLargerThan (Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;
+	public static final fun shouldBeLargerThan ([B[B)[B
+	public static final fun shouldBeLargerThan ([C[C)[C
+	public static final fun shouldBeLargerThan ([D[D)[D
+	public static final fun shouldBeLargerThan ([F[F)[F
+	public static final fun shouldBeLargerThan ([I[I)[I
+	public static final fun shouldBeLargerThan ([J[J)[J
 	public static final fun shouldBeLargerThan ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun shouldBeLargerThan ([S[S)[S
+	public static final fun shouldBeLargerThan ([Z[Z)[Z
 	public static final fun shouldNotBeLargerThan (Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;
+	public static final fun shouldNotBeLargerThan ([B[B)[B
+	public static final fun shouldNotBeLargerThan ([C[C)[C
+	public static final fun shouldNotBeLargerThan ([D[D)[D
+	public static final fun shouldNotBeLargerThan ([F[F)[F
+	public static final fun shouldNotBeLargerThan ([I[I)[I
+	public static final fun shouldNotBeLargerThan ([J[J)[J
 	public static final fun shouldNotBeLargerThan ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun shouldNotBeLargerThan ([S[S)[S
+	public static final fun shouldNotBeLargerThan ([Z[Z)[Z
 }
 
 public final class io/kotest/matchers/collections/MatchersKt {

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -593,12 +593,11 @@ public final class io/kotest/matchers/collections/InorderKt {
 }
 
 public final class io/kotest/matchers/collections/LargerKt {
-	public static final fun beLargerThan (Ljava/util/Collection;)Lio/kotest/matchers/Matcher;
+	public static final fun beLargerThan (Ljava/lang/Iterable;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeLargerThan (Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;
-	public static final fun shouldBeLargerThan (Ljava/lang/Iterable;Ljava/util/Collection;)Ljava/lang/Iterable;
-	public static final fun shouldBeLargerThan (Ljava/util/Collection;Ljava/util/Collection;)Ljava/util/Collection;
-	public static final fun shouldBeLargerThan ([Ljava/lang/Object;Ljava/util/Collection;)[Ljava/lang/Object;
 	public static final fun shouldBeLargerThan ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun shouldNotBeLargerThan (Ljava/lang/Iterable;Ljava/lang/Iterable;)Ljava/lang/Iterable;
+	public static final fun shouldNotBeLargerThan ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
 }
 
 public final class io/kotest/matchers/collections/MatchersKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
@@ -2,38 +2,32 @@ package io.kotest.matchers.collections
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.sequences.beLargerThan
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 
-infix fun <T, U, I : Iterable<T>> I.shouldBeLargerThan(other: Collection<U>): I {
-   toList().shouldBeLargerThan(other)
-   return this
+
+infix fun <T, U, I : Iterable<T>> I.shouldBeLargerThan(other: Iterable<U>): I = apply {
+   toList() should beLargerThan(other)
 }
 
-infix fun <T, U, I : Iterable<T>> I.shouldBeLargerThan(other: Iterable<U>): I {
-   toList().shouldBeLargerThan(other.toList())
-   return this
+infix fun <T, U, I : Iterable<T>> I.shouldNotBeLargerThan(other: Iterable<U>): I = apply {
+   toList() shouldNot beLargerThan(other)
 }
 
-infix fun <T, U> Array<T>.shouldBeLargerThan(other: Collection<U>): Array<T> {
-   asList().shouldBeLargerThan(other)
-   return this
-}
-
-infix fun <T, U> Array<T>.shouldBeLargerThan(other: Array<U>): Array<T> {
+infix fun <T, U> Array<T>.shouldBeLargerThan(other: Array<U>): Array<T> = apply {
    asList().shouldBeLargerThan(other.asList())
-   return this
 }
 
-infix fun <T, U, C : Collection<T>> C.shouldBeLargerThan(other: Collection<U>): C {
-   this should beLargerThan(other)
-   return this
+infix fun <T, U> Array<T>.shouldNotBeLargerThan(other: Array<U>): Array<T> = apply {
+   asList().shouldNotBeLargerThan(other.asList())
 }
 
-fun <T, U> beLargerThan(other: Collection<U>) = object : Matcher<Collection<T>> {
-   override fun test(value: Collection<T>) = MatcherResult(
-      value.size > other.size,
-      { "Collection of size ${value.size} should be larger than collection of size ${other.size}" },
-      {
-         "Collection of size ${value.size} should not be larger than collection of size ${other.size}"
-      })
+fun <T, U> beLargerThan(other: Iterable<U>) = object : Matcher<Iterable<T>> {
+   val otherSize = other.count()
+   override fun test(value: Iterable<T>) = MatcherResult(
+      value.count() > otherSize,
+      { "Collection of size ${value.count()} should be larger than collection of size $otherSize" },
+      { "Collection of size ${value.count()} should not be larger than collection of size $otherSize"}
+   )
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
@@ -2,10 +2,317 @@ package io.kotest.matchers.collections
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
-import io.kotest.matchers.sequences.beLargerThan
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+// region Primitive Type Matchers
+
+/**
+ * Asserts that the size of this [ByteArray] is larger than the size of [other].
+ *
+ * Verifies that the current [ByteArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [ByteArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * byteArrayOf(1, 2, 3) shouldBeLargerThan byteArrayOf(1, 2)    // Assertion passes
+ * byteArrayOf(1) shouldBeLargerThan byteArrayOf(1, 2, 3)      // Assertion fails
+ * ```
+ *
+ * @see ByteArray.shouldNotBeLargerThan
+ */
+infix fun ByteArray.shouldBeLargerThan(other: ByteArray): ByteArray = apply {
+   asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [ByteArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [ByteArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [ByteArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * byteArrayOf(1) shouldNotBeLargerThan byteArrayOf(1, 2, 3)    // Assertion passes
+ * byteArrayOf(1, 2, 3) shouldNotBeLargerThan byteArrayOf(1, 2) // Assertion fails
+ * ```
+ *
+ * @see ByteArray.shouldBeLargerThan
+ */
+infix fun ByteArray.shouldNotBeLargerThan(other: ByteArray): ByteArray = apply {
+   asList() shouldNotBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [IntArray] is larger than the size of [other].
+ *
+ * Verifies that the current [IntArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [IntArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * intArrayOf(1, 2, 3) shouldBeLargerThan intArrayOf(1, 2)    // Assertion passes
+ * intArrayOf(1) shouldBeLargerThan intArrayOf(1, 2, 3)      // Assertion fails
+ * ```
+ *
+ * @see IntArray.shouldNotBeLargerThan
+ */
+infix fun IntArray.shouldBeLargerThan(other: IntArray): IntArray = apply {
+   asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [IntArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [IntArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [IntArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * intArrayOf(1) shouldNotBeLargerThan intArrayOf(1, 2, 3)    // Assertion passes
+ * intArrayOf(1, 2, 3) shouldNotBeLargerThan intArrayOf(1, 2) // Assertion fails
+ * ```
+ *
+ * @see IntArray.shouldBeLargerThan
+ */
+infix fun IntArray.shouldNotBeLargerThan(other: IntArray): IntArray = apply {
+   asList() shouldNotBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [ShortArray] is larger than the size of [other].
+ *
+ * Verifies that the current [ShortArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [ShortArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * shortArrayOf(1, 2, 3) shouldBeLargerThan shortArrayOf(1, 2)    // Assertion passes
+ * shortArrayOf(1) shouldBeLargerThan shortArrayOf(1, 2, 3)      // Assertion fails
+ * ```
+ *
+ * @see ShortArray.shouldNotBeLargerThan
+ */
+infix fun ShortArray.shouldBeLargerThan(other: ShortArray): ShortArray = apply {
+   asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [ShortArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [ShortArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [ShortArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * shortArrayOf(1) shouldNotBeLargerThan shortArrayOf(1, 2, 3)    // Assertion passes
+ * shortArrayOf(1, 2, 3) shouldNotBeLargerThan shortArrayOf(1, 2) // Assertion fails
+ * ```
+ *
+ * @see ShortArray.shouldBeLargerThan
+ */
+infix fun ShortArray.shouldNotBeLargerThan(other: ShortArray): ShortArray = apply {
+   asList() shouldNotBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [LongArray] is larger than the size of [other].
+ *
+ * Verifies that the current [LongArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [LongArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * longArrayOf(1, 2, 3) shouldBeLargerThan longArrayOf(1, 2)    // Assertion passes
+ * longArrayOf(1) shouldBeLargerThan longArrayOf(1, 2, 3)      // Assertion fails
+ * ```
+ *
+ * @see LongArray.shouldNotBeLargerThan
+ */
+infix fun LongArray.shouldBeLargerThan(other: LongArray): LongArray = apply {
+   asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [LongArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [LongArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [LongArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * longArrayOf(1) shouldNotBeLargerThan longArrayOf(1, 2, 3)    // Assertion passes
+ * longArrayOf(1, 2, 3) shouldNotBeLargerThan longArrayOf(1, 2) // Assertion fails
+ * ```
+ *
+ * @see LongArray.shouldBeLargerThan
+ */
+infix fun LongArray.shouldNotBeLargerThan(other: LongArray): LongArray = apply {
+   asList() shouldNotBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [FloatArray] is larger than the size of [other].
+ *
+ * Verifies that the current [FloatArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [FloatArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * floatArrayOf(1.1f, 2.2f, 3.3f) shouldBeLargerThan floatArrayOf(1.1f, 2.2f)    // Assertion passes
+ * floatArrayOf(1.1f) shouldBeLargerThan floatArrayOf(1.1f, 2.2f, 3.3f)        // Assertion fails
+ * ```
+ *
+ * @see FloatArray.shouldNotBeLargerThan
+ */
+infix fun FloatArray.shouldBeLargerThan(other: FloatArray): FloatArray = apply {
+   this.asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [FloatArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [FloatArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [FloatArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * floatArrayOf(1.1f) shouldNotBeLargerThan floatArrayOf(1.1f, 2.2f, 3.3f)    // Assertion passes
+ * floatArrayOf(1.1f, 2.2f, 3.3f) shouldNotBeLargerThan floatArrayOf(1.1f, 2.2f) // Assertion fails
+ * ```
+ *
+ * @see FloatArray.shouldBeLargerThan
+ */
+infix fun FloatArray.shouldNotBeLargerThan(other: FloatArray): FloatArray = apply {
+   this.asList() shouldNotBeLargerThan other.asList()
+}
+
+
+/**
+ * Asserts that the size of this [DoubleArray] is larger than the size of [other].
+ *
+ * Verifies that the current [DoubleArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [DoubleArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * doubleArrayOf(1.1, 2.2, 3.3) shouldBeLargerThan doubleArrayOf(1.1, 2.2)    // Assertion passes
+ * doubleArrayOf(1.1) shouldBeLargerThan doubleArrayOf(1.1, 2.2, 3.3)        // Assertion fails
+ * ```
+ *
+ * @see DoubleArray.shouldNotBeLargerThan
+ */
+infix fun DoubleArray.shouldBeLargerThan(other: DoubleArray): DoubleArray = apply {
+   this.asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [DoubleArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [DoubleArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [DoubleArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * doubleArrayOf(1.1) shouldNotBeLargerThan doubleArrayOf(1.1, 2.2, 3.3)    // Assertion passes
+ * doubleArrayOf(1.1, 2.2, 3.3) shouldNotBeLargerThan doubleArrayOf(1.1, 2.2) // Assertion fails
+ * ```
+ *
+ * @see DoubleArray.shouldBeLargerThan
+ */
+infix fun DoubleArray.shouldNotBeLargerThan(other: DoubleArray): DoubleArray = apply {
+   this.asList() shouldNotBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [CharArray] is larger than the size of [other].
+ *
+ * Verifies that the current [CharArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [CharArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * charArrayOf('a', 'b', 'c') shouldBeLargerThan charArrayOf('a', 'b')    // Assertion passes
+ * charArrayOf('a') shouldBeLargerThan charArrayOf('a', 'b', 'c')        // Assertion fails
+ * ```
+ *
+ * @see CharArray.shouldNotBeLargerThan
+ */
+infix fun CharArray.shouldBeLargerThan(other: CharArray): CharArray = apply {
+   this.asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [CharArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [CharArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [CharArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * charArrayOf('a') shouldNotBeLargerThan charArrayOf('a', 'b', 'c')    // Assertion passes
+ * charArrayOf('a', 'b', 'c') shouldNotBeLargerThan charArrayOf('a', 'b') // Assertion fails
+ * ```
+ *
+ * @see CharArray.shouldBeLargerThan
+ */
+infix fun CharArray.shouldNotBeLargerThan(other: CharArray): CharArray = apply {
+   this.asList() shouldNotBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [BooleanArray] is larger than the size of [other].
+ *
+ * Verifies that the current [BooleanArray] has more elements than the specified [other] array.
+ *
+ * Opposite of [BooleanArray.shouldNotBeLargerThan].
+ *
+ * Example:
+ * ```
+ * booleanArrayOf(true, false, true) shouldBeLargerThan booleanArrayOf(true, false)    // Assertion passes
+ * booleanArrayOf(true) shouldBeLargerThan booleanArrayOf(true, false, true)          // Assertion fails
+ * ```
+ *
+ * @see BooleanArray.shouldNotBeLargerThan
+ */
+infix fun BooleanArray.shouldBeLargerThan(other: BooleanArray): BooleanArray = apply {
+   this.asList() shouldBeLargerThan other.asList()
+}
+
+/**
+ * Asserts that the size of this [BooleanArray] is NOT larger than the size of [other].
+ *
+ * Verifies that the current [BooleanArray] does not have more elements than the specified [other] array.
+ *
+ * Opposite of [BooleanArray.shouldBeLargerThan].
+ *
+ * Example:
+ * ```
+ * booleanArrayOf(true) shouldNotBeLargerThan booleanArrayOf(true, false, true)    // Assertion passes
+ * booleanArrayOf(true, false, true) shouldNotBeLargerThan booleanArrayOf(true, false) // Assertion fails
+ * ```
+ *
+ * @see BooleanArray.shouldBeLargerThan
+ */
+infix fun BooleanArray.shouldNotBeLargerThan(other: BooleanArray): BooleanArray = apply {
+   this.asList() shouldNotBeLargerThan other.asList()
+}
+
+// endregion
 
 /**
  * Asserts that this [Iterable] is larger than [other].

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
@@ -7,27 +7,104 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 
+/**
+ * Asserts that this [Iterable] is larger than [other].
+ *
+ * Compares the sizes of two collections and verifies that the current collection contains more elements than the
+ * specified [other] collection.
+ *
+ * Opposite of [Iterable.shouldNotBeLargerThan].
+ *
+ * ```
+ * listOf(1, 2, 3) shouldBeLargerThan listOf(1, 2)    // Assertion passes
+ * listOf(1) shouldBeLargerThan listOf(1, 2, 3)       // Assertion fails
+ * ```
+ *
+ * @see Iterable.shouldNotBeLargerThan
+ */
 infix fun <T, U, I : Iterable<T>> I.shouldBeLargerThan(other: Iterable<U>): I = apply {
    toList() should beLargerThan(other)
 }
 
+/**
+ * Asserts that this [Iterable] is NOT larger than [other].
+ *
+ * Compares the sizes of two collections and verifies that the current collection does not contain more elements than
+ * the specified [other] collection.
+ *
+ * Opposite of [Iterable.shouldBeLargerThan].
+ *
+ * ```
+ * listOf(1) shouldNotBeLargerThan listOf(1, 2, 3)       // Assertion passes
+ * listOf(1, 2, 3) shouldNotBeLargerThan listOf(1, 2)    // Assertion fails
+ * ```
+ *
+ * @see Iterable.shouldBeLargerThan
+ */
 infix fun <T, U, I : Iterable<T>> I.shouldNotBeLargerThan(other: Iterable<U>): I = apply {
    toList() shouldNot beLargerThan(other)
 }
 
+/**
+ * Asserts that this [Array] is larger than [other].
+ *
+ * Compares the sizes of two arrays and verifies that the current array contains more elements than the specified
+ * [other] array.
+ *
+ * Opposite of [Array.shouldNotBeLargerThan].
+ *
+ * ```
+ * arrayOf(1, 2, 3) shouldBeLargerThan arrayOf(1, 2)    // Assertion passes
+ * arrayOf(1) shouldBeLargerThan arrayOf(1, 2, 3)       // Assertion fails
+ * ```
+ *
+ * @see Array.shouldNotBeLargerThan
+ */
 infix fun <T, U> Array<T>.shouldBeLargerThan(other: Array<U>): Array<T> = apply {
    asList().shouldBeLargerThan(other.asList())
 }
 
+/**
+ * Asserts that this [Array] is NOT larger than [other].
+ *
+ * Compares the sizes of two arrays and verifies that the current array does not contain more elements than the
+ * specified [other] array.
+ *
+ * Opposite of [Array.shouldBeLargerThan].
+ *
+ * ```
+ * arrayOf(1) shouldNotBeLargerThan arrayOf(1, 2, 3)         // Assertion passes
+ * arrayOf(1, 2, 3) shouldNotBeLargerThan arrayOf(1, 2)      // Assertion fails
+ * ```
+ *
+ * @see Array.shouldBeLargerThan
+ */
 infix fun <T, U> Array<T>.shouldNotBeLargerThan(other: Array<U>): Array<T> = apply {
    asList().shouldNotBeLargerThan(other.asList())
 }
 
+/**
+ * Matcher that asserts the size of an [Iterable] is larger than the size of [other].
+ *
+ * This matcher returns a successful result if the number of elements in the tested [Iterable]
+ * is strictly greater than the number of elements in [other].
+ *
+ * Example:
+ * ```
+ * listOf(1, 2, 3) should beLargerThan(listOf(1, 2))    // Assertion passes
+ * listOf(1) shouldNot beLargerThan(listOf(1, 2, 3))    // Assertion passes
+ * ```
+ *
+ * @param other the [Iterable] to compare against.
+ * @return a [Matcher] that validates the size relationship.
+ * @see Iterable.shouldBeLargerThan
+ * @see Iterable.shouldNotBeLargerThan
+ */
 fun <T, U> beLargerThan(other: Iterable<U>) = object : Matcher<Iterable<T>> {
    val otherSize = other.count()
    override fun test(value: Iterable<T>) = MatcherResult(
       value.count() > otherSize,
       { "Collection of size ${value.count()} should be larger than collection of size $otherSize" },
-      { "Collection of size ${value.count()} should not be larger than collection of size $otherSize"}
+      { "Collection of size ${value.count()} should not be larger than collection of size $otherSize" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/LargerTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/LargerTest.kt
@@ -1,0 +1,112 @@
+package io.kotest.matchers.collections
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.throwable.shouldHaveMessage
+
+class LargerTest : FunSpec({
+
+   context("Should Be Larger Than") {
+      context("Iterables") {
+         test("Iterable of size 3 should be larger than iterable of size 2") {
+            val col1 = listOf(1, 2, 3)
+            val col2 = listOf(1, 2)
+            col1 shouldBeLargerThan col2
+         }
+
+         test("Iterable of size 3 should fail to be larger than iterable of size 2") {
+            val col1 = listOf(1, 2, 3)
+            val col2 = listOf(1, 2)
+            shouldThrow<AssertionError> {
+               col2 shouldBeLargerThan col1
+            } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+         }
+      }
+
+      context("Arrays") {
+         test("Array of size 3 should be larger than array of size 2") {
+            val arr1 = arrayOf(1, 2, 3)
+            val arr2 = arrayOf(1, 2)
+            arr1 shouldBeLargerThan arr2
+         }
+
+         test("Array of size 3 should fail to be larger than array of size 2") {
+            val arr1 = arrayOf(1, 2, 3)
+            val arr2 = arrayOf(1, 2)
+            shouldThrow<AssertionError> {
+               arr2 shouldBeLargerThan arr1
+            } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+         }
+      }
+   }
+
+   context("Should NOT Be Larger Than") {
+      context("Iterables") {
+         test("Iterable of size 2 should not be larger than iterable of size 3") {
+            val col1 = listOf(1, 2)
+            val col2 = listOf(1, 2, 3)
+            col1 shouldNotBeLargerThan col2
+         }
+
+         test("Iterable of size 2 should fail to not be larger than iterable of size 3") {
+            val col1 = listOf(1, 2)
+            val col2 = listOf(1, 2, 3)
+            shouldThrow<AssertionError> {
+               col2 shouldNotBeLargerThan col1
+            } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+         }
+      }
+
+      context("Arrays") {
+         test("Array of size 2 should not be larger than array of size 3") {
+            val arr1 = arrayOf(1, 2)
+            val arr2 = arrayOf(1, 2, 3)
+            arr1 shouldNotBeLargerThan arr2
+         }
+
+         test("Array of size 2 should fail to not be larger than array of size 3") {
+            val arr1 = arrayOf(1, 2)
+            val arr2 = arrayOf(1, 2, 3)
+            shouldThrow<AssertionError> {
+               arr2 shouldNotBeLargerThan arr1
+            } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+         }
+      }
+   }
+
+   context("beLargerThan Matchers") {
+      test("passes when the collection is larger") {
+         val larger = listOf(1, 2, 3)
+         val smaller = listOf(1, 2)
+         larger should beLargerThan(smaller)
+      }
+
+      test("fails when the collection is not larger") {
+         val smaller = listOf(1, 2)
+         val larger = listOf(1, 2, 3)
+         smaller shouldNot beLargerThan(larger)
+      }
+
+      test("fails when the collections are of the same size") {
+         val collection1 = listOf(1, 2, 3)
+         val collection2 = listOf(4, 5, 6)
+         collection1 shouldNot beLargerThan(collection2)
+      }
+
+      test("works with empty collections") {
+         val emptyCollection = emptyList<Int>()
+         val nonEmptyCollection = listOf(1)
+         nonEmptyCollection should beLargerThan(emptyCollection)
+         emptyCollection shouldNot beLargerThan(nonEmptyCollection)
+      }
+
+      test("throws no exceptions with empty collections compared") {
+         val empty1 = emptyList<Int>()
+         val empty2 = emptyList<Int>()
+         empty1 shouldNot beLargerThan(empty2)
+      }
+   }
+})

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/LargerTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/LargerTest.kt
@@ -3,13 +3,144 @@ package io.kotest.matchers.collections
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
-import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 class LargerTest : FunSpec({
 
    context("Should Be Larger Than") {
+
+      context("Primitive Arrays") {
+
+         context("ByteArray") {
+            test("ByteArray of size 3 should be larger than ByteArray of size 2") {
+               val arr1 = byteArrayOf(1, 2, 3)
+               val arr2 = byteArrayOf(1, 2)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("ByteArray of size 3 should fail to be larger than ByteArray of size 2") {
+               val arr1 = byteArrayOf(1, 2, 3)
+               val arr2 = byteArrayOf(1, 2)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("IntArray") {
+            test("IntArray of size 3 should be larger than IntArray of size 2") {
+               val arr1 = intArrayOf(1, 2, 3)
+               val arr2 = intArrayOf(1, 2)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("IntArray of size 3 should fail to be larger than IntArray of size 2") {
+               val arr1 = intArrayOf(1, 2, 3)
+               val arr2 = intArrayOf(1, 2)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("ShortArray") {
+            test("ShortArray of size 3 should be larger than ShortArray of size 2") {
+               val arr1 = shortArrayOf(1, 2, 3)
+               val arr2 = shortArrayOf(1, 2)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("ShortArray of size 3 should fail to be larger than ShortArray of size 2") {
+               val arr1 = shortArrayOf(1, 2, 3)
+               val arr2 = shortArrayOf(1, 2)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("LongArray") {
+            test("LongArray of size 3 should be larger than LongArray of size 2") {
+               val arr1 = longArrayOf(1L, 2L, 3L)
+               val arr2 = longArrayOf(1L, 2L)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("LongArray of size 3 should fail to be larger than LongArray of size 2") {
+               val arr1 = longArrayOf(1L, 2L, 3L)
+               val arr2 = longArrayOf(1L, 2L)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("FloatArray") {
+            test("FloatArray of size 3 should be larger than FloatArray of size 2") {
+               val arr1 = floatArrayOf(1.1f, 2.2f, 3.3f)
+               val arr2 = floatArrayOf(1.1f, 2.2f)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("FloatArray of size 3 should fail to be larger than FloatArray of size 2") {
+               val arr1 = floatArrayOf(1.1f, 2.2f, 3.3f)
+               val arr2 = floatArrayOf(1.1f, 2.2f)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("DoubleArray") {
+            test("DoubleArray of size 3 should be larger than DoubleArray of size 2") {
+               val arr1 = doubleArrayOf(1.1, 2.2, 3.3)
+               val arr2 = doubleArrayOf(1.1, 2.2)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("DoubleArray of size 3 should fail to be larger than DoubleArray of size 2") {
+               val arr1 = doubleArrayOf(1.1, 2.2, 3.3)
+               val arr2 = doubleArrayOf(1.1, 2.2)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("CharArray") {
+            test("CharArray of size 3 should be larger than CharArray of size 2") {
+               val arr1 = charArrayOf('a', 'b', 'c')
+               val arr2 = charArrayOf('a', 'b')
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("CharArray of size 3 should fail to be larger than CharArray of size 2") {
+               val arr1 = charArrayOf('a', 'b', 'c')
+               val arr2 = charArrayOf('a', 'b')
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+
+         context("BooleanArray") {
+            test("BooleanArray of size 3 should be larger than BooleanArray of size 2") {
+               val arr1 = booleanArrayOf(true, false, true)
+               val arr2 = booleanArrayOf(true, false)
+               arr1 shouldBeLargerThan arr2
+            }
+
+            test("BooleanArray of size 3 should fail to be larger than BooleanArray of size 2") {
+               val arr1 = booleanArrayOf(true, false, true)
+               val arr2 = booleanArrayOf(true, false)
+               shouldThrow<AssertionError> {
+                  arr2 shouldBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 2 should be larger than collection of size 3"
+            }
+         }
+      }
+
       context("Iterables") {
          test("Iterable of size 3 should be larger than iterable of size 2") {
             val col1 = listOf(1, 2, 3)
@@ -78,6 +209,137 @@ class LargerTest : FunSpec({
    }
 
    context("beLargerThan Matchers") {
+      context("Primitive Arrays") {
+
+         context("ByteArray") {
+            test("ByteArray of size 2 should not be larger than ByteArray of size 3") {
+               val arr1 = byteArrayOf(1, 2)
+               val arr2 = byteArrayOf(1, 2, 3)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("ByteArray of size 2 should fail to not be larger than ByteArray of size 3") {
+               val arr1 = byteArrayOf(1, 2)
+               val arr2 = byteArrayOf(1, 2, 3)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("IntArray") {
+            test("IntArray of size 2 should not be larger than IntArray of size 3") {
+               val arr1 = intArrayOf(1, 2)
+               val arr2 = intArrayOf(1, 2, 3)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("IntArray of size 2 should fail to not be larger than IntArray of size 3") {
+               val arr1 = intArrayOf(1, 2)
+               val arr2 = intArrayOf(1, 2, 3)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("ShortArray") {
+            test("ShortArray of size 2 should not be larger than ShortArray of size 3") {
+               val arr1 = shortArrayOf(1, 2)
+               val arr2 = shortArrayOf(1, 2, 3)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("ShortArray of size 2 should fail to not be larger than ShortArray of size 3") {
+               val arr1 = shortArrayOf(1, 2)
+               val arr2 = shortArrayOf(1, 2, 3)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("LongArray") {
+            test("LongArray of size 2 should not be larger than LongArray of size 3") {
+               val arr1 = longArrayOf(1L, 2L)
+               val arr2 = longArrayOf(1L, 2L, 3L)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("LongArray of size 2 should fail to not be larger than LongArray of size 3") {
+               val arr1 = longArrayOf(1L, 2L)
+               val arr2 = longArrayOf(1L, 2L, 3L)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("FloatArray") {
+            test("FloatArray of size 2 should not be larger than FloatArray of size 3") {
+               val arr1 = floatArrayOf(1.1f, 2.2f)
+               val arr2 = floatArrayOf(1.1f, 2.2f, 3.3f)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("FloatArray of size 2 should fail to not be larger than FloatArray of size 3") {
+               val arr1 = floatArrayOf(1.1f, 2.2f)
+               val arr2 = floatArrayOf(1.1f, 2.2f, 3.3f)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("DoubleArray") {
+            test("DoubleArray of size 2 should not be larger than DoubleArray of size 3") {
+               val arr1 = doubleArrayOf(1.1, 2.2)
+               val arr2 = doubleArrayOf(1.1, 2.2, 3.3)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("DoubleArray of size 2 should fail to not be larger than DoubleArray of size 3") {
+               val arr1 = doubleArrayOf(1.1, 2.2)
+               val arr2 = doubleArrayOf(1.1, 2.2, 3.3)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("CharArray") {
+            test("CharArray of size 2 should not be larger than CharArray of size 3") {
+               val arr1 = charArrayOf('a', 'b')
+               val arr2 = charArrayOf('a', 'b', 'c')
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("CharArray of size 2 should fail to not be larger than CharArray of size 3") {
+               val arr1 = charArrayOf('a', 'b')
+               val arr2 = charArrayOf('a', 'b', 'c')
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+
+         context("BooleanArray") {
+            test("BooleanArray of size 2 should not be larger than BooleanArray of size 3") {
+               val arr1 = booleanArrayOf(true, false)
+               val arr2 = booleanArrayOf(true, false, true)
+               arr1 shouldNotBeLargerThan arr2
+            }
+
+            test("BooleanArray of size 2 should fail to not be larger than BooleanArray of size 3") {
+               val arr1 = booleanArrayOf(true, false)
+               val arr2 = booleanArrayOf(true, false, true)
+               shouldThrow<AssertionError> {
+                  arr2 shouldNotBeLargerThan arr1
+               } shouldHaveMessage "Collection of size 3 should not be larger than collection of size 2"
+            }
+         }
+      }
+
       test("passes when the collection is larger") {
          val larger = listOf(1, 2, 3)
          val smaller = listOf(1, 2)


### PR DESCRIPTION
Please review commit-by-commit, it will be easier.


This PR does a small rework on larger.kt matchers

- Add documentation to all the matchers
- Add tests to all the matchers individually
- Add primitive array matchers as well
- ***Remove Collection version of the matcher as it's a duplicate of the Iterable