### PR TITLE
make-shouldNotThrowExactlyUnit-compatible-with-assertSoftly (#4808)

### DIFF
--- a/documentation/docs/assertions/soft_assertions.md
+++ b/documentation/docs/assertions/soft_assertions.md
@@ -56,7 +56,7 @@ In the following example both `verify` and the second assertion can fail, and we
 
 ```kotlin
 assertSoftly {
-  shouldNotThrowAny {
+  shouldNotThrowAnyUnit {
     verify(exactly = 1) { myClass.myMethod(any()) }
   }
   foo shouldBe bar
@@ -69,7 +69,7 @@ Likewise, in the following example the failure of `verify` will not be ignored, 
 ```kotlin
 assertSoftly {
   (2+2) shouldBe 5
-  shouldNotThrowAny {
+  shouldNotThrowAnyUnit {
     verify(exactly = 1) { myClass.myMethod(any()) }
   }
 }
@@ -80,7 +80,6 @@ assertSoftly {
 * `shouldCompleteWithin`
 * `shouldCompleteBetween`
 * `shouldNotThrowExactly`
-* `shouldNotThrowExactlyUnit`
 * `shouldNotThrowMessage`
 * `shouldThrow`
 * `shouldThrowExactly`
@@ -91,4 +90,4 @@ assertSoftly {
 * `shouldThrowWithMessage`
 * `shouldTimeout`
 
-But `shouldThrowSoftly` is compatible with `assertSoftly`.
+But `shouldThrowSoftly` and `shouldNotThrowExactlyUnit` are compatible with `assertSoftly`.

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/AnyThrowableHandlingTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/throwablehandling/AnyThrowableHandlingTest.kt
@@ -18,88 +18,88 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 class AnyThrowableHandlingTest : FreeSpec() {
 
   init {
-    onShouldThrowAnyMatcher { shouldThrowAnyMatcher ->
-      "Should throw any ($shouldThrowAnyMatcher)" - {
-        "Should throw an exception" - {
-          "When no exception is thrown in the code" {
-            verifyThrowsNoExceptionError {
-              shouldThrowAnyMatcher { /* No exception being thrown */ }
-            }
-          }
-        }
+     onShouldThrowAnyMatcher { shouldThrowAnyMatcher ->
+        "Should throw any ($shouldThrowAnyMatcher)" - {
+           "Should throw an exception" - {
+              "When no exception is thrown in the code" {
+                 verifyThrowsNoExceptionError {
+                    shouldThrowAnyMatcher { /* No exception being thrown */ }
+                 }
+              }
+           }
 
-        "Should return the thrown instance" - {
-          "When an exception is thrown in the code" {
-            val instanceToThrow = FooRuntimeException()
+           "Should return the thrown instance" - {
+              "When an exception is thrown in the code" {
+                 val instanceToThrow = FooRuntimeException()
 
-            verifyReturnsExactly(instanceToThrow) {
-              shouldThrowAnyMatcher { throw instanceToThrow }
-            }
-          }
-        }
-      }
-    }
-
-    onShouldNotThrowAnyMatcher { shouldNotThrowAnyMatcher ->
-      "Should not throw any($shouldNotThrowAnyMatcher)" - {
-        "Should throw an exception" - {
-          "When any exception is thrown in the code" {
-            val exception = FooRuntimeException()
-
-            verifyThrowsAssertionWrapping(exception) {
-              shouldNotThrowAnyMatcher { throw exception }
-            }
-          }
-        }
-
-        "Should not throw an exception" - {
-          "When no exception is thrown in the code" {
-            verifyNoErrorIsThrown {
-              shouldNotThrowAnyMatcher { /* Nothing thrown */ }
-            }
-          }
-        }
-      }
-    }
-
-     "shouldNotThrowAny" - {
-         "should collaborate with assertSoftly if an exception is thrown" {
-            val thrown = shouldThrowExactly<MultiAssertionError> {
-               assertSoftly {
-                  (2 + 2) shouldBe 5
-                  shouldNotThrowAny {
-                     throw Exception("Oops!")
-                  }
-                  (3 - 2) shouldBe 2
-               }
-            }
-            thrown.message.shouldContainInOrder(
-               "The following 3 assertions failed:",
-               "1) expected:<5> but was:<4>",
-               """2) No exception expected, but a Exception was thrown with message: "Oops!".""",
-               "3) expected:<2> but was:<1>",
-            )
-         }
-        "should collaborate with assertSoftly if a non-kotest assertion fails" {
-            val thrown = shouldThrowExactly<MultiAssertionError> {
-               assertSoftly {
-                  (2 + 2) shouldBe 5
-                  shouldNotThrowAny {
-                     failedNonKotestAssertion()
-                  }
-                  (3 - 2) shouldBe 2
-               }
-            }
-            thrown.message.shouldContainInOrder(
-               "The following 3 assertions failed:",
-               "1) expected:<5> but was:<4>",
-               """2) No exception expected, but a AssertionError was thrown with message: "Non-kotest assertion failure".""",
-               "3) expected:<2> but was:<1>",
-            )
-         }
+                 verifyReturnsExactly(instanceToThrow) {
+                    shouldThrowAnyMatcher { throw instanceToThrow }
+                 }
+              }
+           }
         }
      }
 
+     onShouldNotThrowAnyMatcher { shouldNotThrowAnyMatcher ->
+        "Should not throw any($shouldNotThrowAnyMatcher)" - {
+           "Should throw an exception" - {
+              "When any exception is thrown in the code" {
+                 val exception = FooRuntimeException()
+
+                 verifyThrowsAssertionWrapping(exception) {
+                    shouldNotThrowAnyMatcher { throw exception }
+                 }
+              }
+           }
+
+           "Should not throw an exception" - {
+              "When no exception is thrown in the code" {
+                 verifyNoErrorIsThrown {
+                    shouldNotThrowAnyMatcher { /* Nothing thrown */ }
+                 }
+              }
+           }
+        }
+     }
+
+     "shouldNotThrowAnyUnit" - {
+        "should collaborate with assertSoftly if a non-kotest assertion fails" {
+           val thrown = shouldThrowExactly<MultiAssertionError> {
+              assertSoftly {
+                 (2 + 2) shouldBe 5
+                 shouldNotThrowAnyUnit {
+                    failedNonKotestAssertion()
+                 }
+                 (3 - 2) shouldBe 2
+              }
+           }
+           thrown.message.shouldContainInOrder(
+              "The following 3 assertions failed:",
+              "1) expected:<5> but was:<4>",
+              """2) No exception expected, but a AssertionError was thrown with message: "Non-kotest assertion failure".""",
+              "3) expected:<2> but was:<1>",
+           )
+        }
+
+        "should collaborate with assertSoftly if an exception is thrown" {
+           val thrown = shouldThrowExactly<MultiAssertionError> {
+              assertSoftly {
+                 (2 + 2) shouldBe 5
+                 shouldNotThrowAnyUnit {
+                    throw Exception("Oops!")
+                 }
+                 (3 - 2) shouldBe 2
+              }
+           }
+           thrown.message.shouldContainInOrder(
+              "The following 3 assertions failed:",
+              "1) expected:<5> but was:<4>",
+              """2) No exception expected, but a Exception was thrown with message: "Oops!".""",
+              "3) expected:<2> but was:<1>",
+           )
+        }
+     }
+  }
 
   private inline fun onShouldThrowAnyMatcher(func: (ShouldThrowAnyMatcher) -> Unit) {
     func(::shouldThrowAny)

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -636,7 +636,7 @@ public final class io/kotest/assertions/print/platformjvm {
 
 public final class io/kotest/assertions/throwables/AnyThrowableHandlingKt {
 	public static final fun shouldNotThrowAny (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static final fun shouldNotThrowAnyUnit (Lkotlin/jvm/functions/Function0;)Lkotlin/Unit;
+	public static final fun shouldNotThrowAnyUnit (Lkotlin/jvm/functions/Function0;)V
 	public static final fun shouldNotThrowMessage (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun shouldThrowAny (Lkotlin/jvm/functions/Function0;)Ljava/lang/Throwable;
 	public static final fun shouldThrowAnyUnit (Lkotlin/jvm/functions/Function0;)Ljava/lang/Throwable;

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/AnyThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/throwables/AnyThrowableHandling.kt
@@ -37,7 +37,25 @@ inline fun shouldThrowAnyUnit(block: () -> Unit) = shouldThrowAny(block)
  * @see [shouldNotThrowUnit]
  *
  */
-inline fun shouldNotThrowAnyUnit(block: () -> Unit) = shouldNotThrowAny(block)
+inline fun shouldNotThrowAnyUnit(block: () -> Unit) {
+   assertionCounter.inc()
+
+   val thrownException = try {
+      block()
+      null
+   } catch (e: Throwable) {
+      e
+   }
+
+   thrownException?.let {
+      errorCollector.collectOrThrow(
+         failure(
+            "No exception expected, but a ${thrownException::class.simpleName} was thrown with message: \"${thrownException.message}\".",
+            thrownException
+         )
+      )
+   }
+}
 
 /**
  * Verifies that a block of code throws any [Throwable]
@@ -94,7 +112,7 @@ inline fun shouldThrowAny(block: () -> Any?): Throwable {
  * @see [shouldNotThrow]
  *
  */
-inline fun <T> shouldNotThrowAny(block: () -> T): T? {
+inline fun <T> shouldNotThrowAny(block: () -> T): T {
    assertionCounter.inc()
 
    val thrownException = try {
@@ -103,13 +121,10 @@ inline fun <T> shouldNotThrowAny(block: () -> T): T? {
       e
    }
 
-   errorCollector.collectOrThrow(
-      failure(
-         "No exception expected, but a ${thrownException::class.simpleName} was thrown with message: \"${thrownException.message}\".",
-         thrownException
-      )
+   throw failure(
+      "No exception expected, but a ${thrownException::class.simpleName} was thrown with message: \"${thrownException.message}\".",
+      thrownException
    )
-   return null
 }
 
 


### PR DESCRIPTION

* make-shouldNotThrowExactlyUnit-compatible-with-assertSoftly
* restore shouldNotThrowExactly to have its original signature, returning `T` not `T?`

This allows us to have an assertion that is compatible with `assertSoftly` without breaking any contracts