### PR TITLE
Attach launcher method to a spec source file (#4678)

### DIFF
--- a/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/Transformer.kt
+++ b/kotest-framework/kotest-framework-multiplatform-plugin-embeddable-compiler/src/jvmMain/kotlin/io/kotest/framework/multiplatform/embeddablecompiler/Transformer.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.ir.expressions.IrExpression
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.UnsafeDuringIrConstructionAPI
 import org.jetbrains.kotlin.ir.util.constructors
+import org.jetbrains.kotlin.ir.util.file
 import org.jetbrains.kotlin.ir.util.getSimpleFunction
 import org.jetbrains.kotlin.ir.util.kotlinFqName
 import org.jetbrains.kotlin.name.ClassId
@@ -64,7 +65,7 @@ abstract class Transformer(
          return fragment
       }
 
-      val file = declaration.files.first()
+      val file = specs.first().file
       val launcher = generateLauncher(specs, configs, file)
       file.addChild(launcher)
 


### PR DESCRIPTION
Fixes #4678
... hopefully.
Assuming my assumption why it failed in that issue is correct,
this PR should fix the issue by adding the launcher method to the file of the first spec
instead of the first file in the module which might cause the issue.
