### PR TITLE
conditional publication enabled based on runner, to deal with sharded…

### DIFF
--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -1,0 +1,57 @@
+name: publish
+
+on:
+   workflow_dispatch:
+      inputs:
+         version:
+            description: "The release version"
+            required: true
+         branch:
+            description: "The branch to release from"
+            required: true
+            default: 'master'
+
+env:
+   RELEASE_VERSION: ${{ inputs.version }}
+   OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+   OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+   ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+   ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+   NEW_MAVEN_CENTRAL_USERNAME: ${{ secrets.NEW_MAVEN_CENTRAL_USERNAME }}
+   NEW_MAVEN_CENTRAL_PASSWORD: ${{ secrets.NEW_MAVEN_CENTRAL_PASSWORD }}
+
+concurrency:
+   group: "${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}"
+   cancel-in-progress: true
+
+
+permissions:
+   contents: read
+
+
+jobs:
+   publish:
+      strategy:
+         # Not sure if this is still true on new maven central, perhaps parallel uploads are now supported?
+         max-parallel: 1 # Sonatype doesn't like parallel uploads, so disable it where possible
+         fail-fast: false
+         matrix:
+            include:
+               # Publish 'common' components (KotlinMultiplatform,jvm,js) only on Linux, to avoid duplicate publications
+               -  os: ubuntu-latest
+                  args: -P"kotest_enabledPublicationNamePrefixes=KotlinMultiplatform,jvm,js,linux"
+
+               # Windows: MinGW
+               -  os: windows-latest
+                  args: -P"kotest_enabledPublicationNamePrefixes=mingw"
+
+               # Apple: macOS, iOS, tvOS, watchOS
+               -  os: macos-latest
+                  args: -P"kotest_enabledPublicationNamePrefixes=macOS,iOS,tvOS,watchOS"
+
+      uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
+      with:
+         ref: ${{ inputs.ref }}
+         task: publishToAppropriateCentralRepository ${{ matrix.args }} --no-parallel --stacktrace --no-configuration-cache
+         runs-on: ${{ matrix.os }}

--- a/buildSrc/src/main/kotlin/KotestBuildLogicSettings.kt
+++ b/buildSrc/src/main/kotlin/KotestBuildLogicSettings.kt
@@ -1,0 +1,59 @@
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
+import javax.inject.Inject
+
+/**
+ * Common settings for configuring Kotest's build logic.
+ *
+ * The settings need to be accessible during configuration, so they should come from Gradle
+ * properties or environment variables.
+ */
+abstract class KotestBuildLogicSettings @Inject constructor(
+   private val providers: ProviderFactory,
+) {
+
+   /** Controls whether Kotlin Multiplatform JS is enabled */
+   val enableKotlinJs: Provider<Boolean> = kotestFlag("enableKotlinJs", true)
+
+   /** Controls whether Kotlin Multiplatform Native is enabled */
+   val enableKotlinNative: Provider<Boolean> = kotestFlag("enableKotlinNative", false)
+
+   /**
+    * Comma separated list of MavenPublication names that will have the publishing task enabled.
+    * The provided names will be matched ignoring case, and by prefix, so `iOS` will match
+    * `iosArm64`, `iosX64`, and `iosSimulatorArm64`.
+    *
+    * This is used to avoid duplicate publications, which can occur when a Kotlin Multiplatform
+    * project is published in CI/CD on different host machines (Linux, Windows, and macOS).
+    *
+    * For example, by including `jvm` in the values when publishing on Linux, but omitting `jvm` on
+    * Windows and macOS, this results in any Kotlin/JVM publications only being published once.
+    */
+   val enabledPublicationNamePrefixes: Provider<Set<String>> =
+      kotestSetting("enabledPublicationNamePrefixes", "KotlinMultiplatform,Jvm,Js,iOS,macOS,watchOS,tvOS,mingw")
+         .map { enabledPlatforms ->
+            enabledPlatforms
+               .split(",")
+               .map { it.trim() }
+               .filter { it.isNotBlank() }
+               .toSet()
+         }
+
+   private fun kotestSetting(name: String, default: String? = null) =
+      providers.gradleProperty("kotest_$name")
+         .orElse(providers.provider { default }) // workaround for https://github.com/gradle/gradle/issues/12388
+
+   private fun kotestFlag(name: String, default: Boolean) =
+      providers.gradleProperty("kotest_$name").map { it.toBoolean() }.orElse(default)
+
+   companion object {
+      const val EXTENSION_NAME = "kotestSettings"
+
+      /**
+       * Regex for matching the release version.
+       *
+       * If a version does not match this code it should be treated as a SNAPSHOT version.
+       */
+      val releaseVersionRegex = Regex("\\d+.\\d+.\\d+")
+   }
+}

--- a/buildSrc/src/main/kotlin/kotest-base.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-base.gradle.kts
@@ -2,6 +2,8 @@ plugins {
    base
 }
 
+extensions.create(KotestBuildLogicSettings.EXTENSION_NAME, KotestBuildLogicSettings::class)
+
 tasks.withType<AbstractArchiveTask>().configureEach {
    // https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
    isPreserveFileTimestamps = false

--- a/buildSrc/src/main/kotlin/kotest-js-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-js-conventions.gradle.kts
@@ -6,8 +6,10 @@ plugins {
    id("kotlin-conventions")
 }
 
+val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
+
 kotlin {
-   if (!project.hasProperty(Ci.JVM_ONLY)) {
+   if (!project.hasProperty(Ci.JVM_ONLY) && kotestSettings.enableKotlinJs.get()) {
       js {
          browser()
          nodejs()

--- a/buildSrc/src/main/kotlin/kotest-js-not-wasm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-js-not-wasm-conventions.gradle.kts
@@ -5,8 +5,10 @@ plugins {
    id("kotlin-conventions")
 }
 
+val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
+
 kotlin {
-   if (!project.hasProperty(Ci.JVM_ONLY)) {
+   if (!project.hasProperty(Ci.JVM_ONLY) && kotestSettings.enableKotlinJs.get()) {
       js {
          browser()
          nodejs()

--- a/buildSrc/src/main/kotlin/kotest-native-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-native-conventions.gradle.kts
@@ -6,8 +6,10 @@ plugins {
    id("kotlin-conventions")
 }
 
+val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
+
 kotlin {
-   if (!project.hasProperty(Ci.JVM_ONLY)) {
+   if (!project.hasProperty(Ci.JVM_ONLY) && kotestSettings.enableKotlinNative.get()) {
       linuxX64()
       linuxArm64()
 

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -182,6 +182,30 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
    }
 }
 
+//region Letting Kotest settings control which publications are enabled
+val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
+tasks.withType<AbstractPublishToMaven>().configureEach {
+   // use vals - improves Gradle Config Cache compatibility
+   val publicationName = publication.name
+   val enabledPublicationNamePrefixes = kotestSettings.enabledPublicationNamePrefixes
+
+   val isPublicationEnabled = enabledPublicationNamePrefixes.map { prefixes ->
+      prefixes.any { prefix -> publicationName.startsWith(prefix, ignoreCase = true) }
+   }
+
+   // register an input so Gradle can do up-to-date checks
+   inputs.property("publicationEnabled", isPublicationEnabled)
+
+   onlyIf {
+      val enabled = isPublicationEnabled.get()
+      if (!enabled) {
+         logger.lifecycle("[task: $path] publishing for $publicationName is disabled")
+      }
+      enabled
+   }
+}
+//endregion
+
 //region Fix Gradle error Reason: Task <publish> uses this output of task <sign> without declaring an explicit or implicit dependency.
 // https://github.com/gradle/gradle/issues/26091
 tasks.withType<AbstractPublishToMaven>().configureEach {

--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -186,7 +186,8 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
 val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
 tasks.withType<AbstractPublishToMaven>().configureEach {
    // use vals - improves Gradle Config Cache compatibility
-   val publicationName = publication.name
+   // We might get null here if something uses the publication task before the actual publication is created
+   val publicationName = publication?.name ?: "MissingPublicationName"
    val enabledPublicationNamePrefixes = kotestSettings.enabledPublicationNamePrefixes
 
    val isPublicationEnabled = enabledPublicationNamePrefixes.map { prefixes ->

--- a/buildSrc/src/main/kotlin/kotest-watchos-device-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-watchos-device-conventions.gradle.kts
@@ -5,8 +5,10 @@ plugins {
    id("kotlin-conventions")
 }
 
+val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
+
 kotlin {
-   if (!project.hasProperty(Ci.JVM_ONLY)) {
+   if (!project.hasProperty(Ci.JVM_ONLY)&&kotestSettings.enableKotlinNative.get()) {
       watchosDeviceArm64()
 
       // TODO: The "desktop" intermediate source set can be integrated into "native". In this case

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,8 @@ kotlin.incremental.js=true
 
 android.useAndroidX=true
 android.enableJetifier=true
+
+# Kotest build settings
+# enabled/disable Kotlin targets, for improving local dev & CI/CD performance
+kotest_enableKotlinJs=true
+kotest_enableKotlinNative=false


### PR DESCRIPTION
Cherry-picked some stuff from @aSemy's work on Ks3's build setup.

This enables us to only allow publications to be created on certain targets, so we can run macOS builds and just get Apple targets artifacts, etc.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
