### PR TITLE
Wire kotest task to Gradle check task for better integration (fixes #5116)

### DIFF
--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -65,6 +65,11 @@ abstract class KotestPlugin : Plugin<Project> {
          description = TASK_DESCRIPTION
       }
 
+      // Wire the kotest task to the check task so that 'gradle check' runs Kotest tests
+      project.tasks.named(JavaBasePlugin.CHECK_TASK_NAME).configure {
+         dependsOn(KOTEST_TASK_NAME)
+      }
+
       // configures standalone Kotlin JVM projects
       handleKotlinJvm(project)
 


### PR DESCRIPTION
## Summary

Fixes #5116 by wiring the `kotest` task to the standard Gradle `check` task, enabling proper integration with Gradle's verification workflow.

## Problem

The Kotest Gradle plugin created a `kotest` task in the VERIFICATION_GROUP but did not wire it to the standard `check` task. This caused several issues:

1. ❌ Running `gradle check` would NOT run Kotest tests
2. ❌ Users had to remember to run `gradle kotest` explicitly instead of using standard Gradle commands
3. ❌ CI/CD pipelines using `gradle check` would miss Kotest tests entirely
4. ❌ The standard `test` task could fail if no JUnit tests existed, breaking the `check` task

## Solution

Added a simple dependency from the `check` task to the `kotest` task immediately after the kotest task is registered:

```kotlin
// Wire the kotest task to the check task so that 'gradle check' runs Kotest tests
project.tasks.named(JavaBasePlugin.CHECK_TASK_NAME).configure {
   dependsOn(KOTEST_TASK_NAME)
}
```

This follows Gradle best practices where verification tasks should be dependencies of the `check` task.

## Benefits

- ✅ `gradle check` now runs Kotest tests automatically
- ✅ Better integration with standard Gradle workflows
- ✅ CI/CD pipelines work as expected without custom configuration
- ✅ Consistent with how other testing frameworks (JUnit, TestNG) integrate with Gradle
- ✅ Users can rely on standard Gradle commands

## Test plan

- ✅ Built the Gradle plugin successfully
- ✅ Verified compilation with new task wiring
- ✅ Confirmed check task dependency is established

🤖 Generated with [Claude Code](https://claude.com/claude-code)