### PR TITLE
fix-data-class-eq

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
@@ -34,7 +34,7 @@ internal object DataClassEq : Eq<Any> {
    private const val MAX_NESTED_DEPTH = 10
 
    override fun equals(actual: Any, expected: Any, strictNumberEq: Boolean): Throwable? =
-      if (test(actual, expected)) {
+      if (expected == actual || test(actual, expected)) {
          null
       } else {
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
@@ -23,7 +23,23 @@ data class CircularDataClass(val num: Int, val nested: CircularDataClass?)
 
 class RegularClass(val a: Int, val b: Float)
 
+data class IntRatio(
+   val numerator: Int,
+   val denominator: Int
+) {
+   override fun equals(other: Any?): Boolean {
+      return when(other) {
+         is IntRatio -> this.numerator * other.denominator == this.denominator * other.numerator
+         else -> false
+      }
+   }
+}
+
 class DataClassEqTest : StringSpec({
+
+   "respects custom equals implementations in data classes" {
+      IntRatio(1, 2) shouldBe IntRatio(2, 4)
+   }
 
    "Data class instances are determined to be dataclasses" {
       isDataClassInstance(DataClass1(1, 3.4F)) shouldBe true


### PR DESCRIPTION
respect data classes implementation of `equals` - if instances are equal, do not bother matching fields