### PR TITLE
Replace typo in deprecation message of ContainerExtension

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/AbstractContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/AbstractContainerExtension.kt
@@ -6,7 +6,7 @@ import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.spec.Spec
 import org.testcontainers.containers.GenericContainer
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 abstract class AbstractContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerExtension.kt
@@ -53,7 +53,7 @@ import org.testcontainers.containers.GenericContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class ContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerLifecycleMode.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerLifecycleMode.kt
@@ -3,7 +3,7 @@ package io.kotest.extensions.testcontainers
 /**
  * Determines the lifetime of a test container installed in a Kotest extension.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 enum class ContainerLifecycleMode {
 
    /**

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainerExtension.kt
@@ -48,7 +48,7 @@ import java.io.File
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class DockerComposeContainerExtension<T : DockerComposeContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainersExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainersExtension.kt
@@ -15,7 +15,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
 import java.util.Optional
 import org.testcontainers.containers.DockerComposeContainer
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class DockerComposeContainersExtension<T : DockerComposeContainer<*>>(
    private val container: T,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
@@ -3,32 +3,32 @@ package io.kotest.extensions.testcontainers
 import io.kotest.core.TestConfiguration
 import org.testcontainers.lifecycle.Startable
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> T.perTest(): StartablePerTestListener<T> = StartablePerTestListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> T.perSpec(): StartablePerSpecListener<T> = StartablePerSpecListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> T.perProject(): StartablePerProjectListener<T> = StartablePerProjectListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> T.perProject(containerName: String): StartablePerProjectListener<T> =
    StartablePerProjectListener<T>(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> TestConfiguration.configurePerTest(startable: T): T {
    extension(StartablePerTestListener(startable))
    return startable
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> TestConfiguration.configurePerSpec(startable: T): T {
    extension(StartablePerSpecListener(startable))
    return startable
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 fun <T : Startable> TestConfiguration.configurePerProject(startable: T, containerName: String): T {
    extension(StartablePerProjectListener(startable))
    return startable

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
@@ -50,7 +50,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class JdbcDatabaseContainerExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/LifecycleMode.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/LifecycleMode.kt
@@ -1,6 +1,6 @@
 package io.kotest.extensions.testcontainers
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 enum class LifecycleMode {
    Spec, EveryTest, Leaf, Root
 }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ProjectContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ProjectContainerExtension.kt
@@ -53,7 +53,7 @@ import org.testcontainers.containers.GenericContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class ProjectContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SettableDataSource.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SettableDataSource.kt
@@ -6,7 +6,7 @@ import java.sql.Connection
 import java.util.logging.Logger
 import javax.sql.DataSource
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class SettableDataSource(private var ds: HikariDataSource?) : DataSource {
 
    private fun getDs(): DataSource = ds ?: error("DataSource is not ready")

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
@@ -19,7 +19,7 @@ import org.testcontainers.lifecycle.Startable
  * @see
  * [StartablePerTestListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class StartablePerProjectListener<T : Startable>(private val startable: T) : TestListener, ProjectListener {
 
    @Deprecated("The containerName arg is no longer used")

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerSpecListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerSpecListener.kt
@@ -22,7 +22,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
  * @see
  * [StartablePerTestListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class StartablePerSpecListener<T : Startable>(private val startable: T) : TestListener {
    private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerTestListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerTestListener.kt
@@ -19,7 +19,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
  *
  * @see[StartablePerSpecListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class StartablePerTestListener<T : Startable>(private val startable: T) : TestListener {
 
    private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestLifecycleAwareListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestLifecycleAwareListener.kt
@@ -9,7 +9,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
 import java.net.URLEncoder
 import java.util.Optional
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 class TestLifecycleAwareListener(startable: Startable) : TestListener {
    private val testLifecycleAware = startable as? TestLifecycleAware
 
@@ -22,7 +22,7 @@ class TestLifecycleAwareListener(startable: Startable) : TestListener {
    }
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpeccExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
 internal fun TestCase.toTestDescription() = object : TestDescription {
 
    override fun getFilesystemFriendlyName(): String {


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

While making the required changes for v6 i tried to copy the suggested annotation from the deprecation message which i could not import because it was misspelled