### PR TITLE
Use deprecated overloads to highlight non-determinstic arbitrary usage

### DIFF
--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -218,6 +218,7 @@ public final class io/kotest/property/PropertyContext {
 	public final fun collect (Ljava/lang/Object;)V
 	public final fun collect (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun discardPercentage ()I
+	public final fun drop (Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
 	public final fun evals ()I
 	public final fun failures ()I
 	public final fun getConfig ()Lio/kotest/property/PropTestConfig;
@@ -225,9 +226,12 @@ public final class io/kotest/property/PropertyContext {
 	public final fun markEvaluation ()I
 	public final fun markFailure ()V
 	public final fun markSuccess ()V
+	public final fun next (Lio/kotest/property/Arb;)Ljava/lang/Object;
 	public final fun randomSource ()Lio/kotest/property/RandomSource;
+	public final fun single (Lio/kotest/property/Arb;)Ljava/lang/Object;
 	public final fun statistics ()Ljava/util/Map;
 	public final fun successes ()I
+	public final fun take (Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
 }
 
 public final class io/kotest/property/PropertyResult {
@@ -693,6 +697,13 @@ public final class io/kotest/property/arbitrary/ArbitraryBuilder$Companion {
 public abstract interface class io/kotest/property/arbitrary/ArbitraryBuilderContext : io/kotest/property/arbitrary/BaseArbitraryBuilderSyntax {
 }
 
+public final class io/kotest/property/arbitrary/ArbitraryBuilderContext$DefaultImpls {
+	public static fun drop (Lio/kotest/property/arbitrary/ArbitraryBuilderContext;Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+	public static fun next (Lio/kotest/property/arbitrary/ArbitraryBuilderContext;Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public static fun single (Lio/kotest/property/arbitrary/ArbitraryBuilderContext;Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public static fun take (Lio/kotest/property/arbitrary/ArbitraryBuilderContext;Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+}
+
 public final class io/kotest/property/arbitrary/ArbsKt {
 	public static final fun drop (Lio/kotest/property/Arb;ILio/kotest/property/RandomSource;)Lkotlin/sequences/Sequence;
 	public static synthetic fun drop$default (Lio/kotest/property/Arb;ILio/kotest/property/RandomSource;ILjava/lang/Object;)Lkotlin/sequences/Sequence;
@@ -707,6 +718,17 @@ public final class io/kotest/property/arbitrary/ArbsKt {
 
 public abstract interface class io/kotest/property/arbitrary/BaseArbitraryBuilderSyntax {
 	public abstract fun bind (Lio/kotest/property/Arb;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun drop (Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+	public fun next (Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public fun single (Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public fun take (Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+}
+
+public final class io/kotest/property/arbitrary/BaseArbitraryBuilderSyntax$DefaultImpls {
+	public static fun drop (Lio/kotest/property/arbitrary/BaseArbitraryBuilderSyntax;Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+	public static fun next (Lio/kotest/property/arbitrary/BaseArbitraryBuilderSyntax;Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public static fun single (Lio/kotest/property/arbitrary/BaseArbitraryBuilderSyntax;Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public static fun take (Lio/kotest/property/arbitrary/BaseArbitraryBuilderSyntax;Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
 }
 
 public final class io/kotest/property/arbitrary/BigdecimalKt {
@@ -1000,6 +1022,13 @@ public final class io/kotest/property/arbitrary/FloatsKt {
 public abstract interface class io/kotest/property/arbitrary/GenerateArbitraryBuilderContext : io/kotest/property/arbitrary/BaseArbitraryBuilderSyntax {
 }
 
+public final class io/kotest/property/arbitrary/GenerateArbitraryBuilderContext$DefaultImpls {
+	public static fun drop (Lio/kotest/property/arbitrary/GenerateArbitraryBuilderContext;Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+	public static fun next (Lio/kotest/property/arbitrary/GenerateArbitraryBuilderContext;Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public static fun single (Lio/kotest/property/arbitrary/GenerateArbitraryBuilderContext;Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public static fun take (Lio/kotest/property/arbitrary/GenerateArbitraryBuilderContext;Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
+}
+
 public final class io/kotest/property/arbitrary/GeoKt {
 	public static final fun geoLocation (Lio/kotest/property/Arb$Companion;)Lio/kotest/property/Arb;
 }
@@ -1222,8 +1251,12 @@ public abstract class io/kotest/property/arbitrary/SingleShotArbContinuation : i
 	public synthetic fun <init> (Lkotlin/coroutines/CoroutineContext;Lio/kotest/property/arbitrary/SingleShotGenerationMode;Lio/kotest/property/RandomSource;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun bind (Lio/kotest/property/Arb;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun createSingleShotArb (Lio/kotest/property/arbitrary/BaseArbitraryBuilderSyntax;)Lio/kotest/property/Arb;
+	public fun drop (Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
 	public fun getContext ()Lkotlin/coroutines/CoroutineContext;
+	public fun next (Lio/kotest/property/Arb;)Ljava/lang/Object;
 	public fun resumeWith (Ljava/lang/Object;)V
+	public fun single (Lio/kotest/property/Arb;)Ljava/lang/Object;
+	public fun take (Lio/kotest/property/Arb;I)Lkotlin/sequences/Sequence;
 }
 
 public final class io/kotest/property/arbitrary/SingleShotArbContinuation$Restricted : io/kotest/property/arbitrary/SingleShotArbContinuation, io/kotest/property/arbitrary/ArbitraryBuilderContext {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/builders.kt
@@ -1,5 +1,6 @@
 package io.kotest.property.arbitrary
 
+import io.kotest.common.DelicateKotest
 import io.kotest.property.Arb
 import io.kotest.property.Classifier
 import io.kotest.property.RandomSource
@@ -14,6 +15,10 @@ import kotlin.coroutines.RestrictsSuspension
 import kotlin.coroutines.intrinsics.startCoroutineUninterceptedOrReturn
 import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
 import kotlin.coroutines.resume
+import io.kotest.property.arbitrary.drop as unboundDrop
+import io.kotest.property.arbitrary.next as unboundNext
+import io.kotest.property.arbitrary.single as unboundSingle
+import io.kotest.property.arbitrary.take as unboundTake
 
 /**
  * Creates a new [Arb] that performs no shrinking, has no edge cases and
@@ -338,6 +343,22 @@ interface BaseArbitraryBuilderSyntax {
     * [bind] returns the generated value of an arb. This can either be a sample or an edgecase.
     */
    suspend fun <T> Arb<T>.bind(): T
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary usage in arbitrary builder. Use .bind() instead", ReplaceWith("bind()"))
+   fun <T> Arb<T>.next(): T = unboundNext()
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary usage in arbitrary builder. Use .bind() instead", ReplaceWith("bind()"))
+   fun <T> Arb<T>.single(): T = unboundSingle()
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary usage in arbitrary builder. Use .take(count, rs) instead", ReplaceWith("take(count, rs)"))
+   fun <A> Arb<A>.take(count: Int): Sequence<A> = unboundTake(count)
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary usage in arbitrary builder. Use .drop(count, rs) instead", ReplaceWith("drop(count, rs)"))
+   fun <A> Arb<A>.drop(count: Int): Sequence<A> = unboundDrop(count)
 }
 
 @RestrictsSuspension

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/context.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/context.kt
@@ -1,7 +1,12 @@
 package io.kotest.property
 
+import io.kotest.common.DelicateKotest
 import io.kotest.property.statistics.Label
 import kotlin.math.roundToInt
+import io.kotest.property.arbitrary.drop as unboundDrop
+import io.kotest.property.arbitrary.next as unboundNext
+import io.kotest.property.arbitrary.single as unboundSingle
+import io.kotest.property.arbitrary.take as unboundTake
 
 /**
  * A [PropertyContext] is used when executing a property test.
@@ -52,6 +57,22 @@ class PropertyContext(val config: PropTestConfig = PropTestConfig()) {
       generatedSamples.add(sample)
       return sample.value
    }
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary value from PropertyContext. Use .bind() instead", ReplaceWith("bind()"))
+   fun <T> Arb<T>.next(): T = unboundNext()
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary value from PropertyContext. Use .bind() instead", ReplaceWith("bind()"))
+   fun <T> Arb<T>.single(): T = unboundSingle()
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary value from PropertyContext. Use .take(count, randomSource()) instead", ReplaceWith("take(count, randomSource())"))
+   fun <A> Arb<A>.take(count: Int): Sequence<A> = unboundTake(count)
+
+   @DelicateKotest
+   @Deprecated("Non-deterministic arbitrary value from PropertyContext. Use .drop(count, randomSource()) instead", ReplaceWith("drop(count, randomSource())"))
+   fun <A> Arb<A>.drop(count: Int): Sequence<A> = unboundDrop(count)
 
    fun markEvaluation(): Int = evals++
 


### PR DESCRIPTION
This is an attempt to provide warnings when using `.next()`, `.single()`, `.take(n)` and `.drop(n)` within either an ArbitraryBuilder or PropertyContext.

This type of usage will not propagate the `RandomSource` and will instead use `RandomSource.default()` which will result in non-deterministic tests.

NB: It's still possible to call `Arb<A>.samples()` which would still use `RandomSource.default()` without a warning, but I suspect that's rather niche.