### PR TITLE
Fix Exhaustive.Companion.azstring

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/strings.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/strings.kt
@@ -6,7 +6,9 @@ import io.kotest.property.RandomSource
 fun Exhaustive.Companion.azstring(range: IntRange): Exhaustive<String> {
    fun az() = ('a'..'z').map { it.toString() }
    val values = range.toList().flatMap { size ->
-      List(size) { az() }.reduce { acc, seq -> acc.zip(seq).map { (a, b) -> a + b } }
+      List(size) { az() }.reduce { acc, seq -> acc.flatMap { a ->
+         seq.map { b -> a + b } }
+      }
    }
    return values.exhaustive()
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/AzStringTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/AzStringTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.kotest.property.exhaustive
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Exhaustive
+import io.kotest.property.exhaustive.azstring
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class AzStringTest : ShouldSpec ({
+   val oneLetterPermutations = listOf(
+      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+      "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
+   )
+
+   // Produces all permutations aa, ab, ac, ... , zx, zy, zz
+   val twoLetterPermutations = ('a'..'z').flatMap { first ->
+      ('a'..'z').map { second -> "$first$second" }
+   }
+   should("return the all letters for range 1..1") {
+      Exhaustive.Companion.azstring(1..1).values shouldBe oneLetterPermutations
+   }
+
+   should("return the all two letter permutations for range 2..2") {
+      Exhaustive.Companion.azstring(2..2).values shouldBe twoLetterPermutations
+   }
+
+   should("handle ranges") {
+      Exhaustive.Companion.azstring(1..2).values shouldBe oneLetterPermutations + twoLetterPermutations
+   }
+})

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/AzStringTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/AzStringTest.kt
@@ -9,10 +9,9 @@ import io.kotest.property.exhaustive.azstring
 
 @EnabledIf(LinuxOnlyGithubCondition::class)
 class AzStringTest : ShouldSpec ({
-   val oneLetterPermutations = listOf(
-      "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
-      "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"
-   )
+
+   // Produces all letters a, b, c, ... , x, y, z
+   val oneLetterPermutations = ('a'..'z').map { it.toString() }
 
    // Produces all permutations aa, ab, ac, ... , zx, zy, zz
    val twoLetterPermutations = ('a'..'z').flatMap { first ->


### PR DESCRIPTION
According the [documentation](https://kotest.io/docs/proptest/property-test-generators-list.html), "`Exhaustive.azstring(1..2)` ... [returns] `a, b, c, ...., yz, zz`". The `yz` seems to imply that it generates all possible permutations; however, this doesn't seem to be the case. For example for  `Exhaustive.azstring(2..2)` should produce `aa, ab, ac, ... , zx, zy, zz` but instead produces `aa, bb, cc, ... , xx, yy, zz`. There is a mismatch between the code and the documentation. 

My changes updates the code to match the written behavior. If the current behavior is intentional, I can change this pull request to update the documentation instead (and update the test to match the current behavior)