### PR TITLE
Fixing releases for wasmJs targets

### DIFF
--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -39,15 +39,15 @@ jobs:
             include:
                # Publish 'common' components (KotlinMultiplatform,jvm,js) only on Linux, to avoid duplicate publications
                -  os: ubuntu-latest
-                  args: -P"kotest_enabledPublicationNamePrefixes=KotlinMultiplatform,jvm,js,linux"
-
-               # Windows: MinGW
-               -  os: windows-latest
-                  args: -P"kotest_enabledPublicationNamePrefixes=mingw"
-
-               # Apple: macOS, iOS, tvOS, watchOS
-               -  os: macos-latest
-                  args: -P"kotest_enabledPublicationNamePrefixes=macOS,iOS,tvOS,watchOS"
+                  args: -P"kotest_enabledPublicationNamePrefixes=wasmJs"
+#
+#               # Windows: MinGW
+#               -  os: windows-latest
+#                  args: -P"kotest_enabledPublicationNamePrefixes=mingw"
+#
+#               # Apple: macOS, iOS, tvOS, watchOS
+#               -  os: macos-latest
+#                  args: -P"kotest_enabledPublicationNamePrefixes=macOS,iOS,tvOS,watchOS"
 
       uses: ./.github/workflows/run-gradle.yml
       secrets: inherit

--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -39,15 +39,15 @@ jobs:
             include:
                # Publish 'common' components (KotlinMultiplatform,jvm,js) only on Linux, to avoid duplicate publications
                -  os: ubuntu-latest
-                  args: -P"kotest_enabledPublicationNamePrefixes=wasmJs"
-#
-#               # Windows: MinGW
-#               -  os: windows-latest
-#                  args: -P"kotest_enabledPublicationNamePrefixes=mingw"
-#
-#               # Apple: macOS, iOS, tvOS, watchOS
-#               -  os: macos-latest
-#                  args: -P"kotest_enabledPublicationNamePrefixes=macOS,iOS,tvOS,watchOS"
+                  args: -P"kotest_enabledPublicationNamePrefixes=KotlinMultiplatform,jvm,js,wasmJs,linux"
+
+               # Windows: MinGW
+               -  os: windows-latest
+                  args: -P"kotest_enabledPublicationNamePrefixes=mingw"
+
+               # Apple: macOS, iOS, tvOS, watchOS
+               -  os: macos-latest
+                  args: -P"kotest_enabledPublicationNamePrefixes=macOS,iOS,tvOS,watchOS"
 
       uses: ./.github/workflows/run-gradle.yml
       secrets: inherit

--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
    id("kotest-android-native-conventions")
    id("kotest-watchos-device-conventions")
    id("kotest-native-conventions")
+   id("kotest-js-conventions")
    id("kotest-publishing-conventions")
 }
 


### PR DESCRIPTION
wasmJs was missing as enabled prefix in all publication pipes. Adding it on the ubuntu runner.

Also adding kotlin-js-conventions to kotlin-property module so it gets a wasmJs target defined