### PR TITLE
Fix: `InstancePerLeaf` tests fail when a test leaf has siblings

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerLeafSpecExecutor.kt
@@ -118,10 +118,7 @@ internal class InstancePerLeafSpecExecutor(
                }
 
                is SendIgnoredNotification -> context.listener.testIgnored(ops.testCase, ops.reason)
-               is SendFinishedNotification -> {
-                  println("test finished: ${ops.testCase.descriptor.path()}")
-                  context.listener.testFinished(ops.testCase, ops.result)
-               }
+               is SendFinishedNotification -> context.listener.testFinished(ops.testCase, ops.result)
             }
          }
       }
@@ -174,9 +171,6 @@ internal class InstancePerLeafSpecExecutor(
          specContext: SpecContext,
          ref: SpecRef
       ): TestResult {
-         println("executeTest: start")
-         println(testCase.descriptor.path())
-
          // we need a special listener that only listens to the target test case events
          val listener = TargetListeningListener(target, context.listener)
          val executor = TestCaseExecutor(listener, context)
@@ -193,12 +187,6 @@ internal class InstancePerLeafSpecExecutor(
             specContext = specContext
          )
          results.completed(testCase, result)
-
-         println("executeTest: finish")
-         println(testCase.descriptor.path())
-
-         println(testScope.discoveredTests)
-         println(listener.testListenerOperation)
 
          // Add all discovered tests first if they exist
          discoveredOperations.addAll(testScope.discoveredTests)
@@ -278,10 +266,7 @@ internal class InstancePerLeafSpecExecutor(
          var testListenerOperation: TestListenerOperation? = null
 
          override suspend fun testStarted(testCase: TestCase) {
-            if (target == null || testCase.type == TestType.Test) {
-               println("test started: ${testCase.descriptor.path()}")
-               delegate.testStarted(testCase)
-            }
+            if (target == null || testCase.type == TestType.Test) delegate.testStarted(testCase)
          }
 
          override suspend fun testIgnored(testCase: TestCase, reason: String?) {
@@ -290,10 +275,8 @@ internal class InstancePerLeafSpecExecutor(
          }
 
          override suspend fun testFinished(testCase: TestCase, result: TestResult) {
-            if (testCase.type == TestType.Test) {
-               println("test finished: ${testCase.descriptor.path()}")
-               delegate.testFinished(testCase, result)
-            } else if (target == null) testListenerOperation = SendFinishedNotification(testCase, result)
+            if (testCase.type == TestType.Test) delegate.testFinished(testCase, result)
+            else if (target == null) testListenerOperation = SendFinishedNotification(testCase, result)
          }
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/execmode/InstancePerLeafTest.kt
@@ -147,3 +147,34 @@ class InstancePerLeafTest4 : DescribeSpec({
       }
    }
 })
+
+class InstancePerLeafTest5 : DescribeSpec({
+
+   isolationMode = IsolationMode.InstancePerLeaf
+
+   beforeSpec {
+      trace = ""
+   }
+
+   describe("d1") {
+      trace += "d1_"
+
+      context("c1") {
+         trace += "c1_"
+
+         it("i1") {
+            trace += "i1_"
+            trace shouldBe "d1_c1_i1_"
+         }
+
+         context("c2") {
+            trace += "c2_"
+
+            it("i2") {
+               trace += "i2_"
+               trace shouldBe "d1_c1_c2_i2_"
+            }
+         }
+      }
+   }
+})


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

sending notification logic was incorrect