### PR TITLE
prevent android native compilations if native is not enabled

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-android-native-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-android-native-conventions.gradle.kts
@@ -5,8 +5,10 @@ plugins {
    id("kotlin-conventions")
 }
 
+val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
+
 kotlin {
-   if (!project.hasProperty(Ci.JVM_ONLY)) {
+   if (!project.hasProperty(Ci.JVM_ONLY) && kotestSettings.enableKotlinNative.get()) {
       androidNativeX86()
       androidNativeX64()
       androidNativeArm32()


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
