### PR TITLE
Record kotest-assertions-api changes in release_6.0.md

### DIFF
--- a/documentation/docs/release_6.0.md
+++ b/documentation/docs/release_6.0.md
@@ -192,6 +192,12 @@ It is recommended to use `InstancePerRoot` instead.
 
 * Removed `io.kotest.assertions.print.Print<A>.print(A, level)` in favor of the now-undeprecated `print(A)`.
 * Renamed `io.kotest.matchers.maps.contain` to `io.kotest.matchers.maps.mapcontain`.
+* Moved code from `io.kotest:kotest-assertions-api` to `io.kotest:kotest-assertions-shared`, and `io.kotest:kotest-assertions-api` is artifact is no longer published.
+  * `io.kotest.matchers.Matcher`
+  * `io.kotest.matchers.MatcherResult`
+  * `io.kotest.matchers.and`
+  * `io.kotest.matchers.or`
+  *  and [a few more](https://github.com/kotest/kotest/pull/4239)
 
 ## Improvements
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
