### PR TITLE
docs: Update Maven links and badges in Extensions docs

### DIFF
--- a/documentation/docs/extensions/allure.md
+++ b/documentation/docs/extensions/allure.md
@@ -24,7 +24,7 @@ To start, add the below dependency to your Gradle build file.
 io.kotest:kotest-extensions-allure:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-allure.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-allure)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-allure.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-allure)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-allure%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-allure/maven-metadata.xml)
 
 :::note

--- a/documentation/docs/extensions/blockhound.md
+++ b/documentation/docs/extensions/blockhound.md
@@ -11,7 +11,7 @@ The Kotest BlockHound extension activates [BlockHound](https://github.com/reacto
 To use this extension add the `io.kotest:kotest-extensions-blockhound` module to your test compile path.
 :::
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-blockhound.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-blockhound)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-blockhound.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-blockhound)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-blockhound%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-blockhound/maven-metadata.xml)
 
 

--- a/documentation/docs/extensions/clock.md
+++ b/documentation/docs/extensions/clock.md
@@ -5,7 +5,8 @@ sidebar_label: Test Clock
 slug: test_clock.html
 ---
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest/kotest-extensions)](https://search.maven.org/artifact/io.kotest/kotest-extensions)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions/maven-metadata.xml)
 
 The JVM provides the `java.time.Clock` interface which is used to generate `Instant`s. When we have code that relies on time,
 we can use a `Clock` to generate the values, rather than using things like `Instant.now()` or `System.currentTimeMillis()`.
@@ -14,7 +15,7 @@ Then in tests we can provide a fixed or controllable clock which avoids issues w
 In your real code, you provide an instance of Clock.systemUTC() or whatever.
 
 :::note
-The following module is needed: `io.kotest:kotest-extensions` in your build. Search maven central for latest version [here](https://search.maven.org/search?q=kotest-extensions).
+The following module is needed: `io.kotest:kotest-extensions` in your build. Search maven central for latest version [here](https://central.sonatype.com/artifact/io.kotest/kotest-extensions).
 :::
 
 :::note

--- a/documentation/docs/extensions/decoroutinator.md
+++ b/documentation/docs/extensions/decoroutinator.md
@@ -11,7 +11,7 @@ The Kotest Decoroutinator extension integrates [Stacktrace Decoroutinator](https
 To use this extension add the `io.kotest:kotest-extensions-decoroutinator` module to your test compile path.
 :::
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-decoroutinator.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-decoroutinator)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-decoroutinator.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-decoroutinator)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-decoroutinator%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-decoroutinator/maven-metadata.xml)
 
 ### Getting Started

--- a/documentation/docs/extensions/html_reporter.md
+++ b/documentation/docs/extensions/html_reporter.md
@@ -5,7 +5,8 @@ sidebar_label: HTML Reporter
 slug: html_reporter.html
 ---
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-htmlreporter)](https://search.maven.org/artifact/io.kotest/kotest-extensions-htmlreporter)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-htmlreporter.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-htmlreporter)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-htmlreporter%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-htmlreporter/maven-metadata.xml)
 
 When using [JUnit XML](./junit_xml.md), we can generate XML results from tests that are able to produce output with nested
 tests. Unfortunately, Gradle generates its HTML reports with the results it has in-memory, which doesn't support nested
@@ -15,7 +16,7 @@ To solve this, Kotest has a listener that is able to generate HTML reports based
 by [JUnit XML](./junit_xml.md).
 
 :::note
-The following module is needed: `io.kotest:kotest-extensions-htmlreporter` in your build. Search maven central for latest version [here](https://search.maven.org/search?q=kotest-extensions-htmlreporter).
+The following module is needed: `io.kotest:kotest-extensions-htmlreporter` in your build. Search maven central for latest version [here](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-htmlreporter).
 :::
 
 In order to use it, we simply need to add it as a listener through [project config](../framework/project_config.md).

--- a/documentation/docs/extensions/instant.md
+++ b/documentation/docs/extensions/instant.md
@@ -5,6 +5,9 @@ sidebar_label: Current Instant Listeners
 slug: instant.html
 ---
 
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-now.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-now)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-now%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-now/maven-metadata.xml)
+
 :::tip
 Since Kotest 5.6.0, Current instant listeners are located in the artifact `io.kotest:kotest-extensions-now:${kotest-version}`.
 

--- a/documentation/docs/extensions/junit_xml.md
+++ b/documentation/docs/extensions/junit_xml.md
@@ -6,7 +6,8 @@ slug: junit_xml.html
 ---
 
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-junitxml)](https://search.maven.org/artifact/io.kotest/kotest-extensions-junitxml)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-junitxml.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-junitxml)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-junitxml%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-junitxml/maven-metadata.xml)
 
 
 JUnit includes an XML report generator that it calls
@@ -19,7 +20,7 @@ To solve this, Kotest has it's own implementation of the same format, that is co
 tests and/or collapse the names.
 
 :::note
-The following module is needed: `io.kotest:kotest-extensions-junitxml` in your build. Search maven central for latest version [here](https://search.maven.org/search?q=kotest-extensions-junitxml).
+The following module is needed: `io.kotest:kotest-extensions-junitxml` in your build. Search maven central for latest version [here](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-junitxml).
 :::
 
 To configure in your project, you need to add the `JunitXmlReporter` using [project config](../framework/project_config.md).

--- a/documentation/docs/extensions/koin.md
+++ b/documentation/docs/extensions/koin.md
@@ -11,7 +11,7 @@ The [Koin DI Framework](https://insert-koin.io/) can be used with Kotest through
 
 To use the extension in your project, add the dependency to your project:
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-koin.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-koin)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-koin.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-koin)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-koin%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-koin/maven-metadata.xml)
 
 :::note

--- a/documentation/docs/extensions/ktor.md
+++ b/documentation/docs/extensions/ktor.md
@@ -22,8 +22,8 @@ main Kotest releases.
 :::
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-ktor.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-assertions-ktor)
-[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-ktor%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-ktor/maven-metadata.xml)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-ktor.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-assertions-ktor)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-assertions-ktor%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-assertions-ktor/maven-metadata.xml)
 
 
 An example of using the matchers with the server side test support:

--- a/documentation/docs/extensions/mockserver.md
+++ b/documentation/docs/extensions/mockserver.md
@@ -6,7 +6,7 @@ slug: mockserver.html
 ---
 
 
-Kotest provides an [extension](https://github.com/kotest/kotest-extensions-mockserver) for integration with the [MockServer](https://www.mock-server.com) library.
+Kotest provides an [extension](https://github.com/kotest/kotest/tree/master/kotest-extensions/kotest-extensions-mockserver) for integration with the [MockServer](https://www.mock-server.com) library.
 
 :::note
 Requires the `io.kotest:kotest-extensions-mockserver` module to be added to your build.
@@ -18,7 +18,7 @@ main Kotest releases.
 :::
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-mockserver)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-mockserver)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-mockserver%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-mockserver/maven-metadata.xml)
 
 

--- a/documentation/docs/extensions/pitest.md
+++ b/documentation/docs/extensions/pitest.md
@@ -6,13 +6,15 @@ slug: pitest.html
 ---
 
 
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-pitest.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-pitest)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-pitest%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-pitest/maven-metadata.xml)
+
 The Mutation Testing tool [Pitest](https://pitest.org/) is integrated with Kotest via an extension module.
 
 ## Gradle configuration
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-pitest.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-pitest)
 
 After [configuring](https://gradle-pitest-plugin.solidsoft.info/) Pitest,
-add the `io.kotest.extensions:kotest-extensions-pitest` module to your dependencies as well:
+add the `io.kotest:kotest-extensions-pitest` module to your dependencies as well:
 
 ```kotlin
     testImplementation("io.kotest:kotest-extensions-pitest:<version>")
@@ -37,7 +39,6 @@ configure<PitestPluginExtension> {
 This should set everything up, and running `./gradlew pitest` will generate reports in the way you configured.
 
 ## Maven configuration
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-pitest.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-pitest)
 
 First of all, you need to configure the [Maven Pitest plugin](https://pitest.org/quickstart/maven/):
 

--- a/documentation/docs/extensions/spring.md
+++ b/documentation/docs/extensions/spring.md
@@ -28,8 +28,10 @@ register the `SpringExtension` in [project config](../framework/project_config.m
 
 ```kotlin
 package io.kotest.provided
+
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.extensions.spring.SpringExtension
+
 class ProjectConfig : AbstractProjectConfig() {
    override val extensions = listOf(SpringExtension())
 }
@@ -40,6 +42,7 @@ To activate it per test class:
 ```kotlin
 import io.kotest.core.extensions.ApplyExtension
 import io.kotest.extensions.spring.SpringExtension
+
 @ApplyExtension(SpringExtension::class)
 class MyTestSpec : FunSpec() {}
 ```

--- a/documentation/docs/extensions/system.md
+++ b/documentation/docs/extensions/system.md
@@ -15,7 +15,7 @@ This extension is only available on the JVM.
 
 To use this extension, add the dependency to your project:
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-jvm.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest/kotest-extensions-jvm)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-jvm.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-jvm)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-jvm%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-jvm/maven-metadata.xml)
 
 

--- a/documentation/docs/extensions/test_containers.md
+++ b/documentation/docs/extensions/test_containers.md
@@ -28,7 +28,7 @@ To begin, add the following dependency to your Gradle build file.
 io.kotest:kotest-extensions-testcontainers:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-testcontainers)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-testcontainers)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-testcontainers%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-testcontainers/maven-metadata.xml)
 
 

--- a/documentation/docs/extensions/wiremock.md
+++ b/documentation/docs/extensions/wiremock.md
@@ -13,7 +13,7 @@ URL, header and body content patterns etc.
 Kotest provides a module ```kotest-extensions-wiremock``` for integration with wiremock.
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest/kotest-extensions-wiremock)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-wiremock)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-wiremock%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-wiremock/maven-metadata.xml)
 
 

--- a/documentation/versioned_docs/version-6.0/extensions/allure.md
+++ b/documentation/versioned_docs/version-6.0/extensions/allure.md
@@ -24,7 +24,7 @@ To start, add the below dependency to your Gradle build file.
 io.kotest:kotest-extensions-allure:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-allure.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-allure)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-allure.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-allure)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-allure%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-allure/maven-metadata.xml)
 
 :::note

--- a/documentation/versioned_docs/version-6.0/extensions/blockhound.md
+++ b/documentation/versioned_docs/version-6.0/extensions/blockhound.md
@@ -11,7 +11,7 @@ The Kotest BlockHound extension activates [BlockHound](https://github.com/reacto
 To use this extension add the `io.kotest:kotest-extensions-blockhound` module to your test compile path.
 :::
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-blockhound.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-blockhound)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-blockhound.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-blockhound)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-blockhound%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-blockhound/maven-metadata.xml)
 
 

--- a/documentation/versioned_docs/version-6.0/extensions/clock.md
+++ b/documentation/versioned_docs/version-6.0/extensions/clock.md
@@ -5,7 +5,8 @@ sidebar_label: Test Clock
 slug: test_clock.html
 ---
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest/kotest-extensions)](https://search.maven.org/artifact/io.kotest/kotest-extensions)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions/maven-metadata.xml)
 
 The JVM provides the `java.time.Clock` interface which is used to generate `Instant`s. When we have code that relies on time,
 we can use a `Clock` to generate the values, rather than using things like `Instant.now()` or `System.currentTimeMillis()`.
@@ -14,7 +15,7 @@ Then in tests we can provide a fixed or controllable clock which avoids issues w
 In your real code, you provide an instance of Clock.systemUTC() or whatever.
 
 :::note
-The following module is needed: `io.kotest:kotest-extensions` in your build. Search maven central for latest version [here](https://search.maven.org/search?q=kotest-extensions).
+The following module is needed: `io.kotest:kotest-extensions` in your build. Search maven central for latest version [here](https://central.sonatype.com/artifact/io.kotest/kotest-extensions).
 :::
 
 :::note

--- a/documentation/versioned_docs/version-6.0/extensions/decoroutinator.md
+++ b/documentation/versioned_docs/version-6.0/extensions/decoroutinator.md
@@ -11,7 +11,7 @@ The Kotest Decoroutinator extension integrates [Stacktrace Decoroutinator](https
 To use this extension add the `io.kotest:kotest-extensions-decoroutinator` module to your test compile path.
 :::
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-decoroutinator.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-decoroutinator)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-decoroutinator.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-decoroutinator)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-decoroutinator%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-decoroutinator/maven-metadata.xml)
 
 ### Getting Started

--- a/documentation/versioned_docs/version-6.0/extensions/html_reporter.md
+++ b/documentation/versioned_docs/version-6.0/extensions/html_reporter.md
@@ -5,7 +5,8 @@ sidebar_label: HTML Reporter
 slug: html_reporter.html
 ---
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-htmlreporter)](https://search.maven.org/artifact/io.kotest/kotest-extensions-htmlreporter)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-htmlreporter.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-htmlreporter)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-htmlreporter%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-htmlreporter/maven-metadata.xml)
 
 When using [JUnit XML](./junit_xml.md), we can generate XML results from tests that are able to produce output with nested
 tests. Unfortunately, Gradle generates its HTML reports with the results it has in-memory, which doesn't support nested
@@ -15,7 +16,7 @@ To solve this, Kotest has a listener that is able to generate HTML reports based
 by [JUnit XML](./junit_xml.md).
 
 :::note
-The following module is needed: `io.kotest:kotest-extensions-htmlreporter` in your build. Search maven central for latest version [here](https://search.maven.org/search?q=kotest-extensions-htmlreporter).
+The following module is needed: `io.kotest:kotest-extensions-htmlreporter` in your build. Search maven central for latest version [here](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-htmlreporter).
 :::
 
 In order to use it, we simply need to add it as a listener through [project config](../framework/project_config.md).

--- a/documentation/versioned_docs/version-6.0/extensions/instant.md
+++ b/documentation/versioned_docs/version-6.0/extensions/instant.md
@@ -5,6 +5,9 @@ sidebar_label: Current Instant Listeners
 slug: instant.html
 ---
 
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-now.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-now)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-now%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-now/maven-metadata.xml)
+
 :::tip
 Since Kotest 5.6.0, Current instant listeners are located in the artifact `io.kotest:kotest-extensions-now:${kotest-version}`.
 

--- a/documentation/versioned_docs/version-6.0/extensions/junit_xml.md
+++ b/documentation/versioned_docs/version-6.0/extensions/junit_xml.md
@@ -6,7 +6,8 @@ slug: junit_xml.html
 ---
 
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-junitxml)](https://search.maven.org/artifact/io.kotest/kotest-extensions-junitxml)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-junitxml.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-junitxml)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-junitxml%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-junitxml/maven-metadata.xml)
 
 
 JUnit includes an XML report generator that it calls
@@ -19,7 +20,7 @@ To solve this, Kotest has it's own implementation of the same format, that is co
 tests and/or collapse the names.
 
 :::note
-The following module is needed: `io.kotest:kotest-extensions-junitxml` in your build. Search maven central for latest version [here](https://search.maven.org/search?q=kotest-extensions-junitxml).
+The following module is needed: `io.kotest:kotest-extensions-junitxml` in your build. Search maven central for latest version [here](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-junitxml).
 :::
 
 To configure in your project, you need to add the `JunitXmlReporter` using [project config](../framework/project_config.md).

--- a/documentation/versioned_docs/version-6.0/extensions/koin.md
+++ b/documentation/versioned_docs/version-6.0/extensions/koin.md
@@ -11,7 +11,7 @@ The [Koin DI Framework](https://insert-koin.io/) can be used with Kotest through
 
 To use the extension in your project, add the dependency to your project:
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-koin.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-koin)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-koin.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-koin)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-koin%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-koin/maven-metadata.xml)
 
 :::note

--- a/documentation/versioned_docs/version-6.0/extensions/ktor.md
+++ b/documentation/versioned_docs/version-6.0/extensions/ktor.md
@@ -22,8 +22,8 @@ main Kotest releases.
 :::
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-ktor.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-assertions-ktor)
-[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-ktor%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-ktor/maven-metadata.xml)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-assertions-ktor.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-assertions-ktor)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-assertions-ktor%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-assertions-ktor/maven-metadata.xml)
 
 
 An example of using the matchers with the server side test support:

--- a/documentation/versioned_docs/version-6.0/extensions/mockserver.md
+++ b/documentation/versioned_docs/version-6.0/extensions/mockserver.md
@@ -6,7 +6,7 @@ slug: mockserver.html
 ---
 
 
-Kotest provides an [extension](https://github.com/kotest/kotest-extensions-mockserver) for integration with the [MockServer](https://www.mock-server.com) library.
+Kotest provides an [extension](https://github.com/kotest/kotest/tree/master/kotest-extensions/kotest-extensions-mockserver) for integration with the [MockServer](https://www.mock-server.com) library.
 
 :::note
 Requires the `io.kotest:kotest-extensions-mockserver` module to be added to your build.
@@ -18,7 +18,7 @@ main Kotest releases.
 :::
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-mockserver)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-mockserver.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-mockserver)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-mockserver%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-mockserver/maven-metadata.xml)
 
 

--- a/documentation/versioned_docs/version-6.0/extensions/pitest.md
+++ b/documentation/versioned_docs/version-6.0/extensions/pitest.md
@@ -6,13 +6,15 @@ slug: pitest.html
 ---
 
 
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-pitest.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-pitest)
+[<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-pitest%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-pitest/maven-metadata.xml)
+
 The Mutation Testing tool [Pitest](https://pitest.org/) is integrated with Kotest via an extension module.
 
 ## Gradle configuration
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-pitest.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-pitest)
 
 After [configuring](https://gradle-pitest-plugin.solidsoft.info/) Pitest,
-add the `io.kotest.extensions:kotest-extensions-pitest` module to your dependencies as well:
+add the `io.kotest:kotest-extensions-pitest` module to your dependencies as well:
 
 ```kotlin
     testImplementation("io.kotest:kotest-extensions-pitest:<version>")
@@ -37,7 +39,6 @@ configure<PitestPluginExtension> {
 This should set everything up, and running `./gradlew pitest` will generate reports in the way you configured.
 
 ## Maven configuration
-[<img src="https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-extensions-pitest.svg?label=latest%20release"/>](http://search.maven.org/#search|ga|1|kotest-extensions-pitest)
 
 First of all, you need to configure the [Maven Pitest plugin](https://pitest.org/quickstart/maven/):
 

--- a/documentation/versioned_docs/version-6.0/extensions/spring.md
+++ b/documentation/versioned_docs/version-6.0/extensions/spring.md
@@ -28,8 +28,10 @@ register the `SpringExtension` in [project config](../framework/project_config.m
 
 ```kotlin
 package io.kotest.provided
+
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.extensions.spring.SpringExtension
+
 class ProjectConfig : AbstractProjectConfig() {
    override val extensions = listOf(SpringExtension())
 }
@@ -40,6 +42,7 @@ To activate it per test class:
 ```kotlin
 import io.kotest.core.extensions.ApplyExtension
 import io.kotest.extensions.spring.SpringExtension
+
 @ApplyExtension(SpringExtension::class)
 class MyTestSpec : FunSpec() {}
 ```

--- a/documentation/versioned_docs/version-6.0/extensions/system.md
+++ b/documentation/versioned_docs/version-6.0/extensions/system.md
@@ -15,7 +15,7 @@ This extension is only available on the JVM.
 
 To use this extension, add the dependency to your project:
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-jvm.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest/kotest-extensions-jvm)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-jvm.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-jvm)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-jvm%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-jvm/maven-metadata.xml)
 
 

--- a/documentation/versioned_docs/version-6.0/extensions/test_containers.md
+++ b/documentation/versioned_docs/version-6.0/extensions/test_containers.md
@@ -28,7 +28,7 @@ To begin, add the following dependency to your Gradle build file.
 io.kotest:kotest-extensions-testcontainers:${kotest.version}
 ```
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest.extensions/kotest-extensions-testcontainers)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-testcontainers.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-testcontainers)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-testcontainers%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-testcontainers/maven-metadata.xml)
 
 

--- a/documentation/versioned_docs/version-6.0/extensions/wiremock.md
+++ b/documentation/versioned_docs/version-6.0/extensions/wiremock.md
@@ -13,7 +13,7 @@ URL, header and body content patterns etc.
 Kotest provides a module ```kotest-extensions-wiremock``` for integration with wiremock.
 
 
-[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://search.maven.org/artifact/io.kotest/kotest-extensions-wiremock)
+[<img src="https://img.shields.io/maven-central/v/io.kotest/kotest-extensions-wiremock.svg?label=latest%20release"/>](https://central.sonatype.com/artifact/io.kotest/kotest-extensions-wiremock)
 [<img src="https://img.shields.io/maven-metadata/v?metadataUrl=https%3A%2F%2Fcentral.sonatype.com%2Frepository%2Fmaven-snapshots%2Fio%2Fkotest%2Fkotest-extensions-wiremock%2Fmaven-metadata.xml"/>](https://central.sonatype.com/repository/maven-snapshots/io/kotest/kotest-extensions-wiremock/maven-metadata.xml)
 
 


### PR DESCRIPTION
- Fix incorrect Maven groupId (io.kotest.extensions → io.kotest)
- Replace search links with direct links (search.maven.org → central.sonatype.com)
- Add Maven badges (clock.md, html_reporter.md, instant.md, junit_xml.md, pitest.md)
- Polish sameple code in spring.md
