### PR TITLE
dont add implicit nulls if an explicit arb is used. fixes #4723

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
@@ -117,12 +117,14 @@ internal fun <T : Any> Arb.Companion.forClassUsingConstructor(
 
    val arbs: List<Arb<*>> = constructor.parameters.map { param ->
       val arbForProp = relevantProps.firstOrNull { (key, _) -> key.name == param.name }?.second
-      val arb = when {
+      when {
          arbForProp != null -> arbForProp
-         else -> arbForParameter(providedArbs, arbsForProperties, className, param)
+         else -> {
+            val arb = arbForParameter(providedArbs, arbsForProperties, className, param)
+            if (param.type.isMarkedNullable) arb.orNull() else arb
+         }
       }
 
-      if (param.type.isMarkedNullable) arb.orNull() else arb
    }
 
    return Arb.bind(arbs) { params -> constructor.call(*params.toTypedArray()) }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/BindTest.kt
@@ -675,4 +675,18 @@ class BindTest : StringSpec({
       }
    }
 
+   "When binding nullable properties to an arb that does not generate nulls, then no nulls should be implicitly added" {
+      data class Bar(val baz: String)
+      data class Foo(val bar: Bar?)
+
+      val arbBarNotNull = Arb.bind<Bar>()
+      val arbFooWithBar: Arb<Foo> = Arb.bind<Foo> {
+         bind(Foo::bar to arbBarNotNull) // field should never be null since its Arb does not generate nulls
+      }
+
+      checkAll(arbFooWithBar) { foo ->
+         foo.bar != null
+      }
+   }
+
 })


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
