### PR TITLE
Fix `InstancePerLeaf` execution order

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
@@ -25,8 +25,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
-import kotlin.concurrent.atomics.AtomicBoolean
-import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
@@ -41,9 +39,6 @@ internal class InstancePerLeafSpecExecutor(
    private val extensions = SpecExtensions(context.specConfigResolver, context.projectConfigResolver)
    private val materializer = Materializer(context.specConfigResolver)
    private val results = TestResults()
-
-   @OptIn(ExperimentalAtomicApi::class)
-   private val seedUsed = AtomicBoolean(false)
 
    private val inflator = SpecRefInflator(
       registry = context.registry,
@@ -167,7 +162,6 @@ internal class InstancePerLeafSpecExecutor(
 
       private val logger = Logger(LeafLaunchingScope::class)
 
-      @OptIn(ExperimentalAtomicApi::class)
       override suspend fun registerTestCase(nested: NestedTest) {
          logger.log { Pair(testCase.name.name, "Discovered nested test '${nested.name.name}'") }
          val nestedTestCase = materializer.materialize(nested, testCase)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -79,3 +79,40 @@ class InstancePerLeafTest2 : DescribeSpec({
       }
    }
 })
+
+class InstancePerLeafTest3 : DescribeSpec({
+
+   isolationMode = IsolationMode.InstancePerLeaf
+
+   beforeSpec {
+      trace = ""
+   }
+
+   afterSpec {
+      trace shouldBe "d1_c1_i1_d2_c2_i2_"
+   }
+
+   describe("d1") {
+      trace += "d1_"
+
+      context("c1") {
+         trace += "c1_"
+
+         it("i1") {
+            trace += "i1_"
+         }
+      }
+   }
+
+   describe("d2") {
+      trace += "d2_"
+
+      context("c2") {
+         trace += "c2_"
+
+         it("i2") {
+            trace += "i2_"
+         }
+      }
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -11,7 +11,7 @@ class InstancePerLeafTest : DescribeSpec({
    isolationMode = IsolationMode.InstancePerLeaf
 
    afterSpec {
-      trace shouldBe "d1_c1_i1_c2_d1_c2_i2_"
+      trace shouldBe "d1_c1_i_d1_c2_i2_"
    }
 
    describe("d1") {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -52,20 +52,16 @@ class InstancePerLeafTest2 : DescribeSpec({
    }
 
    describe("d1") {
-      println("d1")
       trace += "d1_"
 
       context("c1") {
-         println("c1")
          trace += "c1_"
 
          it("i1") {
-            println("i1")
             trace += "i1_"
          }
 
          it("i2") {
-            println("i2")
             trace += "i2_"
          }
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -10,8 +10,12 @@ class InstancePerLeafTest : DescribeSpec({
 
    isolationMode = IsolationMode.InstancePerLeaf
 
+   beforeSpec {
+      trace = ""
+   }
+
    afterSpec {
-      trace shouldBe "d1_c1_i_d1_c2_i2_"
+      trace shouldBe "d1_c1_i1_d1_c2_i2_"
    }
 
    describe("d1") {
@@ -30,6 +34,47 @@ class InstancePerLeafTest : DescribeSpec({
 
          it("i2") {
             trace += "i2_"
+         }
+      }
+   }
+})
+
+class InstancePerLeafTest2 : DescribeSpec({
+
+   isolationMode = IsolationMode.InstancePerLeaf
+
+   beforeSpec {
+      trace = ""
+   }
+
+   afterSpec {
+      trace shouldBe "d1_c1_i1_d1_c1_i2_d1_c2_i3_"
+   }
+
+   describe("d1") {
+      println("d1")
+      trace += "d1_"
+
+      context("c1") {
+         println("c1")
+         trace += "c1_"
+
+         it("i1") {
+            println("i1")
+            trace += "i1_"
+         }
+
+         it("i2") {
+            println("i2")
+            trace += "i2_"
+         }
+      }
+
+      context("c2") {
+         trace += "c2_"
+
+         it("i3") {
+            trace += "i3_"
          }
       }
    }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

ref https://github.com/kotest/kotest/issues/5022

first, let me appreciate your quick fix for my issue.

unfortunately, your fix seemed not to fix completely
https://github.com/kotest/kotest/issues/5022#issuecomment-3219284408

i tried to fix it by myself. please kindly review my first PR
___

## Solution

the same `LeafLaunchingScope` instances are executed in siblings of test nodes (Container or Leaf).
it means that the first node is always fresh (or seed), and the second and latter nodes always should be executed in fresh spec.
in my solution, i added `hasVisitedFirstNode` property to `LeafLaunchingScope` to manage this.
if the visited nodes are not first one, the node and children nodes will be executed in a fresh spec.
it means that container nodes also can be treated as `target`. so, i extended `executeInFreshSpec` and `target` object comparison

## Concerns

- i removed `AtomicBoolean` and use just `Boolean` instead because the property is enclosed in `LeafLaunchingScope`. do you think this is ok?
- i execute Container type in `executeInFreshSpec`. to do that, i remove `require` block. is that no problem?
- i added some comments and logger. if you think there are more appropriate messages, please let me know.

thank you