### PR TITLE
support arrays of primitives in shouldBeEqualToComparingFields

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -462,13 +462,28 @@ internal fun comparisonToUse(
    (expected is List<*> && actual is List<*>) -> FieldComparison.LIST
    (expected is Map<*, *> && actual is Map<*, *>) -> FieldComparison.MAP
    (expected is Set<*> && actual is Set<*>) -> FieldComparison.SET
-   (expected is Array<*> && actual is Array<*>) -> FieldComparison.ARRAY
+   (isArray(expected) && isArray(actual)) -> FieldComparison.ARRAY
    typeIsJavaOrKotlinBuiltIn(expected) || typeIsJavaOrKotlinBuiltIn(actual) -> FieldComparison.DEFAULT
    useDefaultEqualForFields.contains(expected::class.java.canonicalName) ||
       useDefaultEqualForFields.contains(actual::class.java.canonicalName) -> FieldComparison.DEFAULT
 
    actual::class != expected::class -> FieldComparison.DEFAULT
    else -> FieldComparison.RECURSIVE
+}
+
+internal fun isArray(value: Any?) = when (value) {
+   null -> false
+   is Array<*> -> true
+   value::class.java.isArray -> true
+   is ByteArray -> true
+   is ShortArray -> true
+   is IntArray -> true
+   is LongArray -> true
+   is FloatArray -> true
+   is DoubleArray -> true
+   is CharArray -> true
+   is BooleanArray -> true
+   else -> false
 }
 
 internal fun isEnum(value: Any?) = when (value) {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/IsArrayTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/IsArrayTest.kt
@@ -1,0 +1,27 @@
+package com.sksamuel.kotest.matchers.equality
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.equality.isArray
+import io.kotest.matchers.shouldBe
+
+class IsArrayTest: StringSpec() {
+   init {
+      "isArray true" {
+         isArray(intArrayOf(1, 2, 3)) shouldBe true
+         isArray(arrayOf(1, 2, 3)) shouldBe true
+         isArray(BooleanArray(1)) shouldBe true
+         isArray(CharArray(1)) shouldBe true
+         isArray(ByteArray(1)) shouldBe true
+         isArray(IntArray(1)) shouldBe true
+         isArray(LongArray(1)) shouldBe true
+         isArray(FloatArray(1)) shouldBe true
+         isArray(DoubleArray(1)) shouldBe true
+      }
+      "isArray false" {
+         isArray(listOf(1, 2, 3)) shouldBe false
+         isArray("hello") shouldBe false
+         isArray(123) shouldBe false
+         isArray(null) shouldBe false
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/ReflectionKtTest.kt
@@ -303,6 +303,90 @@ class ReflectionKtTest : FunSpec() {
             EnumWrapper(EnumWithProperties.ONE).shouldBeEqualToComparingFields(EnumWrapper(EnumWithProperties.TWO))
          }.message.shouldContain("expected:<TWO> but was:<ONE>")
       }
+
+      test("shouldBeEqualToComparingFields handles ByteArray") {
+         class Test(
+            val test: kotlin.ByteArray
+         )
+         Test(ByteArray(1)) shouldBeEqualToComparingFields Test(ByteArray(1))
+         val actual = ByteArray(1)
+         actual[0] = 1
+         shouldFail {
+            Test(ByteArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<[1]> but was:<[0]>"
+      }
+
+      test("shouldBeEqualToComparingFields handles CharArray") {
+         class Test(
+            val test: kotlin.CharArray
+         )
+         Test(CharArray(1)) shouldBeEqualToComparingFields Test(CharArray(1))
+         val actual = CharArray(1)
+         actual[0] = '1'
+         shouldFail {
+            Test(CharArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<['1']> but was:<['\u0000']>"
+      }
+
+      test("shouldBeEqualToComparingFields handles ShortArray") {
+         class Test(
+            val test: kotlin.ShortArray
+         )
+         Test(ShortArray(1)) shouldBeEqualToComparingFields Test(ShortArray(1))
+         val actual = ShortArray(1)
+         actual[0] = 1
+         shouldFail {
+            Test(ShortArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<[1]> but was:<[0]>"
+      }
+
+      test("shouldBeEqualToComparingFields handles IntArray") {
+         class Test(
+            val test: kotlin.IntArray
+         )
+         Test(IntArray(1)) shouldBeEqualToComparingFields Test(IntArray(1))
+         val actual = IntArray(1)
+         actual[0] = 1
+         shouldFail {
+            Test(IntArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<[1]> but was:<[0]>"
+      }
+
+      test("shouldBeEqualToComparingFields handles LongArray") {
+         class Test(
+            val test: kotlin.LongArray
+         )
+         Test(LongArray(1)) shouldBeEqualToComparingFields Test(LongArray(1))
+         val actual = LongArray(1)
+         actual[0] = 1L
+         shouldFail {
+            Test(LongArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<[1L]> but was:<[0L]>"
+      }
+
+      test("shouldBeEqualToComparingFields handles FloatArray") {
+         class Test(
+            val test: kotlin.FloatArray
+         )
+         Test(FloatArray(1)) shouldBeEqualToComparingFields Test(FloatArray(1))
+         val actual = FloatArray(1)
+         actual[0] = 1.0F
+         shouldFail {
+            Test(FloatArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<[1.0f]> but was:<[0.0f]>"
+      }
+
+      test("shouldBeEqualToComparingFields handles DoubleArray") {
+         class Test(
+            val test: kotlin.DoubleArray
+         )
+         Test(DoubleArray(1)) shouldBeEqualToComparingFields Test(DoubleArray(1))
+         val actual = DoubleArray(1)
+         actual[0] = 1.0
+         shouldFail {
+            Test(DoubleArray(1)) shouldBeEqualToComparingFields Test(actual)
+         }.message shouldContain "expected:<[1.0]> but was:<[0.0]>"
+      }
    }
 
    data class KeyValuePair<T : Any>(


### PR DESCRIPTION
support arrays of primitives in shouldBeEqualToComparingFields

fixes https://github.com/kotest/kotest/issues/5031

