### PR TITLE
Positive Boolean matchers return non-null by contract

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1056,8 +1056,8 @@ public final class io/kotest/matchers/bigdecimal/ToleranceMatcher : io/kotest/ma
 }
 
 public final class io/kotest/matchers/booleans/BooleanMatchersKt {
-	public static final fun shouldBeFalse (Ljava/lang/Boolean;)Ljava/lang/Boolean;
-	public static final fun shouldBeTrue (Ljava/lang/Boolean;)Ljava/lang/Boolean;
+	public static final fun shouldBeFalse (Ljava/lang/Boolean;)Z
+	public static final fun shouldBeTrue (Ljava/lang/Boolean;)Z
 	public static final fun shouldNotBeFalse (Ljava/lang/Boolean;)Ljava/lang/Boolean;
 	public static final fun shouldNotBeTrue (Ljava/lang/Boolean;)Ljava/lang/Boolean;
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
@@ -2,6 +2,8 @@ package io.kotest.matchers.booleans
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 /**
  * Asserts that this [Boolean] is true
@@ -20,9 +22,14 @@ import io.kotest.matchers.shouldNotBe
  * @see [Boolean?.shouldNotBeFalse]
  * @see [Boolean?.shouldBeFalse]
  */
-fun Boolean?.shouldBeTrue(): Boolean? {
+@OptIn(ExperimentalContracts::class)
+fun Boolean?.shouldBeTrue(): Boolean {
+   contract {
+      returns() implies (this@shouldBeTrue != null)
+   }
+
    this shouldBe true
-   return this
+   return this!!
 }
 
 /**
@@ -64,9 +71,14 @@ fun Boolean?.shouldNotBeTrue(): Boolean? {
  * @see [Boolean?.shouldNotBeTrue]
  * @see [Boolean?.shouldBeTrue]
  */
-fun Boolean?.shouldBeFalse(): Boolean? {
+@OptIn(ExperimentalContracts::class)
+fun Boolean?.shouldBeFalse(): Boolean {
+   contract {
+      returns() implies (this@shouldBeFalse != null)
+   }
+
    this shouldBe false
-   return this
+   return this!!
 }
 
 /**


### PR DESCRIPTION
If `shouldBeTrue` or `shouldBeFalse` pass, we know the Boolean can't be null, so enforce it by contract.