### PR TITLE
reintroduce @Language annotation from now-mulitplatform org.jetbrains:annotations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ blockhound = { module = "io.projectreactor.tools:blockhound", version.ref = "blo
 diffutils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "java-diff-utils" }
 jayway-json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "json-path" }
 jdom2 = { module = "org.jdom:jdom2", version.ref = "jdom2" }
-jetbrainsAnnotations = { module = "org.jetbrains:annotations", version = "26.0.1" }
+jetbrainsAnnotations = { module = "org.jetbrains:annotations", version = "26.0.2" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ blockhound = { module = "io.projectreactor.tools:blockhound", version.ref = "blo
 diffutils = { module = "io.github.java-diff-utils:java-diff-utils", version.ref = "java-diff-utils" }
 jayway-json-path = { module = "com.jayway.jsonpath:json-path", version.ref = "json-path" }
 jdom2 = { module = "org.jdom:jdom2", version.ref = "jdom2" }
+jetbrainsAnnotations = { module = "org.jetbrains:annotations", version = "26.0.1" }
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }

--- a/kotest-assertions/kotest-assertions-json/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-json/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
 
       val commonMain by getting {
          dependencies {
+            compileOnly(libs.jetbrainsAnnotations)
             implementation(projects.kotestCommon)
             implementation(libs.kotlinx.serialization.json)
             implementation(projects.kotestAssertions.kotestAssertionsShared)
@@ -27,6 +28,11 @@ kotlin {
          dependencies {
             implementation(libs.jayway.json.path)
          }
+      }
+
+      // compileOnly is not supported in these source-sets, so needs must expose it as api too
+      named(listOf("nativeMain", "jsMain", "wasmJsMain")::contains).configureEach {
+         dependencies { api(libs.jetbrainsAnnotations) }
       }
    }
 }

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/jsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/jsonMatchers.kt
@@ -10,12 +10,13 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import org.intellij.lang.annotations.Language
 import kotlin.reflect.KClass
 
 @OptIn(ExperimentalSerializationApi::class)
 internal val pretty by lazy { Json { prettyPrint = true; prettyPrintIndent = "  " } }
 
-fun matchJson(expected: String?) = object : Matcher<String?> {
+fun matchJson(@Language("json") expected: String?) = object : Matcher<String?> {
    override fun test(value: String?): MatcherResult {
       val actualJson = try {
          value?.let(pretty::parseToJsonElement)

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import org.intellij.lang.annotations.Language
 
 /**
  * Returns a [Matcher] that verifies that two JSON strings are equal.
@@ -14,7 +15,7 @@ import io.kotest.matchers.shouldNot
  * The [CompareJsonOptions] parameter can be used to configure the matcher behavior.
  */
 fun equalJson(
-   expected: String,
+   @Language("json") expected: String,
    options: CompareJsonOptions
 ): Matcher<String?> =
    Matcher { actual ->
@@ -69,7 +70,7 @@ data class JsonTree(val root: JsonNode, val raw: String)
  *
  * To more precisely control the comparison, use [shouldEqualJson] that accepts a [CompareJsonOptions].
  */
-infix fun String.shouldEqualJson(expected: String): String {
+infix fun String.shouldEqualJson(@Language("json") expected: String): String {
    this should equalJson(expected, CompareJsonOptions())
    return this
 }
@@ -85,7 +86,7 @@ infix fun String.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions
    return this
 }
 
-infix fun String.shouldNotEqualJson(expected: String): String {
+infix fun String.shouldNotEqualJson(@Language("json") expected: String): String {
    this shouldNot equalJson(expected, CompareJsonOptions())
    return this
 }
@@ -100,14 +101,14 @@ infix fun String.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOpti
    return this
 }
 
-infix fun String.shouldEqualSpecifiedJson(expected: String) {
+infix fun String.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
       expected
    }
 }
 
-infix fun String.shouldEqualSpecifiedJsonIgnoringOrder(expected: String) {
+infix fun String.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected: String) {
    shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
       arrayOrder = ArrayOrder.Lenient
@@ -115,7 +116,7 @@ infix fun String.shouldEqualSpecifiedJsonIgnoringOrder(expected: String) {
    }
 }
 
-infix fun String.shouldNotEqualSpecifiedJson(expected: String) {
+infix fun String.shouldNotEqualSpecifiedJson(@Language("json") expected: String) {
    shouldNotEqualJson {
       fieldComparison = FieldComparison.Lenient
       expected

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
@@ -32,6 +32,7 @@ import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.intellij.lang.annotations.Language
 
 private val schemaJsonConfig = Json {
    ignoreUnknownKeys = true
@@ -43,7 +44,7 @@ private val schemaJsonConfig = Json {
  * [shouldMatchSchema]
  */
 @ExperimentalKotest
-fun parseSchema(jsonSchema: String): JsonSchema =
+fun parseSchema(@Language("json") jsonSchema: String): JsonSchema =
    JsonSchema(root = schemaJsonConfig.decodeFromString(SchemaDeserializer, jsonSchema))
 
 @ExperimentalKotest

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/matchers.kt
@@ -6,9 +6,10 @@ import io.kotest.assertions.json.paths.shouldEqualSpecifiedJson
 import io.kotest.assertions.json.paths.shouldEqualSpecifiedJsonIgnoringOrder
 import io.kotest.assertions.json.paths.shouldNotEqualJson
 import io.kotest.assertions.json.paths.shouldNotEqualSpecifiedJson
+import org.intellij.lang.annotations.Language
 import java.io.File
 
-infix fun File.shouldEqualJson(expected: String): File {
+infix fun File.shouldEqualJson(@Language("json") expected: String): File {
    this.toPath().shouldEqualJson(expected)
    return this
 }
@@ -18,7 +19,7 @@ infix fun File.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.(
    return this
 }
 
-infix fun File.shouldNotEqualJson(expected: String): File {
+infix fun File.shouldNotEqualJson(@Language("json") expected: String): File {
    this.toPath().shouldNotEqualJson(expected)
    return this
 }
@@ -28,14 +29,14 @@ infix fun File.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOption
    return this
 }
 
-infix fun File.shouldEqualSpecifiedJson(expected: String) {
+infix fun File.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    this.toPath().shouldEqualSpecifiedJson(expected)
 }
 
-infix fun File.shouldEqualSpecifiedJsonIgnoringOrder(expected: String) {
+infix fun File.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected: String) {
    this.toPath().shouldEqualSpecifiedJsonIgnoringOrder(expected)
 }
 
-infix fun File.shouldNotEqualSpecifiedJson(expected: String) {
+infix fun File.shouldNotEqualSpecifiedJson(@Language("json") expected: String) {
    this.toPath().shouldNotEqualSpecifiedJson(expected)
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
@@ -4,9 +4,10 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import org.intellij.lang.annotations.Language
 import kotlin.contracts.contract
 
-infix fun String?.shouldContainJsonKey(path: String) {
+infix fun String?.shouldContainJsonKey(@Language("JSONPath") path: String) {
    contract {
       returns() implies (this@shouldContainJsonKey != null)
    }
@@ -14,10 +15,10 @@ infix fun String?.shouldContainJsonKey(path: String) {
    this should containJsonKey(path)
 }
 
-infix fun String.shouldNotContainJsonKey(path: String) =
+infix fun String.shouldNotContainJsonKey(@Language("JSONPath") path: String) =
    this shouldNot containJsonKey(path)
 
-fun containJsonKey(path: String) = object : Matcher<String?> {
+fun containJsonKey(@Language("JSONPath") path: String) = object : Matcher<String?> {
 
    override fun test(value: String?): MatcherResult {
       val sub = when (value) {

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -14,9 +14,10 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import org.intellij.lang.annotations.Language
 import kotlin.contracts.contract
 
-inline fun <reified T> String?.shouldContainJsonKeyValue(path: String, value: T) {
+inline fun <reified T> String?.shouldContainJsonKeyValue(@Language("JSONPath") path: String, value: T) {
    contract {
       returns() implies (this@shouldContainJsonKeyValue != null)
    }
@@ -24,10 +25,10 @@ inline fun <reified T> String?.shouldContainJsonKeyValue(path: String, value: T)
    this should containJsonKeyValue(path, value)
 }
 
-inline fun <reified T> String.shouldNotContainJsonKeyValue(path: String, value: T) =
+inline fun <reified T> String.shouldNotContainJsonKeyValue(@Language("JSONPath") path: String, value: T) =
    this shouldNot containJsonKeyValue(path, value)
 
-inline fun <reified T> containJsonKeyValue(path: String, t: T) =
+inline fun <reified T> containJsonKeyValue(@Language("JSONPath") path: String, t: T) =
    containJsonKeyValue(path, t, t?.let { it::class.java } ?: Nothing::class.java)
 
 @KotestInternal
@@ -182,4 +183,3 @@ internal data class JsonSubPathJsonArrayTooShort(
 internal data object JsonSubPathNotFound: JsonSubPathSearchOutcome {
    override fun description() = ""
 }
-

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt
@@ -9,10 +9,11 @@ import io.kotest.matchers.paths.aFile
 import io.kotest.matchers.paths.exist
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import org.intellij.lang.annotations.Language
 import java.nio.file.Path
 import kotlin.io.path.readText
 
-infix fun Path.shouldEqualJson(expected: String): Path {
+infix fun Path.shouldEqualJson(@Language("json") expected: String): Path {
    this should (exist() and aFile() and equalJson(expected, CompareJsonOptions()).contramap { it.readText() })
    return this
 }
@@ -24,7 +25,7 @@ infix fun Path.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.(
    return this
 }
 
-infix fun Path.shouldNotEqualJson(expected: String): Path {
+infix fun Path.shouldNotEqualJson(@Language("json") expected: String): Path {
    this.readText() shouldNot equalJson(expected, CompareJsonOptions())
    return this
 }
@@ -36,14 +37,14 @@ infix fun Path.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOption
    return this
 }
 
-infix fun Path.shouldEqualSpecifiedJson(expected: String) {
+infix fun Path.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    this.shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
       expected
    }
 }
 
-infix fun Path.shouldEqualSpecifiedJsonIgnoringOrder(expected: String) {
+infix fun Path.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected: String) {
    this.shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
       arrayOrder = ArrayOrder.Lenient
@@ -51,7 +52,7 @@ infix fun Path.shouldEqualSpecifiedJsonIgnoringOrder(expected: String) {
    }
 }
 
-infix fun Path.shouldNotEqualSpecifiedJson(expected: String) {
+infix fun Path.shouldNotEqualSpecifiedJson(@Language("json") expected: String) {
    this.shouldNotEqualJson {
       fieldComparison = FieldComparison.Lenient
       expected

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
@@ -5,9 +5,10 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import org.intellij.lang.annotations.Language
 import kotlin.contracts.contract
 
-infix fun String?.shouldMatchJsonResource(resource: String) {
+infix fun String?.shouldMatchJsonResource(@Language("file-reference") resource: String) {
    contract {
       returns() implies (this@shouldMatchJsonResource != null)
    }
@@ -15,7 +16,7 @@ infix fun String?.shouldMatchJsonResource(resource: String) {
    this should matchJsonResource(resource)
 }
 
-infix fun String.shouldNotMatchJsonResource(resource: String) =
+infix fun String.shouldNotMatchJsonResource(@Language("file-reference") resource: String) =
    this shouldNot matchJsonResource(resource)
 
 fun matchJsonResource(resource: String) = object : Matcher<String?> {


### PR DESCRIPTION
This reintroduces the equivalent annotations that were removed as part of https://github.com/kotest/kotest/issues/3590 now that `org.jetbrains:annotations` is multiplatform.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
