### PR TITLE
Docs: fix URL to snapshots

### DIFF
--- a/documentation/docs/quick_start.mdx
+++ b/documentation/docs/quick_start.mdx
@@ -401,5 +401,5 @@ Snapshot are automatically published on each commit to master.
 If you want to test the latest snapshot build, setup the same way described above, change the version to the current snapshot version and add the following repository to your `repositories` block:
 
 ```
-https://oss.sonatype.org/content/repositories/snapshots
+https://s01.oss.sonatype.org/content/repositories/snapshots
 ```


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

We forgot to update it in https://github.com/kotest/kotest/commit/a1233571620e05e587fd261454a7124bd8f6c217.