### PR TITLE
add days when daylight saving time is on/off to edge cases of Arb.datesBetween

### DIFF
--- a/documentation/docs/proptest/date_gens.md
+++ b/documentation/docs/proptest/date_gens.md
@@ -14,9 +14,9 @@ To use, add `io.kotest.extensions:kotest-property-datetime:version` to your buil
 [<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-property-datetime?label=latest%20release"/>](https://search.maven.org/search?q=kotest-property-datetime)
 
 
-| Generator                                                      | Description                                                                             | JVM | JS  | Native |
-|----------------------------------------------------------------|-----------------------------------------------------------------------------------------|-----|-----|--------|
-| `Arb.date(yearRange)`                                          | Generates `LocalDate`s with the year between the given range and other fields randomly. | ✓   | ✓   | ✓      |
-| `Arb.datesBetween(startDate, endDate)`                         | Generates `LocalDate`s in the given range.                                              | ✓   | ✓   | ✓      |
-| `Arb.datetime(yearRange, hourRange, minuteRange, secondRange)` | Generates `LocalDateTime`s with all fields in the given ranges                          | ✓   | ✓   | ✓      |
-| `Arb.instant(range)`                                           | Generates `Instant`s with the epoch randomly generated in the given range               | ✓   | ✓   | ✓      |
+| Generator                                                      | Description                                                                                                                       | JVM | JS  | Native |
+|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|-----|-----|--------|
+| `Arb.date(yearRange)`                                          | Generates `LocalDate`s with the year between the given range and other fields randomly.                                           | ✓   | ✓   | ✓      |
+| `Arb.datesBetween(startDate, endDate, zoneId)`                 | Generates `LocalDate`s in the given range. If zoneId is provided, days of daylight saving time changes are included in edge cases | ✓   | ✓   | ✓      |
+| `Arb.datetime(yearRange, hourRange, minuteRange, secondRange)` | Generates `LocalDateTime`s with all fields in the given ranges                                                                    | ✓   | ✓   | ✓      |
+| `Arb.instant(range)`                                           | Generates `Instant`s with the epoch randomly generated in the given range                                                         | ✓   | ✓   | ✓      |

--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -873,8 +873,8 @@ public final class io/kotest/property/arbitrary/DatesKt {
 	public static final fun javaInstant (Lio/kotest/property/Arb$Companion;Lkotlin/ranges/ClosedRange;)Lio/kotest/property/Arb;
 	public static synthetic fun javaInstant$default (Lio/kotest/property/Arb$Companion;Ljava/time/Instant;Ljava/time/Instant;ILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static final fun localDate (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
-	public static final fun localDate (Lio/kotest/property/Arb$Companion;Ljava/time/LocalDate;Ljava/time/LocalDate;)Lio/kotest/property/Arb;
-	public static synthetic fun localDate$default (Lio/kotest/property/Arb$Companion;Ljava/time/LocalDate;Ljava/time/LocalDate;ILjava/lang/Object;)Lio/kotest/property/Arb;
+	public static final fun localDate (Lio/kotest/property/Arb$Companion;Ljava/time/LocalDate;Ljava/time/LocalDate;Ljava/time/ZoneId;)Lio/kotest/property/Arb;
+	public static synthetic fun localDate$default (Lio/kotest/property/Arb$Companion;Ljava/time/LocalDate;Ljava/time/LocalDate;Ljava/time/ZoneId;ILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static final fun localDateTime (Lio/kotest/property/Arb$Companion;II)Lio/kotest/property/Arb;
 	public static final fun localDateTime (Lio/kotest/property/Arb$Companion;ILjava/lang/Integer;)Lio/kotest/property/Arb;
 	public static final fun localDateTime (Lio/kotest/property/Arb$Companion;Ljava/lang/Integer;I)Lio/kotest/property/Arb;
@@ -882,6 +882,7 @@ public final class io/kotest/property/arbitrary/DatesKt {
 	public static synthetic fun localDateTime$default (Lio/kotest/property/Arb$Companion;ILjava/lang/Integer;ILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static synthetic fun localDateTime$default (Lio/kotest/property/Arb$Companion;Ljava/lang/Integer;IILjava/lang/Object;)Lio/kotest/property/Arb;
 	public static synthetic fun localDateTime$default (Lio/kotest/property/Arb$Companion;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;ILjava/lang/Object;)Lio/kotest/property/Arb;
+	public static final fun localDateTimeChanges (Ljava/time/ZoneId;Ljava/time/LocalDateTime;)Lkotlin/sequences/Sequence;
 	public static final fun localTime (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
 	public static final fun localTime (Lio/kotest/property/Arb$Companion;Ljava/time/LocalTime;Ljava/time/LocalTime;)Lio/kotest/property/Arb;
 	public static synthetic fun localTime$default (Lio/kotest/property/Arb$Companion;Ljava/time/LocalTime;Ljava/time/LocalTime;ILjava/lang/Object;)Lio/kotest/property/Arb;
@@ -1068,6 +1069,29 @@ public final class io/kotest/property/arbitrary/ListShrinker : io/kotest/propert
 	public fun <init> (Lkotlin/ranges/IntRange;)V
 	public synthetic fun shrink (Ljava/lang/Object;)Ljava/util/List;
 	public fun shrink (Ljava/util/List;)Ljava/util/List;
+}
+
+public final class io/kotest/property/arbitrary/LocalDateTimeChange {
+	public fun <init> (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;)V
+	public final fun component1 ()Ljava/time/LocalDateTime;
+	public final fun component2 ()Ljava/time/LocalDateTime;
+	public final fun component3 ()Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;
+	public final fun copy (Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;)Lio/kotest/property/arbitrary/LocalDateTimeChange;
+	public static synthetic fun copy$default (Lio/kotest/property/arbitrary/LocalDateTimeChange;Ljava/time/LocalDateTime;Ljava/time/LocalDateTime;Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;ILjava/lang/Object;)Lio/kotest/property/arbitrary/LocalDateTimeChange;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDateTimeAfter ()Ljava/time/LocalDateTime;
+	public final fun getDateTimeBefore ()Ljava/time/LocalDateTime;
+	public final fun getType ()Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType : java/lang/Enum {
+	public static final field GAP Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;
+	public static final field OVERLAP Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;
+	public static fun values ()[Lio/kotest/property/arbitrary/LocalDateTimeChange$LocalDateTimeChangeType;
 }
 
 public final class io/kotest/property/arbitrary/LocaleKt {

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
@@ -18,6 +18,7 @@ import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 import java.time.temporal.TemporalQueries.localDate
 import java.time.temporal.TemporalQueries.localTime
+import java.time.zone.ZoneOffsetTransition
 import java.util.*
 import kotlin.random.Random
 import kotlin.random.nextInt
@@ -62,7 +63,8 @@ fun Arb.Companion.localDate() = Arb.Companion.localDate(LocalDate.of(1970, 1, 1)
  */
 fun Arb.Companion.localDate(
    minDate: LocalDate = LocalDate.of(1970, 1, 1),
-   maxDate: LocalDate = LocalDate.of(2030, 12, 31)
+   maxDate: LocalDate = LocalDate.of(2030, 12, 31),
+   zoneId: ZoneId? = null,
 ): Arb<LocalDate> {
    require(minDate <= maxDate) { "minDate must be before or equal to maxDate" }
    if (minDate == maxDate) return Arb.constant(minDate)
@@ -74,6 +76,15 @@ fun Arb.Companion.localDate(
 
    val centuryYear = (minDate.year..maxDate.year).firstOrNull { it % 100 == 0 && LocalDate.of(it, 1, 1) in minDate..maxDate }
    if (centuryYear != null) { edgeCases += LocalDate.of(centuryYear, 1, 1) }
+
+   zoneId?.let { zoneId ->
+      edgeCases.addAll(
+         zoneId.localDateTimeChanges(minDate.atStartOfDay())
+         .map { it.dateTimeBefore.toLocalDate() }
+         .filter { it in minDate..maxDate }
+         .take(2)
+      )
+   }
 
    return arbitrary(edgeCases) { rs ->
       val daysBetween = ChronoUnit.DAYS.between(minDate, maxDate)
@@ -379,4 +390,32 @@ fun Arb.Companion.javaDate(
       maxDate = dateFormat.format(maxDate),
       zoneId = zoneId
    )
+}
+
+data class LocalDateTimeChange(
+   val dateTimeBefore: LocalDateTime,
+   val dateTimeAfter: LocalDateTime,
+   val type: LocalDateTimeChangeType,
+) {
+   enum class LocalDateTimeChangeType { GAP, OVERLAP, }
+}
+
+fun ZoneId.localDateTimeChanges(start: LocalDateTime): Sequence<LocalDateTimeChange> {
+   val rules = this.rules
+   var time = start.atZone(this).toInstant()
+   return sequence {
+      var transition = rules.nextTransition(time)
+      while(transition != null) {
+         transition?.let {
+            time = transition.instant.plusSeconds(1)
+            yield(LocalDateTimeChange(
+                  dateTimeBefore = transition.dateTimeBefore,
+                  dateTimeAfter = transition.dateTimeAfter,
+                  type = if (transition.isGap) LocalDateTimeChange.LocalDateTimeChangeType.GAP else LocalDateTimeChange.LocalDateTimeChangeType.OVERLAP,
+               )
+            )
+         }
+         transition = rules.nextTransition(time)
+      }
+   }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -146,6 +146,32 @@ class DateTest : WordSpec({
 
          dates shouldBe generateSequence(minDate) { it.plusDays(1) }.takeWhile { it <= maxDate }.toSet()
       }
+
+      "include changes of daylight saving time in edge cases" {
+         val arb = Arb.localDate(
+            minDate = LocalDate.of(2025, 1, 1),
+            maxDate = LocalDate.of(2025, 12, 31),
+            zoneId = ZoneId.of("America/Chicago")
+         )
+         arb.edgecases().toList() shouldContainExactlyInAnyOrder listOf(
+            LocalDate.of(2025, 1, 1),
+            LocalDate.of(2025, 3, 9),
+            LocalDate.of(2025, 11, 2),
+            LocalDate.of(2025, 12, 31),
+         )
+      }
+
+      "work for UTC when there is no daylight saving time" {
+         val arb = Arb.localDate(
+            minDate = LocalDate.of(2025, 1, 1),
+            maxDate = LocalDate.of(2025, 12, 31),
+            zoneId = ZoneId.of("UTC")
+         )
+         arb.edgecases().toList() shouldContainExactlyInAnyOrder listOf(
+            LocalDate.of(2025, 1, 1),
+            LocalDate.of(2025, 12, 31),
+         )
+      }
    }
 
    "Arb.localTime()" should {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/LocalDateTimeChangesTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/LocalDateTimeChangesTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.kotest.property.arbitrary
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.property.arbitrary.localDateTimeChanges
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.LocalDateTimeChange
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class LocalDateTimeChangesTest: StringSpec() {
+   init {
+       "works for Central time" {
+          ZoneId.of("America/Chicago").localDateTimeChanges(
+             LocalDateTime.of(2025, 9, 12, 1, 2,3)
+          ).take(2).toList() shouldBe listOf(
+             LocalDateTimeChange(
+                dateTimeBefore = LocalDateTime.of(2025, 11, 2, 2, 0,0),
+                dateTimeAfter = LocalDateTime.of(2025, 11, 2, 1, 0,0),
+                type = LocalDateTimeChange.LocalDateTimeChangeType.OVERLAP,
+             ),
+             LocalDateTimeChange(
+                dateTimeBefore = LocalDateTime.of(2026, 3, 8, 2, 0,0),
+                dateTimeAfter = LocalDateTime.of(2026, 3, 8, 3, 0,0),
+                type = LocalDateTimeChange.LocalDateTimeChangeType.GAP,
+             ),
+          )
+       }
+      "works for UTC - no changes" {
+         ZoneId.of("UTC").localDateTimeChanges(
+            LocalDateTime.of(2025, 9, 12, 1, 2,3)
+         ).toList() shouldBe listOf()
+      }
+   }
+}


### PR DESCRIPTION
add days when daylight saving time is on/off to edge cases of Arb.datesBetween, optionally when optional parameter `zoneId` is provided


