### PR TITLE
add inline to `should` and `shouldNotBeNull`

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
@@ -80,7 +80,11 @@ fun <T> T?.shouldNotBeNull(): T {
  *     length should beEven()
  * }
  */
-infix fun <T : Any> T?.shouldNotBeNull(block: T.() -> Unit): T {
+inline infix fun <T : Any> T?.shouldNotBeNull(block: T.() -> Unit): T {
+   contract {
+      returns() implies (this@shouldNotBeNull != null)
+   }
+
    this.shouldNotBeNull()
    block()
    return this

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/should.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/should.kt
@@ -68,7 +68,7 @@ infix fun <T> T.should(matcher: Matcher<T>) {
 infix fun <T> T.shouldNotHave(matcher: Matcher<T>) = shouldNot(matcher)
 infix fun <T> T.shouldNot(matcher: Matcher<T>) = should(matcher.invert())
 
-infix fun <T> T.should(matcher: (T) -> Unit) = matcher(this)
+inline infix fun <T> T.should(matcher: (T) -> Unit) = matcher(this)
 
 fun <T> be(expected: T): Matcher<T> = equalityMatcher(expected)
 fun <T> equalityMatcher(expected: T): Matcher<T> = EqMatcher(expected)


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Allow usage of suspend functions from the existing (if historic) `should` and `shouldNotBeNull`  scope functions.