### PR TITLE
lazily-evaluate-containExactlyInAnyOrder 

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactlyInAnyOrder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactlyInAnyOrder.kt
@@ -129,12 +129,13 @@ fun <T, C : Collection<T>> containExactlyInAnyOrder(
    }
    val countMismatch = countMismatch(expectedGroupedCounts, valueGroupedCounts, verifier)
    val passed = missing.isEmpty() && extra.isEmpty() && countMismatch.isEmpty()
-   val possibleMatches = missing
-      .map { possibleMatchesDescription(actual.toSet(), it) }
-      .filter { it.isNotEmpty() }
-      .joinToString("\n")
 
    val failureMessage = {
+      val possibleMatches = missing
+         .map { possibleMatchesDescription(actual.toSet(), it) }
+         .filter { it.isNotEmpty() }
+         .joinToString("\n")
+
       buildString {
          append("Collection should contain ${expected.print().value} in any order, but was ${actual.print().value}")
          appendLine()


### PR DESCRIPTION
lazily-evaluate-containExactlyInAnyOrder