### PR TITLE
Add KSP processor to replace compiler plugin

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -784,9 +784,6 @@ public final class io/kotest/core/TupleKt {
 }
 
 public final class io/kotest/core/WriteLogKt {
-	public static final fun print (Ljava/lang/String;)V
-	public static final fun println ()V
-	public static final fun println (Ljava/lang/String;)V
 	public static final fun writeLog (Lkotlin/time/TimeMark;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 }
 
@@ -1019,45 +1016,40 @@ public abstract interface class io/kotest/core/descriptors/Descriptor {
 	public abstract fun append (Ljava/lang/String;)Lio/kotest/core/descriptors/Descriptor$TestDescriptor;
 	public abstract fun depth ()I
 	public abstract fun getId ()Lio/kotest/core/descriptors/DescriptorId;
-	public abstract fun getTreePrefix ()Ljava/util/List;
 	public abstract fun hasSharedPath (Lio/kotest/core/descriptors/Descriptor;)Z
 	public abstract fun ids ()Ljava/util/List;
 	public abstract fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public abstract fun isChildOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public abstract fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;)Z
-	public abstract fun isEqualType (Lio/kotest/core/descriptors/Descriptor;)Z
-	public abstract fun isOnPath (Lio/kotest/core/descriptors/Descriptor;)Z
+	public abstract fun isEqual (Lio/kotest/core/descriptors/Descriptor;)Z
 	public abstract fun isParentOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public abstract fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public abstract fun isRootTest ()Z
 	public abstract fun isSpec ()Z
 	public abstract fun isTestCase ()Z
 	public abstract fun parents ()Ljava/util/List;
+	public abstract fun parts ()Ljava/util/List;
 	public abstract fun path ()Lio/kotest/common/DescriptorPath;
-	public abstract fun path (Z)Lio/kotest/common/DescriptorPath;
 	public abstract fun spec ()Lio/kotest/core/descriptors/Descriptor$SpecDescriptor;
 }
 
 public final class io/kotest/core/descriptors/Descriptor$DefaultImpls {
 	public static fun append (Lio/kotest/core/descriptors/Descriptor;Ljava/lang/String;)Lio/kotest/core/descriptors/Descriptor$TestDescriptor;
 	public static fun depth (Lio/kotest/core/descriptors/Descriptor;)I
-	public static fun getTreePrefix (Lio/kotest/core/descriptors/Descriptor;)Ljava/util/List;
 	public static fun hasSharedPath (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun ids (Lio/kotest/core/descriptors/Descriptor;)Ljava/util/List;
 	public static fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isChildOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
-	public static fun isEqualType (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
-	public static fun isOnPath (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
+	public static fun isEqual (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isParentOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isRootTest (Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isSpec (Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isTestCase (Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun parents (Lio/kotest/core/descriptors/Descriptor;)Ljava/util/List;
+	public static fun parts (Lio/kotest/core/descriptors/Descriptor;)Ljava/util/List;
 	public static fun path (Lio/kotest/core/descriptors/Descriptor;)Lio/kotest/common/DescriptorPath;
-	public static fun path (Lio/kotest/core/descriptors/Descriptor;Z)Lio/kotest/common/DescriptorPath;
-	public static synthetic fun path$default (Lio/kotest/core/descriptors/Descriptor;ZILjava/lang/Object;)Lio/kotest/common/DescriptorPath;
 	public static fun spec (Lio/kotest/core/descriptors/Descriptor;)Lio/kotest/core/descriptors/Descriptor$SpecDescriptor;
 }
 
@@ -1070,23 +1062,21 @@ public final class io/kotest/core/descriptors/Descriptor$SpecDescriptor : io/kot
 	public fun depth ()I
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getId ()Lio/kotest/core/descriptors/DescriptorId;
-	public fun getTreePrefix ()Ljava/util/List;
 	public fun hasSharedPath (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun hashCode ()I
 	public fun ids ()Ljava/util/List;
 	public fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isChildOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isEqualType (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isOnPath (Lio/kotest/core/descriptors/Descriptor;)Z
+	public fun isEqual (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isParentOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isRootTest ()Z
 	public fun isSpec ()Z
 	public fun isTestCase ()Z
 	public fun parents ()Ljava/util/List;
+	public fun parts ()Ljava/util/List;
 	public fun path ()Lio/kotest/common/DescriptorPath;
-	public fun path (Z)Lio/kotest/common/DescriptorPath;
 	public fun spec ()Lio/kotest/core/descriptors/Descriptor$SpecDescriptor;
 	public fun toString ()Ljava/lang/String;
 }
@@ -1102,23 +1092,21 @@ public final class io/kotest/core/descriptors/Descriptor$TestDescriptor : io/kot
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getId ()Lio/kotest/core/descriptors/DescriptorId;
 	public final fun getParent ()Lio/kotest/core/descriptors/Descriptor;
-	public fun getTreePrefix ()Ljava/util/List;
 	public fun hasSharedPath (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun hashCode ()I
 	public fun ids ()Ljava/util/List;
 	public fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isChildOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isEqualType (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isOnPath (Lio/kotest/core/descriptors/Descriptor;)Z
+	public fun isEqual (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isParentOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isRootTest ()Z
 	public fun isSpec ()Z
 	public fun isTestCase ()Z
 	public fun parents ()Ljava/util/List;
+	public fun parts ()Ljava/util/List;
 	public fun path ()Lio/kotest/common/DescriptorPath;
-	public fun path (Z)Lio/kotest/common/DescriptorPath;
 	public fun spec ()Lio/kotest/core/descriptors/Descriptor$SpecDescriptor;
 	public fun toString ()Ljava/lang/String;
 }
@@ -1767,18 +1755,6 @@ public final class io/kotest/core/spec/SpecRef$Reference : io/kotest/core/spec/S
 	public final fun copy (Lkotlin/reflect/KClass;)Lio/kotest/core/spec/SpecRef$Reference;
 	public static synthetic fun copy$default (Lio/kotest/core/spec/SpecRef$Reference;Lkotlin/reflect/KClass;ILjava/lang/Object;)Lio/kotest/core/spec/SpecRef$Reference;
 	public fun equals (Ljava/lang/Object;)Z
-	public fun getKclass ()Lkotlin/reflect/KClass;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/kotest/core/spec/SpecRef$Singleton : io/kotest/core/spec/SpecRef {
-	public fun <init> (Lio/kotest/core/spec/Spec;)V
-	public final fun component1 ()Lio/kotest/core/spec/Spec;
-	public final fun copy (Lio/kotest/core/spec/Spec;)Lio/kotest/core/spec/SpecRef$Singleton;
-	public static synthetic fun copy$default (Lio/kotest/core/spec/SpecRef$Singleton;Lio/kotest/core/spec/Spec;ILjava/lang/Object;)Lio/kotest/core/spec/SpecRef$Singleton;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getInstance ()Lio/kotest/core/spec/Spec;
 	public fun getKclass ()Lkotlin/reflect/KClass;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -3114,7 +3090,8 @@ public final class io/kotest/engine/TestEngineLauncher {
 	public final fun withNative ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withPlatform (Lio/kotest/core/Platform;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withProjectConfig (Lio/kotest/core/config/AbstractProjectConfig;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withSpecs ([Lio/kotest/core/spec/Spec;)Lio/kotest/engine/TestEngineLauncher;
+	public final fun withSpecRefs (Ljava/util/List;)Lio/kotest/engine/TestEngineLauncher;
+	public final fun withSpecRefs ([Lio/kotest/core/spec/SpecRef;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withTagExpression (Lio/kotest/engine/tags/TagExpression;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withTeamCityListener ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withWasmJs ()Lio/kotest/engine/TestEngineLauncher;
@@ -3597,9 +3574,9 @@ public final class io/kotest/engine/interceptors/ProjectTimeoutException : java/
 }
 
 public final class io/kotest/engine/launcher/LauncherArgs {
-	public static final field ARG_CANDIDATES Ljava/lang/String;
 	public static final field ARG_LISTENER Ljava/lang/String;
 	public static final field ARG_SPEC Ljava/lang/String;
+	public static final field ARG_SPECS Ljava/lang/String;
 	public static final field DESCRIPTOR Ljava/lang/String;
 	public static final field INSTANCE Lio/kotest/engine/launcher/LauncherArgs;
 	public static final field REPORTER Ljava/lang/String;

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -56,6 +56,14 @@ kotlin {
             implementation(libs.junit.jupiter.engine)
          }
       }
+
+      nativeMain {
+         dependencies {
+            // we need these so we can generate the runKotest test stub
+            implementation(kotlin("test-common"))
+            implementation(kotlin("test-annotations-common"))
+         }
+      }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/logger.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/logger.kt
@@ -50,7 +50,3 @@ fun log(t: Throwable?, f: () -> String) {
 
 @KotestInternal
 expect fun writeLog(start: TimeMark, t: Throwable?, f: () -> String)
-
-expect fun print(str: String)
-expect fun println(str: String)
-expect fun println()

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/SpecRef.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/SpecRef.kt
@@ -18,20 +18,18 @@ sealed interface SpecRef {
    val kclass: KClass<out Spec>
 
    /**
-    * A [SpecRef] that contains only a [kclass] reference and instances
-    * must be created using reflection.
+    * A [SpecRef] that contains only a [kclass] reference and instances are created using reflection.
+    * This allows the engine to instantiate specs with non-empty constructors, eg for dependency injection.
     */
    data class Reference(override val kclass: KClass<out Spec>) : SpecRef
 
    /**
-    * A [SpecRef] that contains a singleton spec [instance].
-    */
-   data class Singleton(val instance: Spec) : SpecRef {
-      override val kclass: KClass<out Spec> = instance::class
-   }
-
-   /**
     * A [SpecRef] that contains a function that can be invoked to construct a spec.
+    * This is required for platforms that do not support reflection, such as Kotlin/JS or Kotlin/Native.
+    * A function ref only supports specs that have no constructor parameters.
     */
-   data class Function(val f: () -> Spec, override val kclass: KClass<out Spec>) : SpecRef
+   data class Function(
+      val f: () -> Spec,
+      override val kclass: KClass<out Spec>,
+   ) : SpecRef
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/TestEngineLauncher.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/TestEngineLauncher.kt
@@ -76,24 +76,20 @@ class TestEngineLauncher(
       )
    }
 
-   fun withSpecs(vararg specs: Spec): TestEngineLauncher {
-      return TestEngineLauncher(
-         platform = platform,
-         listener = listener,
-         config = config,
-         refs = specs.toList().map { SpecRef.Singleton(it) },
-         tagExpression = tagExpression,
-         registry = registry,
-      )
-   }
+   fun withSpecs(vararg specs: Spec): TestEngineLauncher = withSpecs(specs.toList())
+   fun withSpecs(specs: List<Spec>): TestEngineLauncher = withSpecRefs(specs.map { SpecRef.Singleton(it) })
 
    fun withClasses(vararg specs: KClass<out Spec>): TestEngineLauncher = withClasses(specs.toList())
-   fun withClasses(specs: List<KClass<out Spec>>): TestEngineLauncher {
+   fun withClasses(specs: List<KClass<out Spec>>): TestEngineLauncher =
+      withSpecRefs(specs.map { SpecRef.Reference(it) })
+
+   fun withSpecRefs(vararg refs: SpecRef): TestEngineLauncher = withSpecRefs(refs.toList())
+   fun withSpecRefs(refs: List<SpecRef>): TestEngineLauncher {
       return TestEngineLauncher(
          platform = platform,
          listener = listener,
          config = config,
-         refs = specs.toList().map { SpecRef.Reference(it) },
+         refs = refs,
          tagExpression = tagExpression,
          registry = registry,
       )

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/TestEngineLauncher.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/TestEngineLauncher.kt
@@ -76,9 +76,6 @@ class TestEngineLauncher(
       )
    }
 
-   fun withSpecs(vararg specs: Spec): TestEngineLauncher = withSpecs(specs.toList())
-   fun withSpecs(specs: List<Spec>): TestEngineLauncher = withSpecRefs(specs.map { SpecRef.Singleton(it) })
-
    fun withClasses(vararg specs: KClass<out Spec>): TestEngineLauncher = withClasses(specs.toList())
    fun withClasses(specs: List<KClass<out Spec>>): TestEngineLauncher =
       withSpecRefs(specs.map { SpecRef.Reference(it) })

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/DescriptorFilter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/DescriptorFilter.kt
@@ -6,7 +6,9 @@ import io.kotest.core.extensions.Extension
 /**
  * A [DescriptorFilter] can be used to filter specs and tests before they are executed.
  *
- * A given [Descriptor] must be included by all filters for it to be considered enabled at runtime.
+ * A given [Descriptor] must be included by all filters for it to be considered enabled at runtime,
+ * or in other words, if any filter returns [DescriptorFilterResult.Exclude], then the spec or test
+ * will not be executed.
  *
  * If no filters are registered, then all specs and tests will be executed.
  */
@@ -32,14 +34,3 @@ sealed interface DescriptorFilterResult {
    data class Exclude(val reason: String?) : DescriptorFilterResult
 }
 
-/**
- * An implementation of [DescriptorFilter] that only includes descriptors that are
- * members, or descendents of, the given [accept] list.
- */
-class ProvidedDescriptorFilter(private vararg val accept: Descriptor) : DescriptorFilter {
-   override fun filter(descriptor: Descriptor): DescriptorFilterResult {
-      val include = accept.any { it.hasSharedPath(descriptor) }
-      println("ProvidedDescriptorFilter: $descriptor included = $include $accept = ${accept.toList()}")
-      return if (include) DescriptorFilterResult.Include else DescriptorFilterResult.Exclude(null)
-   }
-}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ProvidedDescriptorFilter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ProvidedDescriptorFilter.kt
@@ -1,0 +1,16 @@
+package io.kotest.engine.extensions
+
+import io.kotest.core.descriptors.Descriptor
+
+/**
+ * An implementation of [DescriptorFilter] that only excludes any descriptors that are
+ * not included in or descendents of, the given [accept] list.
+ */
+class ProvidedDescriptorFilter(private vararg val accept: Descriptor) : DescriptorFilter {
+
+   override fun filter(descriptor: Descriptor): DescriptorFilterResult {
+      val include = accept.any { it.hasSharedPath(descriptor) }
+      return if (include) DescriptorFilterResult.Include else DescriptorFilterResult.Exclude(null)
+   }
+
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecRef.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecRef.kt
@@ -14,7 +14,6 @@ internal suspend fun SpecRef.instance(
    projectConfigRegistry: ProjectConfigResolver
 ): Result<Spec> = when (this) {
    is SpecRef.Reference -> instantiate(this.kclass, registry, projectConfigRegistry)
-   is SpecRef.Singleton -> Result.success(this.instance)
    is SpecRef.Function -> Result.success(this.f())
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
@@ -144,7 +144,6 @@ internal class TeamCityWriter(
          .locationHint(Locations.location(testCase.source))
          .build()
       println(msg)
-      println(msg)
    }
 
    /**

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
@@ -36,7 +36,7 @@ internal class TeamCityWriter(
          .message(result.reason)
          .result(result)
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    /**
@@ -50,7 +50,7 @@ internal class TeamCityWriter(
          .parent(testCase.descriptor.parent.path().value)
          .locationHint(Locations.location(testCase.source))
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    /**
@@ -62,19 +62,19 @@ internal class TeamCityWriter(
          .id(name)
          .parent(parent)
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    internal fun outputTestStarted(testName: String) {
-      io.kotest.core.println(TeamCityMessageBuilder.testStarted(prefix, testName).build())
+      println(TeamCityMessageBuilder.testStarted(prefix, testName).build())
    }
 
    internal fun outputTestFailed(testName: String, message: String) {
-      io.kotest.core.println(TeamCityMessageBuilder.testFailed(prefix, testName).message(message).build())
+      println(TeamCityMessageBuilder.testFailed(prefix, testName).message(message).build())
    }
 
    internal fun outputTestFinished(testName: String) {
-      io.kotest.core.println(TeamCityMessageBuilder.testFinished(prefix, testName).build())
+      println(TeamCityMessageBuilder.testFinished(prefix, testName).build())
    }
 
    /**
@@ -90,7 +90,7 @@ internal class TeamCityWriter(
          .withException(result.errorOrNull, details)
          .result(result)
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    /**
@@ -104,7 +104,7 @@ internal class TeamCityWriter(
          .parent(parent)
          .withException(cause, details)
          .build()
-      io.kotest.core.println(msg2)
+      println(msg2)
    }
 
    /**
@@ -120,7 +120,7 @@ internal class TeamCityWriter(
          .locationHint(Locations.location(testCase.source))
          .result(result)
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    internal fun outputTestFinished(name: String, parent: String) {
@@ -129,7 +129,7 @@ internal class TeamCityWriter(
          .id(name)
          .parent(parent)
          .build()
-      io.kotest.core.println(msg3)
+      println(msg3)
    }
 
    /**
@@ -143,7 +143,8 @@ internal class TeamCityWriter(
          .parent(testCase.descriptor.parent.path().value)
          .locationHint(Locations.location(testCase.source))
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
+      println(msg)
    }
 
    /**
@@ -159,7 +160,7 @@ internal class TeamCityWriter(
          .locationHint(Locations.location(testCase.source))
          .result(result)
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    /**
@@ -171,7 +172,7 @@ internal class TeamCityWriter(
          .id(kclass.toDescriptor().path().value)
          .locationHint(Locations.location(kclass))
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 
    internal fun outputTestSuiteStarted(kclass: KClass<*>) {
@@ -180,6 +181,6 @@ internal class TeamCityWriter(
          .id(kclass.toDescriptor().path().value)
          .locationHint(Locations.location(kclass))
          .build()
-      io.kotest.core.println(msg)
+      println(msg)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/core/writeLog.kt
+++ b/kotest-framework/kotest-framework-engine/src/desktopMain/kotlin/io/kotest/core/writeLog.kt
@@ -5,8 +5,7 @@ import kotlin.time.TimeMark
 
 @KotestInternal
 actual fun writeLog(start: TimeMark, t: Throwable?, f: () -> String) {
+   print(start.elapsedNow().inWholeMicroseconds.toString())
+   print("  ")
+   println(f())
 }
-
-actual fun print(str: String) {}
-actual fun println(str: String) {}
-actual fun println() {}

--- a/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/core/writeLog.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/core/writeLog.kt
@@ -10,15 +10,3 @@ actual fun writeLog(start: TimeMark, t: Throwable?, f: () -> String) {
    console.log(f())
    console.log("\n")
 }
-
-actual fun print(str: String) {
-   console.log(str)
-}
-
-actual fun println(str: String) {
-   console.log("$str\n")
-}
-
-actual fun println() {
-   console.log("\n")
-}

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/writeLog.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/writeLog.kt
@@ -30,18 +30,6 @@ actual fun writeLog(start: TimeMark, t: Throwable?, f: () -> String) {
    file.flush()
 }
 
-actual fun print(str: String) {
-   kotlin.io.print(str)
-}
-
-actual fun println(str: String) {
-   kotlin.io.println(str)
-}
-
-actual fun println() {
-   kotlin.io.println()
-}
-
 private fun getPid(): Long {
    return if (currentMajorJavaVersion >= 9) {
       getPidFromProcessHandle()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/main.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/main.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.Spec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.cli.parseArgs
 import io.kotest.engine.extensions.ProvidedDescriptorFilter
-import io.kotest.engine.launcher.LauncherArgs.ARG_CANDIDATES
+import io.kotest.engine.launcher.LauncherArgs.ARG_SPECS
 import io.kotest.engine.launcher.LauncherArgs.ARG_LISTENER
 import io.kotest.engine.launcher.LauncherArgs.DESCRIPTOR
 import io.kotest.engine.launcher.LauncherArgs.REPORTER
@@ -24,8 +24,8 @@ import kotlin.system.exitProcess
 
 object LauncherArgs {
 
-   // required to pass the candidates to the engine
-   const val ARG_CANDIDATES = "candidates"
+   // required to pass the specs to the engine
+   const val ARG_SPECS = "specs"
 
    // these are optional
 
@@ -36,9 +36,16 @@ object LauncherArgs {
    const val DESCRIPTOR = "descriptor"
 
    // these are deprecated kotest 5 flags kept for backwards compatibility
+   @Deprecated("Not used by kotest 6")
    const val ARG_SPEC = "spec"
+
+   @Deprecated("Not used by kotest 6")
    const val TESTPATH = "testpath"
+
+   @Deprecated("Not used by kotest 6")
    const val REPORTER = "reporter"
+
+   @Deprecated("Not used by kotest 6")
    const val WRITER = "writer"
 }
 
@@ -61,15 +68,15 @@ fun main(args: Array<String>) {
 
    // The enigne *must* be given the classes to execute - in Kotest 6 the engine does not perform scanning
    // It is the responsibility of the caller to pass this information.
-   // In Kotest 5 a similar argument was called --spec to specify a single class but kotest 6 uses --candidates
+   // In Kotest 5 a similar argument was called --spec to specify a single class but kotest 6 uses --specs
    // we must support both for backwards compatibility
    // todo do we need to do this? if people are upgrading to kotest 6 they can update the plugin too?
-   val candidatesArg = launcherArgs[ARG_CANDIDATES]
+   val specsArg = launcherArgs[ARG_SPECS]
       ?: launcherArgs[ARG_SPEC]
-      ?: error("The $ARG_CANDIDATES arg must be provided")
+      ?: error("The $ARG_SPECS arg must be provided")
 
    @Suppress("UNCHECKED_CAST")
-   val classes = candidatesArg.split(';').map { Class.forName(it).kotlin as KClass<out Spec> }
+   val classes = specsArg.split(';').map { Class.forName(it).kotlin as KClass<out Spec> }
 
    // we support --descriptor to support an exact descriptor path as a way to run a single test
    val descriptorFilter = buildDescriptorFilter(launcherArgs)

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/ClassVisibilitySpecRefInterceptor.kt
@@ -23,9 +23,9 @@ internal class ClassVisibilitySpecRefInterceptor(
 
    override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       return when {
-         ref.kclass.visibility == KVisibility.PRIVATE &&
+         ref is SpecRef.Reference &&
+            ref.kclass.visibility == KVisibility.PRIVATE &&
             projectConfigResolver.ignorePrivateClasses() -> Result.success(emptyMap())
-
          else -> next.invoke(ref)
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/descriptors/DescriptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/descriptors/DescriptorTest.kt
@@ -1,76 +1,196 @@
 package com.sksamuel.kotest.engine.descriptors
 
+import io.kotest.core.descriptors.Descriptor
+import io.kotest.core.descriptors.DescriptorId
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.descriptors.toDescriptor
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
 
 class DescriptorTest : FunSpec({
 
+   // build up descriptors for :
+   // DescriptorTest/a -- b -- c
+   // DescriptorTest/d -- e
+   // DescriptorTest/f
    val spec = DescriptorTest::class.toDescriptor()
-   val container = spec.append("a context")
-   val test = container.append("nested test")
-   val nestedContainer = test.append("a context")
-   val deepTest = nestedContainer.append("nested test")
+   val jsSpec = Descriptor.SpecDescriptor(DescriptorId("DescriptorTest"))
+
+   val a = spec.append("a")
+   val b = a.append("b")
+   val c = b.append("c")
+   val d = spec.append("d")
+   val e = d.append("e")
+   val f = spec.append("f")
 
    test("isTestCase") {
       spec.isTestCase() shouldBe false
-      container.isTestCase() shouldBe true
-      test.isTestCase() shouldBe true
+      listOf(a, b, c, d, e, f).forAll {
+         it.isTestCase() shouldBe true
+      }
    }
 
    test("isRoot") {
-      spec.isRootTest() shouldBe false
-      container.isRootTest() shouldBe true
-      test.isRootTest() shouldBe false
+      listOf(a, d, f).forAll {
+         it.isRootTest() shouldBe true
+      }
+      listOf(spec, b, c, e).forAll {
+         it.isRootTest() shouldBe false
+      }
    }
 
    test("isChildOf") {
-      container.isChildOf(test) shouldBe false
-      test.isChildOf(test) shouldBe false
-      test.isChildOf(test) shouldBe false
-      container.isChildOf(spec) shouldBe true
-      spec.isChildOf(container) shouldBe false
-      deepTest.isChildOf(container) shouldBe false
-      test.isChildOf(nestedContainer) shouldBe false
+
+      a.isChildOf(b) shouldBe false
+      b.isChildOf(a) shouldBe true
+
+      c.isChildOf(b) shouldBe true
+      b.isChildOf(c) shouldBe false
+
+      d.isChildOf(e) shouldBe false
+
+      spec.isChildOf(a) shouldBe false
+      a.isChildOf(spec) shouldBe true
+      d.isChildOf(spec) shouldBe true
+      f.isChildOf(spec) shouldBe true
    }
 
    test("isParentOf") {
-      container.isParentOf(test) shouldBe true
-      container.isParentOf(container) shouldBe false
-      test.isParentOf(container) shouldBe false
-      test.isParentOf(test) shouldBe false
-      container.isParentOf(spec) shouldBe false
-      spec.isParentOf(container) shouldBe true
-      container.isParentOf(deepTest) shouldBe false
-      nestedContainer.isParentOf(test) shouldBe false
+      a.isParentOf(b) shouldBe true
+      b.isParentOf(a) shouldBe false
+      a.isParentOf(c) shouldBe false
+
+      b.isParentOf(c) shouldBe true
+      c.isParentOf(b) shouldBe false
+
+      d.isParentOf(e) shouldBe true
+      e.isParentOf(d) shouldBe false
+
+      spec.isParentOf(a) shouldBe true
+      a.isParentOf(spec) shouldBe false
+      d.isParentOf(spec) shouldBe false
+      f.isParentOf(spec) shouldBe false
    }
 
    test("isAncestorOf") {
-      container.isAncestorOf(test) shouldBe true
-      spec.isAncestorOf(test) shouldBe true
-      container.isAncestorOf(spec) shouldBe false
-      test.isAncestorOf(spec) shouldBe false
-      container.isAncestorOf(nestedContainer) shouldBe true
-      container.isAncestorOf(deepTest) shouldBe true
+      a.isAncestorOf(b) shouldBe true
+      b.isAncestorOf(a) shouldBe false
+
+      c.isAncestorOf(b) shouldBe false
+      b.isAncestorOf(c) shouldBe true
+      a.isAncestorOf(c) shouldBe true
+      a.isAncestorOf(b) shouldBe true
+
+      d.isAncestorOf(e) shouldBe true
+      e.isAncestorOf(d) shouldBe false
+
+      listOf(a, b, c, d, e, f).forAll {
+         it.isAncestorOf(spec) shouldBe false
+         spec.isAncestorOf(it) shouldBe true
+      }
    }
 
    test("isDescendentOf") {
-      container.isDescendentOf(test) shouldBe false
-      spec.isDescendentOf(test) shouldBe false
-      container.isDescendentOf(spec) shouldBe true
-      test.isDescendentOf(spec) shouldBe true
-      test.isDescendentOf(container) shouldBe true
+
+      a.isDescendentOf(b) shouldBe false
+      b.isDescendentOf(c) shouldBe false
+      b.isDescendentOf(a) shouldBe true
+      c.isDescendentOf(a) shouldBe true
+      c.isDescendentOf(b) shouldBe true
+
+      e.isDescendentOf(d) shouldBe true
+      d.isDescendentOf(e) shouldBe false
+
+      listOf(a, b, c, d, e, f).forAll {
+         it.isDescendentOf(spec) shouldBe true
+         spec.isDescendentOf(it) shouldBe false
+      }
+   }
+
+   test("isDescendentOf without FQNs") {
+
+      a.isDescendentOf(b) shouldBe false
+      b.isDescendentOf(c) shouldBe false
+      b.isDescendentOf(a) shouldBe true
+      c.isDescendentOf(a) shouldBe true
+      c.isDescendentOf(b) shouldBe true
+
+      e.isDescendentOf(d) shouldBe true
+      d.isDescendentOf(e) shouldBe false
+
+      listOf(a, b, c, d, e, f).forAll {
+         it.isDescendentOf(jsSpec) shouldBe true
+         jsSpec.isDescendentOf(it) shouldBe false
+      }
    }
 
    test("isPrefixOf") {
-      container.isPrefixOf(test) shouldBe true
-      test.isPrefixOf(container) shouldBe false
-      spec.isPrefixOf(test) shouldBe true
-      test.isPrefixOf(spec) shouldBe false
-      container.isPrefixOf(spec) shouldBe false
-      spec.isPrefixOf(container) shouldBe true
-      spec.isPrefixOf(spec) shouldBe true
-      test.isPrefixOf(test) shouldBe true
-      container.isPrefixOf(container) shouldBe true
+      spec.isPrefixOf(a) shouldBe true
+      spec.isPrefixOf(b) shouldBe true
+      spec.isPrefixOf(c) shouldBe true
+      a.isPrefixOf(b) shouldBe true
+      a.isPrefixOf(c) shouldBe true
+      b.isPrefixOf(a) shouldBe false
+      c.isPrefixOf(a) shouldBe false
+      c.isPrefixOf(b) shouldBe false
+
+      d.isPrefixOf(e) shouldBe true
+      e.isPrefixOf(d) shouldBe false
+   }
+
+   test("isPrefixOf without FQNs") {
+      jsSpec.isPrefixOf(a) shouldBe true
+      jsSpec.isPrefixOf(b) shouldBe true
+      jsSpec.isPrefixOf(c) shouldBe true
+      a.isPrefixOf(b) shouldBe true
+      a.isPrefixOf(c) shouldBe true
+      b.isPrefixOf(a) shouldBe false
+      c.isPrefixOf(a) shouldBe false
+      c.isPrefixOf(b) shouldBe false
+
+      d.isPrefixOf(e) shouldBe true
+      e.isPrefixOf(d) shouldBe false
+   }
+
+   test("hasSharedPath") {
+
+      listOf(a, b, c, d, e, f).forAll {
+         spec.hasSharedPath(it) shouldBe true
+      }
+
+      a.hasSharedPath(b) shouldBe true
+      a.hasSharedPath(c) shouldBe true
+      b.hasSharedPath(a) shouldBe true
+      b.hasSharedPath(c) shouldBe true
+      c.hasSharedPath(a) shouldBe true
+      c.hasSharedPath(b) shouldBe true
+
+      d.hasSharedPath(e) shouldBe true
+      e.hasSharedPath(d) shouldBe true
+
+      f.hasSharedPath(a) shouldBe false
+      f.hasSharedPath(b) shouldBe false
+      f.hasSharedPath(c) shouldBe false
+   }
+
+   test("hasSharedPath without FQNs") {
+
+      listOf(a, b, c, d, e, f).forAll {
+         jsSpec.hasSharedPath(it) shouldBe true
+      }
+
+      a.hasSharedPath(b) shouldBe true
+      a.hasSharedPath(c) shouldBe true
+      b.hasSharedPath(a) shouldBe true
+      b.hasSharedPath(c) shouldBe true
+      c.hasSharedPath(a) shouldBe true
+      c.hasSharedPath(b) shouldBe true
+
+      d.hasSharedPath(e) shouldBe true
+      e.hasSharedPath(d) shouldBe true
+
+      f.hasSharedPath(a) shouldBe false
+      f.hasSharedPath(b) shouldBe false
+      f.hasSharedPath(c) shouldBe false
    }
 })

--- a/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
+++ b/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
@@ -40,24 +40,29 @@ public final class io/kotest/framework/gradle/SpecsResolver {
 	public static final field INSTANCE Lio/kotest/framework/gradle/SpecsResolver;
 }
 
-public abstract class io/kotest/framework/gradle/tasks/AbstractKotestJvmTask : org/gradle/api/DefaultTask {
+public abstract class io/kotest/framework/gradle/tasks/AbstractKotestTask : org/gradle/api/DefaultTask {
 	public abstract fun getDescriptor ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPackages ()Lorg/gradle/api/provider/Property;
 	public abstract fun getSpecs ()Lorg/gradle/api/provider/Property;
 	public abstract fun getTags ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class io/kotest/framework/gradle/tasks/KotestAndroidTask : io/kotest/framework/gradle/tasks/AbstractKotestJvmTask {
+public abstract class io/kotest/framework/gradle/tasks/KotestAndroidTask : io/kotest/framework/gradle/tasks/AbstractKotestTask {
 	protected final fun execute ()V
 	public abstract fun getCompilationNames ()Lorg/gradle/api/provider/ListProperty;
 }
 
-public abstract class io/kotest/framework/gradle/tasks/KotestJsTask : io/kotest/framework/gradle/tasks/AbstractKotestJvmTask {
+public abstract class io/kotest/framework/gradle/tasks/KotestJsTask : io/kotest/framework/gradle/tasks/AbstractKotestTask {
 	protected final fun execute ()V
 	public abstract fun getNodeExecutable ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class io/kotest/framework/gradle/tasks/KotestJvmTask : io/kotest/framework/gradle/tasks/AbstractKotestJvmTask {
+public abstract class io/kotest/framework/gradle/tasks/KotestJvmTask : io/kotest/framework/gradle/tasks/AbstractKotestTask {
 	protected final fun execute ()V
+}
+
+public abstract class io/kotest/framework/gradle/tasks/KotestNativeTask : io/kotest/framework/gradle/tasks/AbstractKotestTask {
+	protected final fun execute ()V
+	public abstract fun getTarget ()Lorg/gradle/api/provider/Property;
 }
 

--- a/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
+++ b/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
@@ -1,6 +1,6 @@
 public abstract class io/kotest/framework/gradle/KotestExtension {
 	public final fun getAndroidTestSource ()Ljava/lang/String;
-	public abstract fun getFailOnEmptySpecs ()Lorg/gradle/api/provider/Property;
+	public abstract fun getFailOnNoTests ()Lorg/gradle/api/provider/Property;
 	public abstract fun getTagExpression ()Lorg/gradle/api/provider/Property;
 }
 
@@ -35,17 +35,16 @@ public final class io/kotest/framework/gradle/KotestPlugin$handleKotlinMultiplat
 	public final synthetic fun execute (Ljava/lang/Object;)V
 }
 
-public abstract class io/kotest/framework/gradle/tasks/AbstractKotestJvmTask : org/gradle/api/DefaultTask {
-	public static final field Companion Lio/kotest/framework/gradle/tasks/AbstractKotestJvmTask$Companion;
+public final class io/kotest/framework/gradle/SpecsResolver {
 	public static final field DELIMITER Ljava/lang/String;
-	public abstract fun getCandidates ()Lorg/gradle/api/provider/Property;
-	public abstract fun getDescriptor ()Lorg/gradle/api/provider/Property;
-	public abstract fun getPackages ()Lorg/gradle/api/provider/Property;
-	public abstract fun getTags ()Lorg/gradle/api/provider/Property;
-	public abstract fun getTests ()Lorg/gradle/api/provider/Property;
+	public static final field INSTANCE Lio/kotest/framework/gradle/SpecsResolver;
 }
 
-public final class io/kotest/framework/gradle/tasks/AbstractKotestJvmTask$Companion {
+public abstract class io/kotest/framework/gradle/tasks/AbstractKotestJvmTask : org/gradle/api/DefaultTask {
+	public abstract fun getDescriptor ()Lorg/gradle/api/provider/Property;
+	public abstract fun getPackages ()Lorg/gradle/api/provider/Property;
+	public abstract fun getSpecs ()Lorg/gradle/api/provider/Property;
+	public abstract fun getTags ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract class io/kotest/framework/gradle/tasks/KotestAndroidTask : io/kotest/framework/gradle/tasks/AbstractKotestJvmTask {
@@ -53,7 +52,7 @@ public abstract class io/kotest/framework/gradle/tasks/KotestAndroidTask : io/ko
 	public abstract fun getCompilationNames ()Lorg/gradle/api/provider/ListProperty;
 }
 
-public abstract class io/kotest/framework/gradle/tasks/KotestJsTask : org/gradle/api/DefaultTask {
+public abstract class io/kotest/framework/gradle/tasks/KotestJsTask : io/kotest/framework/gradle/tasks/AbstractKotestJvmTask {
 	protected final fun execute ()V
 	public abstract fun getNodeExecutable ()Lorg/gradle/api/provider/Property;
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestExtension.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestExtension.kt
@@ -11,9 +11,9 @@ abstract class KotestExtension internal constructor() {
    abstract val tagExpression: Property<String>
 
    /**
-    * If true, then the build will fail if no spec classes are by the plugin.
+    * If true, then the build will fail if no tests are found by the plugin.
     */
-   abstract val failOnEmptySpecs: Property<Boolean>
+   abstract val failOnNoTests: Property<Boolean>
 
    /**
     * The location of the compiled kotlin classes for Android builds.

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -24,9 +24,10 @@ abstract class KotestPlugin : Plugin<Project> {
 
    companion object {
       const val DESCRIPTION = "Runs tests using Kotest"
-      const val EXTENSION_NAME = "runKotest"
+      const val EXTENSION_NAME = "kotest"
 
       const val JVM_ONLY_TASK_NAME = "kotest"
+
       const val JS_TASK_NAME = "jsKotest"
       const val WASM_JS_TASK_NAME = "wasmJsKotest"
 
@@ -87,9 +88,10 @@ abstract class KotestPlugin : Plugin<Project> {
 
    @Suppress("LABEL_NAME_CLASH")
    private fun handleKotlinMultiplatform(project: Project) {
-      project.plugins.withId(KOTLIN_MULTIPLATFORM_PLUGIN) {
-         project.extensions.configure<KotlinMultiplatformExtension> {
-            this.testableTargets.configureEach {
+      project.plugins.withId(KOTLIN_MULTIPLATFORM_PLUGIN) { // this is the multiplatform plugin, not the kotlin plugin
+         project.extensions.configure<KotlinMultiplatformExtension> { // this is the multiplatform extension
+            val tasks = mutableSetOf<String>()
+            this.testableTargets.configureEach { // are the targets that can run tests
                println("testable target name ${this.name}")
                println("testable target targetName ${this.targetName}")
                println("testable disambiguationClassifier ${this.disambiguationClassifier}")
@@ -97,7 +99,6 @@ abstract class KotestPlugin : Plugin<Project> {
                   when (platformType) {
 
                      KotlinPlatformType.js -> {
-                        println("NodeJsPlugin")
                         project.plugins.apply(NodeJsPlugin::class.java)
                         project.extensions.configure(NodeJsEnvSpec::class.java) {
                            project.tasks.register(JS_TASK_NAME, KotestJsTask::class) {
@@ -106,13 +107,16 @@ abstract class KotestPlugin : Plugin<Project> {
                               nodeExecutable.set(this@configure.executable)
                               inputs.files(project.tasks.named(TASK_COMPILE_TEST_DEV_JS).map { it.outputs.files })
                            }
+                           tasks.add(JS_TASK_NAME)
                         }
                      }
                      KotlinPlatformType.wasm -> println("Todo wasm")
                      KotlinPlatformType.common -> println("Todo common")
                      KotlinPlatformType.jvm -> println("Todo jvm")
                      KotlinPlatformType.androidJvm -> println("Todo androidJvm")
-                     KotlinPlatformType.native -> println("Todo native")
+                     KotlinPlatformType.native -> {
+                        println("Todo native")
+                     }
                   }
 //                  when (targetName) {
 //                     else -> {
@@ -125,6 +129,13 @@ abstract class KotestPlugin : Plugin<Project> {
 //                     }
 //                  }
                }
+            }
+            // add one special task that runs all compilations
+            // todo can we just make a task that runs the other tasks above?
+            project.tasks.register("kotest", AbstractKotestJvmTask::class) {
+               group = JavaBasePlugin.VERIFICATION_GROUP
+               description = DESCRIPTION
+               dependsOn(":$JS_TASK_NAME")
             }
          }
       }
@@ -146,17 +157,19 @@ abstract class KotestPlugin : Plugin<Project> {
                // gradle best practice is to only apply to this project, and users add the plugin to each subproject
                // see https://docs.gradle.org/current/userguide/isolated_projects.html
                project.tasks.register("kotest$capitalTarget", KotestAndroidTask::class) {
+                  group = JavaBasePlugin.VERIFICATION_GROUP
+                  description = DESCRIPTION
                   compilationNames.set(listOf(compilation.name))
                   inputs.files(project.tasks.withType<KotlinCompile>().map { it.outputs.files })
                }
             }
 
             // add one special task that runs all compilations
-            // todo can we just make a task that runs the other tasks above
-            project.tasks.register("kotest", KotestAndroidTask::class) {
-               compilationNames.set(testCompilations.map { it.name })
-               inputs.files(project.tasks.withType<KotlinCompile>().map { it.outputs.files })
-            }
+            // todo can we just make a task that runs the other tasks above?
+//            project.tasks.register("kotest", AbstractKotestJvmTask::class) {
+//               group = JavaBasePlugin.VERIFICATION_GROUP
+//               description = DESCRIPTION
+//            }
          }
       }
    }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -97,6 +97,7 @@ abstract class KotestPlugin : Plugin<Project> {
                   when (platformType) {
 
                      KotlinPlatformType.js -> {
+                        println("NodeJsPlugin")
                         project.plugins.apply(NodeJsPlugin::class.java)
                         project.extensions.configure(NodeJsEnvSpec::class.java) {
                            project.tasks.register(JS_TASK_NAME, KotestJsTask::class) {

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -70,10 +70,6 @@ abstract class KotestPlugin : Plugin<Project> {
          group = JavaBasePlugin.VERIFICATION_GROUP
          description = DESCRIPTION
       }
-      project.tasks.withType<KotestJsTask>().configureEach {
-         group = JavaBasePlugin.VERIFICATION_GROUP
-         description = DESCRIPTION
-      }
    }
 
    private fun handleKotlinJvm(project: Project) {
@@ -132,11 +128,11 @@ abstract class KotestPlugin : Plugin<Project> {
             }
             // add one special task that runs all compilations
             // todo can we just make a task that runs the other tasks above?
-            project.tasks.register("kotest", AbstractKotestJvmTask::class) {
-               group = JavaBasePlugin.VERIFICATION_GROUP
-               description = DESCRIPTION
-               dependsOn(":$JS_TASK_NAME")
-            }
+//            project.tasks.register("kotest", AbstractKotestJvmTask::class) {
+//               group = JavaBasePlugin.VERIFICATION_GROUP
+//               description = DESCRIPTION
+//               dependsOn(":$JS_TASK_NAME")
+//            }
          }
       }
    }
@@ -157,8 +153,6 @@ abstract class KotestPlugin : Plugin<Project> {
                // gradle best practice is to only apply to this project, and users add the plugin to each subproject
                // see https://docs.gradle.org/current/userguide/isolated_projects.html
                project.tasks.register("kotest$capitalTarget", KotestAndroidTask::class) {
-                  group = JavaBasePlugin.VERIFICATION_GROUP
-                  description = DESCRIPTION
                   compilationNames.set(listOf(compilation.name))
                   inputs.files(project.tasks.withType<KotlinCompile>().map { it.outputs.files })
                }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/NativeExecConfiguration.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/NativeExecConfiguration.kt
@@ -1,0 +1,82 @@
+package io.kotest.framework.gradle
+
+import org.gradle.process.ExecSpec
+import org.gradle.process.internal.ExecAction
+
+/**
+ * This [NativeExecConfiguration] is responsible for configuring an [ExecAction] that will run tests
+ * through the kotest engine by executing the debugTest executable created by the native compiler.
+ */
+internal data class NativeExecConfiguration(
+   private val executable: String,
+   private val tags: String? = null,
+   private val descriptor: String? = null,
+   private val specs: List<String> = emptyList(),
+) {
+
+   companion object {
+
+      private const val ARG_TAGS = "--tags"
+
+      // the value used to specify the team city format
+      private const val LISTENER_TC = "teamcity"
+
+      // the value used to specify a console format
+      private const val LISTENER_CONSOLE = "enhanced"
+
+      internal const val IDEA_PROP = "idea.active"
+   }
+
+   fun withCommandLineTags(tags: String?): NativeExecConfiguration {
+      return copy(tags = tags)
+   }
+
+   fun withDescriptor(descriptor: String?): NativeExecConfiguration {
+      return copy(descriptor = descriptor)
+   }
+
+   fun configure(exec: ExecSpec) {
+      exec.setCommandLine(executable)
+      exec.environment("kotest.framework.runtime.native.listener", "TeamCity") // todo support non TCSM
+      if (descriptor != null)
+         exec.environment("kotest.framework.runtime.native.descriptor", descriptor)
+
+      // this must be true so we can handle the failure ourselves by throwing GradleException
+      // otherwise we get a nasty stack trace from gradle
+      exec.isIgnoreExitValue = true
+   }
+
+   /**
+    * If we are running inside intellij, we assume the user has the intellij Kotest plugin installed,
+    * and so we will use the teamcity format, which the plugin will parse and use to render an SMTest view.
+    * If they don't, the output will be the raw service-message format which is designed for parsing
+    * not human consumption.
+    *
+    * If we are not running from intellij, then we use a console output format.
+    */
+   private fun listenerType(): String {
+      return when {
+         isIntellij() -> LISTENER_TC
+         else -> LISTENER_CONSOLE
+      }
+   }
+
+   /**
+    * Returns args to be used for the tag expression.
+    *
+    * If --tags was passed as a command line arg, then that takes precedence over the value
+    * set in the gradle build.
+    *
+    * Returns empty list if no tag expression was specified.
+    */
+   private fun tagsArg(): List<String> {
+      tags?.let { return listOf(ARG_TAGS, it) }
+//      project.kotest()?.tags?.orNull?.let { return listOf(TagsArg, it) }
+      return emptyList()
+   }
+
+   /**
+    * We use the idea system property to determine if we are running inside intellij.
+    */
+   private fun isIntellij() = System.getProperty(IDEA_PROP) != null
+}

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/SpecsResolver.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/SpecsResolver.kt
@@ -1,0 +1,38 @@
+package io.kotest.framework.gradle
+
+import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Property
+
+object SpecsResolver {
+
+   const val DELIMITER = ";"
+
+   /**
+    * Returns the spec classes to include with the launcher command.
+    */
+   internal fun specs(
+      specs: Property<String>,
+      packages: Property<String>,
+      classpath: FileCollection
+   ): List<String> {
+
+      // if the --specs option was specified to the gradle task, then that is the highest priority and we take
+      // that as a delimited list of fully qualified class names
+      val specsFromCommandLine = specs.orNull?.split(DELIMITER)
+      if (specsFromCommandLine != null) return specsFromCommandLine
+
+      // If --specs was omitted, then we scan the classpath
+      val specsFromScanning = TestClassDetector().detect(classpath.asFileTree)
+
+      // if packages was set, we filter down to only classes in those packages
+      val packagesFromOptions = packages.orNull?.split(DELIMITER)?.toSet()
+      val filteredSpecs = if (packagesFromOptions == null) {
+         specsFromScanning
+      } else {
+         specsFromScanning.filter { spec ->
+            packagesFromOptions.contains(spec.packageName)
+         }
+      }
+      return filteredSpecs.map { it.qualifiedName }
+   }
+}

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/TestClassDetector.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/TestClassDetector.kt
@@ -13,7 +13,7 @@ import org.objectweb.asm.Opcodes
 internal class TestClassDetector {
 
    private val parents = mutableMapOf<String, String>()
-   private val candidates = mutableSetOf<String>()
+   private val specs = mutableSetOf<String>()
 
    private val specClasses = listOf(
       "io/kotest/core/spec/style/AnnotationSpec",
@@ -31,7 +31,7 @@ internal class TestClassDetector {
    fun detect(inputs: FileTree): Set<TestClass> {
       parents.clear()
       inputs.filter { it.name.endsWith(".class") }.asFileTree.visit(visitor)
-      return candidates.filter { isSpecClass(it) }.map { toTestClass(it) }.toSet()
+      return specs.filter { isSpecClass(it) }.map { toTestClass(it) }.toSet()
    }
 
    private fun toTestClass(className: String): TestClass {
@@ -70,9 +70,9 @@ internal class TestClassDetector {
          // all classes are added to the parents map so we can traverse the hierarchy later to see if
          // a class extends another class that extends a spec and so on
          add(reader.className, reader.superName)
-         // only non abstract classes are added to the candidates set though
+         // only non abstract classes are added to the specs set though
          if (reader.access and Opcodes.ACC_ABSTRACT == 0)
-            candidates.add(reader.className)
+            specs.add(reader.className)
       }
    }
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/TestLauncherExecBuilder.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/TestLauncherExecBuilder.kt
@@ -12,18 +12,18 @@ internal data class TestLauncherExecBuilder(
    private val classpath: FileCollection? = null,
    private val tags: String? = null,
    private val descriptor: String? = null,
-   private val candidates: List<String> = emptyList(),
+   private val specs: List<String> = emptyList(),
 ) {
 
    companion object {
 
-      // used to specify if we want team city or console output
+      // used to specify if we want team city service messages or console output
       private const val ARG_LISTENER = "--listener"
 
       private const val ARG_TAGS = "--tags"
 
-      // required to pass the candidates to the engine
-      private const val ARG_CANDIDATES = "--candidates"
+      // required to pass the non-filtered list of specs to the engine
+      private const val ARG_SPECS = "--specs"
 
       // used to filter to a single spec or test within a spec
       private const val ARG_DESCRIPTOR = "--descriptor"
@@ -48,8 +48,8 @@ internal data class TestLauncherExecBuilder(
       return copy(classpath = classpath)
    }
 
-   fun withCandidates(candidates: List<String>): TestLauncherExecBuilder {
-      return copy(candidates = candidates)
+   fun withSpecs(specs: List<String>): TestLauncherExecBuilder {
+      return copy(specs = specs)
    }
 
    fun withDescriptor(descriptor: String?): TestLauncherExecBuilder {
@@ -69,7 +69,7 @@ internal data class TestLauncherExecBuilder(
    /**
     * Returns the args to send to the launcher
     */
-   private fun args() = listenerArgs() + tagsArg() + candidatesArg() + descriptorArg()
+   private fun args() = listenerArgs() + tagsArg() + specsArg() + descriptorArg()
 
    /**
     * If we are running inside intellij, we assume the user has the intellij Kotest plugin installed,
@@ -110,14 +110,14 @@ internal data class TestLauncherExecBuilder(
    }
 
    /**
-    * Returns an arg to specify the candidate classes.
+    * Returns an arg to specify the spec classes.
     * This is a semi-colon separated list of fully qualified class names.
     *
-    * If the --candidates arg was passed as a command line arg, then we use that as is, otherwise
+    * If the --spec arg was passed as a command line arg, then we use that as is, otherwise
     * the gradle plugin will have scanned the runtime classpath and found all the spec classes.
     */
-   private fun candidatesArg(): List<String> {
-      return if (candidates.isEmpty()) emptyList() else listOf(ARG_CANDIDATES, candidates.joinToString(";"))
+   private fun specsArg(): List<String> {
+      return if (specs.isEmpty()) emptyList() else listOf(ARG_SPECS, specs.joinToString(";"))
    }
 
    /**

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/TestLauncherJavaExecConfiguration.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/TestLauncherJavaExecConfiguration.kt
@@ -5,10 +5,10 @@ import org.gradle.process.JavaExecSpec
 import org.gradle.process.internal.JavaExecAction
 
 /**
- * This [TestLauncherExecBuilder] is responsible for configuring a [JavaExecAction] that will run tests
- * through the kotest engine.
+ * This [TestLauncherJavaExecConfiguration] is responsible for configuring a [JavaExecAction] that will run tests
+ * through the kotest engine by executing the [io.kotest.engine.launcher.MainKt] main class.
  */
-internal data class TestLauncherExecBuilder(
+internal data class TestLauncherJavaExecConfiguration(
    private val classpath: FileCollection? = null,
    private val tags: String? = null,
    private val descriptor: String? = null,
@@ -40,30 +40,30 @@ internal data class TestLauncherExecBuilder(
       internal const val IDEA_PROP = "idea.active"
    }
 
-   fun withCommandLineTags(tags: String?): TestLauncherExecBuilder {
+   fun withCommandLineTags(tags: String?): TestLauncherJavaExecConfiguration {
       return copy(tags = tags)
    }
 
-   fun withClasspath(classpath: FileCollection): TestLauncherExecBuilder {
+   fun withClasspath(classpath: FileCollection): TestLauncherJavaExecConfiguration {
       return copy(classpath = classpath)
    }
 
-   fun withSpecs(specs: List<String>): TestLauncherExecBuilder {
+   fun withSpecs(specs: List<String>): TestLauncherJavaExecConfiguration {
       return copy(specs = specs)
    }
 
-   fun withDescriptor(descriptor: String?): TestLauncherExecBuilder {
+   fun withDescriptor(descriptor: String?): TestLauncherJavaExecConfiguration {
       return copy(descriptor = descriptor)
    }
 
-   fun configure(spec: JavaExecSpec) {
-      spec.mainClass.set(LAUNCHER_MAIN_CLASS)
-      spec.classpath(this@TestLauncherExecBuilder.classpath)
-      spec.args(this@TestLauncherExecBuilder.args())
+   fun configure(exec: JavaExecSpec) {
+      exec.mainClass.set(LAUNCHER_MAIN_CLASS)
+      exec.classpath(classpath)
+      exec.args(args())
 
       // this must be true so we can handle the failure ourselves by throwing GradleException
       // otherwise we get a nasty stack trace from gradle
-      spec.isIgnoreExitValue = true
+      exec.isIgnoreExitValue = true
    }
 
    /**

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/AbstractKotestJvmTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/AbstractKotestJvmTask.kt
@@ -1,8 +1,6 @@
 package io.kotest.framework.gradle.tasks
 
-import io.kotest.framework.gradle.TestClassDetector
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -15,17 +13,12 @@ abstract class AbstractKotestJvmTask internal constructor() : DefaultTask() {
    @get:Optional
    abstract val descriptor: Property<String>
 
-   @get:Option(option = "tests", description = "Filter to a test path expression")
+   @get:Option(option = "specs", description = "The specs list to avoid scanning")
    @get:Input
    @get:Optional
-   abstract val tests: Property<String>
+   abstract val specs: Property<String>
 
-   @get:Option(option = "candidates", description = "The candidates list to avoid scanning")
-   @get:Input
-   @get:Optional
-   abstract val candidates: Property<String>
-
-   @get:Option(option = "packages", description = "Specify the packages to scan for tests")
+   @get:Option(option = "packages", description = "Specify the packages to limit after scanning")
    @get:Input
    @get:Optional
    abstract val packages: Property<String>
@@ -34,33 +27,4 @@ abstract class AbstractKotestJvmTask internal constructor() : DefaultTask() {
    @get:Input
    @get:Optional
    abstract val tags: Property<String>
-
-   /**
-    * Returns the spec classes to include with the launcher command.
-    */
-   internal fun candidates(classpath: FileCollection): List<String> {
-      // if the --candidates option was specified, then that is the highest priority and we take
-      // that as a delimited list of fully qualified class names
-      val candidatesFromOptions = candidates.orNull?.split(DELIMITER)
-      if (candidatesFromOptions != null) return candidatesFromOptions
-
-      // If --candidates was omitted, then we scan the classpath
-      val candidatesFromScanning = TestClassDetector().detect(classpath.asFileTree)
-//      println("specsFromScanning: $specsFromScanning")
-
-      // if packages was set, we filter down to only classes in those packages
-      val packagesFromOptions = packages.orNull?.split(DELIMITER)?.toSet()
-      val filteredSpecs = if (packagesFromOptions == null) {
-         candidatesFromScanning
-      } else {
-         candidatesFromScanning.filter { spec ->
-            packagesFromOptions.contains(spec.packageName)
-         }
-      }
-      return filteredSpecs.map { it.qualifiedName }
-   }
-
-   companion object {
-      const val DELIMITER = ";"
-   }
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/AbstractKotestTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/AbstractKotestTask.kt
@@ -6,7 +6,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.options.Option
 
-abstract class AbstractKotestJvmTask internal constructor() : DefaultTask() {
+abstract class AbstractKotestTask internal constructor() : DefaultTask() {
 
    @get:Option(option = "descriptor", description = "Filter to a single spec or test")
    @get:Input

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestAndroidTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestAndroidTask.kt
@@ -1,8 +1,8 @@
 package io.kotest.framework.gradle.tasks
 
-import io.kotest.framework.gradle.SpecsResolver
 import io.kotest.framework.gradle.KotestExtension
-import io.kotest.framework.gradle.TestLauncherExecBuilder
+import io.kotest.framework.gradle.SpecsResolver
+import io.kotest.framework.gradle.TestLauncherJavaExecConfiguration
 import org.gradle.api.GradleException
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
@@ -20,7 +20,7 @@ import javax.inject.Inject
 abstract class KotestAndroidTask @Inject internal constructor(
    private val executors: ExecOperations,
    private val objects: ObjectFactory,
-) : AbstractKotestJvmTask() {
+) : AbstractKotestTask() {
 
    @get:Input
    abstract val compilationNames: ListProperty<String>
@@ -59,14 +59,13 @@ abstract class KotestAndroidTask @Inject internal constructor(
 
       val specs = SpecsResolver.specs(specs, packages, classpathWithTests)
 
-      val exec = TestLauncherExecBuilder()
-         .withClasspath(classpathWithTests)
-         .withSpecs(specs)
-         .withDescriptor(descriptor.orNull)
-         .withCommandLineTags(tags.orNull)
-
       val result = executors.javaexec {
-         exec.configure(this)
+         TestLauncherJavaExecConfiguration()
+            .withClasspath(classpathWithTests)
+            .withSpecs(specs)
+            .withDescriptor(descriptor.orNull)
+            .withCommandLineTags(tags.orNull)
+            .configure(this)
       }
 
       if (result.exitValue != 0) {

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestAndroidTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestAndroidTask.kt
@@ -1,5 +1,6 @@
 package io.kotest.framework.gradle.tasks
 
+import io.kotest.framework.gradle.SpecsResolver
 import io.kotest.framework.gradle.KotestExtension
 import io.kotest.framework.gradle.TestLauncherExecBuilder
 import org.gradle.api.GradleException
@@ -56,11 +57,11 @@ abstract class KotestAndroidTask @Inject internal constructor(
          .from(classesPath)
          .from(testClassesPath)
 
-      val candidates = candidates(classpathWithTests)
+      val specs = SpecsResolver.specs(specs, packages, classpathWithTests)
 
       val exec = TestLauncherExecBuilder()
          .withClasspath(classpathWithTests)
-         .withCandidates(candidates)
+         .withSpecs(specs)
          .withDescriptor(descriptor.orNull)
          .withCommandLineTags(tags.orNull)
 

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
@@ -1,6 +1,5 @@
 package io.kotest.framework.gradle.tasks
 
-import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -12,7 +11,7 @@ import javax.inject.Inject
 @CacheableTask // this allows gradle to cache our inputs
 abstract class KotestJsTask @Inject internal constructor(
    private val executors: ExecOperations,
-) : DefaultTask() {
+) : AbstractKotestJvmTask() {
 
    // this is the name of the generated function from the KSP plugin
    // it should always match whatever the plugin is generating
@@ -20,7 +19,7 @@ abstract class KotestJsTask @Inject internal constructor(
 
    // this is the name of the package where the KSP plugin places the generated top level run function
    // it should always match whatever the plugin is generating
-   private val runKotestPackageName = "io.kotest.runtime.js"
+   private val runKotestPackageName = "io.kotest.framework.runtime.js"
 
    @get:Input
    abstract val nodeExecutable: Property<String>
@@ -28,6 +27,7 @@ abstract class KotestJsTask @Inject internal constructor(
    @TaskAction
    protected fun execute() {
       executors.exec {
+         println("specs: ${specs.get()}")
          println("Node executable ${nodeExecutable.get()}")
 
          // the kotlin js compiler uses projectname-test as the module name, eg in build/js/packages

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
@@ -11,7 +11,7 @@ import javax.inject.Inject
 @CacheableTask // this allows gradle to cache our inputs
 abstract class KotestJsTask @Inject internal constructor(
    private val executors: ExecOperations,
-) : AbstractKotestJvmTask() {
+) : AbstractKotestTask() {
 
    // this is the name of the generated function from the KSP plugin
    // it should always match whatever the plugin is generating

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
@@ -14,12 +14,12 @@ abstract class KotestJsTask @Inject internal constructor(
    private val executors: ExecOperations,
 ) : DefaultTask() {
 
-   // this is the name of the generated function from the compiler plugin
-   // it should always match whatever the compiler plugin is using
+   // this is the name of the generated function from the KSP plugin
+   // it should always match whatever the plugin is generating
    private val runKotestFnName = "runKotest"
 
-   // this is the name of the package where the compiler plugin places the generated top level run function
-   // it should always match whatever the compiler plugin is using
+   // this is the name of the package where the KSP plugin places the generated top level run function
+   // it should always match whatever the plugin is generating
    private val runKotestPackageName = "io.kotest.runtime.js"
 
    @get:Input
@@ -28,13 +28,11 @@ abstract class KotestJsTask @Inject internal constructor(
    @TaskAction
    protected fun execute() {
       executors.exec {
-         println("isIntellij=" + IntellijUtils.isIntellij())
          println("Node executable ${nodeExecutable.get()}")
 
          // the kotlin js compiler uses projectname-test as the module name, eg in build/js/packages
          val testModuleName = "${project.name}-test"
          println("JS Test Module $testModuleName")
-
 
          val buildDir = project.layout.buildDirectory.asFile.get().toPath()
 

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJsTask.kt
@@ -27,7 +27,7 @@ abstract class KotestJsTask @Inject internal constructor(
    @TaskAction
    protected fun execute() {
       executors.exec {
-         println("specs: ${specs.get()}")
+         println("specs: ${specs.getOrElse("")}")
          println("Node executable ${nodeExecutable.get()}")
 
          // the kotlin js compiler uses projectname-test as the module name, eg in build/js/packages
@@ -42,10 +42,12 @@ abstract class KotestJsTask @Inject internal constructor(
 
 //         val testFilter = if (tests.orNull == null) null else "'$tests'"
 
+         val descriptorArg = if (descriptor.orNull == null) null else "'${descriptor.get()}'"
+
          // this is the entry point passed to node which references the well defined runKotest function
          val nodeCommand = when {
-            IntellijUtils.isIntellij() -> "require('${moduleFile}').$runKotestPackageName.$runKotestFnName('TeamCity')"
-            else -> "require('${moduleFile}').$runKotestPackageName.$runKotestFnName('Console')"
+            IntellijUtils.isIntellij() -> "require('${moduleFile}').$runKotestPackageName.$runKotestFnName('TeamCity', $descriptorArg)"
+            else -> "require('${moduleFile}').$runKotestPackageName.$runKotestFnName('Console', $descriptorArg)"
          }
          println("Node command :$nodeCommand")
 

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJvmTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestJvmTask.kt
@@ -1,5 +1,6 @@
 package io.kotest.framework.gradle.tasks
 
+import io.kotest.framework.gradle.SpecsResolver
 import io.kotest.framework.gradle.TestLauncherExecBuilder
 import org.gradle.api.GradleException
 import org.gradle.api.plugins.JavaPluginExtension
@@ -21,12 +22,11 @@ abstract class KotestJvmTask @Inject internal constructor(
       val java = project.extensions.getByType(JavaPluginExtension::class.java)
       val test = java.sourceSets.findByName("test") ?: return
 
-      val candidates = this@KotestJvmTask.candidates(test.runtimeClasspath)
-//      candidates.forEach { println("spec: $it") }
+      val specs = SpecsResolver.specs(specs, packages, test.runtimeClasspath)
 
       val exec = TestLauncherExecBuilder()
          .withClasspath(test.runtimeClasspath)
-         .withCandidates(candidates)
+         .withSpecs(specs)
          .withDescriptor(descriptor.orNull)
          .withCommandLineTags(tags.orNull)
 

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestNativeTask.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/tasks/KotestNativeTask.kt
@@ -1,36 +1,36 @@
 package io.kotest.framework.gradle.tasks
 
-import io.kotest.framework.gradle.SpecsResolver
-import io.kotest.framework.gradle.TestLauncherJavaExecConfiguration
+import io.kotest.framework.gradle.NativeExecConfiguration
 import org.gradle.api.GradleException
-import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import org.gradle.process.ExecOperations
+import org.jetbrains.kotlin.gradle.plugin.KotlinTargetWithTests
 import javax.inject.Inject
 
 // gradle requires the class be extendable
 @CacheableTask // this allows gradle to cache our inputs
-abstract class KotestJvmTask @Inject internal constructor(
+abstract class KotestNativeTask @Inject internal constructor(
    private val executors: ExecOperations,
 ) : AbstractKotestTask() {
+
+   @get:Input
+   abstract val target: Property<KotlinTargetWithTests<*, *>>
 
    @TaskAction
    protected fun execute() {
 
-      // todo better way to detect the test compilations ?
-      val java = project.extensions.getByType(JavaPluginExtension::class.java)
-      val test = java.sourceSets.findByName("test") ?: return
+      val binaryPath = "bin/${target.get().name}/debugTest/test.kexe"
+      val kexe = project.layout.buildDirectory.get().asFile.resolve(binaryPath).absolutePath
 
-      val specs = SpecsResolver.specs(specs, packages, test.runtimeClasspath)
-
-      val result = executors.javaexec {
-         TestLauncherJavaExecConfiguration()
-            .withClasspath(test.runtimeClasspath)
-            .withSpecs(specs)
+      val result = executors.exec {
+         NativeExecConfiguration(kexe)
             .withDescriptor(descriptor.orNull)
             .withCommandLineTags(tags.orNull)
             .configure(this)
+         println(this.environment)
       }
 
       if (result.exitValue != 0) {

--- a/kotest-framework/kotest-framework-symbol-processor/api/kotest-framework-symbol-processor.api
+++ b/kotest-framework/kotest-framework-symbol-processor/api/kotest-framework-symbol-processor.api
@@ -1,0 +1,31 @@
+public final class io/kotest/framework/symbol/processor/FindSpecsVisitor : com/google/devtools/ksp/symbol/KSVisitorVoid {
+	public fun <init> ()V
+	public synthetic fun visitClassDeclaration (Lcom/google/devtools/ksp/symbol/KSClassDeclaration;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitClassDeclaration (Lcom/google/devtools/ksp/symbol/KSClassDeclaration;Lkotlin/Unit;)V
+	public synthetic fun visitFile (Lcom/google/devtools/ksp/symbol/KSFile;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun visitFile (Lcom/google/devtools/ksp/symbol/KSFile;Lkotlin/Unit;)V
+}
+
+public final class io/kotest/framework/symbol/processor/JSGenerator {
+	public fun <init> (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)V
+	public final fun generate (Ljava/util/List;Ljava/util/List;)V
+}
+
+public final class io/kotest/framework/symbol/processor/KotestSymbolProcessor : com/google/devtools/ksp/processing/SymbolProcessor {
+	public fun <init> (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)V
+	public fun finish ()V
+	public final fun getVisitor ()Lio/kotest/framework/symbol/processor/FindSpecsVisitor;
+	public fun onError ()V
+	public fun process (Lcom/google/devtools/ksp/processing/Resolver;)Ljava/util/List;
+}
+
+public final class io/kotest/framework/symbol/processor/KotestSymbolProcessorProvider : com/google/devtools/ksp/processing/SymbolProcessorProvider {
+	public fun <init> ()V
+	public fun create (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)Lcom/google/devtools/ksp/processing/SymbolProcessor;
+}
+
+public final class io/kotest/framework/symbol/processor/NativeGenerator {
+	public fun <init> (Lcom/google/devtools/ksp/processing/SymbolProcessorEnvironment;)V
+	public final fun generate (Ljava/util/List;Ljava/util/List;)V
+}
+

--- a/kotest-framework/kotest-framework-symbol-processor/build.gradle.kts
+++ b/kotest-framework/kotest-framework-symbol-processor/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+   id("kotest-jvm-conventions")
+   id("kotest-publishing-conventions")
+}
+
+kotlin {
+   sourceSets {
+      jvmMain {
+         dependencies {
+            implementation("com.google.devtools.ksp:symbol-processing-api:2.2.0-2.0.2")
+         }
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/JSGenerator.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/JSGenerator.kt
@@ -9,14 +9,14 @@ class JSGenerator(private val environment: SymbolProcessorEnvironment) {
    fun generate(files: List<KSFile>, specs: List<KSClassDeclaration>) {
       val outputStream = environment.codeGenerator.createNewFile(
          dependencies = Dependencies(true, *files.toTypedArray()),
-         packageName = "io.kotest.runtime.js",
+         packageName = "io.kotest.framework.runtime.js",
          fileName = "kotest",
          extensionName = "kt"
       )
       outputStream.bufferedWriter().use { writer ->
          writer.write(
             buildString {
-               appendLine("""package io.kotest.runtime.js""")
+               appendLine("""package io.kotest.framework.runtime.js""")
                appendLine()
                appendLine("""import io.kotest.engine.TestEngineLauncher""")
                appendLine("""import io.kotest.core.spec.SpecRef""")

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
@@ -1,0 +1,79 @@
+package io.kotest.framework.symbol.processor
+
+import com.google.devtools.ksp.getAllSuperTypes
+import com.google.devtools.ksp.processing.JsPlatformInfo
+import com.google.devtools.ksp.processing.NativePlatformInfo
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSVisitorVoid
+
+class FindSpecsVisitor : KSVisitorVoid() {
+
+   private val specTypes = setOf(
+      "AnnotationSpec",
+      "BehaviorSpec",
+      "DescribeSpec",
+      "ExpectSpec",
+      "FeatureSpec",
+      "FreeSpec",
+      "FunSpec",
+      "ShouldSpec",
+      "StringSpec",
+      "WordSpec",
+   )
+
+   internal val specs = mutableListOf<KSClassDeclaration>()
+
+   private fun hasSpecSupertype(supertypes: Collection<KSType>): Boolean {
+      return supertypes.map { it.declaration }
+         .filterIsInstance<KSClassDeclaration>()
+         .any { specTypes.contains(it.simpleName.asString()) }
+   }
+
+   private fun isSpec(classDeclaration: KSClassDeclaration): Boolean {
+      val supers = classDeclaration.getAllSuperTypes().toList()
+      return hasSpecSupertype(supers)
+   }
+
+   override fun visitFile(file: KSFile, data: Unit) {
+      file.declarations.forEach { it.accept(this, Unit) }
+   }
+
+   override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
+      super.visitClassDeclaration(classDeclaration, data)
+      if (isSpec(classDeclaration)) {
+         specs.add(classDeclaration)
+      }
+   }
+}
+
+class KotestSymbolProcessor(private val environment: SymbolProcessorEnvironment) : SymbolProcessor {
+
+   val visitor = FindSpecsVisitor()
+
+   override fun process(resolver: Resolver): List<KSAnnotated> {
+      resolver.getAllFiles().forEach { it.accept(visitor, Unit) }
+      return emptyList()
+   }
+
+   override fun finish() {
+      val files = visitor.specs.mapNotNull { it.containingFile }
+      when (environment.platforms.first()) {
+         is JsPlatformInfo -> JSGenerator(environment).generate(files, visitor.specs)
+         is NativePlatformInfo -> NativeGenerator(environment).generate(files, visitor.specs)
+         else -> Unit
+      }
+   }
+}
+
+class KotestSymbolProcessorProvider : SymbolProcessorProvider {
+   override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+      return KotestSymbolProcessor(environment)
+   }
+}

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/NativeGenerator.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/NativeGenerator.kt
@@ -1,0 +1,59 @@
+package io.kotest.framework.symbol.processor
+
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+
+class NativeGenerator(private val environment: SymbolProcessorEnvironment) {
+   fun generate(files: List<KSFile>, specs: List<KSClassDeclaration>) {
+      val outputStream = environment.codeGenerator.createNewFile(
+         dependencies = Dependencies(true, *files.toTypedArray()),
+         packageName = "io.kotest.runtime.native",
+         fileName = "kotest",
+         extensionName = "kt"
+      )
+      outputStream.bufferedWriter().use { writer ->
+         writer.write(
+            buildString {
+               appendLine("""package io.kotest.runtime.native""")
+               appendLine()
+               appendLine("""import io.kotest.engine.TestEngineLauncher""")
+               appendLine("""import io.kotest.core.spec.SpecRef""")
+               appendLine("""import kotlin.test.Test""")
+               appendLine("""import kotlin.test.AfterClass""")
+
+               specs.forEach {
+                  appendLine("""import ${it.qualifiedName?.asString()}""")
+               }
+
+               appendLine(
+                  """
+// we need at least one test otherwise the @AfterClass will not be called
+@Test
+fun configureKotest() {
+}
+
+// we run Kotest after all kotlin.test tests have been executed
+@AfterClass
+fun runKotest() {
+  TestEngineLauncher()
+   .withNative()
+   .withTeamCityListener()
+   .withSpecRefs("""
+               )
+
+               specs.forEach {
+                  appendLine("""SpecRef.Function({ $it() }, $it::class),""")
+               }
+
+               appendLine(
+                  """   )
+   .launch()
+}"""
+               )
+            }
+         )
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/NativeGenerator.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/NativeGenerator.kt
@@ -9,7 +9,7 @@ class NativeGenerator(private val environment: SymbolProcessorEnvironment) {
    fun generate(files: List<KSFile>, specs: List<KSClassDeclaration>) {
       val outputStream = environment.codeGenerator.createNewFile(
          dependencies = Dependencies(true, *files.toTypedArray()),
-         packageName = "io.kotest.runtime.native",
+         packageName = "io.kotest.framework.runtime.native",
          fileName = "kotest",
          extensionName = "kt"
       )

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/NativeGenerator.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/NativeGenerator.kt
@@ -16,7 +16,7 @@ class NativeGenerator(private val environment: SymbolProcessorEnvironment) {
       outputStream.bufferedWriter().use { writer ->
          writer.write(
             buildString {
-               appendLine("""package io.kotest.runtime.native""")
+               appendLine("""package io.kotest.framework.runtime.native""")
                appendLine()
                appendLine("""import io.kotest.engine.TestEngineLauncher""")
                appendLine("""import io.kotest.core.spec.SpecRef""")

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+io.kotest.framework.symbol.processor.KotestSymbolProcessorProvider

--- a/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/RatingBannerRepositoryTest.kt
+++ b/kotest-tests/kotest-tests-core/src/jvmTest/kotlin/com/sksamuel/kotest/RatingBannerRepositoryTest.kt
@@ -1,0 +1,48 @@
+package com.sksamuel.kotest
+
+import io.kotest.core.spec.style.BehaviorSpec
+
+class RatingBannerRepositoryTest : BehaviorSpec({
+
+   Given("Rating banner repository") {
+      When("observing rating banner state with data in store") {
+         Then("should return correct banner model") {
+         }
+      }
+
+      When("observing rating banner state with null boolean value") {
+         Then("should return model with defaults") {
+         }
+      }
+
+      When("setting rating banner to show") {
+         Then("should save appropriate values to data store") {
+         }
+      }
+
+      When("hiding rating banner") {
+         Then("should save appropriate values to data store") {
+         }
+      }
+
+      When("acknowledging rating banner") {
+         Then("should call rating banner service") {
+         }
+      }
+
+      When("triggering in-app rating dialog") {
+         Then("should emit true to in-app rating dialog state") {
+         }
+      }
+
+      When("getting rating trigger") {
+         Then("should return cached trigger value") {
+         }
+      }
+
+      When("observing in-app rating dialog state") {
+         Then("should have initial value of false") {
+         }
+      }
+   }
+})

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -60,6 +60,8 @@ include(
    // gradle plugin to run tests outside of gradle's test task
    ":kotest-framework:kotest-framework-plugin-gradle",
 
+   ":kotest-framework:kotest-framework-symbol-processor",
+
    // compiler plugins to integrate tests with the engine
    ":kotest-framework:kotest-framework-multiplatform-plugin-compiler",
    ":kotest-framework:kotest-framework-multiplatform-plugin-gradle",


### PR DESCRIPTION
If we move to KSP we can use a stable and supported API and not the experimental compiler plugins. This means we shouldn't have to keep making changes each time a new version of Kotlin is released.

This implementation brings full nested test support to JS and Native. 

Also individual tests are now working from intellij for JS platforms, so can you click the run button and run a single test. I still need to confirm that we can do the same for Kotlin Native.

![image](https://github.com/user-attachments/assets/e6b9ba86-3d11-4902-af6b-0fa7ffc91c1f)

There are some further changes required to robust this up that I'll do in follow up PRs.