### PR TITLE
Cleaning up some logging and unnecessary dependency wiring

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-publishing-conventions.gradle.kts
@@ -179,12 +179,6 @@ pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
 
 //region Letting Kotest settings control which publications are enabled
 tasks.withType<AbstractPublishToMaven>().configureEach {
-   mustRunAfter(tasks.withType<GenerateMavenPom>())
-   val outerPath = this.path
-   tasks.named { it.contains("generatePom") }.forEach {
-      println("[task: ${outerPath}] Found generatePom task ${it.path}")
-   }
-
    onlyIf {
       val enabled = isPublicationEnabled(publication.name).get()
       if (!enabled) {
@@ -195,12 +189,12 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
 }
 
 private val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
-private fun isPublicationEnabled(publicationName: String?): Provider<Boolean?> {
-   return publicationName?.let { name ->
+private fun isPublicationEnabled(publicationName: String): Provider<Boolean?> {
+   return publicationName.let { name ->
       kotestSettings.enabledPublicationNamePrefixes.map { prefixes ->
          prefixes.any { prefix -> name.startsWith(prefix, ignoreCase = true) }
       }
-   } ?: providers.provider { null }
+   }
 }
 //endregion
 


### PR DESCRIPTION
I made an attempt to add a dependency to the generateMavenPom task in the hope that it would let the maven publication get created before the isPublicationEnabled property was resolved. This didn't work, but removing the cached input seem to have been enough.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
