### PR TITLE
Add missing Extension marker to core extension and listeners.

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1199,7 +1199,7 @@ public final class io/kotest/core/extensions/RuntimeTagExtension : io/kotest/cor
 	public fun tags ()Lio/kotest/engine/tags/TagExpression;
 }
 
-public abstract interface class io/kotest/core/extensions/SpecExecutionOrderExtension {
+public abstract interface class io/kotest/core/extensions/SpecExecutionOrderExtension : io/kotest/core/extensions/Extension {
 	public abstract fun sort (Ljava/util/List;)Ljava/util/List;
 }
 
@@ -1211,7 +1211,7 @@ public final class io/kotest/core/extensions/SpecExtension$DefaultImpls {
 	public static fun intercept (Lio/kotest/core/extensions/SpecExtension;Lio/kotest/core/spec/Spec;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/extensions/SpecRefExtension {
+public abstract interface class io/kotest/core/extensions/SpecRefExtension : io/kotest/core/extensions/Extension {
 	public abstract fun interceptRef (Lio/kotest/core/spec/SpecRef;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1440,7 +1440,7 @@ public abstract interface class io/kotest/core/listeners/InstantiationErrorListe
 	public abstract fun instantiationError (Lkotlin/reflect/KClass;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/kotest/core/listeners/InstantiationListener {
+public abstract interface class io/kotest/core/listeners/InstantiationListener : io/kotest/core/extensions/Extension {
 	public abstract fun specInstantiated (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/SpecExecutionOrderExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/SpecExecutionOrderExtension.kt
@@ -12,6 +12,6 @@ import io.kotest.core.spec.SpecRef
  * sorted using the [io.kotest.engine.spec.DefaultSpecExecutionOrderExtension] which uses the value of
  * [io.kotest.core.config.AbstractProjectConfig.specExecutionOrder] defined in configuration.
  */
-interface SpecExecutionOrderExtension {
+interface SpecExecutionOrderExtension : Extension {
    fun sort(specs: List<SpecRef>): List<SpecRef>
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/SpecRefExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/SpecRefExtension.kt
@@ -6,7 +6,7 @@ import io.kotest.core.spec.SpecRef
 /**
  * An [Extension] point that allows intercepting execution of [SpecRef]s
  * once they have been selected for execution but before any instantiation
- * has occured.
+ * has occurred.
  *
  * Extensions of this type can elect to continue processing the spec by
  * invoking the process function. By not invoking this function, the spec
@@ -15,6 +15,6 @@ import io.kotest.core.spec.SpecRef
  * Any coroutine context changes are propagated downstream.
  */
 @ExperimentalKotest
-interface SpecRefExtension {
+interface SpecRefExtension : Extension {
    suspend fun interceptRef(ref: SpecRef, process: suspend () -> Unit)
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/listeners/InstantiationListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/listeners/InstantiationListener.kt
@@ -1,11 +1,12 @@
 package io.kotest.core.listeners
 
+import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.Spec
 
 /**
  * An extension point that is used to be notified when a spec is instantiated.
  */
-interface InstantiationListener {
+interface InstantiationListener : Extension {
 
    /**
     * Is notified of a [Spec] that has been created.

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/InstantiationListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/InstantiationListenerTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.listeners.InstantiationListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.matchers.shouldBe
+
+class InstantiationListenerTest : FunSpec() {
+   init {
+
+      test("instantation listener should be detected from project config") {
+
+         val c = object : AbstractProjectConfig() {
+            override val extensions = listOf(MyInstantiationListener)
+         }
+
+         MyInstantiationListener.fired shouldBe null
+
+         TestEngineLauncher()
+            .withListener(NoopTestEngineListener)
+            .withClasses(DummySpec7::class)
+            .withProjectConfig(c)
+            .launch()
+
+         MyInstantiationListener.fired shouldBe "com.sksamuel.kotest.engine.extensions.DummySpec7"
+      }
+   }
+}
+
+object MyInstantiationListener : InstantiationListener {
+   var fired: String? = null
+   override suspend fun specInstantiated(spec: Spec) {
+      fired = spec::class.java.name
+   }
+}
+
+private class DummySpec7 : FunSpec({
+   test("a") {}
+})


### PR DESCRIPTION
Fixed a bug where the `InstantiationListener` was not marked as an `Extension` like the other listeners are.
It could not be registered directly, or found in the extension registry [here](https://github.com/kotest/kotest/blob/090e32115e0e82763ec1d6bbdeb81566a5530039/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecExtensions.kt#L92), unless the implementing class was marked as an `Extension` separately by the user:

```kotlin
suspend fun specInstantiated(spec: Spec) = runCatching {
    logger.log { Pair(spec::class.bestName(), "specInstantiated $spec") }
    specConfigResolver.extensions(spec)
        .filterIsInstance<InstantiationListener>()
        .forEach { it.specInstantiated(spec) }
}
```

Same for `SpecExecutionOrderExtension` and `SpecRefExtension`.
