### PR TITLE
Add support for -0.0 and 0.0 equality in NumberFormat.Lenient mode

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/nodes.kt
@@ -44,9 +44,16 @@ sealed class JsonNode {
 
          if (other.content == content) return true
 
+         val thisDouble = content.toDouble()
+         val otherDouble = other.content.toDouble()
+         if(
+            (thisDouble == 0.0 || thisDouble == -0.0) &&
+            (otherDouble == 0.0 || otherDouble == -0.0)
+         ) return true
+
          // if one or the other uses exponent notation, we must compare by parsed value
          if (content.matches(exponentRegex) xor other.content.matches(exponentRegex)) {
-            return content.toDouble() == other.content.toDouble()
+            return thisDouble == otherDouble
          }
 
          val fractionalZeroesRegex = """(\.\d*)0+$""".toRegex()

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -2,6 +2,7 @@
 
 package com.sksamuel.kotest.tests.json
 
+import io.kotest.assertions.json.NumberFormat
 import io.kotest.assertions.json.PropertyOrder
 import io.kotest.assertions.json.TypeCoercion
 import io.kotest.assertions.json.shouldEqualJson
@@ -646,6 +647,15 @@ expected:<{
   }
 }>"""
          )
+      }
+
+      test("comparing -0.0 and 0.0 double") {
+         val a = """{ "a": -0.0 } """
+         val b = """ { "a" : 0.0 } """
+         a shouldEqualJson {
+            numberFormat = NumberFormat.Lenient
+            b
+         }
       }
 
       test("real world json test") {


### PR DESCRIPTION
# Problem
In the current implementation, NumberFormat in lenient mode treats -0.0 and 0.0 as different values, which can cause unexpected behavior when comparing numbers. This issue occurs when you serializing a double value with Kotlin serialization:
```kotlin
@Serializable
data class SomeValue(
    val num: Double,
)

val json = Json.Default
val value = SomeValue(-0.0)
val actualJson = json.encodeToString(value)
println(actualJson) // prints: {"num":-0.0}
```

# Solution
Enhanced Number.lenientEquals to handle this edge case