### PR TITLE
allow to verify if Boolean property in jsonSchema is true or false (addresses #5171)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1057,6 +1057,8 @@ public final class io/kotest/matchers/bigdecimal/ToleranceMatcher : io/kotest/ma
 }
 
 public final class io/kotest/matchers/booleans/BooleanMatchersKt {
+	public static final fun beFalse ()Lio/kotest/matchers/Matcher;
+	public static final fun beTrue ()Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeFalse (Ljava/lang/Boolean;)Z
 	public static final fun shouldBeTrue (Ljava/lang/Boolean;)Z
 	public static final fun shouldNotBeFalse (Ljava/lang/Boolean;)Ljava/lang/Boolean;

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
@@ -2,16 +2,16 @@ package io.kotest.matchers.booleans
 
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-private fun booleanMatcher(expected: Boolean) = object : Matcher<Boolean> {
-   override fun test(value: Boolean) = MatcherResult(
+private fun booleanMatcher(expected: Boolean) = object : Matcher<Boolean?> {
+   override fun test(value: Boolean?) = MatcherResult(
       value == expected,
-      { "$value should be $expected" },
-      { "$value should not be ${!expected}" }
+      { "$value should equal $expected" },
+      { "$value should not equal $expected" }
    )
 }
 /**
@@ -46,7 +46,7 @@ fun Boolean?.shouldBeTrue(): Boolean {
       returns() implies (this@shouldBeTrue != null)
    }
 
-   this shouldBe true
+   this should beTrue()
    return this!!
 }
 /**
@@ -67,7 +67,7 @@ fun Boolean?.shouldBeTrue(): Boolean {
  * @see [Boolean?.shouldNotBeFalse]
  */
 fun Boolean?.shouldNotBeTrue(): Boolean? {
-   this shouldNotBe true
+   this shouldNot beTrue()
    return this
 }
 
@@ -94,7 +94,7 @@ fun Boolean?.shouldBeFalse(): Boolean {
       returns() implies (this@shouldBeFalse != null)
    }
 
-   this shouldBe false
+   this should beFalse()
    return this!!
 }
 
@@ -116,6 +116,6 @@ fun Boolean?.shouldBeFalse(): Boolean {
  * @see [Boolean?.shouldNotBeTrue]
  */
 fun Boolean?.shouldNotBeFalse(): Boolean? {
-   this shouldNotBe false
+   this shouldNot beFalse()
    return this
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
@@ -1,9 +1,27 @@
 package io.kotest.matchers.booleans
 
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
+
+private fun booleanMatcher(expected: Boolean) = object : Matcher<Boolean> {
+   override fun test(value: Boolean) = MatcherResult(
+      value == expected,
+      { "$value should be $expected" },
+      { "$value should not be ${!expected}" }
+   )
+}
+/**
+ * Match that verifies a given [Boolean] is `true`.
+ */
+fun beTrue() = booleanMatcher(true)
+/**
+ * Match that verifies a given [Boolean] is `false`.
+ */
+fun beFalse() = booleanMatcher(false)
 
 /**
  * Asserts that this [Boolean] is true
@@ -31,7 +49,6 @@ fun Boolean?.shouldBeTrue(): Boolean {
    this shouldBe true
    return this!!
 }
-
 /**
  * Asserts that this [Boolean] is not true
  *

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/boolean/BooleanMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/boolean/BooleanMatchersTest.kt
@@ -92,6 +92,9 @@ class BooleanMatchersTest : FreeSpec() {
          shouldThrow<AssertionError> {
             true shouldNot beTrue()
          }
+         shouldThrow<AssertionError> {
+            null should beTrue()
+         }
       }
 
       "beFalse matcher should match false and not match true" {
@@ -105,6 +108,9 @@ class BooleanMatchersTest : FreeSpec() {
          }
          shouldThrow<AssertionError> {
             false shouldNot beFalse()
+         }
+         shouldThrow<AssertionError> {
+            null should beFalse()
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/boolean/BooleanMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/boolean/BooleanMatchersTest.kt
@@ -2,11 +2,15 @@ package com.sksamuel.kotest.matchers.boolean
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.booleans.beFalse
+import io.kotest.matchers.booleans.beTrue
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.booleans.shouldNotBeFalse
 import io.kotest.matchers.booleans.shouldNotBeTrue
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 
 @Suppress("KotlinConstantConditions")
 class BooleanMatchersTest : FreeSpec() {
@@ -74,6 +78,34 @@ class BooleanMatchersTest : FreeSpec() {
 
       "Boolean shouldNotBeTrue should not fail for null" {
          null.shouldNotBeTrue()
+      }
+
+      "beTrue matcher should match true and not match false" {
+         true should beTrue()
+         false shouldNot beTrue()
+      }
+
+      "beTrue matcher should throw" {
+         shouldThrow<AssertionError> {
+            false should beTrue()
+         }
+         shouldThrow<AssertionError> {
+            true shouldNot beTrue()
+         }
+      }
+
+      "beFalse matcher should match false and not match true" {
+         false should beFalse()
+         true shouldNot beFalse()
+      }
+
+      "beFalse matcher should throw" {
+         shouldThrow<AssertionError> {
+            true should beFalse()
+         }
+         shouldThrow<AssertionError> {
+            false shouldNot beFalse()
+         }
       }
    }
 }

--- a/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
+++ b/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
@@ -463,7 +463,8 @@ public final class io/kotest/assertions/json/paths/MatchersKt {
 public final class io/kotest/assertions/json/schema/BuilderKt {
 	public static final fun array (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IIZLio/kotest/assertions/json/ContainsSpec;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
 	public static synthetic fun array$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IIZLio/kotest/assertions/json/ContainsSpec;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
-	public static final fun boolean (Lio/kotest/assertions/json/schema/JsonSchema$Builder;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
+	public static final fun boolean (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
+	public static synthetic fun boolean$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
 	public static final fun containsSpec (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IILkotlin/jvm/functions/Function1;)Lio/kotest/assertions/json/ContainsSpec;
 	public static synthetic fun containsSpec$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/assertions/json/ContainsSpec;
 	public static final fun decimal (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonDecimal;
@@ -519,10 +520,33 @@ public final class io/kotest/assertions/json/schema/JsonSchema$JsonArray : io/ko
 }
 
 public final class io/kotest/assertions/json/schema/JsonSchema$JsonBoolean : io/kotest/assertions/json/schema/JsonSchemaElement, io/kotest/assertions/json/schema/ValueNode {
-	public static final field INSTANCE Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
+	public static final field Companion Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/kotest/matchers/Matcher;)V
+	public synthetic fun <init> (Lio/kotest/matchers/Matcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/kotest/matchers/Matcher;
+	public final fun copy (Lio/kotest/matchers/Matcher;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;Lio/kotest/matchers/Matcher;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun getMatcher ()Lio/kotest/matchers/Matcher;
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 	public fun typeName ()Ljava/lang/String;
+}
+
+public final synthetic class io/kotest/assertions/json/schema/JsonSchema$JsonBoolean$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class io/kotest/assertions/json/schema/JsonSchema$JsonBoolean$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class io/kotest/assertions/json/schema/JsonSchema$JsonDecimal : io/kotest/assertions/json/schema/JsonSchema$JsonNumber, io/kotest/assertions/json/schema/JsonSchemaElement, io/kotest/assertions/json/schema/ValueNode {
@@ -595,8 +619,8 @@ public final class io/kotest/assertions/json/schema/JsonSchema$JsonObjectBuilder
 	public fun <init> ()V
 	public final fun array (Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)V
 	public static synthetic fun array$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonObjectBuilder;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public final fun boolean (Ljava/lang/String;Z)V
-	public static synthetic fun boolean$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonObjectBuilder;Ljava/lang/String;ZILjava/lang/Object;)V
+	public final fun boolean (Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)V
+	public static synthetic fun boolean$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonObjectBuilder;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun build ()Lio/kotest/assertions/json/schema/JsonSchema$JsonObject;
 	public final fun decimal (Ljava/lang/String;ZLkotlin/jvm/functions/Function0;)V
 	public static synthetic fun decimal$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonObjectBuilder;Ljava/lang/String;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)V

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -126,7 +126,8 @@ data class JsonSchema(
       fun boolean(
          name: String,
          optional: Boolean = false,
-      ) = withProperty(name, optional) { boolean() }
+         matcherBuilder: () -> Matcher<Boolean>? = { null }
+      ) = withProperty(name, optional) { boolean(matcherBuilder) }
 
       fun `null`(
          name: String,
@@ -181,7 +182,9 @@ data class JsonSchema(
    }
 
    @Serializable
-   object JsonBoolean : JsonSchemaElement, ValueNode<Boolean> {
+   data class JsonBoolean(
+      override val matcher: Matcher<Boolean>? = null
+   ) : JsonSchemaElement, ValueNode<Boolean> {
       override fun typeName() = "boolean"
    }
 
@@ -231,7 +234,7 @@ fun JsonSchema.Builder.decimal(matcherBuilder: () -> Matcher<Double>? = { null }
  * It supports no further configuration. The actual value must always be either true or false.
  */
 @ExperimentalKotest
-fun JsonSchema.Builder.boolean() = JsonSchema.JsonBoolean
+fun JsonSchema.Builder.boolean(matcherBuilder: () -> Matcher<Boolean>? = { null })  = JsonSchema.JsonBoolean(matcherBuilder())
 
 /**
  * Creates a [JsonSchema.Null] node, which is a leaf node that must always be null, if present.

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
@@ -168,7 +168,10 @@ private fun validate(
          } else violation("Expected ${expected.typeName()}, but was ${tree.type()}")
 
       is JsonNode.BooleanNode ->
-         if (!isCompatible(tree, expected))
+         if (expected is JsonSchema.JsonBoolean) {
+            violation(expected.matcher, tree.value)
+         }
+         else if (!isCompatible(tree, expected))
             violation("Expected ${expected.typeName()}, but was ${tree.type()}")
          else emptyList()
    }

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
@@ -36,6 +36,10 @@ class SchemaWithMatcherTest : FunSpec(
          test("Booleans with true matchers fails") {
             shouldFail { """ { "prop": false } """ shouldMatchSchema booleansWithTrue }
                .message shouldBe "$.prop => false should be true"
+            shouldFail { """ { "prop": "notABool" } """ shouldMatchSchema booleansWithTrue }
+               .message shouldBe "$.prop => Expected boolean, but was string"
+            shouldFail { """ { "prop": "true" } """ shouldMatchSchema booleansWithTrue }
+               .message shouldBe "$.prop => Expected boolean, but was string"
          }
 
          test("Booleans with false matchers") {
@@ -45,6 +49,10 @@ class SchemaWithMatcherTest : FunSpec(
          test("Booleans with false matchers fails") {
             shouldFail { """ { "prop": true } """ shouldMatchSchema booleansWithFalse }
                .message shouldBe "$.prop => true should be false"
+            shouldFail { """ { "prop": "notABool" } """ shouldMatchSchema booleansWithFalse }
+               .message shouldBe "$.prop => Expected boolean, but was string"
+            shouldFail { """ { "prop": "false" } """ shouldMatchSchema booleansWithFalse }
+               .message shouldBe "$.prop => Expected boolean, but was string"
          }
       }
 

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
@@ -4,6 +4,8 @@ import io.kotest.assertions.shouldFail
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.and
+import io.kotest.matchers.booleans.beFalse
+import io.kotest.matchers.booleans.beTrue
 import io.kotest.matchers.doubles.beGreaterThanOrEqualTo
 import io.kotest.matchers.doubles.beLessThanOrEqualTo
 import io.kotest.matchers.doubles.beMultipleOf
@@ -22,6 +24,30 @@ class SchemaWithMatcherTest : FunSpec(
          shouldFail { "3" shouldMatchSchema evenNumbers }
             .message shouldBe "$ => 3.0 should be multiple of 2.0"
       }
+
+      context("Boolean with matchers") {
+         val booleansWithTrue = jsonSchema { obj { boolean("prop") { beTrue() } } }
+         val booleansWithFalse = jsonSchema { obj { boolean("prop") { beFalse() } } }
+
+         test("Booleans with true matchers") {
+            """ { "prop": true } """ shouldMatchSchema booleansWithTrue
+         }
+
+         test("Booleans with true matchers fails") {
+            shouldFail { """ { "prop": false } """ shouldMatchSchema booleansWithTrue }
+               .message shouldBe "$.prop => false should be true"
+         }
+
+         test("Booleans with false matchers") {
+            """ { "prop": false } """ shouldMatchSchema booleansWithFalse
+         }
+
+         test("Booleans with false matchers fails") {
+            shouldFail { """ { "prop": true } """ shouldMatchSchema booleansWithFalse }
+               .message shouldBe "$.prop => true should be false"
+         }
+      }
+
 
       context("smoke") {
          val schema = jsonSchema {

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/SchemaWithMatcherTest.kt
@@ -35,7 +35,7 @@ class SchemaWithMatcherTest : FunSpec(
 
          test("Booleans with true matchers fails") {
             shouldFail { """ { "prop": false } """ shouldMatchSchema booleansWithTrue }
-               .message shouldBe "$.prop => false should be true"
+               .message shouldBe "$.prop => false should equal true"
             shouldFail { """ { "prop": "notABool" } """ shouldMatchSchema booleansWithTrue }
                .message shouldBe "$.prop => Expected boolean, but was string"
             shouldFail { """ { "prop": "true" } """ shouldMatchSchema booleansWithTrue }
@@ -48,7 +48,7 @@ class SchemaWithMatcherTest : FunSpec(
 
          test("Booleans with false matchers fails") {
             shouldFail { """ { "prop": true } """ shouldMatchSchema booleansWithFalse }
-               .message shouldBe "$.prop => true should be false"
+               .message shouldBe "$.prop => true should equal false"
             shouldFail { """ { "prop": "notABool" } """ shouldMatchSchema booleansWithFalse }
                .message shouldBe "$.prop => Expected boolean, but was string"
             shouldFail { """ { "prop": "false" } """ shouldMatchSchema booleansWithFalse }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

1. Addresses https://github.com/kotest/kotest/issues/5171 by exposing `matcherBuilder: () -> Matcher<Boolean>?` in `JsonSchema.JsonBoolean` to provide some matchers.
2. adds `beTrue()` and `beFalse()` `Matcher<Boolean>` functions 
3. uses new boolean matchers for existing boolean assertions
