### PR TITLE
Don't use KotestAssertionFailedError if there is no comparison

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/nonjvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.nonjvm.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/nonjvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.nonjvm.kt
@@ -21,12 +21,16 @@ actual fun createAssertionError(
       }
    }
 
-   return KotestAssertionFailedError(
-      message = messageString,
-      cause = cause,
-      expected = expected?.value?.value,
-      actual = actual?.value?.value
-   )
+   return if (expected == null && actual == null) {
+      AssertionError(message, cause)
+   } else {
+      KotestAssertionFailedError(
+         message = messageString,
+         cause = cause,
+         expected = expected?.value?.value,
+         actual = actual?.value?.value
+      )
+   }
 }
 
 /**


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
