### PR TITLE
Fix concurrency documentation

### DIFF
--- a/documentation/docs/framework/concurrency.md
+++ b/documentation/docs/framework/concurrency.md
@@ -6,7 +6,7 @@ slug: concurrency.html
 
 !!! note "Kotest 5.0"
   This document describes the concurrency features introduced in Kotest 5.0 that were marked experimental and have been changed for Kotest 6.0.
-  If you are using Kotest 6.0, please see [new concurrency documentation](https://kotest.io/docs/framework/concurrency6.0.html).
+  If you are using Kotest 6.0, please see [new concurrency documentation](https://kotest.io/docs/framework/concurrency6.html).
 
 
 Concurrency is at the heart of Kotlin, with compiler support for continuations (suspend functions), enabling

--- a/documentation/versioned_docs/version-6.0/framework/concurrency.md
+++ b/documentation/versioned_docs/version-6.0/framework/concurrency.md
@@ -6,7 +6,7 @@ slug: concurrency.html
 
 !!! note "Kotest 5.0"
   This document describes the concurrency features introduced in Kotest 5.0 that were marked experimental and have been changed for Kotest 6.0.
-  If you are using Kotest 6.0, please see [new concurrency documentation](https://kotest.io/docs/framework/concurrency6.0.html).
+  If you are using Kotest 6.0, please see [new concurrency documentation](https://kotest.io/docs/framework/concurrency6.html).
 
 
 Concurrency is at the heart of Kotlin, with compiler support for continuations (suspend functions), enabling


### PR DESCRIPTION
Fix broken link to version 6.0 concurrency documentation.
