### PR TITLE
Removing explicit call to Gradle wrapper wrapper-validation

### DIFF
--- a/.github/workflows/run-gradle.yml
+++ b/.github/workflows/run-gradle.yml
@@ -45,9 +45,6 @@ jobs:
             with:
                ref: ${{ github.event.inputs.ref }}
 
-         -  name: Validate Gradle Wrapper
-            uses: gradle/actions/wrapper-validation@v3
-
          -  name: Setup JDK
             uses: actions/setup-java@v4
             with:


### PR DESCRIPTION
Since setup-gradle@v4, this is done implicitly.

See: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
