### PR TITLE
Restrict @ApplyExtension to the target class

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,8 @@ arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-optics = { module = "io.arrow-kt:arrow-optics", version.ref = "arrow" }
 arrow-functions = { module = "io.arrow-kt:arrow-functions", version.ref = "arrow" }
 
+byte-buddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "byte-buddy" }
+
 decoroutinator = { module = "dev.reformator.stacktracedecoroutinator:stacktrace-decoroutinator-jvm", version.ref = "decoroutinator" }
 
 fuel = { module = "com.github.kittinunf.fuel:fuel", version.ref = "fuel" }
@@ -120,10 +122,11 @@ kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version 
 
 pitest = { module = "org.pitest:pitest", version.ref = "pitest" }
 
+spring-beans = { group = "org.springframework", name = "spring-beans", version.ref = "spring" }
 spring-context = { group = "org.springframework", name = "spring-context", version.ref = "spring" }
 spring-test = { group = "org.springframework", name = "spring-test", version.ref = "spring" }
-spring-boot-test = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "spring-boot" }
-byte-buddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "byte-buddy" }
+spring-boot-starter-test = { group = "org.springframework.boot", name = "spring-boot-starter-test", version.ref = "spring-boot" }
+spring-boot-starter-web = { group = "org.springframework.boot", name = "spring-boot-starter-web", version.ref = "spring-boot" }
 
 kotlin-poet = { group = "com.squareup", name = "kotlinpoet", version.ref = "kotlin-poet" }
 

--- a/kotest-common/src/jvmMain/kotlin/io/kotest/common/reflection/instantiation.jvm.kt
+++ b/kotest-common/src/jvmMain/kotlin/io/kotest/common/reflection/instantiation.jvm.kt
@@ -1,11 +1,13 @@
 package io.kotest.common.reflection
 
 import kotlin.reflect.KClass
+import kotlin.reflect.KVisibility
 
 actual val instantiations: Instantiations = ReflectionInstantiations
 
 object ReflectionInstantiations : Instantiations {
    override fun <T : Any> newInstanceNoArgConstructorOrObjectInstance(kclass: KClass<T>): T {
+      if (kclass.visibility == KVisibility.PRIVATE) error("Cannot use private class ${kclass.qualifiedName}")
       return when (val obj = kclass.objectInstance) {
          null -> kclass.java.getDeclaredConstructor().newInstance()
          else -> obj

--- a/kotest-extensions/kotest-extensions-spring/api/kotest-extensions-spring.api
+++ b/kotest-extensions/kotest-extensions-spring/api/kotest-extensions-spring.api
@@ -1,6 +1,10 @@
+public final class io/kotest/extensions/spring/ContextKt {
+	public static final fun testContextManager (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/kotest/extensions/spring/Properties {
 	public static final field INSTANCE Lio/kotest/extensions/spring/Properties;
-	public static final field springIgnoreWarning Ljava/lang/String;
+	public static final field SPRING_IGNORE_WARNING Ljava/lang/String;
 }
 
 public final class io/kotest/extensions/spring/SpringAutowireConstructorExtension : io/kotest/core/extensions/ConstructorExtension {
@@ -16,11 +20,9 @@ public final class io/kotest/extensions/spring/SpringExtension : io/kotest/core/
 	public fun afterTest (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun beforeAny (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun getIgnoreSpringListenerOnFinalClassWarning ()Z
 	public fun instantiate (Lkotlin/reflect/KClass;)Lio/kotest/core/spec/Spec;
 	public fun intercept (Lio/kotest/core/spec/Spec;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun intercept (Lio/kotest/core/test/TestCase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun setIgnoreSpringListenerOnFinalClassWarning (Z)V
 }
 
 public final class io/kotest/extensions/spring/SpringTestContextCoroutineContextElement : kotlin/coroutines/AbstractCoroutineContextElement {
@@ -40,10 +42,6 @@ public final class io/kotest/extensions/spring/SpringTestExtension : io/kotest/c
 	public fun intercept (Lio/kotest/core/spec/Spec;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun intercept (Lio/kotest/core/test/TestCase;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setIgnoreSpringListenerOnFinalClassWarning (Z)V
-}
-
-public final class io/kotest/extensions/spring/SpringTestExtensionKt {
-	public static final fun testContextManager (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/extensions/spring/SpringTestLifecycleMode : java/lang/Enum {

--- a/kotest-extensions/kotest-extensions-spring/build.gradle.kts
+++ b/kotest-extensions/kotest-extensions-spring/build.gradle.kts
@@ -11,12 +11,13 @@ kotlin {
             implementation(libs.kotlin.reflect)
             implementation(libs.spring.context)
             implementation(libs.spring.test)
+            implementation(libs.spring.boot.starter.web)
             implementation(libs.byte.buddy)
          }
       }
       jvmTest {
          dependencies {
-            implementation(libs.spring.boot.test)
+            implementation(libs.spring.boot.starter.test)
          }
       }
    }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/Properties.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/Properties.kt
@@ -1,5 +1,5 @@
 package io.kotest.extensions.spring
 
 object Properties {
-   const val springIgnoreWarning = "kotest.listener.spring.ignore.warning"
+   const val SPRING_IGNORE_WARNING = "kotest.listener.spring.ignore.warning"
 }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
@@ -2,6 +2,7 @@
 
 package io.kotest.extensions.spring
 
+import io.kotest.core.Logger
 import io.kotest.core.extensions.ConstructorExtension
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.SpecExtension
@@ -10,21 +11,14 @@ import io.kotest.core.listeners.AfterTestListener
 import io.kotest.core.listeners.BeforeTestListener
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 import io.kotest.core.test.TestType
 import io.kotest.core.test.isRootTest
+import io.kotest.engine.test.TestResult
 import kotlinx.coroutines.withContext
-import net.bytebuddy.ByteBuddy
-import net.bytebuddy.description.modifier.Visibility
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
-import net.bytebuddy.implementation.FixedValue
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory
 import org.springframework.test.context.TestContextManager
-import java.lang.reflect.Method
-import java.lang.reflect.Modifier
-import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
-import kotlin.reflect.full.primaryConstructor
 
 /**
  * An [Extension] which adds support for testing spring components.
@@ -40,29 +34,27 @@ class SpringExtension(
    private val mode: SpringTestLifecycleMode = SpringTestLifecycleMode.Test
 ) : ConstructorExtension, SpecExtension, TestCaseExtension, BeforeTestListener, AfterTestListener {
 
-   override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
-      // we only instantiate via spring if there's actually parameters in the constructor
-      // otherwise there's nothing to inject there
-      val constructor = clazz.primaryConstructor
-      return if (constructor == null || constructor.parameters.isEmpty()) {
-         null
-      } else {
-         val manager = TestContextManager(clazz.java)
-         val context = manager.testContext.applicationContext
-         context.autowireCapableBeanFactory.autowire(
-            clazz.java,
-            AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR, true
-         ) as Spec
-      }
+   private val logger = Logger(SpringExtension::class)
+
+   private val managers = ConcurrentHashMap<KClass<*>, TestContextManager>()
+
+   override fun <T : Spec> instantiate(clazz: KClass<T>): Spec {
+      // Each time a TestContextManager is created, any @ContextCustomizerFactories are executed.
+      // This somehow causes spring to create a new application context, for without the factories annotation it works
+      val manager = getTestContextManager(clazz)
+      val context = manager.testContext.applicationContext
+
+      logger.log { Pair(clazz.simpleName, "Spring extension will try to create autowired instance") }
+      return context.autowireCapableBeanFactory.autowire(
+         clazz.java,
+         AutowireCapableBeanFactory.AUTOWIRE_CONSTRUCTOR, true
+      ) as Spec
    }
 
-   var ignoreSpringListenerOnFinalClassWarning: Boolean = false
-
    override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
-      safeClassName(spec::class)
-
-      val context = TestContextManager(spec::class.java)
-      withContext(SpringTestContextCoroutineContextElement(context)) {
+      SpringJavaCompatibility.checkForSafeClassName(spec::class)
+      val manager = getTestContextManager(spec::class)
+      withContext(SpringTestContextCoroutineContextElement(manager)) {
          testContextManager().beforeTestClass()
          testContextManager().prepareTestInstance(spec)
          execute(spec)
@@ -71,7 +63,7 @@ class SpringExtension(
    }
 
    override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
-      val methodName = method(testCase)
+      val methodName = SpringJavaCompatibility.methodHandle(testCase)
       if (testCase.isApplicable()) {
          testContextManager().beforeTestExecution(testCase.spec, methodName)
       }
@@ -84,14 +76,14 @@ class SpringExtension(
 
    override suspend fun beforeAny(testCase: TestCase) {
       if (testCase.isApplicable()) {
-         val methodName = method(testCase)
+         val methodName = SpringJavaCompatibility.methodHandle(testCase)
          testContextManager().beforeTestMethod(testCase.spec, methodName)
       }
    }
 
    override suspend fun afterAny(testCase: TestCase, result: TestResult) {
       if (testCase.isApplicable()) {
-         val methodName = method(testCase)
+         val methodName = SpringJavaCompatibility.methodHandle(testCase)
          testContextManager().afterTestMethod(testCase.spec, methodName, null as Throwable?)
       }
    }
@@ -102,58 +94,9 @@ class SpringExtension(
    private fun TestCase.isApplicable() = (mode == SpringTestLifecycleMode.Root && isRootTest()) ||
       (mode == SpringTestLifecycleMode.Test && type == TestType.Test)
 
-   /**
-    * Generates a fake [Method] for the given [TestCase].
-    *
-    * Check https://github.com/kotest/kotest/issues/950#issuecomment-524127221
-    * for an in-depth explanation. Too much to write here
-    */
-   private fun method(testCase: TestCase): Method = if (Modifier.isFinal(testCase.spec::class.java.modifiers)) {
-      if (!ignoreFinalWarning) {
-         @Suppress("MaxLineLength")
-         println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
+   private fun getTestContextManager(kclass: KClass<*>): TestContextManager {
+      return managers.getOrPut(kclass) {
+         TestContextManager(kclass.java)
       }
-      // the method here must exist since we can't add our own
-      this@SpringExtension::class.java.methods.firstOrNull { it.name == "intercept" }
-         ?: error("Could not find method 'intercept' to attach spring lifecycle methods to")
-   } else {
-      val methodName = methodName(testCase)
-      val fakeSpec = ByteBuddy()
-         .subclass(testCase.spec::class.java)
-         .defineMethod(methodName, String::class.java, Visibility.PUBLIC)
-         .intercept(FixedValue.value("Foo"))
-         .make()
-         .load(this::class.java.classLoader, ClassLoadingStrategy.Default.CHILD_FIRST)
-         .loaded
-      fakeSpec.getMethod(methodName)
    }
-
-   /**
-    * Checks for a safe class name and throws if invalid
-    * https://kotlinlang.org/docs/keyword-reference.html#soft-keywords
-    */
-   internal fun safeClassName(kclass: KClass<*>) {
-      // these are names java won't let us use but are ok from kotlin
-      if (kclass.java.name.split('.').any { illegals.contains(it) })
-         error("Spec package name cannot contain a java keyword: ${illegals.joinToString(",")}")
-   }
-
-   /**
-    * Generates a fake method name for the given [TestCase].
-    * The method name is taken from the test case name with a random element.
-    */
-   internal fun methodName(testCase: TestCase): String = (testCase.name.name + "_" + UUID.randomUUID().toString())
-      .replace(methodNameRegex, "_")
-      .let {
-         if (it.first().isLetter()) it else "_$it"
-      }
-
-   private val illegals =
-      listOf("import", "finally", "catch", "const", "final", "inner", "protected", "private", "public")
-
-   private val methodNameRegex = "[^a-zA-Z_0-9]".toRegex()
-
-   private val ignoreFinalWarning =
-      ignoreSpringListenerOnFinalClassWarning ||
-         !System.getProperty(Properties.springIgnoreWarning, "false").toBoolean()
 }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringJavaCompatibility.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringJavaCompatibility.kt
@@ -1,0 +1,76 @@
+package io.kotest.extensions.spring
+
+import io.kotest.core.Logger
+import io.kotest.core.test.TestCase
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.description.modifier.Visibility
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.implementation.FixedValue
+import java.lang.reflect.Method
+import java.lang.reflect.Modifier
+import java.util.UUID
+import kotlin.reflect.KClass
+
+internal object SpringJavaCompatibility {
+
+   private val logger = Logger(SpringJavaCompatibility::class)
+
+   var ignoreSpringListenerOnFinalClassWarning: Boolean = false
+
+   /**
+    * Generates a fake [Method] for the given [TestCase].
+    *
+    * Check https://github.com/kotest/kotest/issues/950#issuecomment-524127221
+    * for an in-depth explanation. Too much to write here
+    */
+   fun methodHandle(testCase: TestCase): Method = if (Modifier.isFinal(testCase.spec::class.java.modifiers)) {
+      if (!ignoreFinalWarning) {
+         @Suppress("MaxLineLength")
+         println("Using SpringListener on a final class. If any Spring annotation fails to work, try making this class open.")
+      }
+      // the method here must exist since we can't add our own
+      val methods = this@SpringJavaCompatibility::class.java.methods
+      methods.firstOrNull { it.name == "methodHandle" }
+         ?: error("Could not find a method to attach spring lifecycle methods to: ${methods.map { it.name }}")
+   } else {
+      val methodName = methodName(testCase)
+      val fakeSpec = ByteBuddy()
+         .subclass(testCase.spec::class.java)
+         .defineMethod(methodName, String::class.java, Visibility.PUBLIC)
+         .intercept(FixedValue.value("Foo"))
+         .make()
+         .load(this::class.java.classLoader, ClassLoadingStrategy.Default.CHILD_FIRST)
+         .loaded
+      fakeSpec.getMethod(methodName)
+   }
+
+   /**
+    * Checks for a safe class name and throws if invalid
+    * https://kotlinlang.org/docs/keyword-reference.html#soft-keywords
+    */
+   fun checkForSafeClassName(kclass: KClass<*>) {
+      logger.log { Pair(kclass.simpleName, "Checking for spring safe class name") }
+      // these are names java won't let us use but are ok from kotlin
+      if (kclass.java.name.split('.').any { illegals.contains(it) })
+         error("Spec package name cannot contain a java keyword: ${illegals.joinToString(",")}")
+   }
+
+   /**
+    * Generates a fake method name for the given [TestCase].
+    * The method name is taken from the test case name with a random element.
+    */
+   fun methodName(testCase: TestCase): String = (testCase.name.name + "_" + UUID.randomUUID().toString())
+      .replace(methodNameRegex, "_")
+      .let {
+         if (it.first().isLetter()) it else "_$it"
+      }
+
+   private val illegals =
+      listOf("import", "finally", "catch", "const", "final", "inner", "protected", "private", "public")
+
+   private val methodNameRegex = "[^a-zA-Z_0-9]".toRegex()
+
+   private val ignoreFinalWarning =
+      ignoreSpringListenerOnFinalClassWarning ||
+         !System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
+}

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
@@ -6,9 +6,9 @@ import io.kotest.core.extensions.SpecExtension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 import io.kotest.core.test.TestType
 import io.kotest.core.test.isRootTest
+import io.kotest.engine.test.TestResult
 import kotlinx.coroutines.withContext
 import net.bytebuddy.ByteBuddy
 import net.bytebuddy.description.modifier.Visibility
@@ -18,32 +18,7 @@ import org.springframework.test.context.TestContextManager
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.UUID
-import kotlin.coroutines.AbstractCoroutineContextElement
-import kotlin.coroutines.CoroutineContext
-import kotlin.coroutines.coroutineContext
 import kotlin.reflect.KClass
-
-class SpringTestContextCoroutineContextElement(val value: TestContextManager) : AbstractCoroutineContextElement(Key) {
-   companion object Key : CoroutineContext.Key<SpringTestContextCoroutineContextElement>
-}
-
-/**
- * Determines how the spring test context lifecycle is mapped to test cases.
- *
- * [SpringTestLifecycleMode.Root] will setup and teardown the test context before and after root tests only.
- * [SpringTestLifecycleMode.Test] will setup and teardown the test context only at leaf tests.
- *
- */
-enum class SpringTestLifecycleMode {
-   Root, Test
-}
-
-/**
- * Returns the [TestContextManager] from a test or spec.
- */
-suspend fun testContextManager(): TestContextManager =
-   coroutineContext[SpringTestContextCoroutineContextElement]?.value
-      ?: error("No TestContextManager defined in this coroutine context")
 
 @Deprecated("Use SpringExtension which combines this and SpringAutowireConstructorExtension. Deprecated since 6.0")
 class SpringTestExtension(private val mode: SpringTestLifecycleMode = SpringTestLifecycleMode.Test) : TestCaseExtension,
@@ -138,5 +113,5 @@ class SpringTestExtension(private val mode: SpringTestLifecycleMode = SpringTest
 
    private val ignoreFinalWarning =
       ignoreSpringListenerOnFinalClassWarning ||
-         !System.getProperty(Properties.springIgnoreWarning, "false").toBoolean()
+         !System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
 }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/context.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/context.kt
@@ -1,0 +1,30 @@
+@file:Suppress("MemberVisibilityCanBePrivate")
+
+package io.kotest.extensions.spring
+
+import org.springframework.test.context.TestContextManager
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+
+class SpringTestContextCoroutineContextElement(val value: TestContextManager) : AbstractCoroutineContextElement(Key) {
+   companion object Key : CoroutineContext.Key<SpringTestContextCoroutineContextElement>
+}
+
+/**
+ * Determines how the spring test context lifecycle is mapped to test cases.
+ *
+ * [SpringTestLifecycleMode.Root] will setup and teardown the test context before and after root tests only.
+ * [SpringTestLifecycleMode.Test] will setup and teardown the test context only at leaf tests.
+ *
+ */
+enum class SpringTestLifecycleMode {
+   Root, Test
+}
+
+/**
+ * Returns the [TestContextManager] from a test or spec.
+ */
+suspend fun testContextManager(): TestContextManager =
+   coroutineContext[SpringTestContextCoroutineContextElement]?.value
+      ?: error("No TestContextManager defined in this coroutine context")

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTest.kt
@@ -1,11 +1,11 @@
 package io.kotest.extensions.spring
 
+import io.kotest.core.descriptors.toDescriptor
 import io.kotest.core.names.TestNameBuilder
 import io.kotest.core.source.SourceRef
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
-import io.kotest.core.descriptors.toDescriptor
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
@@ -29,7 +29,7 @@ class SpringExtensionTest : WordSpec() {
             testContextManager().shouldNotBeNull()
          }
          "generate applicable method name for a root test" {
-            SpringExtension().methodName(
+            SpringJavaCompatibility.methodName(
                TestCase(
                   descriptor = SpringExtensionTest::class.toDescriptor()
                      .append("0foo__!!55@#woo"),
@@ -42,7 +42,7 @@ class SpringExtensionTest : WordSpec() {
             ) shouldStartWith "_0foo____55__woo"
          }
          "generate applicable method name for a nested test" {
-            SpringExtension().methodName(
+            SpringJavaCompatibility.methodName(
                TestCase(
                   descriptor = SpringExtensionTest::class.toDescriptor()
                      .append("0foo__!!55@#woo")

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/WithContextCustomizerFactoryTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/WithContextCustomizerFactoryTest.kt
@@ -1,0 +1,68 @@
+//package io.kotest.extensions.spring
+//
+//import ch.qos.logback.classic.Level
+//import ch.qos.logback.classic.spi.ILoggingEvent
+//import ch.qos.logback.core.read.ListAppender
+//import io.kotest.core.extensions.ApplyExtension
+//import io.kotest.core.spec.style.FunSpec
+//import io.kotest.matchers.shouldBe
+//import org.slf4j.LoggerFactory
+//import org.springframework.boot.autoconfigure.SpringBootApplication
+//import org.springframework.boot.runApplication
+//import org.springframework.boot.test.context.SpringBootTest
+//import org.springframework.boot.test.web.server.LocalServerPort
+//import org.springframework.boot.web.embedded.tomcat.TomcatWebServer
+//import org.springframework.context.ConfigurableApplicationContext
+//import org.springframework.test.context.ContextConfigurationAttributes
+//import org.springframework.test.context.ContextCustomizer
+//import org.springframework.test.context.ContextCustomizerFactories
+//import org.springframework.test.context.ContextCustomizerFactory
+//import org.springframework.test.context.MergedContextConfiguration
+//
+//@SpringBootTest(
+//   webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+//   classes = [KotestV6Application::class]
+//)
+//@ContextCustomizerFactories(DummyContextCustomizerFactory::class)
+//@ApplyExtension(SpringExtension::class)
+//class WithContextCustomizerFactoryTest(
+//   @param:LocalServerPort val port: Int
+//) : FunSpec({
+//
+//   val logger = LoggerFactory.getLogger(TomcatWebServer::class.java) as ch.qos.logback.classic.Logger
+//   val memoryLogAppender = logger.getAppender("MEMORY") as ListAppender<ILoggingEvent>
+//
+//   afterTest {
+//      memoryLogAppender.reset()
+//   }
+//
+//   test("should log only one tomcat started") {
+//      memoryLogAppender.countTomcatStartedLogs() shouldBe 1
+//   }
+//})
+//
+//fun ListAppender<ILoggingEvent>.countTomcatStartedLogs() = list
+//   .filter { event -> event.level == Level.INFO && event.toString().contains("Tomcat initialized with port") }
+//   .size
+//
+//fun ListAppender<ILoggingEvent>.reset() = list.clear()
+//
+//@SpringBootApplication
+//open class KotestV6Application
+//
+//fun main(args: Array<String>) {
+//   runApplication<KotestV6Application>(*args)
+//}
+//
+//class DummyContextCustomizerFactory : ContextCustomizerFactory {
+//   override fun createContextCustomizer(
+//      testClass: Class<*>,
+//      configAttributes: MutableList<ContextConfigurationAttributes>
+//   ): ContextCustomizer = DummyCustomizer(testClass)
+//}
+//
+//class DummyCustomizer(private val testClass: Class<*>) : ContextCustomizer {
+//   override fun customizeContext(context: ConfigurableApplicationContext, mergedConfig: MergedContextConfiguration) {
+//      println("STARTING customizer!")
+//   }
+//}

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/resources/logback.xml.disabled
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/resources/logback.xml.disabled
@@ -1,0 +1,18 @@
+
+<configuration>
+    <appender name="MEMORY" class="ch.qos.logback.core.read.ListAppender">
+    </appender>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="org.springframework.boot.web.embedded.tomcat.TomcatWebServer"
+            level="INFO">
+        <appender-ref ref="MEMORY"/>
+    </logger>
+</configuration>

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3052,6 +3052,7 @@ public final class io/kotest/engine/TestEngineLauncher {
 	public final fun withJvm ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withListener (Lio/kotest/engine/listener/TestEngineListener;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withNative ()Lio/kotest/engine/TestEngineLauncher;
+	public final fun withNoOpListener ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withPlatform (Lio/kotest/common/Platform;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withProjectConfig (Lio/kotest/core/config/AbstractProjectConfig;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withSpecRefs (Ljava/util/List;)Lio/kotest/engine/TestEngineLauncher;
@@ -3348,11 +3349,14 @@ public final class io/kotest/engine/errors/HandleEngineError_jvmKt {
 public final class io/kotest/engine/extensions/DefaultExtensionRegistry : io/kotest/engine/extensions/ExtensionRegistry {
 	public fun <init> ()V
 	public fun add (Lio/kotest/core/extensions/Extension;)V
+	public fun add (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 	public fun all ()Ljava/util/List;
 	public fun clear ()V
+	public fun get (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public fun isEmpty ()Z
 	public fun isNotEmpty ()Z
 	public fun remove (Lio/kotest/core/extensions/Extension;)V
+	public fun remove (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 }
 
 public abstract interface class io/kotest/engine/extensions/DescriptorFilter : io/kotest/core/extensions/Extension {
@@ -3383,11 +3387,14 @@ public final class io/kotest/engine/extensions/DescriptorFilterResult$Include : 
 public final class io/kotest/engine/extensions/EmptyExtensionRegistry : io/kotest/engine/extensions/ExtensionRegistry {
 	public static final field INSTANCE Lio/kotest/engine/extensions/EmptyExtensionRegistry;
 	public fun add (Lio/kotest/core/extensions/Extension;)V
+	public fun add (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 	public fun all ()Ljava/util/List;
 	public fun clear ()V
+	public fun get (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public fun isEmpty ()Z
 	public fun isNotEmpty ()Z
 	public fun remove (Lio/kotest/core/extensions/Extension;)V
+	public fun remove (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 }
 
 public abstract class io/kotest/engine/extensions/ExtensionException : java/lang/Exception {
@@ -3459,11 +3466,14 @@ public final class io/kotest/engine/extensions/ExtensionException$PrepareSpecExc
 
 public abstract interface class io/kotest/engine/extensions/ExtensionRegistry {
 	public abstract fun add (Lio/kotest/core/extensions/Extension;)V
+	public abstract fun add (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 	public abstract fun all ()Ljava/util/List;
 	public abstract fun clear ()V
+	public abstract fun get (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public abstract fun isEmpty ()Z
 	public abstract fun isNotEmpty ()Z
 	public abstract fun remove (Lio/kotest/core/extensions/Extension;)V
+	public abstract fun remove (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 }
 
 public final class io/kotest/engine/extensions/IncludeDescriptorFilter : io/kotest/engine/extensions/DescriptorFilter {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
@@ -1,6 +1,7 @@
 package io.kotest.engine.extensions
 
 import io.kotest.core.extensions.Extension
+import kotlin.reflect.KClass
 
 /**
  * An [ExtensionRegistry] is a collection of [Extension]s that can be added to or removed from.
@@ -10,9 +11,29 @@ import io.kotest.core.extensions.Extension
  *
  */
 interface ExtensionRegistry {
+
    fun all(): List<Extension>
+
+   /**
+    * Returns all extensions that are registered to a specific kclass.
+    */
+   fun get(kClass: KClass<*>): List<Extension>
+
+   /**
+    * Adds a global [Extension] to this registry.
+    * A global extension will be available to all specs.
+    */
    fun add(extension: Extension)
+
+   /**
+    * Adds a restricted [Extension] to this registry.
+    * A restricted extension is only available to the registered spec class.
+    */
+   fun add(extension: Extension, kclass: KClass<*>)
+
    fun remove(extension: Extension)
+   fun remove(extension: Extension, kclass: KClass<*>)
+
    fun clear()
    fun isEmpty(): Boolean
    fun isNotEmpty(): Boolean
@@ -20,16 +41,28 @@ interface ExtensionRegistry {
 
 class DefaultExtensionRegistry : ExtensionRegistry {
 
-   private val extensions = mutableListOf<Extension>()
+   private val extensions = mutableListOf<Pair<Extension, KClass<*>?>>()
 
-   override fun all(): List<Extension> = extensions.toList()
+   override fun all(): List<Extension> = extensions.map { it.first }
+
+   override fun get(kClass: KClass<*>): List<Extension> {
+      return extensions.filter { it.second == kClass }.map { it.first }
+   }
 
    override fun add(extension: Extension) {
-      extensions.add(extension)
+      extensions.add(Pair(extension, null))
+   }
+
+   override fun add(extension: Extension, kclass: KClass<*>) {
+      extensions.add(Pair(extension, kclass))
    }
 
    override fun remove(extension: Extension) {
-      extensions.remove(extension)
+      extensions.remove(Pair(extension, null))
+   }
+
+   override fun remove(extension: Extension, kclass: KClass<*>) {
+      extensions.remove(Pair(extension, kclass))
    }
 
    override fun clear() {
@@ -43,12 +76,20 @@ class DefaultExtensionRegistry : ExtensionRegistry {
 object EmptyExtensionRegistry : ExtensionRegistry {
 
    override fun all(): List<Extension> = emptyList()
+   override fun get(kClass: KClass<*>): List<Extension> = emptyList()
 
    override fun add(extension: Extension) {
       throw UnsupportedOperationException("Cannot add to an empty extension registry")
    }
 
+   override fun add(extension: Extension, kclass: KClass<*>) {
+      throw UnsupportedOperationException("Cannot add to an empty extension registry")
+   }
+
    override fun remove(extension: Extension) {
+   }
+
+   override fun remove(extension: Extension, kclass: KClass<*>) {
    }
 
    override fun clear() {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/SpecRefInterceptorPipeline.kt
@@ -58,7 +58,7 @@ internal class SpecRefInterceptorPipeline(
          if (platform == Platform.JVM) EnabledIfInterceptor(listener, context.specExtensions()) else null,
          if (platform == Platform.JVM) DisabledIfInterceptor(listener, context.specExtensions()) else null,
          IgnoredSpecInterceptor(listener, context.specExtensions()),
-         if (platform == Platform.JVM) ApplyExtensionsInterceptor(context.registry) else null,
+         if (platform == Platform.JVM) ApplyExtensionsInterceptor(context.listener, context.registry) else null,
          DescriptorFilterSpecRefInterceptor(listener, context.projectConfigResolver, context.specExtensions()),
 //         SystemPropertyDescriptorFilterInterceptor(listener, context.specExtensions()),
          TagsInterceptor(listener, context.projectConfigResolver, context.specExtensions()),

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/ApplyExtensionsInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/ApplyExtensionsInterceptor.kt
@@ -2,17 +2,20 @@ package io.kotest.engine.spec.interceptor.ref
 
 import io.kotest.common.JVMOnly
 import io.kotest.common.reflection.annotation
+import io.kotest.common.reflection.bestName
 import io.kotest.common.reflection.instantiations
+import io.kotest.core.Logger
 import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
 import io.kotest.engine.extensions.ExtensionRegistry
-import io.kotest.engine.extensions.SpecWrapperExtension
 import io.kotest.engine.flatMap
+import io.kotest.engine.listener.TestEngineListener
 import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.SpecRefInterceptor
 import io.kotest.engine.test.TestResult
+import io.kotest.engine.test.TestResultBuilder
 
 /**
  * If a [Spec] is annotated with the [ApplyExtension] annotation, registers any extensions
@@ -23,19 +26,35 @@ import io.kotest.engine.test.TestResult
  * Note: [ApplyExtension] is only applied on the JVM.
  */
 @JVMOnly
-internal class ApplyExtensionsInterceptor(private val registry: ExtensionRegistry) : SpecRefInterceptor {
+internal class ApplyExtensionsInterceptor(
+   private val listener: TestEngineListener,
+   private val registry: ExtensionRegistry
+) : SpecRefInterceptor {
+
+   private val logger = Logger(ApplyExtensionsInterceptor::class)
 
    override suspend fun intercept(ref: SpecRef, next: NextSpecRefInterceptor): Result<Map<TestCase, TestResult>> {
       return runCatching {
          val classes = ref.kclass.annotation<ApplyExtension>()?.extensions?.toList() ?: emptyList()
-         classes
-            .map { instantiations.newInstanceNoArgConstructorOrObjectInstance(it) }
-            .map { SpecWrapperExtension(it, ref.kclass) }
+         classes.map { instantiations.newInstanceNoArgConstructorOrObjectInstance(it) }
       }.flatMap { exts ->
-         exts.forEach { registry.add(it) }
-         next.invoke(ref).apply {
-            exts.forEach { registry.remove(it) }
+
+         exts.forEach {
+            logger.log { Pair(ref.kclass.bestName(), "Registering extension $it") }
+            registry.add(it, ref.kclass)
          }
+
+         next.invoke(ref).apply {
+            exts.forEach {
+               logger.log { Pair(ref.kclass.bestName(), "Removing extension $it") }
+               registry.remove(it, ref.kclass)
+            }
+         }
+
+      }.onFailure {
+         // spec would not have been started at this point, so we need to start it so we can fail it with an error
+         listener.specStarted(ref)
+         listener.specFinished(ref, TestResultBuilder.builder().withError(it).build())
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/ApplyExtensionsInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/ref/ApplyExtensionsInterceptor.kt
@@ -37,6 +37,10 @@ internal class ApplyExtensionsInterceptor(
       return runCatching {
          val classes = ref.kclass.annotation<ApplyExtension>()?.extensions?.toList() ?: emptyList()
          classes.map { instantiations.newInstanceNoArgConstructorOrObjectInstance(it) }
+      }.onFailure {
+         // spec would not have been started at this point, so we need to start it so we can fail it with an error
+         listener.specStarted(ref)
+         listener.specFinished(ref, TestResultBuilder.builder().withError(it).build())
       }.flatMap { exts ->
 
          exts.forEach {
@@ -50,11 +54,6 @@ internal class ApplyExtensionsInterceptor(
                registry.remove(it, ref.kclass)
             }
          }
-
-      }.onFailure {
-         // spec would not have been started at this point, so we need to start it so we can fail it with an error
-         listener.specStarted(ref)
-         listener.specFinished(ref, TestResultBuilder.builder().withError(it).build())
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/SpecInstantiator.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/SpecInstantiator.kt
@@ -1,19 +1,14 @@
 package io.kotest.engine.spec
 
 import io.kotest.common.KotestInternal
-import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.extensions.ConstructorExtension
-import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.PostInstantiationExtension
 import io.kotest.core.spec.Spec
 import io.kotest.engine.config.ProjectConfigResolver
 import io.kotest.engine.extensions.ExtensionRegistry
 import io.kotest.engine.instantiateOrObject
 import io.kotest.engine.mapError
-import io.kotest.common.reflection.annotation
 import kotlin.reflect.KClass
-import kotlin.reflect.full.createInstance
-import kotlin.reflect.full.isSubclassOf
 
 /**
  * Creates an instance of a [Spec].
@@ -61,26 +56,18 @@ class SpecInstantiator(
       }
    }
 
-   /**
-    * Returns any Extensions of type T registered via @ApplyExtension on the spec.
-    */
-   private inline fun <reified T : Extension> extensionsFromApplyExtension(kclass: KClass<*>): List<T> {
-      val components = kclass.annotation<ApplyExtension>()?.extensions ?: return emptyList()
-      return components.filter { it.isSubclassOf(T::class) }.map { (it.objectInstance ?: it.createInstance()) as T }
-   }
-
    private fun constructorExtensions(
       kclass: KClass<*>
    ): List<ConstructorExtension> {
       return projectConfigResolver.extensionsOf<ConstructorExtension>() +
-         extensionsFromApplyExtension<ConstructorExtension>(kclass)
+         registry.get(kclass).filterIsInstance<ConstructorExtension>()
    }
 
    private fun postInstantiationExtensions(
       kclass: KClass<*>
    ): List<PostInstantiationExtension> {
       return projectConfigResolver.extensionsOf<PostInstantiationExtension>() +
-         extensionsFromApplyExtension<PostInstantiationExtension>(kclass)
+         registry.get(kclass).filterIsInstance<PostInstantiationExtension>()
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/active/LauncherTestFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/active/LauncherTestFilterTest.kt
@@ -18,7 +18,7 @@ private var counter = 0
 class LauncherTestFilterTest : FunSpec() {
    init {
       // disabled until filters can be added to one launcher independently
-      test("!filter added via launcher should filter test cases") {
+      test("filter added via launcher should filter test cases") {
 
          val filter = object : DescriptorFilter {
             override fun filter(descriptor: Descriptor): DescriptorFilterResult {
@@ -39,7 +39,7 @@ class LauncherTestFilterTest : FunSpec() {
             .launch()
       }
 
-      test("!filter with test path added via launcher should filter test cases") {
+      test("filter with test path added via launcher should filter test cases") {
 
          val filter = object : DescriptorFilter {
             override fun filter(descriptor: Descriptor): DescriptorFilterResult {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/ApplyExtensionsInterceptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/ApplyExtensionsInterceptorTest.kt
@@ -8,14 +8,16 @@ import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.extensions.DefaultExtensionRegistry
-import io.kotest.engine.extensions.SpecWrapperExtension
 import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.engine.listener.NoopTestEngineListener
 import io.kotest.engine.spec.interceptor.NextSpecRefInterceptor
 import io.kotest.engine.spec.interceptor.ref.ApplyExtensionsInterceptor
+import io.kotest.engine.test.TestResult
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.time.Duration.Companion.seconds
 
@@ -25,11 +27,10 @@ class ApplyExtensionsInterceptorTest : FunSpec() {
 
       test("ApplyExtensionsInterceptor should apply extensions") {
          val registry = DefaultExtensionRegistry()
-         ApplyExtensionsInterceptor(registry)
+         ApplyExtensionsInterceptor(NoopTestEngineListener, registry)
             .intercept(SpecRef.Reference(MyAnnotatedSpec::class), object : NextSpecRefInterceptor {
                override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
-                  val wrapper = registry.all().single() as SpecWrapperExtension
-                  wrapper.delegate.shouldBeInstanceOf<Foo>()
+                  registry.all().single().shouldBeInstanceOf<Foo>()
                   return Result.success(emptyMap())
                }
             })
@@ -37,11 +38,10 @@ class ApplyExtensionsInterceptorTest : FunSpec() {
 
       test("ApplyExtensionsInterceptor should apply extensions where the primary constructor is not no-args") {
          val registry = DefaultExtensionRegistry()
-         ApplyExtensionsInterceptor(registry)
+         ApplyExtensionsInterceptor(NoopTestEngineListener, registry)
             .intercept(SpecRef.Reference(MyAnnotatedSpec2::class), object : NextSpecRefInterceptor {
                override suspend fun invoke(ref: SpecRef): Result<Map<TestCase, TestResult>> {
-                  val wrapper = registry.all().single() as SpecWrapperExtension
-                  wrapper.delegate.shouldBeInstanceOf<Bar>()
+                  registry.all().single().shouldBeInstanceOf<Bar>()
                   return Result.success(emptyMap())
                }
             })
@@ -50,13 +50,24 @@ class ApplyExtensionsInterceptorTest : FunSpec() {
       test("ApplyExtensionsInterceptor should apply extensions where the referenced extension is an object") {
 
          val collector = CollectingTestEngineListener()
-         TestEngineLauncher().withListener(collector)
+         TestEngineLauncher()
+            .withListener(collector)
             .withClasses(MyAnnotatedSpec3::class)
             .launch()
 
          // if apply extension was not applied, it would fail to intercept the failing test
          collector.tests.keys.single().name.name shouldBe "foo"
          collector.tests.values.single().isSuccess shouldBe true
+      }
+
+      test("ApplyExtensions should error for a private object") {
+         val collector = CollectingTestEngineListener()
+         TestEngineLauncher()
+            .withListener(collector)
+            .withClasses(MyAnnotatedSpec4::class)
+            .launch()
+         collector.specs.toList()
+            .first().second.errorOrNull.shouldNotBeNull().message shouldContain "Cannot use private class"
       }
    }
 }
@@ -73,6 +84,14 @@ class Baz : TestCaseExtension {
    }
 }
 
+private object PrivateTestExtension : TestCaseExtension {
+   var counter = 0
+   override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {
+      counter++
+      return execute(testCase)
+   }
+}
+
 @ApplyExtension(Foo::class)
 private class MyAnnotatedSpec : FunSpec()
 
@@ -83,5 +102,12 @@ private class MyAnnotatedSpec2 : FunSpec()
 private class MyAnnotatedSpec3 : FunSpec() {
    init {
       test("foo") { error("boom") }
+   }
+}
+
+@ApplyExtension(PrivateTestExtension::class)
+private class MyAnnotatedSpec4 : FunSpec() {
+   init {
+      test("foo") { }
    }
 }


### PR DESCRIPTION
Update SpecInstantiator to take annotations from registery
Add test for spring custom context factories
Tidy up spring extension code
Tests work but require JDK 17 to run so disabled for now

Fixes #5056

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
