### PR TITLE
Restore io.kotest.assertions.fail

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -56,6 +56,7 @@ public final class io/kotest/assertions/ExtractingKt {
 }
 
 public final class io/kotest/assertions/FailKt {
+	public static final fun fail (Ljava/lang/String;)Ljava/lang/Void;
 	public static final fun shouldFail (Lkotlin/jvm/functions/Function0;)Ljava/lang/AssertionError;
 	public static final fun shouldFailWithMessage (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/AssertionError;
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/fail.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/fail.kt
@@ -48,3 +48,5 @@ inline fun shouldFailWithMessage(message: String, block: () -> Any?): AssertionE
    shouldFail(block).also { t ->
       t.message shouldBe message
    }
+
+fun fail(msg: String): Nothing = AssertionErrorBuilder.fail(msg)


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
