### PR TITLE
Alex/reproduce race conditions (#5162)

### DIFF
--- a/documentation/docs/framework/race_conditions.md
+++ b/documentation/docs/framework/race_conditions.md
@@ -1,0 +1,75 @@
+---
+title: Reproduce Race Conditions
+slug: race_conditions.html
+---
+
+A simple tool to reproduce some common race conditions such as deadlocks in automated tests.
+<br/>
+<br/>
+For example, suppose that we need to reproduce a deadlock between two threads that are trying to modify two Postgres tables in different order.
+
+| Orders       | Items        |
+|--------------|--------------|
+| Thread 1     | Thread 2     |
+| Lock Order 1 |              |
+|              | Lock Item 2  |
+| Lock Item 2  |              |
+|              | Lock Order 1 |
+
+A brute force approach would be to run this scenario many times, hoping that eventually we shall reproduce the deadlock. Eventually this should work, but we shall have to spend some time setting up the test, and we might have to wait until it does reproduce.
+<br/>
+<br/>
+Kotest's `runInParallel` makes the task much easier, and the deadlock is reproduced on the first attempt. The following code shows how to do this, assuming that `executeSql` function is implemented and does execute SQL.
+Both threads do the following:
+* begin a transaction
+* update one table
+* wait for the other thread to complete its first update
+* try to update the other table
+
+This is a textbook scenario of a deadlock, and it is reliably reproduced every time we run this code. All the busywork of setting up threads and synchronizing them is handled by `runInParallel`.
+
+```kotlin
+// Prerequisites:
+executeSql(
+  "DROP TABLE IF EXISTS test0",
+  "DROP TABLE IF EXISTS test1",
+  "SELECT 1 AS id, 'green' AS color INTO test0",
+  "SELECT 1 AS id, 'yellow' AS color INTO test1",
+)
+
+// reproduce a deadlock
+
+var successCount = 0
+var thrownExceptions = mutableListOf<Throwable>()
+runInParallel(
+  { runner ->
+    try {
+      executeSql(jdbi, "UPDATE test0 SET color = 'blue' WHERE id = 1")
+      jdbi.useTransaction<Exception> { handle ->
+        handle.execute("UPDATE test0 SET color = 'blue' WHERE id = 1")
+        runner.await() // wait for the other thread to do its thing
+        handle.execute("UPDATE test1 SET color = 'purple' WHERE id = 1")
+        successCount++
+      }
+    } catch (ex: Throwable) {
+      thrownExceptions.add(ex)
+    }
+  },
+  { runner ->
+    try {
+      jdbi.useTransaction<Exception> { handle ->
+        handle.execute("UPDATE test1 SET color = 'blue' WHERE id = 1")
+        runner.await() // wait for the other thread to do its thing
+        handle.execute("UPDATE test0 SET color = 'purple' WHERE id = 1")
+        successCount++
+      }
+    } catch (ex: Throwable) {
+      thrownExceptions.add(ex)
+    }
+  }
+)
+successCount shouldBe 1
+thrownExceptions shouldHaveSize 1
+isDeadlock(thrownExceptions[0]) shouldBe true
+
+```

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -206,6 +206,7 @@ module.exports = {
     },
     "framework/test_factories",
     "framework/fake_functions",
+    "framework/race_conditions",
     "framework/test_output",
     {
       "type": "category",

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -3482,3 +3482,15 @@ public final class io/kotest/matchers/url/MatchersKt {
 	public static final fun shouldNotHaveRef (Ljava/net/URL;Ljava/lang/String;)V
 }
 
+public final class io/kotest/raceConditions/ParallelRunner {
+	public static final field Companion Lio/kotest/raceConditions/ParallelRunner$Companion;
+	public fun <init> (J[Lkotlin/jvm/functions/Function1;)V
+	public fun <init> ([Lkotlin/jvm/functions/Function1;)V
+	public final fun await ()I
+	public final fun run ()V
+}
+
+public final class io/kotest/raceConditions/ParallelRunner$Companion {
+	public final fun runInParallel ([Lkotlin/jvm/functions/Function1;)V
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/raceConditions/ParallelRunner.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/raceConditions/ParallelRunner.kt
@@ -1,0 +1,31 @@
+package io.kotest.raceConditions
+
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.thread
+
+class ParallelRunner(
+   private val timeoutInMs: Long,
+   vararg tasks: (runner: ParallelRunner) -> Unit) {
+   private val tasks = tasks.toList()
+   private val barrier = CyclicBarrier(tasks.size)
+
+   constructor(vararg tasks: (runner: ParallelRunner) -> Unit): this(1000L, *(tasks))
+
+   fun run() {
+      val threads = tasks.map { task ->
+         thread(start = true) {
+            task(this)
+         }
+      }
+      threads.forEach { it.join() }
+   }
+
+   fun await() = barrier.await(timeoutInMs, TimeUnit.MILLISECONDS)
+
+   companion object {
+      fun runInParallel(vararg tasks: (runner: ParallelRunner) -> Unit) {
+         ParallelRunner(*(tasks)).run()
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
@@ -1,8 +1,9 @@
 package io.kotest.raceConditions
 
-import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.raceConditions.ParallelRunner.Companion.runInParallel
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -13,50 +14,29 @@ import java.time.LocalDateTime
 @EnabledIf(LinuxOnlyGithubCondition::class)
 class ParallelRunnerTest: StringSpec() {
    init {
-      "two tasks wait on each other" {
+      /*
+      A typical race condition - two tasks mutate shared state without synchronization
+       */
+      "two tasks share one mutable state, both make the same decision at the same time" {
+         val box = Box(maxCapacity = 2)
+         box.addItem("apple")
          runInParallel({ runner: ParallelRunner ->
-            timedPrint("a1")
+            val hasCapacity = box.hasCapacity()
             runner.await()
-            timedPrint("a2")
+            if(hasCapacity) {
+               box.addItem("banana")
+            }
          },
             { runner: ParallelRunner ->
-               timedPrint("b1")
+               val hasCapacity = box.hasCapacity()
                runner.await()
-               timedPrint("b2")
+               if(hasCapacity) {
+                  box.addItem("orange")
+               }
             }
          )
-      }
-
-      "two tasks wait on each other, twice" {
-         runInParallel({ runner: ParallelRunner ->
-            timedPrint("-a1")
-            runner.await()
-            timedPrint("-a2")
-            runner.await()
-            timedPrint("-a3")
-         },
-            { runner: ParallelRunner ->
-               timedPrint("-b1")
-               runner.await()
-               runner.await()
-               timedPrint("-b2")
-            }
-         )
-      }
-
-      "one thread blows up, another times out" {
-         runInParallel({ runner: ParallelRunner ->
-            runner.await()
-            timedPrint("first task")
-            runner.await()
-         },
-            { runner: ParallelRunner ->
-               runner.await()
-               timedPrint("second task")
-               throw RuntimeException("Oops")
-            }
-         )
-         timedPrint("All done")
+         // capacity is exceeded as a result of race condition
+         box.items() shouldContainExactlyInAnyOrder listOf("apple", "banana", "orange")
       }
 
       "demo for mockkStatic".config(enabled = true) {
@@ -113,4 +93,14 @@ Time: 2023-01-02T03:04:05, Thread: 51, Second thread - after mocking 2023-01-02T
 
    private fun timedPrint(message: String) =
       println("Time: ${LocalDateTime.now()}, Thread: ${Thread.currentThread()}, $message")
+
+   private data class Box(val maxCapacity: Int) {
+      private val items = mutableListOf<String>()
+
+      fun addItem(item: String) = items.add(item)
+
+      fun hasCapacity() = items.size < maxCapacity
+
+      fun items() = items.toList()
+   }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
@@ -1,6 +1,8 @@
 package io.kotest.raceConditions
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.raceConditions.ParallelRunner.Companion.runInParallel
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -8,6 +10,7 @@ import io.mockk.mockkStatic
 import java.time.Clock
 import java.time.LocalDateTime
 
+@EnabledIf(LinuxOnlyGithubCondition::class)
 class ParallelRunnerTest: StringSpec() {
    init {
       "two tasks wait on each other" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
@@ -1,0 +1,113 @@
+package io.kotest.raceConditions
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.raceConditions.ParallelRunner.Companion.runInParallel
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
+import java.time.Clock
+import java.time.LocalDateTime
+
+class ParallelRunnerTest: StringSpec() {
+   init {
+      "two tasks wait on each other" {
+         runInParallel({ runner: ParallelRunner ->
+            timedPrint("a1")
+            runner.await()
+            timedPrint("a2")
+         },
+            { runner: ParallelRunner ->
+               timedPrint("b1")
+               runner.await()
+               timedPrint("b2")
+            }
+         )
+      }
+
+      "two tasks wait on each other, twice" {
+         runInParallel({ runner: ParallelRunner ->
+            timedPrint("-a1")
+            runner.await()
+            timedPrint("-a2")
+            runner.await()
+            timedPrint("-a3")
+         },
+            { runner: ParallelRunner ->
+               timedPrint("-b1")
+               runner.await()
+               runner.await()
+               timedPrint("-b2")
+            }
+         )
+      }
+
+      "one thread blows up, another times out" {
+         runInParallel({ runner: ParallelRunner ->
+            runner.await()
+            timedPrint("first task")
+            runner.await()
+         },
+            { runner: ParallelRunner ->
+               runner.await()
+               timedPrint("second task")
+               throw RuntimeException("Oops")
+            }
+         )
+         timedPrint("All done")
+      }
+
+      "demo for mockkStatic".config(enabled = true) {
+         runInParallel({ runner: ParallelRunner ->
+            timedPrint("Before mock on same thread: ${LocalDateTime.now().toString()}")
+            runner.await()
+            mockkStatic(LocalDateTime::class)
+            val localTime = LocalDateTime.of(2022, 4, 27, 12, 34, 56)
+            every { LocalDateTime.now(any<Clock>()) } returns localTime
+            runner.await()
+            timedPrint("After mock on same thread: ${LocalDateTime.now().toString()}")
+         },
+            { runner: ParallelRunner ->
+               timedPrint("Before mock on other thread: ${LocalDateTime.now().toString()}")
+               runner.await()
+               runner.await()
+               timedPrint("After mock on other thread: ${LocalDateTime.now().toString()}")
+            }
+         )
+         /*
+Time: 2023-05-12T13:14:07.815923, Thread: 51, Before mock on other thread: 2023-05-12T13:14:07.737748
+Time: 2023-05-12T13:14:07.816011, Thread: 50, Before mock on same thread: 2023-05-12T13:14:07.737736
+Time: 2022-04-27T12:34:56, Thread: 51, After mock on other thread: 2022-04-27T12:34:56
+Time: 2022-04-27T12:34:56, Thread: 50, After mock on same thread: 2022-04-27T12:34:56
+          */
+      }
+
+      "demo for mockkStatic - can remock".config(enabled = true) {
+         runInParallel({ runner: ParallelRunner ->
+            mockkStatic(LocalDateTime::class)
+            val localTime = LocalDateTime.of(2022, 4, 27, 12, 34, 56)
+            every { LocalDateTime.now(any<Clock>()) } returns localTime
+            timedPrint("First thread - after mocking ${LocalDateTime.now().toString()}")
+            clearAllMocks()
+            runner.await()
+            timedPrint("First thread - after clearing mock ${LocalDateTime.now().toString()}")
+         },
+            { runner: ParallelRunner ->
+               runner.await()
+               mockkStatic(LocalDateTime::class)
+               val localTime = LocalDateTime.of(2023, 1, 2, 3, 4, 5)
+               every { LocalDateTime.now(any<Clock>()) } returns localTime
+               timedPrint("Second thread - after mocking ${LocalDateTime.now().toString()}")
+            }
+         )
+         /*
+Time: 2022-04-27T12:34:56, Thread: 50, First thread - after mocking 2022-04-27T12:34:56
+Time: 2023-01-02T03:04:05, Thread: 50, First thread - after clearing mock 2023-05-12T13:30:06.908020
+Time: 2023-01-02T03:04:05, Thread: 51, Second thread - after mocking 2023-01-02T03:04:05
+          */
+      }
+
+   }
+
+   private fun timedPrint(message: String) =
+      println("Time: ${LocalDateTime.now()}, Thread: ${Thread.currentThread()}, $message")
+}


### PR DESCRIPTION
Add a simple tool to reproduce some common race conditions such as deadlocks in automated tests.

