### PR TITLE
Add version for kotlin-reflect

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,8 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+
 konform = { module = "io.konform:konform", version.ref = "konform" }
 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }


### PR DESCRIPTION
Sets the version based on the kotlin version in use. Fixes #4860
