### PR TITLE
add Arb.datesBetween

### DIFF
--- a/documentation/docs/proptest/date_gens.md
+++ b/documentation/docs/proptest/date_gens.md
@@ -14,8 +14,9 @@ To use, add `io.kotest.extensions:kotest-property-datetime:version` to your buil
 [<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-property-datetime?label=latest%20release"/>](https://search.maven.org/search?q=kotest-property-datetime)
 
 
-| Generator                                                     | Description                                                                             | JVM | JS  | Native |
-|---------------------------------------------------------------|-----------------------------------------------------------------------------------------|-----|-----|--------|
-| `Arb.date(yearRange)`                                         | Generates `LocalDate`s with the year between the given range and other fields randomly. | ✓   | ✓   | ✓      |
+| Generator                                                      | Description                                                                             | JVM | JS  | Native |
+|----------------------------------------------------------------|-----------------------------------------------------------------------------------------|-----|-----|--------|
+| `Arb.date(yearRange)`                                          | Generates `LocalDate`s with the year between the given range and other fields randomly. | ✓   | ✓   | ✓      |
+| `Arb.datesBetween(startDate, endDate)`                         | Generates `LocalDate`s in the given range.                                              | ✓   | ✓   | ✓      |
 | `Arb.datetime(yearRange, hourRange, minuteRange, secondRange)` | Generates `LocalDateTime`s with all fields in the given ranges                          | ✓   | ✓   | ✓      |
-| `Arb.instant(range)`                                          | Generates `Instant`s with the epoch randomly generated in the given range               | ✓   | ✓   | ✓      |
+| `Arb.instant(range)`                                           | Generates `Instant`s with the epoch randomly generated in the given range               | ✓   | ✓   | ✓      |

--- a/kotest-property/kotest-property-datetime/api/kotest-property-datetime.api
+++ b/kotest-property/kotest-property-datetime/api/kotest-property-datetime.api
@@ -1,6 +1,7 @@
 public final class io/kotest/property/kotlinx/datetime/DatesKt {
 	public static final fun date (Lio/kotest/property/Arb$Companion;Lkotlin/ranges/IntRange;)Lio/kotest/property/Arb;
 	public static synthetic fun date$default (Lio/kotest/property/Arb$Companion;Lkotlin/ranges/IntRange;ILjava/lang/Object;)Lio/kotest/property/Arb;
+	public static final fun datesBetween (Lio/kotest/property/Arb$Companion;Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)Lio/kotest/property/Arb;
 	public static final fun datetime (Lio/kotest/property/Arb$Companion;Lkotlin/ranges/IntRange;Lkotlin/ranges/IntRange;Lkotlin/ranges/IntRange;Lkotlin/ranges/IntRange;)Lio/kotest/property/Arb;
 	public static synthetic fun datetime$default (Lio/kotest/property/Arb$Companion;Lkotlin/ranges/IntRange;Lkotlin/ranges/IntRange;Lkotlin/ranges/IntRange;Lkotlin/ranges/IntRange;ILjava/lang/Object;)Lio/kotest/property/Arb;
 }

--- a/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
+++ b/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
+import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import kotlin.random.nextInt
@@ -22,6 +23,19 @@ fun Arb.Companion.date(
    yearRange: IntRange = 1970..Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year,
 ): Arb<LocalDate> = arbitrary {
    LocalDate(it.random.nextInt(yearRange), 1, 1).plus(it.random.nextInt(0..364), DateTimeUnit.DAY)
+}
+
+/**
+ * Returns an [Arb] where each value is a [LocalDate] in the given range of dates.
+ */
+fun Arb.Companion.datesBetween(
+   startDate: LocalDate,
+   endDate: LocalDate,
+): Arb<LocalDate> {
+   val daysRange: IntRange = 0..(endDate - startDate).days
+   return arbitrary {
+      startDate.plus(it.random.nextInt(daysRange), DateTimeUnit.DAY)
+   }
 }
 
 /**

--- a/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
+++ b/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
@@ -33,7 +33,9 @@ fun Arb.Companion.datesBetween(
    endDate: LocalDate,
 ): Arb<LocalDate> {
    val daysRange: IntRange = 0..(endDate - startDate).days
-   return arbitrary {
+   return arbitrary(
+      edgecases = listOf(startDate, endDate),
+   ) {
       startDate.plus(it.random.nextInt(daysRange), DateTimeUnit.DAY)
    }
 }

--- a/kotest-property/kotest-property-datetime/src/commonTest/kotlin/io/kotest/property/kotlinx/datetime/DatesBetweenTest.kt
+++ b/kotest-property/kotest-property-datetime/src/commonTest/kotlin/io/kotest/property/kotlinx/datetime/DatesBetweenTest.kt
@@ -1,0 +1,30 @@
+package io.kotest.property.kotlinx.datetime
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import kotlinx.datetime.LocalDate
+
+class DatesBetweenTest: StringSpec() {
+   init {
+      "should generate dates in the given range" {
+         val startDate = LocalDate(2020, 1, 1)
+         val endDate = LocalDate(2020, 12, 31)
+         io.kotest.property.forAll(
+            Arb.Companion.datesBetween(startDate, endDate),
+         ) { date ->
+            date in startDate..endDate
+         }
+      }
+      "should generate all dates in range" {
+         val startDate = LocalDate(2020, 1, 1)
+         val endDate = LocalDate(2020, 1, 11)
+         Arb.Companion.datesBetween(startDate, endDate)
+            .samples()
+            .take(100_000)
+            .map { it.value }
+            .toSet()
+            .size shouldBe 11
+      }
+   }
+}


### PR DESCRIPTION
add Arb.datesBetween, example:

```kotlin
      "should generate dates in the given range" {
         val startDate = LocalDate(2020, 1, 1)
         val endDate = LocalDate(2020, 12, 31)
         io.kotest.property.forAll(
            Arb.Companion.datesBetween(startDate, endDate),
         ) { date ->
            date in startDate..endDate
         }
      }
```