### PR TITLE
allow StringSpec to use withData

### DIFF
--- a/documentation/docs/framework/datatesting/nested.md
+++ b/documentation/docs/framework/datatesting/nested.md
@@ -6,6 +6,7 @@ slug: nested-tests.html
 
 Kotest's data testing is extremely flexible and allows to unlimited nesting of data test constructs.
 Each extra nest will create another layer of nesting in the test output providing the cartesian join of all inputs.
+Please note that while `StringSpec` supports `withData`, this spec does not support `Nested Data Tests`.
 
 For example, in the following code snippet, we have two layers of nesting.
 

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -2944,6 +2944,23 @@ public final class io/kotest/datatest/ShouldSpecRootKt {
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/ShouldSpecRootScope;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)V
 }
 
+public final class io/kotest/datatest/StringSpecRootKt {
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/util/Map;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Lkotlin/jvm/functions/Function1;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Lkotlin/jvm/functions/Function1;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)V
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Ljava/util/Map;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Lkotlin/jvm/functions/Function1;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Lkotlin/jvm/functions/Function1;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Lkotlin/jvm/functions/Function1;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+	public static final fun withData (Lio/kotest/core/spec/style/scopes/StringSpecScope;Lkotlin/sequences/Sequence;Lkotlin/jvm/functions/Function3;)Ljava/lang/Void;
+}
+
 public final class io/kotest/datatest/WordSpecRootKt {
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function3;)V
 	public static final fun withData (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/Object;Ljava/lang/Object;[Ljava/lang/Object;Lkotlin/jvm/functions/Function3;)V

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/stringSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/stringSpecRoot.kt
@@ -1,0 +1,180 @@
+package io.kotest.datatest
+
+import io.kotest.core.spec.style.scopes.StringSpecRootScope
+import io.kotest.core.spec.style.scopes.StringSpecScope
+import io.kotest.engine.stable.StableIdents
+
+/**
+ * Registers tests at the root level for each element.
+ *
+ * The test name will be generated from the stable properties of the elements. See [StableIdents].
+ */
+fun <T> StringSpecRootScope.withData(
+   first: T,
+   second: T, // we need two elements here so the compiler can disambiguate from the sequence version
+   vararg rest: T,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   withData(listOf(first, second) + rest, test)
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   first: T,
+   second: T,
+   vararg rest: T,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+fun <T> StringSpecRootScope.withData(
+   nameFn: (T) -> String,
+   first: T,
+   second: T,  // we need two elements here so the compiler can disambiguate from the sequence version
+   vararg rest: T,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   withData(nameFn, listOf(first, second) + rest, test)
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   nameFn: (T) -> String,
+   first: T,
+   second: T,
+   vararg rest: T,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+/**
+ * Registers tests at the root level for each element of [ts].
+ *
+ * The test name will be generated from the stable properties of the elements. See [StableIdents].
+ */
+fun <T> StringSpecRootScope.withData(
+   ts: Sequence<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   withData(ts.toList(), test)
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   ts: Sequence<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+/**
+ * Registers tests at the root level for each element of [ts].
+ *
+ * The test name will be generated from the stable properties of the elements. See [StableIdents].
+ */
+fun <T> StringSpecRootScope.withData(
+   nameFn: (T) -> String,
+   ts: Sequence<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   withData(nameFn, ts.toList(), test)
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   nameFn: (T) -> String,
+   ts: Sequence<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+/**
+ * Registers tests at the root level for each element of [ts].
+ *
+ * The test name will be generated from the stable properties of the elements. See [StableIdents].
+ */
+fun <T> StringSpecRootScope.withData(
+   ts: Iterable<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   withData({ StableIdents.getStableIdentifier(it) }, ts, test)
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   ts: Iterable<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+/**
+ * Registers tests at the root level for each element of [ts].
+ *
+ * The test name will be generated from the given [nameFn] function.
+ */
+fun <T> StringSpecRootScope.withData(
+   nameFn: (T) -> String,
+   ts: Iterable<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   ts.forEach { t ->
+      nameFn(t).invoke { this.test(t) }
+   }
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   nameFn: (T) -> String,
+   ts: Iterable<T>,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+/**
+ * Registers tests at the root level for each tuple of [data], with the first value of the tuple
+ * used as the test name, and the second value passed to the test.
+ */
+fun <T> StringSpecRootScope.withData(
+   data: Map<String, T>,
+   test: suspend StringSpecScope.(T) -> Unit
+) {
+   data.forEach { (name, t) ->
+      name.invoke { this.test(t) }
+   }
+}
+
+@Deprecated(
+   "Nested withData is not supported inside StringSpec test bodies.",
+   level = DeprecationLevel.ERROR
+)
+fun <T> StringSpecScope.withData(
+   data: Map<String, T>,
+   test: suspend StringSpecScope.(T) -> Unit
+): Nothing = error("Nested withData is not supported in StringSpec")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestingRepeatedNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestingRepeatedNameTest.kt
@@ -2,6 +2,7 @@ package io.kotest.datatest
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.matchers.shouldBe
@@ -132,6 +133,20 @@ private class RepeatedNamesFunSpec : FunSpec() {
 }
 
 private class RepeatedNamesRootFunSpec : FunSpec() {
+   init {
+      withData(
+         Foo("sam"),
+         Foo("ham"),
+         Foo("sham"),
+         Foo("sham"),
+         Foo("ham"),
+         Foo("ham"),
+         Foo("sam"),
+      ) { }
+   }
+}
+
+private class RepeatedNamesRootStringSpec : StringSpec() {
    init {
       withData(
          Foo("sam"),

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/styles/StringSpecDataTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/styles/StringSpecDataTest.kt
@@ -1,0 +1,92 @@
+package io.kotest.datatest.styles
+
+import io.kotest.core.names.DuplicateTestNameMode
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.datatest.FruitWithMemberNameCollision
+import io.kotest.datatest.PythagTriple
+import io.kotest.datatest.withData
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldHaveLength
+
+class StringSpecDataTest : StringSpec() {
+   init {
+
+      duplicateTestNameMode = DuplicateTestNameMode.Silent
+
+      var count = 0
+
+      afterTest {
+         count++
+      }
+
+      afterSpec {
+         count shouldBe 19
+      }
+
+      // test root level with varargs
+      withData(
+         PythagTriple(3, 4, 5),
+         PythagTriple(6, 8, 10),
+      ) { (a, b, c) ->
+         a * a + b * b shouldBe c * c
+      }
+
+      // test root level with a sequence
+      withData(
+         sequenceOf(
+            PythagTriple(8, 15, 17),
+            PythagTriple(9, 12, 15),
+            PythagTriple(15, 20, 25),
+         )
+      ) { (a, b, c) ->
+         a * a + b * b shouldBe c * c
+      }
+
+      // test root level with an iterable
+      withData(
+         listOf(
+            PythagTriple(8, 15, 17),
+            PythagTriple(9, 12, 15),
+            PythagTriple(15, 20, 25),
+         )
+      ) { (a, b, c) ->
+         a * a + b * b shouldBe c * c
+      }
+
+      // testing repeated names get mangled
+      var index = 0
+      withData("a", "a", "a") {
+         when (index) {
+            0 -> this.testCase.name.name shouldBe "a"
+            1 -> this.testCase.name.name shouldBe "(1) a"
+            2 -> this.testCase.name.name shouldBe "(2) a"
+         }
+         index++
+      }
+
+      // tests with varargs
+      withData("p", "q") { a ->
+         a shouldHaveLength 1
+      }
+
+      // tests with sequences
+      withData(listOf("r", "s")) { a ->
+         a shouldHaveLength 1
+      }
+
+      // tests with iterables
+      withData(sequenceOf("x", "y")) { a ->
+         a shouldHaveLength 1
+      }
+
+
+      // handle collision between function name and property name
+      withData(
+         FruitWithMemberNameCollision("apple", 11),
+         FruitWithMemberNameCollision("orange", 12),
+      ) { (_, weight) ->
+         weight shouldBeGreaterThan 10
+      }
+   }
+}


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
This attempts to introduce `withData` to `StringSpec` as per this issue I created https://github.com/kotest/kotest/issues/5073.

The idea behind this PR is that `StringSpec` can have access to its own `withData` implementation, by calling the only `method` it has to add tests (`invoke`) and disallowing nested `withData` tests 