### PR TITLE
Fix kotest plugin in project with Kotlin 2.2.20

### DIFF
--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -154,11 +154,7 @@ abstract class KotestPlugin : Plugin<Project> {
                         // Testable target: linuxX64, platformType: native, disambiguationClassifier: linuxX64
                         // Testable target: mingwX64, platformType: native, disambiguationClassifier: mingwX64
                         KotlinPlatformType.wasm -> handleWasm(target)
-                        KotlinPlatformType.native -> {
-                           // we don't want to wire stuff to non-buildable targets (i.e. ios target on a linux host)
-                           // so we check if the target is publishable
-                           if (target.publishable) handleNative(target)
-                        }
+                        KotlinPlatformType.native -> handleNative(target)
                      }
                   }
                }
@@ -183,6 +179,9 @@ abstract class KotestPlugin : Plugin<Project> {
          null -> target.project.logger.info("> Skipping tests for ${target.name} because no task $nativeTaskName found")
 
          is KotlinNativeTest -> {
+            // we don't want to wire stuff to non-enabled targets (i.e. ios target on a linux host)
+            // so we check if the task is enabled
+            if (!existing.isEnabled) return
 
             val moduleTestDir = getModuleTestReportsDir(target.project, existing.name).get()
             moduleTestDir.asFile.mkdirs()


### PR DESCRIPTION
Calling `target.publishable` throws an exception in a Kotlin multiplatform project when using Kotlin 2.2.20. This seems to be a Kotlin internal issue because `getOrThrow()` is called on a non-completed future and I can't find an exposed API to complete it.

As a workaround instead of checking if the target is publishable I check if the original task is enabled or not.