### PR TITLE
Removing deprecated Print function w/o level

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -425,45 +425,35 @@ public final class io/kotest/assertions/jvmerrorcollector {
 
 public final class io/kotest/assertions/print/ArrayPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/ArrayPrint;
-	public fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/BooleanPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/BooleanPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Z)Lio/kotest/assertions/print/Printed;
 	public fun print (ZI)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/BytePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/BytePrint;
-	public fun print (B)Lio/kotest/assertions/print/Printed;
 	public fun print (BI)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/CharPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/CharPrint;
-	public fun print (C)Lio/kotest/assertions/print/Printed;
 	public fun print (CI)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/CharRangePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/CharRangePrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Lkotlin/ranges/CharRange;)Lio/kotest/assertions/print/Printed;
 	public fun print (Lkotlin/ranges/CharRange;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/DataClassPrintJvm : io/kotest/assertions/print/Print {
 	public fun <init> ()V
-	public fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
@@ -473,57 +463,43 @@ public final class io/kotest/assertions/print/DataClassPrintKt {
 
 public final class io/kotest/assertions/print/DoublePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/DoublePrint;
-	public fun print (D)Lio/kotest/assertions/print/Printed;
 	public fun print (DI)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/FilePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/FilePrint;
-	public fun print (Ljava/io/File;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/io/File;I)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/FloatPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/FloatPrint;
-	public fun print (F)Lio/kotest/assertions/print/Printed;
 	public fun print (FI)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/IntPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/IntPrint;
-	public fun print (I)Lio/kotest/assertions/print/Printed;
 	public fun print (II)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/IntRangePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/IntRangePrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Lkotlin/ranges/IntRange;)Lio/kotest/assertions/print/Printed;
 	public fun print (Lkotlin/ranges/IntRange;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/IterablePrint : io/kotest/assertions/print/Print {
 	public fun <init> ()V
-	public fun print (Ljava/lang/Iterable;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/lang/Iterable;I)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/KClassPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/KClassPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Lkotlin/reflect/KClass;)Lio/kotest/assertions/print/Printed;
 	public fun print (Lkotlin/reflect/KClass;I)Lio/kotest/assertions/print/Printed;
 }
 
@@ -531,52 +507,40 @@ public final class io/kotest/assertions/print/ListPrint : io/kotest/assertions/p
 	public fun <init> ()V
 	public fun <init> (Lio/kotest/assertions/ConfigValue;)V
 	public synthetic fun <init> (Lio/kotest/assertions/ConfigValue;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Ljava/util/List;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/util/List;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/LongPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/LongPrint;
-	public fun print (J)Lio/kotest/assertions/print/Printed;
 	public fun print (JI)Lio/kotest/assertions/print/Printed;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/LongRangePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/LongRangePrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Lkotlin/ranges/LongRange;)Lio/kotest/assertions/print/Printed;
 	public fun print (Lkotlin/ranges/LongRange;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/MapPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/MapPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Ljava/util/Map;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/util/Map;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/NullPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/NullPrint;
-	public fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/PathPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/PathPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Ljava/nio/file/Path;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/nio/file/Path;I)Lio/kotest/assertions/print/Printed;
 }
 
 public abstract interface class io/kotest/assertions/print/Print {
-	public abstract fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public abstract fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
@@ -626,73 +590,56 @@ public final class io/kotest/assertions/print/Printers {
 
 public final class io/kotest/assertions/print/ShortPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/ShortPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (S)Lio/kotest/assertions/print/Printed;
 	public fun print (SI)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/StringPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/StringPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Ljava/lang/String;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/lang/String;I)Lio/kotest/assertions/print/Printed;
 	public final fun showNoWrap (Ljava/lang/String;)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/ToStringPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/ToStringPrint;
-	public fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/UBytePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/UBytePrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 	public fun print-0ky7B_Q (BI)Lio/kotest/assertions/print/Printed;
-	public fun print-7apg3OU (B)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/UIntPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/UIntPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print-WZ4Q5Ns (I)Lio/kotest/assertions/print/Printed;
 	public fun print-qim9Vi0 (II)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/UIntRangePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/UIntRangePrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Lkotlin/ranges/UIntRange;)Lio/kotest/assertions/print/Printed;
 	public fun print (Lkotlin/ranges/UIntRange;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/ULongPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/ULongPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 	public fun print-4PLdz1A (JI)Lio/kotest/assertions/print/Printed;
-	public fun print-VKZWuLQ (J)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/ULongRangePrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/ULongRangePrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
-	public fun print (Lkotlin/ranges/ULongRange;)Lio/kotest/assertions/print/Printed;
 	public fun print (Lkotlin/ranges/ULongRange;I)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/UShortPrint : io/kotest/assertions/print/Print {
 	public static final field INSTANCE Lio/kotest/assertions/print/UShortPrint;
-	public synthetic fun print (Ljava/lang/Object;)Lio/kotest/assertions/print/Printed;
 	public synthetic fun print (Ljava/lang/Object;I)Lio/kotest/assertions/print/Printed;
 	public fun print-vckuEUM (SI)Lio/kotest/assertions/print/Printed;
-	public fun print-xj2QHRw (S)Lio/kotest/assertions/print/Printed;
 }
 
 public final class io/kotest/assertions/print/platformjvm {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ArrayPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ArrayPrint.kt
@@ -2,9 +2,6 @@ package io.kotest.assertions.print
 
 object ArrayPrint : Print<Any> {
 
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Any): Printed = print(a, 0)
-
    @Suppress("UNCHECKED_CAST")
    override fun print(a: Any, level: Int): Printed = when (a) {
       is LongArray -> ListPrint<Long>().print(a.asList(), level)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/IterablePrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/IterablePrint.kt
@@ -1,8 +1,6 @@
 package io.kotest.assertions.print
 
 class IterablePrint<T> : Print<Iterable<T>> {
-   @Deprecated("Use print(a, level) to respect level hints. Deprecated in 5.0.3", ReplaceWith("print(a, 0)"))
-   override fun print(a: Iterable<T>): Printed = print(a, 0)
    override fun print(a: Iterable<T>, level: Int): Printed = ListPrint<T>().print(a.toList(), level)
 }
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/KClassPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/KClassPrint.kt
@@ -4,6 +4,5 @@ import io.kotest.mpp.bestName
 import kotlin.reflect.KClass
 
 object KClassPrint: Print<KClass<*>> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: KClass<*>): Printed = a.bestName().printed()
+   override fun print(a: KClass<*>, level: Int): Printed = a.bestName().printed()
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/ListPrint.kt
@@ -5,9 +5,6 @@ import io.kotest.assertions.ConfigValue
 
 class ListPrint<T>(private val limitConfigValue: ConfigValue<Int> = AssertionsConfig.maxCollectionPrintSize) : Print<List<T>> {
 
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: List<T>): Printed = print(a, 0)
-
    override fun print(a: List<T>, level: Int): Printed {
       return if (a.isEmpty()) Printed("[]") else {
          val limit = limitConfigValue.value

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/MapPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/MapPrint.kt
@@ -6,7 +6,4 @@ object MapPrint : Print<Map<*, *>> {
       return Printed(a.map { (k, v) -> recursiveRepr(a, k, level).value to recursiveRepr(a, v, level).value }
          .toString())
    }
-
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Map<*, *>): Printed = print(a, 0)
 }

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/Print.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/Print.kt
@@ -15,16 +15,14 @@ import kotlin.reflect.KClass
  */
 interface Print<in A> {
 
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   fun print(a: A): Printed
-
    /**
     * Returns a [Printed] for the given instance [a], with a recursion
     * level hint.
     */
-   @Suppress("DEPRECATION")
-   fun print(a: A, level: Int): Printed = print(a)
+   fun print(a: A, level: Int): Printed = print(a, level)
 }
+
+internal fun Print<*>.indent(level: Int): String = "  ".repeat(level)
 
 internal const val PRINT_DEPRECATION_MSG = "Use print(a, level) to respect level hints. Deprecated in 5.0.3"
 

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/StringPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/StringPrint.kt
@@ -14,8 +14,7 @@ object StringPrint : Print<String> {
       else -> a.printed()
    }
 
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: String): Printed = when {
+   override fun print(a: String, level: Int): Printed = when {
       a == "" -> "<empty string>".printed()
       a.isBlank() -> a.replace(" ", "\\s").wrap().printed()
       else -> a.wrap().printed()

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/primitive.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/print/primitive.kt
@@ -1,74 +1,61 @@
 package io.kotest.assertions.print
 
 object NullPrint : Print<Any?> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Any?): Printed = Printed("<null>")
+   override fun print(a: Any?, level: Int): Printed = "${indent(level)}<null>".printed()
 }
 
 object BooleanPrint : Print<Boolean> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Boolean): Printed = "$a".printed()
+   override fun print(a: Boolean, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object DoublePrint : Print<Double> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Double): Printed = a.toString().printed()
+   override fun print(a: Double, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 /**
  * Floats's are printed out as is, with the suffix f.
  */
 object FloatPrint : Print<Float> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Float): Printed = "${a}f".printed()
+   override fun print(a: Float, level: Int): Printed = "${indent(level)}${a}f".printed()
 }
 
 /**
  * Long's are printed out as is, with the suffix L.
  */
 object LongPrint : Print<Long> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Long): Printed = "${a}L".printed()
+   override fun print(a: Long, level: Int): Printed = "${indent(level)}${a}L".printed()
 }
 
 object IntPrint : Print<Int> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Int): Printed = a.toString().printed()
+   override fun print(a: Int, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object CharPrint : Print<Char> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Char): Printed = "'$a'".printed()
+   override fun print(a: Char, level: Int): Printed = "${indent(level)}'$a'".printed()
 }
 
 object ShortPrint : Print<Short> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Short): Printed = a.toString().printed()
+   override fun print(a: Short, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object BytePrint : Print<Byte> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Byte): Printed = a.toString().printed()
+   override fun print(a: Byte, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
-object UBytePrint: Print<UByte> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: UByte): Printed = "$a (UByte)".printed()
+object UBytePrint : Print<UByte> {
+   override fun print(a: UByte, level: Int): Printed = "${indent(level)}$a (UByte)".printed()
 }
 
-object UShortPrint: Print<UShort> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: UShort): Printed = "$a (UShort)".printed()
+object UShortPrint : Print<UShort> {
+   override fun print(a: UShort, level: Int): Printed = "${indent(level)}$a (UShort)".printed()
 }
 
-object UIntPrint: Print<UInt> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: UInt): Printed = "$a (UInt)".printed()
+object UIntPrint : Print<UInt> {
+   override fun print(a: UInt, level: Int): Printed = "${indent(level)}$a (UInt)".printed()
 }
 
-object ULongPrint: Print<ULong> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: ULong): Printed = "$a (ULong)".printed()
+object ULongPrint : Print<ULong> {
+   override fun print(a: ULong, level: Int): Printed = "${indent(level)}$a (ULong)".printed()
 }
 
 /**
@@ -76,32 +63,25 @@ object ULongPrint: Print<ULong> {
  * to object a [Printed] result.
  */
 object ToStringPrint : Print<Any> {
-   override fun print(a: Any, level: Int): Printed = a.toString().printed()
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Any): Printed = a.toString().printed()
+   override fun print(a: Any, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object LongRangePrint : Print<LongRange> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: LongRange): Printed = Printed(a.toString())
+   override fun print(a: LongRange, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object IntRangePrint : Print<IntRange> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: IntRange): Printed = Printed(a.toString())
+   override fun print(a: IntRange, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object CharRangePrint : Print<CharRange> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: CharRange): Printed = Printed(a.toString())
+   override fun print(a: CharRange, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object ULongRangePrint : Print<ULongRange> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: ULongRange): Printed = Printed(a.toString())
+   override fun print(a: ULongRange, level: Int): Printed = "${indent(level)}$a".printed()
 }
 
 object UIntRangePrint : Print<UIntRange> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: UIntRange): Printed = Printed(a.toString())
+   override fun print(a: UIntRange, level: Int): Printed = "${indent(level)}$a".printed()
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/print/FilePrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/print/FilePrint.kt
@@ -3,6 +3,5 @@ package io.kotest.assertions.print
 import java.io.File
 
 object FilePrint : Print<File> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: File): Printed = a.path.printed()
+   override fun print(a: File, level: Int): Printed = (indent(level) + a.path).printed()
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/print/PathPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/print/PathPrint.kt
@@ -3,6 +3,5 @@ package io.kotest.assertions.print
 import java.nio.file.Path
 
 object PathPrint : Print<Path> {
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Path): Printed = a.toString().printed()
+   override fun print(a: Path, level: Int): Printed = a.toString().printed()
 }

--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/print/dataClassPrint.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/print/dataClassPrint.kt
@@ -6,9 +6,6 @@ actual fun <A : Any> dataClassPrint(): Print<A> = DataClassPrintJvm()
 
 class DataClassPrintJvm : Print<Any> {
 
-   @Deprecated(PRINT_DEPRECATION_MSG)
-   override fun print(a: Any): Printed = print(a, 0)
-
    override fun print(a: Any, level: Int): Printed {
       if (level == 10) return Printed("<...>")
       require(a::class.isData) { "This instance of the Print typeclass only supports data classes" }
@@ -22,19 +19,21 @@ class DataClassPrintJvm : Print<Any> {
          append("(")
          props.forEach { property ->
             append(System.lineSeparator())
-            append("  ")
-            append("".padEnd(level * 2, ' '))
+            append(indent(level + 1))
             append(property.name.padEnd(maxNameLength, ' '))
             append("  =  ")
             val propertyValue = property.getter.call(a)
             when {
                propertyValue == null -> append(NullPrint.print(null, 0).value)
                propertyValue::class.isData -> append(DataClassPrintJvm().print(propertyValue, level + 1).value)
-               else -> append(property.getter.call(a).print(level + 1).value)
+               else -> {
+                  // remove leading/trailing whitespace, since we already applied indent on this line
+                  append(property.getter.call(a).print(level + 1).value.trim())
+               }
             }
          }
          append(System.lineSeparator())
-         append("".padEnd(level * 2, ' '))
+         append(indent(level))
          append(")")
       }
       return if (level > 0) {


### PR DESCRIPTION
Removes the deprecated `print(a: A)`, which was deprecated in favor of `print(a: A, level: Int)`. 

All print's have been adjusted to indent based on `level`.
