### PR TITLE
add haveContentTypeMatching matcher

### DIFF
--- a/kotest-assertions/kotest-assertions-ktor/api/kotest-assertions-ktor.api
+++ b/kotest-assertions/kotest-assertions-ktor/api/kotest-assertions-ktor.api
@@ -32,6 +32,7 @@ public final class io/kotest/assertions/ktor/ResponsesKt {
 
 public final class io/kotest/assertions/ktor/client/HeadersKt {
 	public static final fun haveContentType (Lio/ktor/http/ContentType;)Lio/kotest/matchers/Matcher;
+	public static final fun haveContentTypeMatching (Lio/ktor/http/ContentType;)Lio/kotest/matchers/Matcher;
 	public static final fun haveHeader (Ljava/lang/String;)Lio/kotest/matchers/Matcher;
 	public static final fun haveHeader (Ljava/lang/String;Ljava/lang/String;)Lio/kotest/matchers/Matcher;
 	public static final fun haveVersion (Lio/ktor/http/HttpProtocolVersion;)Lio/kotest/matchers/Matcher;
@@ -40,6 +41,7 @@ public final class io/kotest/assertions/ktor/client/HeadersKt {
 	public static final fun shouldHaveContentEncoding (Lio/ktor/client/statement/HttpResponse;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldHaveContentEncoding (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldHaveContentType (Lio/ktor/client/statement/HttpResponse;Lio/ktor/http/ContentType;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun shouldHaveContentTypeMatching (Lio/ktor/client/statement/HttpResponse;Lio/ktor/http/ContentType;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldHaveETag (Lio/ktor/client/statement/HttpResponse;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldHaveETag (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldHaveHeader (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
@@ -50,6 +52,7 @@ public final class io/kotest/assertions/ktor/client/HeadersKt {
 	public static final fun shouldNotHaveContentEncoding (Lio/ktor/client/statement/HttpResponse;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldNotHaveContentEncoding (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldNotHaveContentType (Lio/ktor/client/statement/HttpResponse;Lio/ktor/http/ContentType;)Lio/ktor/client/statement/HttpResponse;
+	public static final fun shouldNotHaveContentTypeMatching (Lio/ktor/client/statement/HttpResponse;Lio/ktor/http/ContentType;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldNotHaveETag (Lio/ktor/client/statement/HttpResponse;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldNotHaveETag (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;
 	public static final fun shouldNotHaveHeader (Lio/ktor/client/statement/HttpResponse;Ljava/lang/String;)Lio/ktor/client/statement/HttpResponse;

--- a/kotest-assertions/kotest-assertions-ktor/src/commonMain/kotlin/io/kotest/assertions/ktor/client/headers.kt
+++ b/kotest-assertions/kotest-assertions-ktor/src/commonMain/kotlin/io/kotest/assertions/ktor/client/headers.kt
@@ -130,6 +130,26 @@ fun haveContentType(contentType: ContentType) = object : Matcher<HttpResponse> {
    }
 }
 
+infix fun HttpResponse.shouldHaveContentTypeMatching(contentType: ContentType): HttpResponse {
+   this should haveContentTypeMatching(contentType)
+   return this
+}
+
+infix fun HttpResponse.shouldNotHaveContentTypeMatching(contentType: ContentType): HttpResponse {
+   this shouldNot haveContentTypeMatching(contentType)
+   return this
+}
+
+fun haveContentTypeMatching(contentType: ContentType) = object : Matcher<HttpResponse> {
+   override fun test(value: HttpResponse): MatcherResult {
+      return MatcherResult(
+         value.contentType()?.match(contentType) == true,
+         { "Response should match Content-Type $contentType but was ${value.contentType()}." },
+         { "Response should not match Content-Type $contentType." },
+      )
+   }
+}
+
 fun haveHeader(headerName: String) = object : Matcher<HttpResponse> {
    override fun test(value: HttpResponse): MatcherResult = MatcherResult(
       value.headers.contains(headerName),

--- a/kotest-assertions/kotest-assertions-ktor/src/jvmTest/kotlin/io/kotest/assertions/ktor/client/ResponseTest.kt
+++ b/kotest-assertions/kotest-assertions-ktor/src/jvmTest/kotlin/io/kotest/assertions/ktor/client/ResponseTest.kt
@@ -137,7 +137,7 @@ class ResponseKtTest : FreeSpec({
       }
    }
 
-   "ContentType assertions" {
+   "ContentType equals" {
       testApplication {
          routing { get("/") { call.respondText("ok") } }
          client.get("/").apply {
@@ -149,6 +149,40 @@ class ResponseKtTest : FreeSpec({
             shouldThrow<AssertionError> {
                shouldHaveContentType(ContentType.Application.GZip)
             }.message shouldBe "Response should have Content-Type application/gzip but was text/plain; charset=UTF-8."
+         }
+      }
+   }
+
+   "ContentType matches" {
+      testApplication {
+         routing { get("/") { call.respondText("ok") } }
+         client.get("/").apply {
+            shouldHaveContentTypeMatching(ContentType.Any)
+            shouldHaveContentTypeMatching(ContentType.Text.Any)
+            shouldHaveContentTypeMatching(ContentType.Text.Plain)
+            shouldHaveContentTypeMatching(ContentType.Text.Plain.withParameter("charset", "*"))
+            shouldHaveContentTypeMatching(ContentType.Text.Plain.withParameter("charset", "UTF-8"))
+
+            shouldNotHaveContentTypeMatching(ContentType.Text.Plain.withParameter("charset", "UTF-8").withParameter("missing", "*"))
+            shouldNotHaveContentTypeMatching(ContentType.Text.Plain.withParameter("charset", "UTF-8").withParameter("extra", "param"))
+            shouldNotHaveContentTypeMatching(ContentType.Application.GZip)
+
+            shouldThrow<AssertionError> {
+               shouldNotHaveContentTypeMatching(ContentType.Text.Any)
+            }.message shouldBe "Response should not match Content-Type text/*."
+            shouldThrow<AssertionError> {
+               shouldNotHaveContentTypeMatching(ContentType.Text.Plain)
+            }.message shouldBe "Response should not match Content-Type text/plain."
+            shouldThrow<AssertionError> {
+               shouldNotHaveContentTypeMatching(ContentType.Text.Plain.withParameter("charset", "UTF-8"))
+            }.message shouldBe "Response should not match Content-Type text/plain; charset=UTF-8."
+
+            shouldThrow<AssertionError> {
+               shouldHaveContentTypeMatching(ContentType.Application.GZip)
+            }.message shouldBe "Response should match Content-Type application/gzip but was text/plain; charset=UTF-8."
+            shouldThrow<AssertionError> {
+               shouldHaveContentTypeMatching(ContentType.Text.Plain.withParameter("charset", "UTF-8").withParameter("missing", "*"))
+            }.message shouldBe "Response should match Content-Type text/plain; charset=UTF-8; missing=* but was text/plain; charset=UTF-8."
          }
       }
    }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
