### PR TITLE
docs(schema): Move limitations to a separate section

### DIFF
--- a/documentation/docs/assertions/json/schema.md
+++ b/documentation/docs/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.3.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.3.x/assertions/json/schema.md
@@ -62,20 +62,6 @@ val personSchema = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -90,3 +76,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.4.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.4.x/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.5.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.5.x/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.6.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.6.x/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.7.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.7.x/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.8.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.8.x/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum

--- a/documentation/versioned_docs/version-5.9.x/assertions/json/schema.md
+++ b/documentation/versioned_docs/version-5.9.x/assertions/json/schema.md
@@ -87,20 +87,6 @@ val uniqueArray = jsonSchema {
 }
 ```
 
-⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
-
-* $defs and $refs
-* Recursive schemas
-* Parsing of schema composition
-* string.format
-* array.prefixItems,
-* array.contains,
-* array.items = false
-* array.maxContains
-* array.minContains
-* array.uniqueItems
-* enum
-
 ## Validating
 
 Once a schema has been defined, you can validate `String` and `kotlinx.serialization.JsonElement` against it:
@@ -115,3 +101,18 @@ Once a schema has been defined, you can validate `String` and `kotlinx.serializa
 // Passes, since address isn't required and `additionalProperties` are allowed
 ```
 
+## Limitations
+
+⚠️ Note that Kotest only supports a subset of JSON schema currently. Currently, missing support for:
+
+* $defs and $refs
+* Recursive schemas
+* Parsing of schema composition
+* string.format
+* array.prefixItems,
+* array.contains,
+* array.items = false
+* array.maxContains
+* array.minContains
+* array.uniqueItems
+* enum


### PR DESCRIPTION
Make more clear that these limitation do not only affect building schemas, but also their validation. Also see [1].

[1]: https://github.com/kotest/kotest/issues/2980#issuecomment-3009295673