### PR TITLE
make-eventually-behave-consistently

### DIFF
--- a/documentation/docs/assertions/eventually.md
+++ b/documentation/docs/assertions/eventually.md
@@ -152,12 +152,12 @@ eventually(config) {
 
 As an alternative to passing in a set of exceptions, we can provide a function which is invoked, passing in the throw
 exception. This function should return true if the exception should be ignored, or false if the exception should bubble
-out.
+out. If `expectedExceptions` is specified and the set is not empty, this function will be ignored.
 
 ```kotlin
 val config = eventuallyConfig {
   duration = 5.seconds
-  expectedExceptions = { it is UserNotFoundException }
+  expectedExceptionsFn = { it is UserNotFoundException }
 }
 
 eventually(config) {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
@@ -100,7 +100,8 @@ private fun EventuallyConfigurationBuilder.build(): EventuallyConfiguration {
       initialDelay = this.initialDelay,
       intervalFn = this.intervalFn ?: DurationFn { interval },
       retries = this.retries,
-      expectedExceptionsFn = { t -> this.expectedExceptions.any { it.isInstance(t) } || this.expectedExceptionsFn(t) },
+      expectedExceptionsFn = { t -> this.expectedExceptions.any { it.isInstance(t) } ||
+         (this.expectedExceptions.isEmpty() && this.expectedExceptionsFn(t)) } ,
       listener = this.listener ?: NoopEventuallyListener,
       shortCircuit = this.shortCircuit,
       includeFirst = this.includeFirst,
@@ -170,7 +171,7 @@ class EventuallyConfigurationBuilder {
     * A set of exceptions, which, if thrown, will cause the test function to be retried.
     * By default, all exceptions are retried.
     *
-    * This set is applied in addition to the values specified by [expectedExceptionsFn].
+    * This set, if provided and not empty, overrides the logic specified by [expectedExceptionsFn].
     */
    var expectedExceptions: Set<KClass<out Throwable>> = EventuallyConfigurationDefaults.expectedExceptions
 
@@ -179,7 +180,7 @@ class EventuallyConfigurationBuilder {
     * function retried. By default, this function returns true for all exceptions, or in other words,
     * all errors cause the test function to be retried.
     *
-    * This function is applied in addition to the values specified by [expectedExceptions].
+    * This function is applied only when no values are specified by [expectedExceptions].
     */
    var expectedExceptionsFn: (Throwable) -> Boolean = EventuallyConfigurationDefaults.expectedExceptionsFn
 


### PR DESCRIPTION
Fix https://github.com/kotest/kotest/issues/4838

Before the fix, `expectedExceptions = setOf` did not work as documented. Instead, it was retrying on every exception. But if the same exceptions were checked for in a function, it did work.

This fix makes `expectedExceptions = setOf` work exactly the same as the function checking for the same exceptions. To make that happen, I had to change the requirements - `expectedExceptions` no longer supplements the function. Instead, it overrides the function.

With the fix, `eventually` work consistently in both following cases:

when we define a Set:

```kotlin
val config = eventuallyConfig {
            duration = 5.seconds
            expectedExceptions = setOf(IOException::class)
         }
```

and when we define a function:

```koltin
val config = eventuallyConfig {
            duration = 5.seconds
            expectedExceptionsFn = { ex -> ex is IOException }
         }
```
