### PR TITLE
Add dependency of libs.kotlinx.coroutines.test to :kotest-assertions:kotest-assertions-core

### DIFF
--- a/kotest-assertions/kotest-assertions-core/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-core/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
          dependencies {
             implementation(projects.kotestProperty)
             implementation(libs.kotlinx.coroutines.core)
+            implementation(libs.kotlinx.coroutines.test)
             implementation(libs.opentest4j)
             implementation(libs.apache.commons.lang)
             implementation(libs.mockk)


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

## Changes

- Add dependency of libs.kotlinx.coroutines.test to :kotest-assertions:kotest-assertions-core

## Motivation

It is necessary to add this dependency to run `:kotest-assertions:kotest-assertions-core` locally.

## Related PRs

- https://github.com/kotest/kotest/pull/4849