### PR TITLE
`PackageConfig` checked bug

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/PackageConfigLoader.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/PackageConfigLoader.kt
@@ -50,10 +50,24 @@ internal object PackageConfigLoader {
          listOf(packageName)
    }
 
+   /**
+    * Loads the package configuration class whose expected FQN is derived from [packageConfigName].
+    *
+    * Behavior:
+    * - Returns `null` if the class does not exist.
+    * - Returns `null` if the class exists but does not extend `AbstractPackageConfig`.
+    * - Returns an `AbstractPackageConfig` instance if the class is a valid subtype and can be instantiated.
+    * - Throws if the class exists and is a subtype of `AbstractPackageConfig` but instantiation fails.
+    *
+    * @param packageName the package to probe.
+    * @return the instantiated `AbstractPackageConfig` or `null` when not present or not a subtype.
+    * @throws Throwable if instantiation of a valid subtype fails.
+    */
    private fun loadPackageConfig(packageName: String): AbstractPackageConfig? {
-      // ok to skip if the class doesn't exist
-      val kclass = runCatching { Class.forName(packageConfigName(packageName)).kotlin }.getOrNull() ?: return null
-      // but should fail if the class exists but cannot be instantiated
+      val kclass = runCatching { Class.forName(packageConfigName(packageName)).kotlin }.getOrNull()
+         ?.takeIf { AbstractPackageConfig::class.java.isAssignableFrom(it.java) }
+         ?: return null
+
       return instantiateOrObject(kclass).getOrThrow() as AbstractPackageConfig
    }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
Addresses bug reported in https://github.com/kotest/kotest/issues/5125 by checking that the `kclass` returned is assignable from `AbstractPackageConfig`, meaning that the `kclass` extends it, rather than just checking on name equality.

### How to test this - now
- create a random class, or data class (as per example in issue) called `PackageConfig` with some `ctor` params in a test package
- run the test and watch it not fail
- create a class called `PackageConfig`, make it extend `AbstractPackageConfig` and watch it properly use this `PackageConfig` as expected

### How to test this - before
- create a random class, or data class (as per example in issue) called `PackageConfig` with some `ctor` params in a test package
- remove the new `takeIf` clause
- run the test and watch it fail
