### PR TITLE
Update the beforeSpec method in JdbcDatabaseContainerExtension to not call itself recursively

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
@@ -68,6 +68,7 @@ class JdbcDatabaseContainerExtension(
    AfterTestListener,
    AfterSpecListener {
 
+   private val beforeSpecFn = beforeSpec
    private var dataSource: HikariDataSource? = null
 
    /**
@@ -101,7 +102,7 @@ class JdbcDatabaseContainerExtension(
    }
 
    override suspend fun beforeSpec(spec: Spec) {
-      beforeSpec(spec)
+      beforeSpecFn(spec)
    }
 
    override suspend fun afterSpec(spec: Spec) {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
@@ -101,7 +101,7 @@ class JdbcDatabaseContainerExtension(
    }
 
    override suspend fun beforeSpec(spec: Spec) {
-      beforeSpec(spec)
+      this.beforeSpec(spec)
    }
 
    override suspend fun afterSpec(spec: Spec) {


### PR DESCRIPTION
The beforeSpec method is calling itself recursively instead of calling the class constructor parameter. 