### PR TITLE
using root coordinates in BOM instead of -jvm variants. fixes #4596

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -169,7 +169,10 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
                kotestBomService.coordinates.addAll(
                   providers
                      .provider {
-                        "${this@publication.groupId}:${this@publication.artifactId}:${this@publication.version}"
+                        // We are publishing the -jvm jars in the root variants so we can simply remove the -jvm suffix
+                        // See: publishPlatformArtifactsInRootModule
+                        val artifactId = this@publication.artifactId.replace("-jvm", "")
+                        "${this@publication.groupId}:$artifactId:${this@publication.version}"
                      }
                      .zip(includeInKotestBom) { coords, enabled ->
                         if (enabled) listOf(coords) else emptyList()

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -171,11 +171,10 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
                      .provider {
                         // We are publishing the -jvm jars in the root variants so we can simply remove the -jvm suffix
                         // See: publishPlatformArtifactsInRootModule
-                        val artifactId = this@publication.artifactId.replace("-jvm", "")
-                        "${this@publication.groupId}:$artifactId:${this@publication.version}"
+                        "${this@publication.groupId}:${this@publication.artifactId}:${this@publication.version}"
                      }
                      .zip(includeInKotestBom) { coords, enabled ->
-                        if (enabled) listOf(coords) else emptyList()
+                        if (enabled) listOf(coords, coords.replace("-jvm", "")) else emptyList()
                      }
                )
             }


### PR DESCRIPTION
## Testing:

Run `./gradlew :kotest-bom:publishKotestBomPublicationToDevPublishMavenRepository`
Check the file `kotest-bom/build/publications/KotestBom/pom-default.xml`

You can do the same check before and after and see that we get all `-jvm` variants on master, and root variants after the change.


fixes #4596