### PR TITLE
fix(arrow): collect clues on failures

### DIFF
--- a/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCase.kt
+++ b/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCase.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions.arrow.fx.coroutines
 
 import arrow.fx.coroutines.ExitCase
+import io.kotest.assertions.AssertionErrorBuilder
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 import kotlinx.coroutines.CancellationException
@@ -13,9 +14,9 @@ public fun ExitCase.shouldBeCancelled(
     returns() implies (this@shouldBeCancelled is ExitCase.Cancelled)
   }
   return when (this) {
-    is ExitCase.Completed -> throw AssertionError(failureMessage(this))
+    is ExitCase.Completed -> AssertionErrorBuilder.fail(failureMessage(this))
     is ExitCase.Cancelled -> this
-    is ExitCase.Failure -> throw AssertionError(failureMessage(this))
+    is ExitCase.Failure -> AssertionErrorBuilder.fail(failureMessage(this))
   }
 }
 
@@ -38,8 +39,8 @@ public fun ExitCase.shouldBeCompleted(
   }
   return when (this) {
     is ExitCase.Completed -> this
-    is ExitCase.Cancelled -> throw AssertionError(failureMessage(this))
-    is ExitCase.Failure -> throw AssertionError(failureMessage(this))
+    is ExitCase.Cancelled -> AssertionErrorBuilder.fail(failureMessage(this))
+    is ExitCase.Failure -> AssertionErrorBuilder.fail(failureMessage(this))
   }
 }
 
@@ -51,8 +52,8 @@ public fun ExitCase.shouldBeFailure(
     returns() implies (this@shouldBeFailure is ExitCase.Failure)
   }
   return when (this) {
-    is ExitCase.Completed -> throw AssertionError(failureMessage(this))
-    is ExitCase.Cancelled -> throw AssertionError(failureMessage(this))
+    is ExitCase.Completed -> AssertionErrorBuilder.fail(failureMessage(this))
+       is ExitCase.Cancelled -> AssertionErrorBuilder.fail(failureMessage(this))
     is ExitCase.Failure -> this
   }
 }

--- a/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonTest/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCaseTest.kt
+++ b/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonTest/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCaseTest.kt
@@ -2,6 +2,7 @@ package io.kotest.assertions.arrow.fx.coroutines
 
 import arrow.fx.coroutines.ExitCase
 import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.map
@@ -73,4 +74,42 @@ class ExitCaseTest : StringSpec({
       ExitCase.Failure(e).shouldBeFailure(e)
     }
   }
+
+   "shouldBeCancelled collects clues" {
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected ExitCase.Cancelled, but found ExitCase.Completed") {
+         withClue("a clue:") { ExitCase.Completed.shouldBeCancelled() }
+      }
+
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected ExitCase.Cancelled, but found Failure(failure=java.lang.RuntimeException: an error)") {
+         withClue("a clue:") { ExitCase.Failure(RuntimeException("an error")).shouldBeCancelled() }
+      }
+   }
+
+   "shouldBeCompleted collects clues" {
+      shouldThrowWithMessage<AssertionError>(
+         "a clue:\nExpected ExitCase.Completed, but found Cancelled(exception=java.util.concurrent.CancellationException: an error)",
+      ) {
+         withClue("a clue:") { ExitCase.Cancelled(CancellationException("an error")).shouldBeCompleted() }
+      }
+
+      shouldThrowWithMessage<AssertionError>(
+         "a clue:\nExpected ExitCase.Completed, but found Failure(failure=java.lang.RuntimeException: an error)",
+      ) {
+         withClue("a clue:") { ExitCase.Failure(RuntimeException("an error")).shouldBeCompleted() }
+      }
+   }
+
+   "shouldBeFailure collects clues" {
+      shouldThrowWithMessage<AssertionError>(
+         "a clue:\nExpected ExitCase.Failure, but found ExitCase.Completed",
+      ) {
+         withClue("a clue:") { ExitCase.Completed.shouldBeFailure() }
+      }
+
+      shouldThrowWithMessage<AssertionError>(
+         "a clue:\nExpected ExitCase.Failure, but found Cancelled(exception=java.util.concurrent.CancellationException: an error)",
+      ) {
+         withClue("a clue:") { ExitCase.Cancelled(CancellationException("an error")).shouldBeFailure() }
+      }
+   }
 })

--- a/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonTest/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCaseTest.kt
+++ b/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonTest/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCaseTest.kt
@@ -1,6 +1,7 @@
 package io.kotest.assertions.arrow.fx.coroutines
 
 import arrow.fx.coroutines.ExitCase
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.map
@@ -11,6 +12,18 @@ import kotlinx.coroutines.CancellationException
 class ExitCaseTest : StringSpec({
   "shouldBeCancelled" {
     ExitCase.Cancelled(CancellationException("")).shouldBeCancelled()
+
+     shouldThrowWithMessage<AssertionError>("Expected ExitCase.Cancelled, but found ExitCase.Completed") {
+        ExitCase.Completed.shouldBeCancelled()
+     }
+
+     checkAll(Arb.string()) { s ->
+        shouldThrowWithMessage<AssertionError>(
+           "Expected ExitCase.Cancelled, but found Failure(failure=java.lang.RuntimeException: $s)",
+        ) {
+           ExitCase.Failure(RuntimeException(s)).shouldBeCancelled()
+        }
+     }
   }
 
   "shouldBeCancelled(e)" {
@@ -21,12 +34,38 @@ class ExitCaseTest : StringSpec({
 
   "shouldBeCompleted" {
     ExitCase.Completed.shouldBeCompleted()
+
+     checkAll(Arb.string()) { s ->
+        shouldThrowWithMessage<AssertionError>(
+           "Expected ExitCase.Completed, but found Cancelled(exception=java.util.concurrent.CancellationException: $s)",
+        ) {
+           ExitCase.Cancelled(CancellationException(s)).shouldBeCompleted()
+        }
+
+        shouldThrowWithMessage<AssertionError>(
+           "Expected ExitCase.Cancelled, but found Failure(failure=java.lang.RuntimeException: $s)",
+        ) {
+           ExitCase.Failure(RuntimeException(s)).shouldBeCancelled()
+        }
+     }
   }
 
   "shouldBeFailure" {
     checkAll(Arb.string().map(::RuntimeException)) { e ->
       ExitCase.Failure(e).shouldBeFailure()
     }
+
+     shouldThrowWithMessage<AssertionError>("Expected ExitCase.Failure, but found ExitCase.Completed") {
+        ExitCase.Completed.shouldBeFailure()
+     }
+
+     checkAll(Arb.string()) { s ->
+        shouldThrowWithMessage<AssertionError>(
+           "Expected ExitCase.Failure, but found Cancelled(exception=java.util.concurrent.CancellationException: $s)",
+        ) {
+           ExitCase.Cancelled(CancellationException(s)).shouldBeFailure()
+        }
+     }
   }
 
   "shouldBeFailure(e)" {

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Either.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Either.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.Either.Left
 import arrow.core.Either.Right
 import arrow.core.identity
+import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.arrow.shouldBe
 import io.kotest.assertions.arrow.shouldNotBe
 import io.kotest.matchers.assertionCounter
@@ -38,7 +39,7 @@ public fun <A, B> Either<A, B>.shouldBeRight(failureMessage: (A) -> String = { "
 
    return when (this) {
       is Right -> value
-      is Left -> throw AssertionError(failureMessage(value))
+      is Left -> AssertionErrorBuilder.fail(failureMessage(value))
    }
 }
 
@@ -74,7 +75,7 @@ public fun <A, B> Either<A, B>.shouldBeLeft(failureMessage: (B) -> String = { "E
 
    return when (this) {
       is Left -> value
-      is Right -> throw AssertionError(failureMessage(value))
+      is Right -> AssertionErrorBuilder.fail(failureMessage(value))
    }
 }
 

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
@@ -4,6 +4,7 @@ import arrow.core.Ior
 import arrow.core.Ior.Left
 import arrow.core.Ior.Right
 import arrow.core.Ior.Both
+import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.arrow.shouldBe
 import io.kotest.assertions.arrow.shouldNotBe
 import kotlin.contracts.ExperimentalContracts
@@ -25,7 +26,7 @@ public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A, B>) -> String 
 
    return when (this) {
       is Right -> value
-      else -> throw AssertionError(failureMessage(this))
+      else -> AssertionErrorBuilder.fail(failureMessage(this))
    }
 }
 
@@ -47,7 +48,7 @@ public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A, B>) -> String =
 
    return when (this) {
       is Left -> value
-      else -> throw AssertionError(failureMessage(this))
+      else -> AssertionErrorBuilder.fail(failureMessage(this))
    }
 }
 

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Option.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Option.kt
@@ -3,6 +3,7 @@ package io.kotest.assertions.arrow.core
 import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
+import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.arrow.shouldBe
 import io.kotest.assertions.arrow.shouldNotBe
 import io.kotest.matchers.assertionCounter
@@ -35,7 +36,7 @@ public fun <A> Option<A>.shouldBeSome(failureMessage: () -> String = { "Expected
    assertionCounter.inc()
 
    return when (this) {
-      None -> throw AssertionError(failureMessage())
+      None -> AssertionErrorBuilder.fail(failureMessage())
       is Some -> value
    }
 }
@@ -73,6 +74,6 @@ public fun <A> Option<A>.shouldBeNone(failureMessage: (Some<A>) -> String = { "E
 
    return when (this) {
       None -> None
-      is Some -> throw AssertionError(failureMessage(this))
+      is Some -> AssertionErrorBuilder.fail(failureMessage(this))
    }
 }

--- a/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/EitherMatchers.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/EitherMatchers.kt
@@ -1,6 +1,9 @@
 package io.kotest.assertions.arrow.core
 
 import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
@@ -12,6 +15,10 @@ class EitherMatchers : StringSpec({
   "shouldBeRight"{
     checkAll(Arb.int()) { i ->
       Either.Right(i) shouldBeRight i
+
+      shouldThrowWithMessage<AssertionError>("Expected Either.Right, but found Either.Left with value $i") {
+        i.left() shouldBeRight i
+      }
     }
   }
 
@@ -27,6 +34,10 @@ class EitherMatchers : StringSpec({
   "shouldBeLeft"{
     checkAll(Arb.int()) { i ->
       Either.Left(i) shouldBeLeft i
+
+      shouldThrowWithMessage<AssertionError>("Expected Either.Left, but found Either.Right with value $i") {
+        i.right() shouldBeLeft i
+      }
     }
   }
 

--- a/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/EitherMatchers.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/EitherMatchers.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
 import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
@@ -48,5 +49,21 @@ class EitherMatchers : StringSpec({
     ) { (a, b) ->
       Either.Left(a) shouldNotBeLeft b
     }
+  }
+
+  "shouldBeRight collects clues" {
+     shouldThrowWithMessage<AssertionError>(
+        "a clue:\nExpected Either.Right, but found Either.Left with value 1",
+     ) {
+        withClue("a clue:") { 1.left().shouldBeRight() }
+     }
+  }
+
+  "shouldBeLeft collects clues" {
+     shouldThrowWithMessage<AssertionError>(
+        "a clue:\nExpected Either.Left, but found Either.Right with value 1",
+     ) {
+        withClue("a clue:") { 1.right().shouldBeLeft() }
+     }
   }
 })

--- a/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/IorMatchers.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/IorMatchers.kt
@@ -1,7 +1,10 @@
 package io.kotest.assertions.arrow.core
 
 import arrow.core.Ior
+import arrow.core.leftIor
+import arrow.core.rightIor
 import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
@@ -74,4 +77,22 @@ class IorMatchers : StringSpec({
       }
     }
   }
+
+   "shouldBeRight collects clues" {
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected Ior.Right, but found Left") {
+         withClue("a clue:") { 1.leftIor().shouldBeRight() }
+      }
+   }
+
+   "shouldBeLeft collects clues" {
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected Ior.Left, but found Right") {
+         withClue("a clue:") { 1.rightIor().shouldBeLeft() }
+      }
+   }
+
+   "shouldBeBoth collects clues" {
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected ior to be a Both, but was: Right") {
+         withClue("a clue:") { 1.rightIor().shouldBeBoth() }
+      }
+   }
 })

--- a/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/IorMatchers.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/IorMatchers.kt
@@ -1,19 +1,28 @@
 package io.kotest.assertions.arrow.core
 
 import arrow.core.Ior
+import io.kotest.assertions.throwables.shouldThrowWithMessage
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.filter
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.string
 import io.kotest.property.checkAll
-import io.kotest.matchers.shouldBe
 
 class IorMatchers : StringSpec({
   "shouldBeRight"{
     checkAll(Arb.int()) { i ->
       Ior.Right(i) shouldBeRight i
+
+      shouldThrowWithMessage<AssertionError>("Expected Ior.Right, but found Left") {
+        Ior.Left(i) shouldBeRight i
+      }
+
+      shouldThrowWithMessage<AssertionError>("Expected Ior.Right, but found Both") {
+        Ior.Both(i, i) shouldBeRight i
+      }
     }
   }
 
@@ -29,6 +38,14 @@ class IorMatchers : StringSpec({
   "shouldBeLeft"{
     checkAll(Arb.int()) { i ->
       Ior.Left(i) shouldBeLeft i
+
+      shouldThrowWithMessage<AssertionError>("Expected Ior.Left, but found Right") {
+        Ior.Right(i) shouldBeLeft i
+      }
+
+      shouldThrowWithMessage<AssertionError>("Expected Ior.Left, but found Both") {
+        Ior.Both(i, i) shouldBeLeft i
+      }
     }
   }
 
@@ -47,6 +64,14 @@ class IorMatchers : StringSpec({
       ior.shouldBeBoth()
       ior.leftValue shouldBe i
       ior.rightValue shouldBe j
+
+      shouldThrowWithMessage<AssertionError>("Expected ior to be a Both, but was: Left") {
+        Ior.Left(i).shouldBeBoth()
+      }
+
+      shouldThrowWithMessage<AssertionError>("Expected ior to be a Both, but was: Right") {
+        Ior.Right(i).shouldBeBoth()
+      }
     }
   }
 })

--- a/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/OptionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonTest/kotlin/io/kotest/assertions/arrow/core/OptionMatchers.kt
@@ -1,8 +1,11 @@
 package io.kotest.assertions.arrow.core
 
+import arrow.core.None
 import arrow.core.Option
 import arrow.core.Some
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -52,4 +55,16 @@ class OptionMatchers : StringSpec({
 
     Option.fromNullable<String>(null).shouldBeNone()
   }
+
+   "shouldNotBeSome collects clues" {
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected Some, but found None") {
+         withClue("a clue:") { None.shouldBeSome() }
+      }
+   }
+
+   "shouldNotBeNone collects clues" {
+      shouldThrowWithMessage<AssertionError>("a clue:\nExpected None, but found Some with value 1") {
+         withClue("a clue:") { Some(1).shouldBeNone() }
+      }
+   }
 })


### PR DESCRIPTION
fix for https://github.com/kotest/kotest/issues/5138

- **test(arrow): assert unhappy paths for either + ior**
- **fix(arrow): collect clues on failures.**
- **test(arrow-fx): assert unhappy paths for ExitCase.**
- **fix(arrow-fx): collect clues on failures.**