### PR TITLE
handle edge case when different values print exactly the same 

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -2,6 +2,8 @@ package io.kotest.matchers.maps
 
 import io.kotest.assertions.ErrorCollectionMode
 import io.kotest.assertions.errorCollector
+import io.kotest.assertions.failureWithTypeInformation
+import io.kotest.assertions.getFailureWithTypeInformation
 import io.kotest.assertions.print.print
 import io.kotest.assertions.runWithMode
 import io.kotest.matchers.Matcher
@@ -118,10 +120,12 @@ fun <K, V> mapcontain(key: K, v: V): Matcher<Map<K, V>> = object : Matcher<Map<K
       val passed = (key in value) && value[key] == v
       val mismatchDescription = {
          when {
-            key in value -> listOf("value was different:",
-               "Expected: <${v.print().value}>",
-               "But was:  <${value[key].print().value}>",
-               ).joinToString("\n")
+            key in value -> getFailureWithTypeInformation(
+               expected = v,
+               actual = value[key],
+               prependMessage = "value was different: "
+            ).message ?: ""
+
             else -> "key was not in the map"
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.matchers.string.shouldStartWith
+import java.math.BigDecimal
 import java.util.LinkedList
 
 class MapMatchersTest : WordSpec() {
@@ -107,8 +108,7 @@ class MapMatchersTest : WordSpec() {
                map.shouldContain(1, "c")
             }.message.shouldContainInOrder(
                "Map should contain mapping 1=c but value was different:",
-               "Expected: <\"c\">",
-               "But was:  <\"a\">"
+               "expected:<\"c\"> but was:<\"a\">"
             )
             shouldThrow<AssertionError> {
                map.shouldContain(4, "e")
@@ -117,8 +117,7 @@ class MapMatchersTest : WordSpec() {
                map should mapcontain(2, "a")
             }.message.shouldContainInOrder(
                "Map should contain mapping 2=a but value was different:",
-               """Expected: <"a">""",
-               """But was:  <"b">""",
+               """expected:<"a"> but was:<"b">""",
                "Same value found for the following entries: [1=a]",
                )
          }
@@ -161,6 +160,15 @@ class MapMatchersTest : WordSpec() {
          "pass for key not in map and null value" {
             val map = mapOf("apple" to "green")
             map shouldNotContain("lemon" to null)
+         }
+         "expose different types that print identically" {
+            val thrown = shouldThrow<AssertionError> {
+               mapOf("a" to BigDecimal("1.5")) shouldContain("a" to 1.5)
+            }
+            thrown.message.shouldContainInOrder(
+               "Map should contain mapping a=1.5 but value was different:",
+               "expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"
+            )
          }
       }
 

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -216,6 +216,8 @@ public final class io/kotest/assertions/FailuresKt {
 	public static synthetic fun failure$default (Lio/kotest/assertions/Expected;Lio/kotest/assertions/Actual;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Throwable;
 	public static final fun failureWithTypeInformation (Lio/kotest/assertions/ExpectedWithType;Lio/kotest/assertions/ActualWithType;Ljava/lang/String;)Ljava/lang/Throwable;
 	public static synthetic fun failureWithTypeInformation$default (Lio/kotest/assertions/ExpectedWithType;Lio/kotest/assertions/ActualWithType;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Throwable;
+	public static final fun getFailureWithTypeInformation (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Throwable;
+	public static synthetic fun getFailureWithTypeInformation$default (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Throwable;
 }
 
 public final class io/kotest/assertions/IntellijFormatterKt {

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -216,8 +216,6 @@ public final class io/kotest/assertions/FailuresKt {
 	public static synthetic fun failure$default (Lio/kotest/assertions/Expected;Lio/kotest/assertions/Actual;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Throwable;
 	public static final fun failureWithTypeInformation (Lio/kotest/assertions/ExpectedWithType;Lio/kotest/assertions/ActualWithType;Ljava/lang/String;)Ljava/lang/Throwable;
 	public static synthetic fun failureWithTypeInformation$default (Lio/kotest/assertions/ExpectedWithType;Lio/kotest/assertions/ActualWithType;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Throwable;
-	public static final fun getFailureWithTypeInformation (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Throwable;
-	public static synthetic fun getFailureWithTypeInformation$default (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/Throwable;
 }
 
 public final class io/kotest/assertions/IntellijFormatterKt {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/failures.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/failures.kt
@@ -56,6 +56,7 @@ fun failure(expected: Expected, actual: Actual, prependMessage: String = ""): Th
    )
 }
 
+@KotestInternal
 fun<V> getFailureWithTypeInformation(
    expected: V,
    actual: V?,

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/failures.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/failures.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.print.PrintedWithType
 import io.kotest.assertions.print.printWithType
 import io.kotest.assertions.print.printed
 import io.kotest.mpp.stacktraces
+import io.kotest.common.KotestInternal
 
 data class Expected(val value: Printed)
 data class Actual(val value: Printed)

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/failures.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/failures.kt
@@ -2,6 +2,7 @@ package io.kotest.assertions
 
 import io.kotest.assertions.print.Printed
 import io.kotest.assertions.print.PrintedWithType
+import io.kotest.assertions.print.printWithType
 import io.kotest.assertions.print.printed
 import io.kotest.mpp.stacktraces
 
@@ -54,6 +55,16 @@ fun failure(expected: Expected, actual: Actual, prependMessage: String = ""): Th
       actual
    )
 }
+
+fun<V> getFailureWithTypeInformation(
+   expected: V,
+   actual: V?,
+   prependMessage: String = ""
+) = failureWithTypeInformation(
+   ExpectedWithType(expected.printWithType()),
+   ActualWithType(actual.printWithType()),
+   prependMessage
+)
 
 fun failureWithTypeInformation(
    expected: ExpectedWithType,


### PR DESCRIPTION
handle edge case when different values print exactly the same:

```kotlin
 val thrown = shouldThrow<AssertionError> {
     mapOf("a" to BigDecimal("1.5")) shouldContain("a" to 1.5)
  }
  thrown.message.shouldContainInOrder(
     "Map should contain mapping a=1.5 but value was different:",
     "expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"
  )
```