### PR TITLE
Increment the assertion counter in Arrow assertions that do not call core assertions

### DIFF
--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Either.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Either.kt
@@ -6,6 +6,7 @@ import arrow.core.Either.Right
 import arrow.core.identity
 import io.kotest.assertions.arrow.shouldBe
 import io.kotest.assertions.arrow.shouldNotBe
+import io.kotest.matchers.assertionCounter
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -30,20 +31,22 @@ import kotlin.contracts.contract
  */
 @OptIn(ExperimentalContracts::class)
 public fun <A, B> Either<A, B>.shouldBeRight(failureMessage: (A) -> String = { "Expected Either.Right, but found Either.Left with value $it" }): B {
-  contract {
-    returns() implies (this@shouldBeRight is Right<B>)
-  }
-  return when (this) {
-    is Right -> value
-    is Left -> throw AssertionError(failureMessage(value))
-  }
+   contract {
+      returns() implies (this@shouldBeRight is Right<B>)
+   }
+   assertionCounter.inc()
+
+   return when (this) {
+      is Right -> value
+      is Left -> throw AssertionError(failureMessage(value))
+   }
 }
 
 public infix fun <A, B> Either<A, B>.shouldBeRight(b: B): B =
-  shouldBeRight().shouldBe(b)
+   shouldBeRight().shouldBe(b)
 
 public infix fun <A, B> Either<A, B>.shouldNotBeRight(b: B): B =
-  shouldBeRight().shouldNotBe(b)
+   shouldBeRight().shouldNotBe(b)
 
 /**
  * smart casts to [Either.Left] and fails with [failureMessage] otherwise.
@@ -64,21 +67,23 @@ public infix fun <A, B> Either<A, B>.shouldNotBeRight(b: B): B =
  */
 @OptIn(ExperimentalContracts::class)
 public fun <A, B> Either<A, B>.shouldBeLeft(failureMessage: (B) -> String = { "Expected Either.Left, but found Either.Right with value $it" }): A {
-  contract {
-    returns() implies (this@shouldBeLeft is Left<A>)
-  }
-  return when (this) {
-    is Left -> value
-    is Right -> throw AssertionError(failureMessage(value))
-  }
+   contract {
+      returns() implies (this@shouldBeLeft is Left<A>)
+   }
+   assertionCounter.inc()
+
+   return when (this) {
+      is Left -> value
+      is Right -> throw AssertionError(failureMessage(value))
+   }
 }
 
 public infix fun <A, B> Either<A, B>.shouldBeLeft(a: A): A =
-  shouldBeLeft().shouldBe(a)
+   shouldBeLeft().shouldBe(a)
 
 public infix fun <A, B> Either<A, B>.shouldNotBeLeft(a: A): A =
-  shouldBeLeft().shouldNotBe(a)
+   shouldBeLeft().shouldNotBe(a)
 
 /** for testing success & error scenarios with an [Either] generator **/
 public fun <A> Either<Throwable, A>.rethrow(): A =
-  fold({ throw it }, ::identity)
+   fold({ throw it }, ::identity)

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
@@ -10,67 +10,71 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.assertionCounter
 import io.kotest.matchers.should
 
 /**
  * smart casts to [Ior.Right] and fails with [failureMessage] otherwise.
  */
 @OptIn(ExperimentalContracts::class)
-public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Right, but found ${it::class.simpleName}" }): B {
-  contract {
-    returns() implies (this@shouldBeRight is Right<B>)
-  }
-  return when (this) {
-    is Right -> value
-    else -> throw AssertionError(failureMessage(this))
-  }
+public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A, B>) -> String = { "Expected Ior.Right, but found ${it::class.simpleName}" }): B {
+   contract {
+      returns() implies (this@shouldBeRight is Right<B>)
+   }
+   assertionCounter.inc()
+
+   return when (this) {
+      is Right -> value
+      else -> throw AssertionError(failureMessage(this))
+   }
 }
 
 public infix fun <A, B> Ior<A, B>.shouldBeRight(b: B): B =
-  shouldBeRight().shouldBe(b)
+   shouldBeRight().shouldBe(b)
 
 public infix fun <A, B> Ior<A, B>.shouldNotBeRight(b: B): B =
-  shouldBeRight().shouldNotBe(b)
+   shouldBeRight().shouldNotBe(b)
 
 /**
  * smart casts to [Ior.Left] and fails with [failureMessage] otherwise.
  */
 @OptIn(ExperimentalContracts::class)
-public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A,B>) -> String = { "Expected Ior.Left, but found ${it::class.simpleName}" }): A {
-  contract {
-    returns() implies (this@shouldBeLeft is Left<A>)
-  }
-  return when (this) {
-    is Left -> value
-    else -> throw AssertionError(failureMessage(this))
-  }
+public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A, B>) -> String = { "Expected Ior.Left, but found ${it::class.simpleName}" }): A {
+   contract {
+      returns() implies (this@shouldBeLeft is Left<A>)
+   }
+   assertionCounter.inc()
+
+   return when (this) {
+      is Left -> value
+      else -> throw AssertionError(failureMessage(this))
+   }
 }
 
 public infix fun <A, B> Ior<A, B>.shouldBeLeft(a: A): A =
-  shouldBeLeft().shouldBe(a)
+   shouldBeLeft().shouldBe(a)
 
 public infix fun <A, B> Ior<A, B>.shouldNotBeLeft(a: A): A =
-  shouldBeLeft().shouldNotBe(a)
+   shouldBeLeft().shouldNotBe(a)
 
-public fun <A,B> beBoth(): Matcher<Ior<A,B>> = Matcher {
- ior ->
-  MatcherResult(
-    ior is Both,
-    { "Expected ior to be a Both, but was: ${ior::class.simpleName}" },
-    { "Expected ior to not be a Both." }
-  )
+public fun <A, B> beBoth(): Matcher<Ior<A, B>> = Matcher { ior ->
+   MatcherResult(
+      ior is Both,
+      { "Expected ior to be a Both, but was: ${ior::class.simpleName}" },
+      { "Expected ior to not be a Both." }
+   )
 }
 
 /**
  * smart casts to [Ior.Both]
  */
 @OptIn(ExperimentalContracts::class)
-public fun <A, B> Ior<A, B>.shouldBeBoth(): Ior.Both<A,B> {
-  contract {
-    returns() implies (this@shouldBeBoth is Ior.Both<A,B>)
-  }
+public fun <A, B> Ior<A, B>.shouldBeBoth(): Ior.Both<A, B> {
+   contract {
+      returns() implies (this@shouldBeBoth is Ior.Both<A, B>)
+   }
 
-  this should beBoth()
+   this should beBoth()
 
-  return this as Ior.Both<A,B>
+   return this as Ior.Both<A, B>
 }

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Option.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Option.kt
@@ -5,6 +5,7 @@ import arrow.core.Option
 import arrow.core.Some
 import io.kotest.assertions.arrow.shouldBe
 import io.kotest.assertions.arrow.shouldNotBe
+import io.kotest.matchers.assertionCounter
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -28,20 +29,22 @@ import kotlin.contracts.contract
  */
 @OptIn(ExperimentalContracts::class)
 public fun <A> Option<A>.shouldBeSome(failureMessage: () -> String = { "Expected Some, but found None" }): A {
-  contract {
-    returns() implies (this@shouldBeSome is Some<A>)
-  }
-  return when (this) {
-    None -> throw AssertionError(failureMessage())
-    is Some -> value
-  }
+   contract {
+      returns() implies (this@shouldBeSome is Some<A>)
+   }
+   assertionCounter.inc()
+
+   return when (this) {
+      None -> throw AssertionError(failureMessage())
+      is Some -> value
+   }
 }
 
 public infix fun <A> Option<A>.shouldBeSome(a: A): A =
-  shouldBeSome().shouldBe(a)
+   shouldBeSome().shouldBe(a)
 
 public infix fun <A> Option<A>.shouldNotBeSome(a: A): A =
-  shouldBeSome().shouldNotBe(a)
+   shouldBeSome().shouldNotBe(a)
 
 /**
  * smart casts to [None] and fails with [failureMessage] otherwise.
@@ -63,11 +66,13 @@ public infix fun <A> Option<A>.shouldNotBeSome(a: A): A =
  */
 @OptIn(ExperimentalContracts::class)
 public fun <A> Option<A>.shouldBeNone(failureMessage: (Some<A>) -> String = { "Expected None, but found Some with value ${it.value}" }): None {
-  contract {
-    returns() implies (this@shouldBeNone is None)
-  }
-  return when (this) {
-    None -> None
-    is Some -> throw AssertionError(failureMessage(this))
-  }
+   contract {
+      returns() implies (this@shouldBeNone is None)
+   }
+   assertionCounter.inc()
+
+   return when (this) {
+      None -> None
+      is Some -> throw AssertionError(failureMessage(this))
+   }
 }

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Raise.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Raise.kt
@@ -4,6 +4,7 @@ import arrow.core.raise.Raise
 import arrow.core.raise.recover
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.print.print
+import io.kotest.matchers.assertionCounter
 
 /**
  * Verifies if a block of code will raise a specified type of [T] (or subclasses).
@@ -18,17 +19,19 @@ import io.kotest.assertions.print.print
  * ```
  */
 public inline fun <reified T> shouldRaise(block: Raise<Any?>.() -> Any?): T {
-  val expectedRaiseClass = T::class
-  return recover({
-    block(this)
-     AssertionErrorBuilder.fail("Expected to raise ${expectedRaiseClass.simpleName} but nothing was raised.")
-  }) { raised ->
-    when (raised) {
-      is T -> raised
-      null -> AssertionErrorBuilder.fail("Expected to raise ${expectedRaiseClass.simpleName} but <null> was raised instead.")
-      else -> AssertionErrorBuilder.fail("Expected to raise ${expectedRaiseClass.simpleName} but ${raised::class.simpleName} was raised instead.")
-    }
-  }
+   assertionCounter.inc()
+
+   val expectedRaiseClass = T::class
+   return recover({
+      block(this)
+      AssertionErrorBuilder.fail("Expected to raise ${expectedRaiseClass.simpleName} but nothing was raised.")
+   }) { raised ->
+      when (raised) {
+         is T -> raised
+         null -> AssertionErrorBuilder.fail("Expected to raise ${expectedRaiseClass.simpleName} but <null> was raised instead.")
+         else -> AssertionErrorBuilder.fail("Expected to raise ${expectedRaiseClass.simpleName} but ${raised::class.simpleName} was raised instead.")
+      }
+   }
 }
 
 /**
@@ -41,7 +44,9 @@ public inline fun <reified T> shouldRaise(block: Raise<Any?>.() -> Any?): T {
  * ```
  */
 public inline fun <T> shouldNotRaise(block: Raise<Any?>.() -> T): T {
-  return recover(block) { raised ->
-     AssertionErrorBuilder.fail("No raise expected, but ${raised.print().value} was raised.")
-  }
+   assertionCounter.inc()
+
+   return recover(block) { raised ->
+      AssertionErrorBuilder.fail("No raise expected, but ${raised.print().value} was raised.")
+   }
 }


### PR DESCRIPTION
Some of the Arrow assertions (those with an optional failure message in particular) do not increment the assertion counter and cause false positives with `AssertionMode.Error` enabled.
This PR just adds the calls to increment the counter to the affected functions.