### PR TITLE
add matcher for referential equality

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -12,7 +12,8 @@ Matchers provided by the `kotest-assertions-core` module.
 
 | General                                 |                                                                                                  |
 |-----------------------------------------|--------------------------------------------------------------------------------------------------|
-| `obj.shouldBe(other)`                   | General purpose assertion that the given obj and other are both equal                            |
+| `obj.shouldBe(other)`                   | General purpose assertion that the given obj and other are both equal (aka ==)                   |
+| `obj.shouldBeSameInstance(other)`       | General purpose assertion that the given obj and other are the same instance (aka ===)           |
 | `obj::prop.shouldHaveValue(other)`      | General purpose assertion on a property value printing information of the property on failure.   |
 | `expr.shouldBeTrue()`                   | Convenience assertion that the expression is true. Equivalent to `expr.shouldBe(true)`           |
 | `expr.shouldBeFalse()`                  | Convenience assertion that the expression is false. Equivalent to `expr.shouldBe(false)`         |

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1456,6 +1456,12 @@ public final class io/kotest/matchers/equality/ReflectionKt {
 	public static final fun shouldNotBeEqualToUsingFields (Ljava/lang/Object;Ljava/lang/Object;[Lkotlin/reflect/KProperty;)V
 }
 
+public final class io/kotest/matchers/equals/SameInstanceKt {
+	public static final fun beSameInstance (Ljava/lang/Object;)Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeSameInstance (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun shouldNotBeSameInstance (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;
+}
+
 public final class io/kotest/matchers/equals/ShouldEqualKt {
 	public static final fun beEqual (Ljava/lang/Object;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeEqual (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
@@ -1,0 +1,39 @@
+package io.kotest.matchers.equals
+
+import io.kotest.assertions.getFailureWithTypeInformation
+import io.kotest.assertions.print.print
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
+import kotlin.math.exp
+
+infix fun <A : Any> A.shouldBeSameInstance(expected: A): A {
+   this should beSameInstance(expected)
+   return this
+}
+
+infix fun <A : Any> A.shouldNotBeSameInstance(expected: A): A {
+   this shouldNot beSameInstance(expected)
+   return this
+}
+
+/**
+ * Verifies that two values are the same using [equals].
+ */
+fun <A> beSameInstance(expected: A): Matcher<A> = object : Matcher<A> {
+   override fun test(value: A): MatcherResult {
+      val passed = value === expected
+      val differenceMessage =  {
+         when {
+            passed -> ""
+            value == expected -> "the instances were equal yet different."
+            else -> getFailureWithTypeInformation(expected, value, "they were different: ").message ?: ""
+         }
+      }
+      return MatcherResult(
+         passed,
+         { "<${value.print().value}> should be same instance as <${expected.print().value}>, but ${differenceMessage()}" },
+         { "<${value.print().value}> should not be same instance as <${expected.print().value}>, but it was." })
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
@@ -10,10 +10,7 @@ import kotlin.math.exp
 
 infix fun <A : Any> A.shouldBeSameInstance(expected: A): A = also { it should beSameInstance(expected) }
 
-infix fun <A : Any> A.shouldNotBeSameInstance(expected: A): A {
-   this shouldNot beSameInstance(expected)
-   return this
-}
+infix fun <A : Any> A.shouldNotBeSameInstance(expected: A): A = also { it shouldNot beSameInstance(expected) }
 
 /**
  * Verifies that two values are the same using [equals].

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
@@ -13,7 +13,7 @@ infix fun <A : Any> A.shouldBeSameInstance(expected: A): A = also { it should be
 infix fun <A : Any> A.shouldNotBeSameInstance(expected: A): A = also { it shouldNot beSameInstance(expected) }
 
 /**
- * Verifies that two values are the same using [equals].
+ * Verifies that two values are the same using referencial equality aka ===.
  */
 fun <A> beSameInstance(expected: A): Matcher<A> = object : Matcher<A> {
    override fun test(value: A): MatcherResult {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
@@ -21,7 +21,7 @@ fun <A> beSameInstance(expected: A): Matcher<A> = object : Matcher<A> {
       val differenceMessage =  {
          when {
             passed -> ""
-            value == expected -> "the instances were equal yet different."
+            value == expected -> "the instances were equal using equals but have different references"
             else -> getFailureWithTypeInformation(expected, value, "they were different: ").message ?: ""
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/SameInstance.kt
@@ -8,10 +8,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.math.exp
 
-infix fun <A : Any> A.shouldBeSameInstance(expected: A): A {
-   this should beSameInstance(expected)
-   return this
-}
+infix fun <A : Any> A.shouldBeSameInstance(expected: A): A = also { it should beSameInstance(expected) }
 
 infix fun <A : Any> A.shouldNotBeSameInstance(expected: A): A {
    this shouldNot beSameInstance(expected)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/equals/SameInstanceTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/equals/SameInstanceTest.kt
@@ -1,0 +1,59 @@
+package io.kotest.matchers.equals
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContainInOrder
+
+class SameInstanceTest: WordSpec() {
+   init {
+       "shouldBeSameInstance" should {
+          "detect same instance" {
+             val a = "hello"
+             val b = a
+             a shouldBeSameInstance b
+          }
+          "detect equal but different instances" {
+             val a = "hello"
+             val b = "hello world".substring(0, 5)
+             shouldThrow<AssertionError> {
+                a shouldBeSameInstance b
+             }.message shouldBe """<"hello"> should be same instance as <"hello">, but the instances were equal yet different."""
+          }
+            "detect different instances" {
+               val a = "hello"
+               val b = "world"
+               shouldThrow<AssertionError> {
+                  a shouldBeSameInstance b
+               }.message.shouldContainInOrder(
+                  """<"hello"> should be same instance as <"world">""",
+                  """expected:<"world"> but was:<"hello">"""
+               )
+            }
+       }
+      "shouldNotBeSameInstance" should {
+         "detect same instance" {
+            val a = "hello"
+            val b = a
+            shouldThrow<AssertionError> {
+               a shouldNotBeSameInstance b
+            }.message shouldBe """<"hello"> should not be same instance as <"hello">, but it was."""
+         }
+         "detect equal but different instances" {
+            val a = "hello"
+            val b = "hello world".substring(0, 5)
+            shouldNotThrowAny {
+               a shouldNotBeSameInstance b
+            }
+         }
+         "detect different instances" {
+            val a = "hello"
+            val b = "world"
+            shouldNotThrowAny {
+               a shouldNotBeSameInstance b
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
add matcher for referential equality:

```kotlin
            val a = "hello"
             val b = "hello world".substring(0, 5)
             shouldThrow<AssertionError> {
                a shouldBeSameInstance b
             }.message shouldBe """<"hello"> should be same instance as <"hello">, but the instances were equal yet different."""
```
