### PR TITLE
allow to verify if json schema prop is null (addresses #5172)

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
@@ -146,7 +146,12 @@ private fun validate(
          } else violation("Expected ${expected.typeName()}, but was object")
       }
 
-      is JsonNode.NullNode -> TODO("Check how Json schema handles null")
+      is JsonNode.NullNode -> {
+         if (!isCompatible(tree, expected))
+            violation("Expected ${expected.typeName()}, but was ${tree.type()}")
+         else
+            emptyList()
+      }
 
       is JsonNode.NumberNode ->
          when (expected) {
@@ -183,4 +188,5 @@ private class SchemaViolation(
 private fun isCompatible(actual: JsonNode, schema: JsonSchemaElement) =
    (actual is JsonNode.BooleanNode && schema is JsonSchema.JsonBoolean) ||
       (actual is JsonNode.StringNode && schema is JsonSchema.JsonString) ||
-      (actual is JsonNode.NumberNode && schema is JsonSchema.JsonNumber)
+      (actual is JsonNode.NumberNode && schema is JsonSchema.JsonNumber) ||
+      (actual is JsonNode.NullNode && schema is JsonSchema.Null)

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/JsonSchemaNullTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/JsonSchemaNullTest.kt
@@ -4,7 +4,7 @@ import io.kotest.assertions.shouldFail
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class JsonSchemaNullTest: FunSpec(
+class JsonSchemaNullTest : FunSpec(
    {
       val jsonWithNulls =
          // language=JSON
@@ -18,7 +18,7 @@ class JsonSchemaNullTest: FunSpec(
                "prop6": "",
                "prop7": 0
             }
-            """
+         """
       context("Null matchers") {
          test("null value matches null matcher") {
             jsonWithNulls shouldMatchSchema jsonSchema {

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/JsonSchemaNullTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/JsonSchemaNullTest.kt
@@ -1,0 +1,53 @@
+package io.kotest.assertions.json.schema
+
+import io.kotest.assertions.shouldFail
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class JsonSchemaNullTest: FunSpec(
+   {
+      val jsonWithNulls =
+         // language=JSON
+         """
+            {
+               "prop1": null,
+               "prop2": 1,
+               "prop3": "string",
+               "prop4": true,
+               "prop5": "null",
+               "prop6": "",
+               "prop7": 0
+            }
+            """
+      context("Null matchers") {
+         test("null value matches null matcher") {
+            jsonWithNulls shouldMatchSchema jsonSchema {
+               obj {
+                  `null`("prop1")
+               }
+            }
+         }
+         test("non-null value does not match null matcher") {
+            shouldFail {
+               jsonWithNulls shouldMatchSchema jsonSchema {
+                  obj {
+                     `null`("prop2")
+                     `null`("prop3")
+                     `null`("prop4")
+                     `null`("prop5")
+                     `null`("prop6")
+                     `null`("prop7")
+                  }
+               }
+            }.message shouldBe
+               """
+               $.prop2 => Expected null, but was number
+               $.prop3 => Expected null, but was string
+               $.prop4 => Expected null, but was boolean
+               $.prop5 => Expected null, but was string
+               $.prop6 => Expected null, but was string
+               $.prop7 => Expected null, but was number
+               """.trimIndent()
+         }
+      }
+   })


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Addresses this [issue](https://github.com/kotest/kotest/issues/5172) by implementing null checks in JsonSchema 
