### PR TITLE
Added backwards compatible flags for reporter/writer

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3692,9 +3692,11 @@ public final class io/kotest/engine/launcher/LauncherArgs {
 	public static final field DESCRIPTOR Ljava/lang/String;
 	public static final field INSTANCE Lio/kotest/engine/launcher/LauncherArgs;
 	public static final field LISTENER Ljava/lang/String;
+	public static final field REPORTER Ljava/lang/String;
 	public static final field SPEC Ljava/lang/String;
 	public static final field TERMCOLORS Ljava/lang/String;
 	public static final field TESTPATH Ljava/lang/String;
+	public static final field WRITER Ljava/lang/String;
 }
 
 public final class io/kotest/engine/launcher/MainKt {

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/main.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/main.kt
@@ -7,9 +7,11 @@ import io.kotest.engine.extensions.ProvidedDescriptorFilter
 import io.kotest.engine.launcher.LauncherArgs.CANDIDATES
 import io.kotest.engine.launcher.LauncherArgs.DESCRIPTOR
 import io.kotest.engine.launcher.LauncherArgs.LISTENER
+import io.kotest.engine.launcher.LauncherArgs.REPORTER
 import io.kotest.engine.launcher.LauncherArgs.SPEC
 import io.kotest.engine.launcher.LauncherArgs.TERMCOLORS
 import io.kotest.engine.launcher.LauncherArgs.TESTPATH
+import io.kotest.engine.launcher.LauncherArgs.WRITER
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.engine.listener.LoggingTestEngineListener
 import io.kotest.engine.listener.PinnedSpecTestEngineListener
@@ -30,6 +32,8 @@ object LauncherArgs {
    // these are deprecated kotest 5 flags kept for backwards compatibility
    const val SPEC = "spec"
    const val TESTPATH = "testpath"
+   const val REPORTER = "reporter"
+   const val WRITER = "writer"
 }
 
 /**
@@ -74,7 +78,7 @@ fun main(args: Array<String>) {
    }
 
    val console = TestEngineListenerBuilder.builder()
-      .withType(launcherArgs[LISTENER]) // sets the output type, will be detected if not specified
+      .withType(launcherArgs[LISTENER] ?: launcherArgs[REPORTER] ?: launcherArgs[WRITER]) // sets the output type, will be detected if not specified
       .withTermColors(launcherArgs[TERMCOLORS]) // if using the console, determines the prettiness of the output
       .build()
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
