### PR TITLE
Enable to execute `beforeSpec` lifecycle hooks for each `InstancePerLeaf` test execution

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
@@ -62,13 +62,13 @@ internal class InstancePerLeafSpecExecutor(
          // but any leaf tests will execute in a fresh instance of the spec.
 
          pipeline.execute(seed, specContext) {
-            launchRootTests(seed, ref, specContext)
+            launchRootTests(seed, ref)
             Result.success(results.toMap())
          }.map { results.toMap() }
       }
    }
 
-   private suspend fun launchRootTests(seed: Spec, ref: SpecRef, specContext: SpecContext) {
+   private suspend fun launchRootTests(seed: Spec, ref: SpecRef) {
 
       val roots = materializer.materialize(seed)
 
@@ -81,6 +81,7 @@ internal class InstancePerLeafSpecExecutor(
 
       coroutineScope { // will wait for all tests to complete
          roots.forEach {
+            val specContext = SpecContext.create()
             launch {
                semaphore.withPermit {
                   executeTest(it, null, specContext, ref)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
@@ -98,7 +98,7 @@ internal class InstancePerLeafSpecExecutor(
     *
     * It will locate the root that is the parent of the given [TestCase] and execute it in the new spec instance.
     */
-   private suspend fun executeInFreshSpec(testCase: TestCase, ref: SpecRef, specContext: SpecContext) {
+   private suspend fun executeInFreshSpec(testCase: TestCase, ref: SpecRef) {
       logger.log { "Enqueuing in a fresh spec ${testCase.descriptor}" }
 
       val spec = inflator.inflate(ref).getOrThrow()
@@ -106,6 +106,8 @@ internal class InstancePerLeafSpecExecutor(
       // we need to find the same root test but in the newly created spec
       val root = materializer.materialize(spec).first { it.descriptor.isPrefixOf(testCase.descriptor) }
       logger.log { "Located root for target $root" }
+
+      val specContext = SpecContext.create()
 
       // we switch to a new coroutine for each spec instance
       withContext(CoroutineName("spec-scope-" + spec.hashCode())) {
@@ -173,7 +175,7 @@ internal class InstancePerLeafSpecExecutor(
          }
          if (hasVisitedFirstNode) {
             logger.log { Pair(testCase.name.name, "Executing in fresh spec") }
-            executeInFreshSpec(nestedTestCase, ref, specContext)
+            executeInFreshSpec(nestedTestCase, ref)
             return
          }
          hasVisitedFirstNode = true

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
@@ -19,14 +19,14 @@ import io.kotest.engine.spec.interceptor.SpecInterceptorPipeline
 import io.kotest.engine.test.TestCaseExecutionListener
 import io.kotest.engine.test.TestCaseExecutor
 import io.kotest.engine.test.TestResult
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 
 @Suppress("DEPRECATION")
 @Deprecated("The semantics of instance per leaf are confusing and this mode should be avoided")
@@ -141,7 +141,7 @@ internal class InstancePerLeafSpecExecutor(
             testCase = testCase,
             target = target,
             specContext = specContext,
-            coroutineContext = coroutineContext,
+            coroutineContext = currentCoroutineContext(),
             ref = ref
          ),
          specContext = specContext

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -14,10 +14,6 @@ class InstancePerLeafTest : DescribeSpec({
       trace = ""
    }
 
-   afterSpec {
-      trace shouldBe "d1_c1_i1_d1_c2_i2_"
-   }
-
    describe("d1") {
       trace += "d1_"
 
@@ -26,6 +22,7 @@ class InstancePerLeafTest : DescribeSpec({
 
          it("i1") {
             trace += "i1_"
+            trace shouldBe "d1_c1_i1_"
          }
       }
 
@@ -34,6 +31,7 @@ class InstancePerLeafTest : DescribeSpec({
 
          it("i2") {
             trace += "i2_"
+            trace shouldBe "d1_c2_i2_"
          }
       }
    }
@@ -47,10 +45,6 @@ class InstancePerLeafTest2 : DescribeSpec({
       trace = ""
    }
 
-   afterSpec {
-      trace shouldBe "d1_c1_i1_d1_c1_i2_d1_c2_i3_"
-   }
-
    describe("d1") {
       trace += "d1_"
 
@@ -59,10 +53,12 @@ class InstancePerLeafTest2 : DescribeSpec({
 
          it("i1") {
             trace += "i1_"
+            trace shouldBe "d1_c1_i1_"
          }
 
          it("i2") {
             trace += "i2_"
+            trace shouldBe "d1_c1_i2_"
          }
       }
 
@@ -71,6 +67,7 @@ class InstancePerLeafTest2 : DescribeSpec({
 
          it("i3") {
             trace += "i3_"
+            trace shouldBe "d1_c2_i3_"
          }
       }
    }
@@ -84,10 +81,6 @@ class InstancePerLeafTest3 : DescribeSpec({
       trace = ""
    }
 
-   afterSpec {
-      trace shouldBe "d1_c1_i1_d2_c2_i2_"
-   }
-
    describe("d1") {
       trace += "d1_"
 
@@ -96,6 +89,7 @@ class InstancePerLeafTest3 : DescribeSpec({
 
          it("i1") {
             trace += "i1_"
+            trace shouldBe "d1_c1_i1_"
          }
       }
    }
@@ -108,6 +102,7 @@ class InstancePerLeafTest3 : DescribeSpec({
 
          it("i2") {
             trace += "i2_"
+            trace shouldBe "d2_c2_i2_"
          }
       }
    }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

ref #5061 

## Change points

as-is: use the same `specContext` instance on all test execution.
to-be: create new `specContext` instance every time when the tests are executed in fresh spec or new roots

## Why
[Lifecycle document](https://kotest.io/docs/framework/lifecycle-hooks.html) says that `beforeSpec` is called for each test instances (i.e., test execution in fresh spec), but currently no.
this PR fixes the behavior

## Concerns
this PR fixes only `beforeSpec` issue.
it means `afterSpec` still doesn't work well
i'll investigate this more deeply later.

thank you