### PR TITLE
Support reflective binding of java classes

### DIFF
--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
@@ -5,12 +5,14 @@ import io.kotest.property.Arb
 import io.kotest.property.resolution.CommonTypeArbResolver
 import io.kotest.property.resolution.GlobalArbResolver
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 import kotlin.reflect.KParameter
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.full.starProjectedType
+import kotlin.reflect.jvm.kotlinFunction
 import kotlin.reflect.typeOf
 
 /**
@@ -104,7 +106,10 @@ internal fun <T : Any> Arb.Companion.forClassUsingConstructor(
    kclass: KClass<T>
 ): Arb<T> {
    val className = kclass.qualifiedName ?: kclass.simpleName
-   val constructor = kclass.primaryConstructor ?: error("Could not locate a primary constructor for $className")
+   val constructor = kclass.primaryConstructor
+      ?: (kclass.java.constructors.first().kotlinFunction as? KFunction<T>)
+      ?: error("Could not locate a primary constructor for $className")
+
    check(kclass.visibility != KVisibility.PRIVATE) { "The class $className must be public." }
    check(constructor.visibility != KVisibility.PRIVATE) { "The primary constructor of $className must be public." }
 

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
@@ -107,9 +107,10 @@ internal fun <T : Any> Arb.Companion.forClassUsingConstructor(
    val className = kclass.qualifiedName ?: kclass.simpleName
    val constructor = kclass.primaryConstructor
       ?: determineFallbackConstructor(kclass)
-      ?: error("Could not locate a primary constructor for $className")
+      ?: error("Could not locate a suitable constructor for $className")
 
    check(kclass.visibility != KVisibility.PRIVATE) { "The class $className must be public." }
+   // Fallback constructors are never private, so this can only be relevant for the primary constructor.
    check(constructor.visibility != KVisibility.PRIVATE) { "The primary constructor of $className must be public." }
 
    if (constructor.parameters.isEmpty()) {

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/jvmbind.kt
@@ -107,7 +107,7 @@ internal fun <T : Any> Arb.Companion.forClassUsingConstructor(
 ): Arb<T> {
    val className = kclass.qualifiedName ?: kclass.simpleName
    val constructor = kclass.primaryConstructor
-      ?: (kclass.java.constructors.first().kotlinFunction as? KFunction<T>)
+      ?: (kclass.java.constructors.firstNotNullOfOrNull { it.kotlinFunction as? KFunction<T> })
       ?: error("Could not locate a primary constructor for $className")
 
    check(kclass.visibility != KVisibility.PRIVATE) { "The class $className must be public." }

--- a/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaClassWithOnePublicConstructorWithAtLeastOneArg.java
+++ b/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaClassWithOnePublicConstructorWithAtLeastOneArg.java
@@ -1,0 +1,28 @@
+package com.sksamuel.kotest.property;
+
+public class JavaClassWithOnePublicConstructorWithAtLeastOneArg {
+   private final int bar;
+   private final String baz;
+
+   private JavaClassWithOnePublicConstructorWithAtLeastOneArg(int bar, String baz) {
+      // if this constructor was used, baz would be an arbitrary string.
+      this.bar = bar;
+      this.baz = baz;
+   }
+
+   public JavaClassWithOnePublicConstructorWithAtLeastOneArg() {
+      throw new IllegalArgumentException("Should not be called, since there is no zero-arg constructor");
+   }
+
+   public JavaClassWithOnePublicConstructorWithAtLeastOneArg(int bar) {
+      this(bar, "baz");
+   }
+
+   public int getBar() {
+      return bar;
+   }
+
+   public String getBaz() {
+      return baz;
+   }
+}

--- a/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaClassWithOnlyZeroArgConstructor.java
+++ b/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaClassWithOnlyZeroArgConstructor.java
@@ -1,17 +1,17 @@
 package com.sksamuel.kotest.property;
 
-public class JavaFoo {
+public class JavaClassWithOnlyZeroArgConstructor {
    private final int bar;
    private final String baz;
 
-   private JavaFoo(int bar, String baz) {
+   private JavaClassWithOnlyZeroArgConstructor(int bar, String baz) {
       // if this constructor was used, baz would be an arbitrary string.
       this.bar = bar;
       this.baz = baz;
    }
 
-   public JavaFoo(int bar) {
-      this(bar, "baz");
+   public JavaClassWithOnlyZeroArgConstructor() {
+      this(42, "baz");
    }
 
    public int getBar() {

--- a/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaClassWithoutNonPrivateConstructor.java
+++ b/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaClassWithoutNonPrivateConstructor.java
@@ -1,0 +1,6 @@
+package com.sksamuel.kotest.property;
+
+public class JavaClassWithoutNonPrivateConstructor {
+   private JavaClassWithoutNonPrivateConstructor() {
+   }
+}

--- a/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaFoo.java
+++ b/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaFoo.java
@@ -1,13 +1,24 @@
 package com.sksamuel.kotest.property;
 
 public class JavaFoo {
-   private int bar;
+   private final int bar;
+   private final String baz;
+
+   private JavaFoo(int bar, String baz) {
+      // if this constructor was used, baz would be an arbitrary string.
+      this.bar = bar;
+      this.baz = baz;
+   }
 
    public JavaFoo(int bar) {
-      this.bar = bar;
+      this(bar, "baz");
    }
 
    public int getBar() {
       return bar;
+   }
+
+   public String getBaz() {
+      return baz;
    }
 }

--- a/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaFoo.java
+++ b/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/JavaFoo.java
@@ -1,0 +1,13 @@
+package com.sksamuel.kotest.property;
+
+public class JavaFoo {
+   private int bar;
+
+   public JavaFoo(int bar) {
+      this.bar = bar;
+   }
+
+   public int getBar() {
+      return bar;
+   }
+}

--- a/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/NestedJavaClasses.java
+++ b/kotest-property/src/jvmTest/java/com/sksamuel/kotest/property/NestedJavaClasses.java
@@ -1,0 +1,23 @@
+package com.sksamuel.kotest.property;
+
+public class NestedJavaClasses {
+   private final JavaClassWithOnePublicConstructorWithAtLeastOneArg oneArg;
+   private final JavaClassWithOnlyZeroArgConstructor zeroArg;
+
+   public NestedJavaClasses(
+      JavaClassWithOnlyZeroArgConstructor zeroArg,
+      JavaClassWithOnePublicConstructorWithAtLeastOneArg oneArg
+   ) {
+      // if this constructor was used, baz would be an arbitrary string.
+      this.zeroArg = zeroArg;
+      this.oneArg = oneArg;
+   }
+
+   public JavaClassWithOnePublicConstructorWithAtLeastOneArg getOneArg() {
+      return oneArg;
+   }
+
+   public JavaClassWithOnlyZeroArgConstructor getZeroArg() {
+      return zeroArg;
+   }
+}

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import com.sksamuel.kotest.property.JavaFoo
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
@@ -8,6 +9,7 @@ import io.kotest.inspectors.forAll
 import io.kotest.inspectors.forAtLeastOne
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -234,6 +236,13 @@ class ReflectiveBindTest : StringSpec(
       "Arb.bind for set of sealed type should not fail target size requirement" {
          val arb = Arb.bind<Set<Shape3d>>()
          arb.take(100).toList()
+      }
+
+      "Arb.bind should reflectively bind java classes" {
+         val javaFoo = Arb.bind<JavaFoo>()
+         javaFoo.take(100).toList().forAll {
+            it.bar.shouldNotBeNull()
+         }
       }
    }
 ) {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import com.sksamuel.kotest.property.JavaClassWithoutNonPrivateConstructor
 import com.sksamuel.kotest.property.JavaFoo
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.EnabledIf
@@ -242,7 +243,14 @@ class ReflectiveBindTest : StringSpec(
          val javaFoo = Arb.bind<JavaFoo>()
          javaFoo.take(100).toList().forAll {
             it.bar.shouldNotBeNull()
+            it.baz.shouldBe("baz") // Default value set in JavaFoo public constructor
          }
+      }
+
+      "Arb.bind should fail with good message when java class has no relevant constructor" {
+         shouldThrow<IllegalStateException> {
+            Arb.bind<JavaClassWithoutNonPrivateConstructor>().next()
+         }.message shouldBe "Could not locate a primary constructor for com.sksamuel.kotest.property.JavaClassWithoutNonPrivateConstructor"
       }
    }
 ) {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ReflectiveBindTest.kt
@@ -252,7 +252,7 @@ class ReflectiveBindTest : StringSpec(
       "When binding Java classes - Arb.bind should fail with good message when there is no relevant constructor" {
          shouldThrow<IllegalStateException> {
             Arb.bind<JavaClassWithoutNonPrivateConstructor>().next()
-         }.message shouldBe "Could not locate a primary constructor for com.sksamuel.kotest.property.JavaClassWithoutNonPrivateConstructor"
+         }.message shouldBe "Could not locate a suitable constructor for com.sksamuel.kotest.property.JavaClassWithoutNonPrivateConstructor"
       }
 
       "When binding Java classes - Arb.bind should handle nested classes" {


### PR DESCRIPTION
Fixes #4901 with minimal changes.

We can consider adding support for customizing exactly which constructor should be used if there's enough desire for it. I played around with doing so in https://github.com/kotest/kotest/commit/5e6cea232f12eb0a2fd5fab7aa76532ca248d267, but I feel the cost of adding that support is not warranted at this point in time.

If we get reasons to revisit the jvmbind APIs for some other reason, I think it would be a good thing to consider including at that time.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
