### PR TITLE
Fixes the WIP version in version selector dropdown in docs

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -154,7 +154,7 @@ module.exports = {
             docs: {
                versions: {
                   current: {
-                     label: `5.9 🚧`,
+                     label: `6.0 🚧`,
                   },
                },
                sidebarPath: require.resolve('./sidebars.js'),


### PR DESCRIPTION
Was showing 5.9 as next version as well

![image](https://github.com/user-attachments/assets/40cb50da-d5ac-4493-8b51-144fda12fe7a)

