### PR TITLE
fix(extensions): Use the correct materialized type for TestContainer

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
+++ b/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
@@ -396,7 +396,7 @@ public final class io/kotest/extensions/testcontainers/TestContainerProjectExten
 	public fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun mount (Lkotlin/jvm/functions/Function1;)V
+	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/GenericContainer;
 	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -416,7 +416,7 @@ public final class io/kotest/extensions/testcontainers/TestContainerSpecExtensio
 	public fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun mount (Lkotlin/jvm/functions/Function1;)V
+	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/GenericContainer;
 	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
@@ -16,13 +16,14 @@ import org.testcontainers.containers.GenericContainer
  *
  * @param container the specific test container type
  */
-class TestContainerProjectExtension(
-   private val container: GenericContainer<*>,
-) : MountableExtension<GenericContainer<*>, Unit>, AfterProjectListener, TestListener {
+class TestContainerProjectExtension<T : GenericContainer<*>>(
+   private val container: T,
+) : MountableExtension<T, T>, AfterProjectListener, TestListener {
 
-   override fun mount(configure: GenericContainer<*>.() -> Unit): Unit {
+   override fun mount(configure: T.() -> Unit): T {
       configure(container)
       container.start()
+      return container
    }
 
    override suspend fun afterProject() {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerSpecExtension.kt
@@ -16,13 +16,14 @@ import org.testcontainers.containers.GenericContainer
  *
  * @param container the specific test container type
  */
-class TestContainerSpecExtension(
-   private val container: GenericContainer<*>,
-) : MountableExtension<GenericContainer<*>, Unit>, AfterSpecListener, TestListener {
+class TestContainerSpecExtension<T : GenericContainer<*>>(
+   private val container: T,
+) : MountableExtension<T, T>, AfterSpecListener, TestListener {
 
-   override fun mount(configure: GenericContainer<*>.() -> Unit): Unit {
+   override fun mount(configure: T.() -> Unit): T {
       configure(container)
       container.start()
+      return container
    }
 
    override suspend fun afterSpec(spec: Spec) {


### PR DESCRIPTION
This restores the typing from the deprecated `ContainerExtension`. Otherwise `install` would always return `Unit`.