### PR TITLE
Alex/fail softly (#5128)

### DIFF
--- a/documentation/docs/assertions/soft_assertions.md
+++ b/documentation/docs/assertions/soft_assertions.md
@@ -42,6 +42,15 @@ assertSoftly {
 }
 ```
 
+Note, however, that `failSoftly` is compatible with `assertSoftly`, so the following code will report both failures:
+
+```kotlin
+assertSoftly {
+  2*2 shouldBe 5
+  failSoftly("Something happened")
+}
+```
+
 Likewise, if `mockk`'s `verify(...)` fails in the following example, the second assertion will not execute:
 
 ```kotlin

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -30,6 +30,7 @@ public final class io/kotest/assertions/AssertionErrorBuilder {
 public final class io/kotest/assertions/AssertionErrorBuilder$Companion {
 	public final fun create ()Lio/kotest/assertions/AssertionErrorBuilder;
 	public final fun fail (Ljava/lang/String;)Ljava/lang/Void;
+	public final fun failSoftly (Ljava/lang/String;)V
 }
 
 public final class io/kotest/assertions/AssertionErrorBuilder_jvmKt {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions
 
 import io.kotest.assertions.print.Printed
+import io.kotest.matchers.errorCollector
 
 /**
  * Use this object to create exceptions on a target platform.
@@ -29,6 +30,20 @@ data class AssertionErrorBuilder(
        */
       fun fail(message: String): Nothing {
          throw create().withMessage(message).build()
+      }
+
+      /**
+       * Convenience method to create an [AssertionError] with the given [message] and throw or collect it.
+       * The error message provided will have any clue context prepended.
+       *
+       * Use this method when you want to throw or collect an [AssertionError] with a specific message and have
+       * no expected or actual values to compare, or any underlying cause.
+       * The collected message will work within `assertSoftly { }` blocks.
+       */
+      fun failSoftly(message: String) {
+         errorCollector.collectOrThrow(
+            create().withMessage(message).build()
+         )
       }
 
       /**

--- a/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/AssertionErrorBuilderSoftlyTest.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmTest/kotlin/com/sksamuel/kotest/AssertionErrorBuilderSoftlyTest.kt
@@ -1,0 +1,23 @@
+package com.sksamuel.kotest
+
+import io.kotest.assertions.AssertionErrorBuilder
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+class AssertionErrorBuilderSoftlyTest: StringSpec() {
+   init {
+      "failSoftly works with assertSoftly" {
+         val thrown = shouldThrowAny {
+             assertSoftly {
+                 AssertionErrorBuilder.failSoftly("Oops!")
+                 2 * 2 shouldBe 5
+             }
+         }
+         thrown.message shouldContain "Oops!"
+         thrown.message shouldContain "expected:<5> but was:<4>"
+      }
+   }
+}


### PR DESCRIPTION
add `failSoftly` - a lightweight way to build your own assertion which is 
* compatible with `assertSoftly`
* only requires to build one message, does not need to have messages for both success and failure, which is the case most of the time we build our own custom matchers
