### PR TITLE
Fix double Spring context initialization with @ContextCustomizerFacto…

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/api/kotest-extensions-spring.api
+++ b/kotest-extensions/kotest-extensions-spring/api/kotest-extensions-spring.api
@@ -9,6 +9,7 @@ public final class io/kotest/extensions/spring/SpringAutowireConstructorExtensio
 }
 
 public final class io/kotest/extensions/spring/SpringExtension : io/kotest/core/extensions/ConstructorExtension, io/kotest/core/extensions/SpecExtension, io/kotest/core/extensions/TestCaseExtension, io/kotest/core/listeners/AfterTestListener, io/kotest/core/listeners/BeforeTestListener {
+	public static final field Companion Lio/kotest/extensions/spring/SpringExtension$Companion;
 	public fun <init> ()V
 	public fun <init> (Lio/kotest/extensions/spring/SpringTestLifecycleMode;)V
 	public synthetic fun <init> (Lio/kotest/extensions/spring/SpringTestLifecycleMode;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -21,6 +22,9 @@ public final class io/kotest/extensions/spring/SpringExtension : io/kotest/core/
 	public fun intercept (Lio/kotest/core/spec/Spec;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun intercept (Lio/kotest/core/test/TestCase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setIgnoreSpringListenerOnFinalClassWarning (Z)V
+}
+
+public final class io/kotest/extensions/spring/SpringExtension$Companion {
 }
 
 public final class io/kotest/extensions/spring/SpringTestContextCoroutineContextElement : kotlin/coroutines/AbstractCoroutineContextElement {


### PR DESCRIPTION
# Fix double Spring context initialization with @ContextCustomizerFactories

## Issue
When using Kotest 6 with Spring extension and the `@ContextCustomizerFactories` annotation, the Spring application context is initialized twice instead of once. This regression was introduced in Kotest 6.0 when the `SpringExtension` combined the functionality of `SpringAutowireConstructorExtension` and `SpringTestExtension`.

## Root Cause
The issue stems from `SpringExtension` creating two separate `TestContextManager` instances:

1. **First instance**: Created in the `instantiate()` method when a spec class has constructor parameters that need autowiring
2. **Second instance**: Created in the `intercept(spec: Spec)` method for managing the Spring test lifecycle

Each `TestContextManager` instance can potentially create its own `ApplicationContext`. When `@ContextCustomizerFactories` is present, it affects Spring's context caching behavior, resulting in two separate contexts being initialized.

### Code Flow Analysis
```kotlin
// First TestContextManager created here for constructor injection
override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
    // ...
    val manager = TestContextManager(clazz.java)  // <-- Instance 1
    val context = manager.testContext.applicationContext
    // ...
}

// Second TestContextManager created here for lifecycle management  
override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
    val context = TestContextManager(spec::class.java)  // <-- Instance 2
    // ...
}
```

## Solution
The fix introduces a cache to ensure the same `TestContextManager` instance is reused throughout the spec lifecycle:

```kotlin
companion object {
    private val testContextManagerCache = ConcurrentHashMap<Class<*>, TestContextManager>()
}
```

Both methods now use `computeIfAbsent()` to retrieve or create the `TestContextManager`:
- `instantiate()`: `testContextManagerCache.computeIfAbsent(clazz.java) { TestContextManager(it) }`
- `intercept()`: `testContextManagerCache.computeIfAbsent(spec::class.java) { TestContextManager(it) }`

## Testing
The fix has been validated with the reproduction example provided in issue #5056:
- ✅ Without `@ContextCustomizerFactories`: Single context initialization (as expected)
- ✅ With `@ContextCustomizerFactories`: Single context initialization (fixed)
- ✅ Kotest 5 behavior maintained: Single context initialization

### Test Results
```
# Before fix (Kotest 6.0.1)
WithContextCustomizerFactoryTest: 2 Spring contexts initialized ❌
WithoutContextCustomizerFactoryTest: 1 Spring context initialized ✅

# After fix (Kotest 6.0.0-LOCAL)
WithContextCustomizerFactoryTest: 1 Spring context initialized ✅
WithoutContextCustomizerFactoryTest: 1 Spring context initialized ✅
```

## Impact
- **Fixes**: Issue #5056 - Double Spring context initialization
- **Maintains**: Backward compatibility with existing Spring tests
- **Improves**: Test performance by avoiding redundant context initialization

## References
- Issue: #5056
- Reproduction example: https://github.com/manuarlin/kotest-v6-potential-issue


# Code Changes Summary

## Modified File
`kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt`

## Changes Made

1. **Added import**: `import java.util.concurrent.ConcurrentHashMap`

2. **Added companion object with cache**:
```kotlin
companion object {
    // Cache to store TestContextManager instances per spec class to avoid double initialization
    private val testContextManagerCache = ConcurrentHashMap<Class<*>, TestContextManager>()
}
```

3. **Modified `instantiate` method** to use the cache:
```kotlin
// Before:
val manager = TestContextManager(clazz.java)

// After:
val manager = testContextManagerCache.computeIfAbsent(clazz.java) { TestContextManager(it) }
```

4. **Modified `intercept(spec: Spec)` method** to use the cache:
```kotlin
// Before:
val context = TestContextManager(spec::class.java)

// After:
val context = testContextManagerCache.computeIfAbsent(spec::class.java) { TestContextManager(it) }
```

## API Changes
The companion object addition required updating the API file:
- Run `./gradlew :kotest-extensions:kotest-extensions-spring:apiDump` to update API declarations
- Added `SpringExtension$Companion` to the public API