### PR TITLE
when values have different types but same printed value, describe mismatch of types

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1804,6 +1804,7 @@ public final class io/kotest/matchers/maps/MapMatchersKt {
 	public static final fun containAnyValues ([Ljava/lang/Object;)Lio/kotest/matchers/Matcher;
 	public static final fun containExactly (Ljava/util/Map;)Lio/kotest/matchers/Matcher;
 	public static final fun containExactly ([Lkotlin/Pair;)Lio/kotest/matchers/Matcher;
+	public static final fun describeTypedMismatch (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun haveKey (Ljava/lang/Object;)Lio/kotest/matchers/Matcher;
 	public static final fun haveKeys ([Ljava/lang/Object;)Lio/kotest/matchers/Matcher;
 	public static final fun haveSize (I)Lio/kotest/matchers/Matcher;

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -1,6 +1,7 @@
 package io.kotest.matchers.maps
 
 import io.kotest.assertions.ErrorCollectionMode
+import io.kotest.assertions.describeTypedMismatch
 import io.kotest.assertions.errorCollector
 import io.kotest.assertions.print.print
 import io.kotest.assertions.runWithMode

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -109,7 +109,7 @@ fun <K, V> contain(key: K, v: V): Matcher<Map<K, V>> = object : Matcher<Map<K, V
       val possibleMatches = if(passed) "" else describePossibleMatches(key, v, value)
       return MatcherResult(
          passed,
-         { "Map should contain mapping $key=$v but was ${buildActualValue(value)}$possibleMatches" },
+         { "Map should contain mapping $key=$v but was ${buildActualValue(value)}${describeTypedMismatch(value[key], v)}$possibleMatches" },
          { "Map should not contain mapping $key=$v but was $value" }
       )
    }
@@ -133,6 +133,17 @@ fun <K, V> contain(key: K, v: V): Matcher<Map<K, V>> = object : Matcher<Map<K, V
       prefix = "\nSimilar values found:\n"
    )
 
+}
+
+fun describeTypedMismatch(expected: Any?, actual: Any?): String {
+   val expectedType = expected?.let { it::class.qualifiedName } ?: return ""
+   val actualType = actual?.let { it::class.qualifiedName } ?: return ""
+   val expectedPrintValue = expected.print().value
+   val actualPrintValue = actual.print().value
+   return if(expectedPrintValue == actualPrintValue) {
+      "\nExpected type $expectedType, but was $actualType"
+   } else
+   ""
 }
 
 internal fun printIfNotEmpty(string: String, prefix: String = "", suffix: String = ""): String =

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -22,7 +22,7 @@ fun <K, V> mapcontain(key: K, v: V) = object : Matcher<Map<K, V>> {
       )
       key in value.keys && value[key] != v -> MapContainResult(
          false,
-         "Map should contain mapping $key=$v but was ${buildActualValue(value)}"
+         "Map should contain mapping $key=$v but was ${buildActualValue(value)}${describeTypedMismatch(v, value[key])}"
       )
       else -> MapContainResult(true, "")
    }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -1,5 +1,6 @@
 package io.kotest.matchers.maps
 
+import io.kotest.assertions.describeTypedMismatch
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/DescribeTypedMismatchTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/DescribeTypedMismatchTest.kt
@@ -1,7 +1,7 @@
 package com.sksamuel.kotest.matchers.maps
 
+import io.kotest.assertions.describeTypedMismatch
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.maps.describeTypedMismatch
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/DescribeTypedMismatchTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/DescribeTypedMismatchTest.kt
@@ -1,0 +1,35 @@
+package com.sksamuel.kotest.matchers.maps
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.maps.describeTypedMismatch
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+
+class DescribeTypedMismatchTest: StringSpec() {
+   init {
+       "empty string for null expected" {
+          describeTypedMismatch(
+             expected = null,
+             actual = 1.5
+          ) shouldBe ""
+       }
+      "empty string for null actual" {
+         describeTypedMismatch(
+            expected = 1.5,
+            actual = null
+         ) shouldBe ""
+      }
+      "empty string for different print values" {
+         describeTypedMismatch(
+            expected = BigDecimal("1.6"),
+            actual = 1.5
+         ) shouldBe ""
+      }
+      "type mismatch for same print values" {
+         describeTypedMismatch(
+            expected = BigDecimal("1.5"),
+            actual = 1.5
+         ) shouldBe "\nExpected type java.math.BigDecimal, but was kotlin.Double"
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldStartWith
+import java.math.BigDecimal
 import java.util.LinkedList
 
 class MapMatchersTest : WordSpec() {
@@ -152,6 +153,15 @@ class MapMatchersTest : WordSpec() {
          "pass for key not in map and null value" {
             val map = mapOf("apple" to "green")
             map shouldNotContain("lemon" to null)
+         }
+         "handle case of values with different types" {
+            val message = shouldThrow<AssertionError> {
+               mapOf("apple" to 1.5) shouldContain ("apple" to BigDecimal("1.5"))
+            }.message
+            message.shouldContainInOrder(
+               "Map should contain mapping apple=1.5 but was apple=1.5",
+               "Expected type java.math.BigDecimal, but was kotlin.Double",
+            )
          }
       }
 

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -115,6 +115,10 @@ public final class io/kotest/assertions/CounterKt {
 	public static final fun inc (Lio/kotest/assertions/AssertionCounter;I)V
 }
 
+public final class io/kotest/assertions/DescribeTypedMismatch_jvmKt {
+	public static final fun describeTypedMismatch (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/String;
+}
+
 public final class io/kotest/assertions/DiffLargeStringKt {
 	public static final fun diffLargeString (Ljava/lang/String;Ljava/lang/String;)Lkotlin/Pair;
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+expect fun describeTypedMismatch(expected: Any?, actual: Any?): String

--- a/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.desktop.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/desktopMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.desktop.kt
@@ -1,0 +1,5 @@
+package io.kotest.assertions
+
+actual fun describeTypedMismatch(expected: Any?, actual: Any?): String {
+   TODO("Not yet implemented")
+}

--- a/kotest-assertions/kotest-assertions-shared/src/jsHostedMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.jsHosted.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jsHostedMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.jsHosted.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+actual fun describeTypedMismatch(expected: Any?, actual: Any?): String = ""

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.jvm.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.jvm.kt
@@ -1,0 +1,14 @@
+package io.kotest.assertions
+
+import io.kotest.assertions.print.print
+
+actual fun describeTypedMismatch(expected: Any?, actual: Any?): String {
+   val expectedType = expected?.let { it::class.qualifiedName } ?: return ""
+   val actualType = actual?.let { it::class.qualifiedName } ?: return ""
+   val expectedPrintValue = expected.print().value
+   val actualPrintValue = actual.print().value
+   return if(expectedPrintValue == actualPrintValue) {
+      "\nExpected type $expectedType, but was $actualType"
+   } else
+      ""
+}

--- a/kotest-assertions/kotest-assertions-shared/src/nativeMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.native.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/nativeMain/kotlin/io/kotest/assertions/DescribeTypedMismatch.native.kt
@@ -1,0 +1,3 @@
+package io.kotest.assertions
+
+actual fun describeTypedMismatch(expected: Any?, actual: Any?): String = ""


### PR DESCRIPTION
there are edge cases when values are of different types, but they print exactly the same. and the message is not super helpful: 

`Map should contain mapping apple=1.5 but was apple=1.5`

let's add more info to help, `Expected type java.math.BigDecimal, but was kotlin.Double`:
```kotlin
           val message = shouldThrow<AssertionError> {
               mapOf("apple" to 1.5) shouldContain ("apple" to BigDecimal("1.5"))
            }.message
            message.shouldContainInOrder(
               "Map should contain mapping apple=1.5 but was apple=1.5",
               "Expected type java.math.BigDecimal, but was kotlin.Double",
            )
```

I've made `describeTypedMismatch` `public` because there are some other cases in other modules when we want to use it, in another PR, later on
