### PR TITLE
Enable to call `afterSpec` hooks on `InstancePerLeaf` correctly

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
@@ -102,10 +102,13 @@ internal class InstancePerLeafSpecExecutor(
 
    private suspend fun launchRootTest(seed: Spec, root: TestCase, ref: SpecRef) {
       val specContext = SpecContext.create()
+      val spec = inflator.inflate(ref).getOrThrow()
 
-      pipeline.execute(seed, specContext) {
-         val result = executeTest(root, null, specContext, ref)
-         Result.success(mapOf(root to result))
+      withContext(CoroutineName("spec-scope-" + spec.hashCode())) {
+         pipeline.execute(seed, specContext) {
+            val result = executeTest(root, null, specContext, ref)
+            Result.success(mapOf(root to result))
+         }
       }
 
       while (testQueue.isNotEmpty()) {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -114,18 +114,30 @@ class InstancePerLeafTest4 : DescribeSpec({
 
    isolationMode = IsolationMode.InstancePerLeaf
 
-   afterSpec {
-      println("afterSpec")
-      println(currentCoroutineContext()[CoroutineName.Key]?.name)
-   }
+//   afterSpec {
+//      println("afterSpec")
+//      println(currentCoroutineContext()[CoroutineName.Key]?.name)
+//   }
 
-   describe("foo") {
+   describe("d") {
       println("d")
-      context("a") { it("a") { println("a"); println(currentCoroutineContext()[CoroutineName.Key]?.name) } }
-      context("b") {
-         it("b") { println("b"); println(currentCoroutineContext()[CoroutineName.Key]?.name) }
-         it("b2") { println("b2"); println(currentCoroutineContext()[CoroutineName.Key]?.name) }
+      context("c1") {
+         it("i1") {
+            println("a")
+         }
       }
-      context("c") { it("c") { println("c"); println(currentCoroutineContext()[CoroutineName.Key]?.name) } }
+      context("c2") {
+         it("i2") {
+            println("b")
+         }
+         it("i3") {
+            println("b2")
+         }
+      }
+      context("c3") {
+         it("i4") {
+            println("c")
+         }
+      }
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -3,8 +3,6 @@ package com.sksamuel.kotest.engine.spec.execmode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import kotlinx.coroutines.CoroutineName
-import kotlinx.coroutines.currentCoroutineContext
 
 private var trace = ""
 
@@ -114,10 +112,13 @@ class InstancePerLeafTest4 : DescribeSpec({
 
    isolationMode = IsolationMode.InstancePerLeaf
 
-//   afterSpec {
-//      println("afterSpec")
-//      println(currentCoroutineContext()[CoroutineName.Key]?.name)
-//   }
+   beforeSpec {
+      println("beforeSpec")
+   }
+
+   afterSpec {
+      println("afterSpec")
+   }
 
    describe("d") {
       println("d")

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -121,8 +121,8 @@ class InstancePerLeafTest4 : DescribeSpec({
 
    afterSpec {
       when (counter) {
-         1 -> trace shouldBe "d1_c1_i1_hoge"
-         2 -> trace shouldBe "d1_c2_i2_hoge"
+         1 -> trace shouldBe "d1_c1_i1_"
+         2 -> trace shouldBe "d1_c2_i2_"
          else -> error("Should have run 2 tests")
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -3,6 +3,8 @@ package com.sksamuel.kotest.engine.spec.execmode
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.currentCoroutineContext
 
 private var trace = ""
 
@@ -105,5 +107,25 @@ class InstancePerLeafTest3 : DescribeSpec({
             trace shouldBe "d2_c2_i2_"
          }
       }
+   }
+})
+
+class InstancePerLeafTest4 : DescribeSpec({
+
+   isolationMode = IsolationMode.InstancePerLeaf
+
+   afterSpec {
+      println("afterSpec")
+      println(currentCoroutineContext()[CoroutineName.Key]?.name)
+   }
+
+   describe("foo") {
+      println("d")
+      context("a") { it("a") { println("a"); println(currentCoroutineContext()[CoroutineName.Key]?.name) } }
+      context("b") {
+         it("b") { println("b"); println(currentCoroutineContext()[CoroutineName.Key]?.name) }
+         it("b2") { println("b2"); println(currentCoroutineContext()[CoroutineName.Key]?.name) }
+      }
+      context("c") { it("c") { println("c"); println(currentCoroutineContext()[CoroutineName.Key]?.name) } }
    }
 })

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -108,36 +108,41 @@ class InstancePerLeafTest3 : DescribeSpec({
    }
 })
 
+private var counter = 0 // to confirm afterSpec hook in InstancePerLeafTest4
+
 class InstancePerLeafTest4 : DescribeSpec({
 
    isolationMode = IsolationMode.InstancePerLeaf
 
    beforeSpec {
-      println("beforeSpec")
+      trace = ""
+      counter++
    }
 
    afterSpec {
-      println("afterSpec")
+      when (counter) {
+         1 -> trace shouldBe "d1_c1_i1_hoge"
+         2 -> trace shouldBe "d1_c2_i2_hoge"
+         else -> error("Should have run 2 tests")
+      }
    }
 
-   describe("d") {
-      println("d")
+   describe("d1") {
+      trace += "d1_"
+
       context("c1") {
+         trace += "c1_"
+
          it("i1") {
-            println("a")
+            trace += "i1_"
          }
       }
+
       context("c2") {
+         trace += "c2_"
+
          it("i2") {
-            println("b")
-         }
-         it("i3") {
-            println("b2")
-         }
-      }
-      context("c3") {
-         it("i4") {
-            println("c")
+            trace += "i2_"
          }
       }
    }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

ref: https://github.com/kotest/kotest/pull/5066

## Background

currently, `InstancePerLeaf` test doesn't call `afterSpec` hooks for each test case execution.
this PR tries to fix the issue

## Root cause

since `executeInFreshSpec` is called as a recursive function, `pipeline#execute` for first test case execution will be completed after executing all leaves.

e.g.,

```
d1 --- i1
    |- i2
```

about the above test case, the execution order will be like

`(start d1 for i1) -> (start i1) -> (finish i1) -> (start d1 for i2) -> (start i2) -> (finish i2) -> (finish d1 for i2) -> (finish d1 for i1)`

but `afterSpec` should be called after `(finish i1)`

## Solution

change to execute test in not recursive function but isolated queue after completing one leaf execution.
in this solution, discovered test candidates are not executed immediately in the test execution but put to queue and executed after the discovering completed (i.e., afterSpec is executed)

to notify the test results to JUnit platform correctly, test ignored/finished notifications are also put to the same queue
