### PR TITLE
chore: fix master builds

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -41,22 +41,22 @@ jobs:
                   args: -P"kotest_enabledPublicationNamePrefixes=KotlinMultiplatform,jvm"
                # JS+Wasm
                -  os: ubuntu-latest
-                  args: >
+                  args: >-
                      -P"kotest_enableKotlinJs=true"
                      -P"kotest_enabledPublicationNamePrefixes=js,wasm"
                # Linux+Android
                -  os: ubuntu-latest
-                  args: >
+                  args: >-
                      -P"kotest_enableKotlinNative=true"
                      -P"kotest_enabledPublicationNamePrefixes=linux,android"
                # Windows: MinGW
                -  os: windows-latest
-                  args: >
+                  args: >-
                      -P"kotest_enableKotlinNative=true"
                      -P"kotest_enabledPublicationNamePrefixes=mingw"
                # Apple: macOS,iOS,tvOS,watchOS
                -  os: macos-latest
-                  args:  >
+                  args: >-
                      -P"kotest_enableKotlinNative=true"
                      -P"kotest_enabledPublicationNamePrefixes=macOS,iOS,tvOS,watchOS"
       uses: ./.github/workflows/run-gradle.yml


### PR DESCRIPTION
use stripping block chomp on args to avoid early truncation of gradle command

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
