### PR TITLE
Remove periods from test names only at TCSM stage

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
@@ -4,6 +4,7 @@ import io.kotest.core.Logger
 import io.kotest.core.descriptors.toDescriptor
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
+import io.kotest.engine.teamcity.names.TeamCityTestNameSanitizer
 import io.kotest.engine.test.TestResult
 import io.kotest.engine.test.names.DisplayNameFormatting
 import kotlin.reflect.KClass
@@ -30,7 +31,7 @@ internal class TeamCityWriter(
     */
    internal fun outputTestIgnored(testCase: TestCase, result: TestResult.Ignored) {
       val msg = TeamCityMessageBuilder
-         .testIgnored(prefix, formatting.format(testCase))
+         .testIgnored(prefix, formatting.format(santizeTestCaseName(testCase)))
          .id(testCase.descriptor.path().value)
          .parent(testCase.descriptor.parent.path().value)
          .locationHint(Locations.location(testCase.source))
@@ -46,7 +47,7 @@ internal class TeamCityWriter(
    internal fun outputTestStarted(testCase: TestCase) {
       logger.log { Pair(testCase.name.name, "startTest ${testCase.descriptor.path().value}") }
       val msg = TeamCityMessageBuilder
-         .testStarted(prefix, formatting.format(testCase))
+         .testStarted(prefix, formatting.format(santizeTestCaseName(testCase)))
          .id(testCase.descriptor.path().value)
          .parent(testCase.descriptor.parent.path().value)
          .locationHint(Locations.location(testCase.source))
@@ -90,7 +91,7 @@ internal class TeamCityWriter(
     */
    internal fun outputTestFailed(testCase: TestCase, result: TestResult, details: Boolean) {
       val msg = TeamCityMessageBuilder
-         .testFailed(prefix, formatting.format(testCase))
+         .testFailed(prefix, formatting.format(santizeTestCaseName(testCase)))
          .id(testCase.descriptor.path().value)
          .parent(testCase.descriptor.parent.path().value)
          .duration(result.duration)
@@ -120,7 +121,7 @@ internal class TeamCityWriter(
    internal fun outputTestFinished(testCase: TestCase, result: TestResult) {
       logger.log { Pair(testCase.name.name, "finishTest ${testCase.descriptor.path().value}") }
       val msg = TeamCityMessageBuilder
-         .testFinished(prefix, formatting.format(testCase))
+         .testFinished(prefix, formatting.format(santizeTestCaseName(testCase)))
          .id(testCase.descriptor.path().value)
          .parent(testCase.descriptor.parent.path().value)
          .duration(result.duration)
@@ -144,7 +145,7 @@ internal class TeamCityWriter(
    internal fun outputTestSuiteStarted(testCase: TestCase) {
       logger.log { Pair(testCase.name.name, "startTestSuite ${testCase.descriptor.path().value}") }
       val msg = TeamCityMessageBuilder
-         .testSuiteStarted(prefix, formatting.format(testCase))
+         .testSuiteStarted(prefix, formatting.format(santizeTestCaseName(testCase)))
          .id(testCase.descriptor.path().value)
          .parent(testCase.descriptor.parent.path().value)
          .locationHint(Locations.location(testCase.source))
@@ -158,7 +159,7 @@ internal class TeamCityWriter(
    internal fun outputTestSuiteFinished(testCase: TestCase, result: TestResult) {
       logger.log { Pair(testCase.name.name, "finishTestSuite ${testCase.descriptor.path().value}") }
       val msg = TeamCityMessageBuilder
-         .testSuiteFinished(prefix, formatting.format(testCase))
+         .testSuiteFinished(prefix, formatting.format(santizeTestCaseName(testCase)))
          .id(testCase.descriptor.path().value)
          .parent(testCase.descriptor.parent.path().value)
          .duration(result.duration)
@@ -188,5 +189,10 @@ internal class TeamCityWriter(
          .id(ref.kclass.toDescriptor().path().value)
          .build()
       println(msg)
+   }
+
+   internal fun santizeTestCaseName(testCase: TestCase): TestCase {
+      val name = TeamCityTestNameSanitizer.sanitize(testCase.name, testCase.parent?.name)
+      return testCase.copy(name = name)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/ParentNameStripper.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/ParentNameStripper.kt
@@ -7,7 +7,7 @@ import io.kotest.core.names.TestName
 // start of the nested test to make the child nest have a different prefix.
 // Also note: This only affects non-MPP tests, as MPP tests have the platform name added
 internal object ParentNameStripper {
-   fun stripe(name: TestName, parent: TestName?): String {
+   fun strip(name: TestName, parent: TestName?): String {
       return when {
          parent == null -> name.name
          name.name.startsWith(parent.name) -> "- " + name.name

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/ParentNameStripper.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/ParentNameStripper.kt
@@ -1,0 +1,17 @@
+package io.kotest.engine.teamcity.names
+
+import io.kotest.core.names.TestName
+
+// Note: intellij has a bug, where if a child test has a name that starts with the parent test name,
+// then it will remove the common prefix from the child, to workaround this, we will add a dash at the
+// start of the nested test to make the child nest have a different prefix.
+// Also note: This only affects non-MPP tests, as MPP tests have the platform name added
+internal object ParentNameStripper {
+   fun stripe(name: TestName, parent: TestName?): String {
+      return when {
+         parent == null -> name.name
+         name.name.startsWith(parent.name) -> "- " + name.name
+         else -> name.name
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/TeamCityTestNameEscaper.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/TeamCityTestNameEscaper.kt
@@ -1,4 +1,4 @@
-package io.kotest.engine.test.names
+package io.kotest.engine.teamcity.names
 
 /**
  * Escapes/fixes test names that break in TeamCity formats.

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/TeamCityTestNameSanitizer.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/TeamCityTestNameSanitizer.kt
@@ -1,0 +1,15 @@
+package io.kotest.engine.teamcity.names
+
+import io.kotest.core.names.TestName
+
+/**
+ * Sanitizes test names to work around platform/framework limitations.
+ * Delegates to various specific workaround implementations.
+ */
+internal object TeamCityTestNameSanitizer {
+
+   fun sanitize(name: TestName, parent: TestName?): TestName {
+      val parentStripped = ParentNameStripper.stripe(name, parent)
+      return name.copy(name = TeamCityTestNameEscaper.escape(parentStripped))
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/TeamCityTestNameSanitizer.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/names/TeamCityTestNameSanitizer.kt
@@ -9,7 +9,7 @@ import io.kotest.core.names.TestName
 internal object TeamCityTestNameSanitizer {
 
    fun sanitize(name: TestName, parent: TestName?): TestName {
-      val parentStripped = ParentNameStripper.stripe(name, parent)
+      val parentStripped = ParentNameStripper.strip(name, parent)
       return name.copy(name = TeamCityTestNameEscaper.escape(parentStripped))
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
@@ -20,7 +20,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 @EnabledIf(LinuxOnlyGithubCondition::class)
-class    TeamCityTestEngineListenerTest : FunSpec() {
+class TeamCityTestEngineListenerTest : FunSpec() {
 
    init {
 
@@ -408,6 +408,34 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
 a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='523' result_status='Success']
+a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+"""
+      }
+
+      test("should remove periods from output") {
+         val aperiods = a.copy(
+            parent = null,
+            name = TestNameBuilder.builder("a.b.c").build(),
+            descriptor = a.descriptor.append("a.b.c"),
+            source = SourceRef.ClassLineSource("foo.bar.Test", 17),
+         )
+
+         val output = captureStandardOut {
+            val listener = TeamCityTestEngineListener("a", details = false)
+            listener.engineStarted()
+            listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
+            listener.testStarted(aperiods)
+            listener.testFinished(aperiods, TestResult.Success(124.milliseconds))
+            listener.specFinished(
+               SpecRef.Reference(TeamCityTestEngineListenerTest::class),
+               TestResult.Success(0.seconds)
+            )
+            listener.engineFinished(emptyList())
+         }
+         output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
+a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='a b c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- a.b.c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
+a[testSuiteFinished name='a b c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- a.b.c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='124' result_status='Success']
 a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/test/names/TeamCityTestNameEscaperTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/engine/test/names/TeamCityTestNameEscaperTest.kt
@@ -1,6 +1,7 @@
 package io.kotest.engine.test.names
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.teamcity.names.TeamCityTestNameEscaper
 import io.kotest.matchers.shouldBe
 
 class TeamCityTestNameEscaperTest : FunSpec() {


### PR DESCRIPTION
Fixes #5064

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
