### PR TITLE
Improved resource and json matchers

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -2955,14 +2955,13 @@ public final class io/kotest/matchers/resource/ByteArrayMatchersKt {
 }
 
 public final class io/kotest/matchers/resource/StringMatchersKt {
-	public static final fun matchResource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Z)Lio/kotest/matchers/Matcher;
-	public static final fun resourceAsString (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun matchResource (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZZ)Lio/kotest/matchers/Matcher;
 	public static final fun shouldMatchResource (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun shouldMatchResource (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Z)Ljava/lang/String;
-	public static synthetic fun shouldMatchResource$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/lang/String;
+	public static final fun shouldMatchResource (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZZ)Ljava/lang/String;
+	public static synthetic fun shouldMatchResource$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZZILjava/lang/Object;)Ljava/lang/String;
 	public static final fun shouldNotMatchResource (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-	public static final fun shouldNotMatchResource (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Z)Ljava/lang/String;
-	public static synthetic fun shouldNotMatchResource$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Ljava/lang/String;
+	public static final fun shouldNotMatchResource (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZZ)Ljava/lang/String;
+	public static synthetic fun shouldNotMatchResource$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ZZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class io/kotest/matchers/result/FailureMatcher : io/kotest/matchers/Matcher {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/byteArrayMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/byteArrayMatchers.kt
@@ -16,7 +16,7 @@ import kotlin.io.path.writeBytes
 infix fun ByteArray.shouldMatchResource(
    path: String
 ): ByteArray {
-   this should matchResource(path, ::be)
+   this should matchResource(resourcePath = path, matcherProvider = ::be)
    return this
 }
 
@@ -26,7 +26,7 @@ infix fun ByteArray.shouldMatchResource(
 infix fun ByteArray.shouldNotMatchResource(
    path: String
 ): ByteArray {
-   this shouldNot matchResource(path, ::be)
+   this shouldNot matchResource(resourcePath = path, matcherProvider = ::be)
    return this
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/stringMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/stringMatchers.kt
@@ -84,23 +84,23 @@ fun matchResource(
 ) = object : Matcher<String> {
 
    override fun test(value: String): MatcherResult {
-      val resource = getResource(resourcePath)
-      val resourceValue = resource.readText()
+      val expectedUrl = getResource(resourcePath)
+      val expected = expectedUrl.readText()
 
       val normalizedActual = if (ignoreLineSeparators) value.toLF() else value
-      val normalizedExpected = if (ignoreLineSeparators) resourceValue.toLF() else resourceValue
+      val normalizedExpected = if (ignoreLineSeparators) expected.toLF() else expected
 
       val trimmedActual = if (trim) normalizedActual.trim() else normalizedActual
       val trimmedExpected = if (trim) normalizedExpected.trim() else normalizedExpected
 
-      return matcherProvider(normalizedExpected).test(normalizedActual).let {
+      return matcherProvider(trimmedExpected).test(trimmedActual).let {
          ComparisonMatcherResult(
             passed = it.passed(),
             actual = StringPrint.printUnquoted(trimmedActual),
             expected = StringPrint.printUnquoted(trimmedExpected),
             failureMessageFn = {
 
-               val actualFilePath = normalizedActual.writeToActualValueFile(resource)
+               val actualFilePath = normalizedActual.writeToActualValueFile(expectedUrl)
 
                """${it.failureMessage()}
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/stringMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/stringMatchers.kt
@@ -1,6 +1,7 @@
 package io.kotest.matchers.resource
 
-import io.kotest.matchers.ComparableMatcherResult
+import io.kotest.assertions.print.StringPrint
+import io.kotest.matchers.ComparisonMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.be
@@ -20,7 +21,7 @@ import kotlin.io.path.writeText
 infix fun String.shouldMatchResource(
    path: String
 ): String {
-   this should matchResource(path, ::be, ignoreLineSeparators = true)
+   this should matchResource(path, ::be, ignoreLineSeparators = true, trim = false)
    return this
 }
 
@@ -32,19 +33,28 @@ infix fun String.shouldMatchResource(
 infix fun String.shouldNotMatchResource(
    path: String
 ): String {
-   this shouldNot matchResource(path, ::be, ignoreLineSeparators = true)
+   this shouldNot matchResource(path, ::be, ignoreLineSeparators = true, trim = false)
    return this
 }
 
 /**
  * Will match if the given String and the resource value matches using matcher provided by [matcherProvider]
+ *
+ * @param ignoreLineSeparators if true, will ignore differences in "\r", "\n" and "\r\n", so it is not dependent on the system line separator.
+ * @param trim if true, will trim the expected and actual values before comparing them.
  */
 fun String.shouldMatchResource(
-  path: String,
-  matcherProvider: (String) -> Matcher<String>,
-  ignoreLineSeparators: Boolean = true
+   path: String,
+   matcherProvider: (String) -> Matcher<String> = ::be,
+   ignoreLineSeparators: Boolean = true,
+   trim: Boolean = false,
 ): String {
-   this should matchResource(path, matcherProvider, ignoreLineSeparators)
+   this should matchResource(
+      resourcePath = path,
+      matcherProvider = matcherProvider,
+      ignoreLineSeparators = ignoreLineSeparators,
+      trim = trim,
+   )
    return this
 }
 
@@ -52,57 +62,64 @@ fun String.shouldMatchResource(
  * Will match if the given String and the resource value **not** matches using matcher provided by [matcherProvider]
  */
 fun String.shouldNotMatchResource(
-  path: String,
-  matcherProvider: (String) -> Matcher<String>,
-  ignoreLineSeparators: Boolean = true
+   path: String,
+   matcherProvider: (String) -> Matcher<String> = ::be,
+   ignoreLineSeparators: Boolean = true,
+   trim: Boolean = false,
 ): String {
-   this shouldNot matchResource(path, matcherProvider, ignoreLineSeparators)
+   this shouldNot matchResource(
+      resourcePath = path,
+      matcherProvider = matcherProvider,
+      ignoreLineSeparators = ignoreLineSeparators,
+      trim = trim
+   )
    return this
 }
 
 fun matchResource(
-  resourcePath: String,
-  matcherProvider: (String) -> Matcher<String>,
-  ignoreLineSeparators: Boolean
+   resourcePath: String,
+   matcherProvider: (String) -> Matcher<String>,
+   ignoreLineSeparators: Boolean,
+   trim: Boolean,
 ) = object : Matcher<String> {
 
    override fun test(value: String): MatcherResult {
       val resource = getResource(resourcePath)
       val resourceValue = resource.readText()
 
-      val normalizedValue = if (ignoreLineSeparators) value.toLF() else value
-      val normalizedResourceValue = if (ignoreLineSeparators) resourceValue.toLF() else resourceValue
+      val normalizedActual = if (ignoreLineSeparators) value.toLF() else value
+      val normalizedExpected = if (ignoreLineSeparators) resourceValue.toLF() else resourceValue
 
-      return matcherProvider(normalizedResourceValue).test(normalizedValue).let {
-         ComparableMatcherResult(
-            it.passed(),
-            {
-               val actualFilePath = normalizedValue.writeToActualValueFile(resource)
+      val trimmedActual = if (trim) normalizedActual.trim() else normalizedActual
+      val trimmedExpected = if (trim) normalizedExpected.trim() else normalizedExpected
+
+      return matcherProvider(normalizedExpected).test(normalizedActual).let {
+         ComparisonMatcherResult(
+            passed = it.passed(),
+            actual = StringPrint.printUnquoted(trimmedActual),
+            expected = StringPrint.printUnquoted(trimmedExpected),
+            failureMessageFn = {
+
+               val actualFilePath = normalizedActual.writeToActualValueFile(resource)
 
                """${it.failureMessage()}
 
-expected to match resource, but they differed
-Expected : $resourcePath
-Actual   : $actualFilePath
-
-"""
+            expected to match resource, but they differed
+            Expected : $resourcePath
+            Actual   : $actualFilePath"""
             },
-            {
+            negatedFailureMessageFn = {
                """${it.negatedFailureMessage()}
 
-expected not to match resource, but they match
-Expected : $resourcePath
-
-"""
+            expected not to match resource, but they match
+            Expected : $resourcePath"""
             },
-            normalizedValue,
-            normalizedResourceValue,
          )
       }
    }
 }
 
-fun resourceAsString(path: String) = getResource(path).readText()
+internal fun resourceAsString(path: String) = getResource(path).readText()
 
 internal fun getResource(path: String): URL =
    object {}.javaClass.getResource(path) ?: error("Failed to get resource at $path")

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/resource/ByteArrayResourceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/resource/ByteArrayResourceMatchersTest.kt
@@ -1,9 +1,10 @@
 package com.sksamuel.kotest.matchers.resource
 
 import io.kotest.assertions.AssertionErrorBuilder
+import io.kotest.assertions.print.StringPrint
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
-import io.kotest.matchers.ComparableMatcherResult
+import io.kotest.matchers.ComparisonMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.file.shouldExist
@@ -55,6 +56,16 @@ class ByteArrayResourceMatchersTest : ShouldSpec({
 
          actualValueFile.shouldExist()
          actualValueFile.readBytes() shouldBe givenValue
+      }
+
+      should("include diff") {
+         val givenValue = byteArrayOf(1, 2)
+
+         val errorMessage = shouldThrow<AssertionError> {
+            givenValue shouldMatchResource "/resourceMatchersTest/expected/binary42.bin"
+         }.message ?: AssertionErrorBuilder.fail("Cannot get error message")
+
+         errorMessage shouldContain "expected:<[4, 2]> but was:<[1, 2]"
       }
 
    }
@@ -122,12 +133,12 @@ class ByteArrayResourceMatchersTest : ShouldSpec({
 private fun lastBytesMatch(bytes: ByteArray) = object : Matcher<ByteArray> {
    override fun test(value: ByteArray): MatcherResult {
       val last = value.last()
-      return ComparableMatcherResult(
-         last == bytes.last(),
-         { "expected to match resource, but they differed" },
-         { "expected not to match resource, but they match" },
-         last.toString(),
-         bytes.last().toString()
+      return ComparisonMatcherResult(
+         passed = last == bytes.last(),
+         actual = StringPrint.printUnquoted(last.toString()),
+         expected = StringPrint.printUnquoted(bytes.last().toString()),
+         failureMessageFn = { "expected to match resource, but they differed" },
+         negatedFailureMessageFn = { "expected not to match resource, but they match" },
       )
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/resource/StringResourceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/resource/StringResourceMatchersTest.kt
@@ -57,6 +57,22 @@ class StringResourceMatchersTest : ShouldSpec({
          actualValueFile.readText() shouldBe givenValue
       }
 
+      should("include diff") {
+         val givenValue = "not a test resource"
+
+         val errorMessage = shouldThrow<AssertionError> {
+            givenValue shouldMatchResource "/resourceMatchersTest/expected/testResource.txt"
+         }.message ?: AssertionErrorBuilder.fail("Cannot get error message")
+
+         errorMessage shouldContain """expected:<test
+resource
+> but was:<not a test resource>"""
+      }
+
+      should("support trim") {
+         val givenValue = "     not a test resource       "
+         givenValue.shouldMatchResource("/resourceMatchersTest/expected/testResource.txt", trim = true)
+      }
    }
 
    context("shouldMatchResource with custom matcher") {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/resource/StringResourceMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/resource/StringResourceMatchersTest.kt
@@ -70,7 +70,7 @@ resource
       }
 
       should("support trim") {
-         val givenValue = "     not a test resource       "
+         val givenValue = "      test\nresource\n      "
          givenValue.shouldMatchResource("/resourceMatchersTest/expected/testResource.txt", trim = true)
       }
    }

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/jsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/jsonMatchers.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions.json
 
-import io.kotest.matchers.ComparableMatcherResult
+import io.kotest.assertions.print.StringPrint
+import io.kotest.matchers.ComparisonMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -20,7 +21,7 @@ fun matchJson(@Language("json") expected: String?) = object : Matcher<String?> {
    override fun test(value: String?): MatcherResult {
       val actualJson = try {
          value?.let(pretty::parseToJsonElement)
-      } catch (ex: Exception) {
+      } catch (_: Exception) {
          return MatcherResult(
             false,
             { "expected: actual json to be valid json: $value" },
@@ -30,7 +31,7 @@ fun matchJson(@Language("json") expected: String?) = object : Matcher<String?> {
 
       val expectedJson = try {
          expected?.let(pretty::parseToJsonElement)
-      } catch (ex: Exception) {
+      } catch (_: Exception) {
          return MatcherResult(
             false,
             { "expected: expected json to be valid json: $expected" },
@@ -38,12 +39,12 @@ fun matchJson(@Language("json") expected: String?) = object : Matcher<String?> {
          )
       }
 
-      return ComparableMatcherResult(
-         actualJson == expectedJson,
+      return ComparisonMatcherResult(
+         passed = actualJson == expectedJson,
+         actual = StringPrint.printUnquoted(actualJson.toString()),
+         expected = StringPrint.printUnquoted(expectedJson.toString()),
          { "expected json to match, but they differed\n" },
          { "expected not to match with: $expectedJson but match: $actualJson" },
-         actualJson.toString(),
-         expectedJson.toString()
       )
    }
 }
@@ -57,7 +58,7 @@ fun beValidJson() = object : Matcher<String?> {
             { "expected: actual json to be valid json: $value" },
             { "expected: actual json to be invalid json: $value" }
          )
-      } catch (ex: Exception) {
+      } catch (_: Exception) {
          MatcherResult(
             false,
             { "expected: actual json to be valid json: $value" },
@@ -72,7 +73,7 @@ fun beJsonType(kClass: KClass<*>) = object : Matcher<String?> {
    override fun test(value: String?): MatcherResult {
       val element = try {
          value?.let(pretty::parseToJsonElement)
-      } catch (ex: Exception) {
+      } catch (_: Exception) {
          return MatcherResult(
             false,
             { "expected: actual json to be valid json: $value" },

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -1,7 +1,8 @@
 package io.kotest.assertions.json
 
 import io.kotest.assertions.json.comparisons.compare
-import io.kotest.matchers.ComparableMatcherResult
+import io.kotest.assertions.print.StringPrint
+import io.kotest.matchers.ComparisonMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -53,12 +54,12 @@ private fun equalJsonTree(
          options,
       )?.asString()
 
-      ComparableMatcherResult(
-         error == null,
-         { "$error\n" },
-         { "Expected values to not match" },
-         value.raw,
-         expected.raw,
+      ComparisonMatcherResult(
+         passed = error == null,
+         actual = StringPrint.printUnquoted(value.raw),
+         expected = StringPrint.printUnquoted(expected.raw),
+         failureMessageFn = { "$error\n" },
+         negatedFailureMessageFn = { "Expected values to not match" },
       )
    }
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions.json
 
-import io.kotest.matchers.ComparableMatcherResult
+import io.kotest.assertions.print.StringPrint
+import io.kotest.matchers.ComparisonMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -27,12 +28,12 @@ fun matchJsonResource(resource: String) = object : Matcher<String?> {
          pretty.parseToJsonElement(it.readText())
       } ?: throw AssertionError("File should exist in resources: $resource")
 
-      return ComparableMatcherResult(
-         actualJson == expectedJson,
-         { "expected json to match, but they differed\n" },
-         { "expected not to match with: $expectedJson but match: $actualJson" },
-         actualJson.toString(),
-         expectedJson.toString(),
+      return ComparisonMatcherResult(
+         passed = actualJson == expectedJson,
+         actual = StringPrint.printUnquoted(actualJson.toString()),
+         expected = StringPrint.printUnquoted(expectedJson.toString()),
+         failureMessageFn = { "expected json to match, but they differed\n" },
+         negatedFailureMessageFn = { "expected not to match with: $expectedJson but match: $actualJson" },
       )
    }
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmTest/kotlin/com/sksamuel/kotest/tests/json/EqualTest.kt
@@ -44,7 +44,7 @@ class EqualTest : FunSpec() {
          }.shouldHaveMessage("Expected values to not match")
       }
 
-      test("f:comparing strings in objects") {
+      test("comparing strings in objects") {
 
          checkAll(Arb.string(1..10, Codepoint.az())) { string ->
             val a = """ { "a" : "$string" } """

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/Matcher.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/Matcher.kt
@@ -124,7 +124,7 @@ data class ComparisonMatcherResult(
    override fun negatedFailureMessage(): String = negatedFailureMessageFn()
 }
 
-@Deprecated("Use ValuesMatcherResult")
+@Deprecated("Use ComparisonMatcherResult")
 interface ComparableMatcherResult : MatcherResult {
 
    fun actual(): String
@@ -148,7 +148,7 @@ interface ComparableMatcherResult : MatcherResult {
    }
 }
 
-@Deprecated("Use ValuesMatcherResult")
+@Deprecated("Use ComparisonMatcherResult")
 interface EqualityMatcherResult : MatcherResult {
 
    fun actual(): Any?

--- a/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/DefaultFqnConfigClassTest.kt
+++ b/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/DefaultFqnConfigClassTest.kt
@@ -16,7 +16,7 @@ class DefaultFqnConfigClassTest : FunSpec() {
             .withListener(collector)
             .withClasses(BarTest::class)
             .launch()
-         collector.result("bar")?.errorOrNull?.message shouldBe "Test 'bar' did not complete within 2ms"
+         collector.result("bar")?.errorOrNull?.message shouldBe "Test 'bar' did not complete within 25ms"
       }
    }
 }

--- a/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -4,5 +4,5 @@ import io.kotest.core.config.AbstractProjectConfig
 import kotlin.time.Duration.Companion.milliseconds
 
 class ProjectConfig : AbstractProjectConfig() {
-   override val invocationTimeout = 2.milliseconds
+   override val invocationTimeout = 25.milliseconds
 }


### PR DESCRIPTION
- Updated deprecation messages to reflect the transition from `ValuesMatcherResult` to `ComparisonMatcherResult`.
- Improved flexibility of resource matchers by introducing `trim`
- Updated some json matchers to show the proper diff in intellij