### PR TITLE
Fix wasmJS support for browser tests

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3037,7 +3037,6 @@ public final class io/kotest/engine/TestAbortedException : java/lang/Throwable {
 public final class io/kotest/engine/TestEngineLauncher {
 	public fun <init> ()V
 	public fun <init> (Lio/kotest/common/Platform;Ljava/util/List;Lio/kotest/core/config/AbstractProjectConfig;Ljava/util/List;Lio/kotest/engine/tags/TagExpression;Lio/kotest/engine/extensions/ExtensionRegistry;)V
-	public fun <init> (Lio/kotest/engine/listener/TestEngineListener;)V
 	public final fun addExtension (Lio/kotest/core/extensions/Extension;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun addExtensions (Ljava/util/List;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun addExtensions ([Lio/kotest/core/extensions/Extension;)Lio/kotest/engine/TestEngineLauncher;
@@ -3055,6 +3054,7 @@ public final class io/kotest/engine/TestEngineLauncher {
 	public final fun withJs ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withJvm ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withListener (Lio/kotest/engine/listener/TestEngineListener;)Lio/kotest/engine/TestEngineLauncher;
+	public final fun withListeners (Ljava/util/Collection;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withNative ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withNoOpListener ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withPlatform (Lio/kotest/common/Platform;)Lio/kotest/engine/TestEngineLauncher;
@@ -3334,17 +3334,6 @@ public final class io/kotest/engine/coroutines/CoroutineDispatcherFactoryKt {
 
 public final class io/kotest/engine/coroutines/TestSchedulerKt {
 	public static final fun getTestScheduler (Lio/kotest/core/test/TestScope;)Lkotlinx/coroutines/test/TestCoroutineScheduler;
-}
-
-public final class io/kotest/engine/coroutines/TestScopeElement : kotlin/coroutines/CoroutineContext$Element {
-	public static final field Companion Lio/kotest/engine/coroutines/TestScopeElement$Companion;
-	public fun <init> (Lkotlinx/coroutines/test/TestScope;)V
-	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
-	public fun get (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext$Element;
-	public fun getKey ()Lkotlin/coroutines/CoroutineContext$Key;
-	public final fun getTestScope ()Lkotlinx/coroutines/test/TestScope;
-	public fun minusKey (Lkotlin/coroutines/CoroutineContext$Key;)Lkotlin/coroutines/CoroutineContext;
-	public fun plus (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
 }
 
 public final class io/kotest/engine/coroutines/TestScopeElement$Companion : kotlin/coroutines/CoroutineContext$Key {

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -97,6 +97,13 @@ kotlin {
          }
       }
 
+      wasmJsMain {
+         dependencies {
+            // used to write to the console with fancy colours!
+            implementation(libs.mordant)
+         }
+      }
+
       macosMain {
          dependencies {
             // used to write to the console with fancy colours!
@@ -105,6 +112,13 @@ kotlin {
       }
 
       iosMain {
+         dependencies {
+            // used to write to the console with fancy colours!
+            implementation(libs.mordant)
+         }
+      }
+
+      watchosMain {
          dependencies {
             // used to write to the console with fancy colours!
             implementation(libs.mordant)

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -117,13 +117,6 @@ kotlin {
             implementation(libs.mordant)
          }
       }
-
-      watchosMain {
-         dependencies {
-            // used to write to the console with fancy colours!
-            implementation(libs.mordant)
-         }
-      }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/jsMain/kotlin/io/kotest/engine/TestEngineLauncher.js.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsMain/kotlin/io/kotest/engine/TestEngineLauncher.js.kt
@@ -1,0 +1,7 @@
+package io.kotest.engine
+
+import io.kotest.common.Platform
+import io.kotest.engine.listener.TestEngineListener
+
+// setup by the KSP plugin
+internal actual fun Platform.listeners(): List<TestEngineListener> = emptyList()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/TestEngineLauncher.jvm.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/TestEngineLauncher.jvm.kt
@@ -1,0 +1,7 @@
+package io.kotest.engine
+
+import io.kotest.common.Platform
+import io.kotest.engine.listener.TestEngineListener
+
+// listeners will be setup by the gradle plugins / junit platform
+internal actual fun Platform.listeners(): List<TestEngineListener> = emptyList()

--- a/kotest-framework/kotest-framework-engine/src/nativeMain/kotlin/io/kotest/engine/TestEngineLauncher.native.kt
+++ b/kotest-framework/kotest-framework-engine/src/nativeMain/kotlin/io/kotest/engine/TestEngineLauncher.native.kt
@@ -1,0 +1,6 @@
+package io.kotest.engine
+
+import io.kotest.common.Platform
+import io.kotest.engine.listener.TestEngineListener
+
+internal actual fun Platform.listeners(): List<TestEngineListener> = emptyList()

--- a/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/TestEngineLauncher.wasmJs.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/TestEngineLauncher.wasmJs.kt
@@ -1,0 +1,23 @@
+package io.kotest.engine
+
+import io.kotest.common.Platform
+import io.kotest.engine.js.isJavascriptTestFrameworkAvailable
+import io.kotest.engine.listener.ConsoleTestEngineListener
+import io.kotest.engine.listener.TeamCityTestEngineListener
+import io.kotest.engine.listener.TestEngineListener
+
+internal actual fun Platform.listeners(): List<TestEngineListener> {
+   return if (isJavascriptTestFrameworkAvailable()) {
+      // if we have a javascript test framework available (eg running in the browser), then Kotest
+      // will route test events using the framework functions, so we don't want to output using TCSM
+      // todo these events don't appear in gradle output, might be a kotlin.test issue or something wrong in kotest
+      // todo perhaps the kotlin.test is grabbing all stdout output in order to pick out the JS framework output
+      listOf(ConsoleTestEngineListener())
+   } else {
+      // if we have no javascript test framework, eg running wasm inside NodeJS, then we will output TCSM messages
+      // which the kotlin.test gradle plugin will pickup and process inside intellij.
+      // For output when runing through gradle directly, we add the console listener
+      // todo would be good to figure out if we're inside intellij or not and not include the console listener if so
+      listOf(TeamCityTestEngineListener(), ConsoleTestEngineListener())
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/console/ConsoleRenderer.wasmJs.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/console/ConsoleRenderer.wasmJs.kt
@@ -1,3 +1,29 @@
 package io.kotest.engine.console
 
-actual val consoleRenderer: ConsoleRenderer = PlainConsoleRenderer
+import com.github.ajalt.mordant.rendering.AnsiLevel
+import com.github.ajalt.mordant.rendering.TextColors
+import com.github.ajalt.mordant.rendering.TextStyles
+import com.github.ajalt.mordant.terminal.Terminal
+
+actual val consoleRenderer: ConsoleRenderer = MordantConsoleRenderer
+
+object MordantConsoleRenderer : ConsoleRenderer {
+
+   private val t = Terminal(AnsiLevel.TRUECOLOR)
+
+   override fun println() = t.println()
+   override fun println(str: String) = t.println(str)
+   override fun print(str: String) = t.print(str)
+
+   override fun bold(str: String) = TextStyles.bold(str)
+   override fun green(str: String) = TextColors.green(str)
+   override fun greenBold(str: String) = (TextColors.green + TextStyles.bold).invoke(str)
+   override fun red(str: String) = TextColors.red(str)
+   override fun redBold(str: String) = (TextColors.red + TextStyles.bold)(str)
+   override fun brightRed(str: String) = TextColors.brightRed(str)
+   override fun brightRedBold(str: String) = (TextColors.brightRed + TextStyles.bold).invoke(str)
+   override fun yellow(str: String) = TextColors.yellow(str)
+   override fun yellowBold(str: String) = (TextColors.yellow + TextStyles.bold).invoke(str)
+   override fun brightYellow(str: String) = TextColors.brightYellow(str)
+   override fun brightYellowBold(str: String) = (TextColors.brightYellow + TextStyles.bold).invoke(str)
+}

--- a/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/errors/handleEngineError.wasmJs.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/errors/handleEngineError.wasmJs.kt
@@ -5,10 +5,10 @@ package io.kotest.engine.errors
 import io.kotest.engine.EngineResult
 import io.kotest.engine.js.exitProcess
 import io.kotest.engine.js.printStderr
-import io.kotest.engine.spec.execution.isNodeJs
+import io.kotest.engine.js.isNodeJsRuntime
 
 actual fun handleEngineResult(result: EngineResult) {
-   if (isNodeJs()) {
+   if (isNodeJsRuntime()) {
       if (result.errors.isNotEmpty()) {
          printStderr(result.errors.first().stackTraceToString())
          exitProcess(1)

--- a/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/js/isJavascriptTestFrameworkAvailable.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/js/isJavascriptTestFrameworkAvailable.kt
@@ -1,0 +1,9 @@
+package io.kotest.engine.js
+
+/**
+ * Returns true if a Jasmine-like Javascript test framework is available.
+ *
+ * This depends if we have a JS runtime, and if we are running inside the browser or node/js.
+ */
+internal fun isJavascriptTestFrameworkAvailable(): Boolean =
+   js("typeof describe === 'function' && typeof it === 'function'")

--- a/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/js/isNodeJsRuntime.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/js/isNodeJsRuntime.kt
@@ -1,0 +1,9 @@
+package io.kotest.engine.js
+
+/**
+ * Returns true if the current runtime environment is NodeJS.
+ *
+ * @see https://stackoverflow.com/a/31090240
+ */
+internal fun isNodeJsRuntime(): Boolean =
+   js("(new Function('try { return this === global; } catch(e) { return false; }'))()")

--- a/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/spec/execution/SpecRefExecutor.wasmJs.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmJsMain/kotlin/io/kotest/engine/spec/execution/SpecRefExecutor.wasmJs.kt
@@ -3,6 +3,7 @@ package io.kotest.engine.spec.execution
 import io.kotest.core.spec.Spec
 import io.kotest.engine.interceptors.EngineContext
 import io.kotest.engine.js.KotlinJsSpecExecutor
+import io.kotest.engine.js.isJavascriptTestFrameworkAvailable
 
 /**
  * Javascript can be compiled to both wasm and js. In the case of wasm, although the language is JS,
@@ -10,20 +11,5 @@ import io.kotest.engine.js.KotlinJsSpecExecutor
  * the we use  the [SingleInstanceSpecExecutor] which is the default executor for Kotest.
  */
 internal actual fun specExecutor(context: EngineContext, spec: Spec): SpecExecutor {
-   return if (kotlinJsTestFrameworkAvailable()) KotlinJsSpecExecutor(context) else SingleInstanceSpecExecutor(context)
+   return if (isJavascriptTestFrameworkAvailable()) KotlinJsSpecExecutor(context) else SingleInstanceSpecExecutor(context)
 }
-
-/**
- * Detects if a jasmine-like Kotlin JS test framework is available by checking
- * for the presence of `describe` and `it` functions.
- */
-private fun kotlinJsTestFrameworkAvailable(): Boolean =
-   js("typeof describe === 'function' && typeof it === 'function'")
-
-/**
- * Returns true if the current runtime environment is NodeJS.
- *
- * @see https://stackoverflow.com/a/31090240
- */
-internal fun isNodeJs(): Boolean =
-   js("(new Function('try { return this === global; } catch(e) { return false; }'))()")

--- a/kotest-framework/kotest-framework-engine/src/wasmWasiMain/kotlin/io/kotest/engine/TestEngineLauncher.wasmWasi.kt
+++ b/kotest-framework/kotest-framework-engine/src/wasmWasiMain/kotlin/io/kotest/engine/TestEngineLauncher.wasmWasi.kt
@@ -1,0 +1,6 @@
+package io.kotest.engine
+
+import io.kotest.common.Platform
+import io.kotest.engine.listener.TestEngineListener
+
+internal actual fun Platform.listeners(): List<TestEngineListener> = emptyList()

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
@@ -74,7 +74,8 @@ class KotestSymbolProcessor(private val environment: SymbolProcessorEnvironment)
       when (val platform = environment.platforms.first()) {
          is JsPlatformInfo -> JSGenerator(environment).generate(files, visitor.specs, visitor.configs)
          is NativePlatformInfo -> NativeGenerator(environment).generate(files, visitor.specs, visitor.configs)
-         // todo we need some way of determining if WASI or Wasm JS, so we can use the WasmWasiGenerator
+         // todo we need some way of determining if the Wasi variant of Wasm, so we can use the WasmWasiGenerator
+         // see https://github.com/google/ksp/issues/2544
          else if platform.platformName.contains("wasm-js") ->
             WasmJsGenerator(environment).generate(files, visitor.specs, visitor.configs)
          else -> error("Unsupported platform: ${environment.platforms.first()}")
@@ -82,6 +83,7 @@ class KotestSymbolProcessor(private val environment: SymbolProcessorEnvironment)
    }
 }
 
+@Suppress("unused") // is referenced in the service resource file
 class KotestSymbolProcessorProvider : SymbolProcessorProvider {
    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
       return KotestSymbolProcessor(environment)

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/WasmJsGenerator.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/WasmJsGenerator.kt
@@ -61,11 +61,8 @@ val promise = TestEngineLauncher()
             .addCode(""".withProjectConfig(${configs.first().qualifiedName?.asString()}())""")
             .addCode("\n")
       }
+      // for wasm, we detect which listeners to add at runtime
       function
-         .addCode(""".withConsoleListener()""")
-         .addCode("\n")
-         .addCode(""".withTeamCityListener()""")
-         .addCode("\n")
          .addCode(""".promise() as Promise<JsAny?>""")
          .addCode("\n")
 


### PR DESCRIPTION
Also upgrade wasm to full colour console output.

Fixes #5072

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
