### PR TITLE
Skip modules in PR on !linux when JVM only

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-jvm-conventions.gradle.kts
@@ -77,8 +77,6 @@ tasks.withType<JavaCompile>().configureEach {
 }
 //endregion
 
-
-//region JVM Test config
 tasks.withType<Test>().configureEach {
    jvmArgumentProviders.add(
       SystemPropertiesArgumentProvider.SystemPropertiesArgumentProvider(

--- a/buildSrc/src/main/kotlin/linux-only-tests-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/linux-only-tests-conventions.gradle.kts
@@ -1,0 +1,11 @@
+// this convention disables CI tests unless we are running on the linux runner, to be used by modules
+// that have no platform specific code that needs to be tested on all platforms. This speeds up builds
+// on the slower macos/windows github action runners which bottleneck our builds
+
+plugins {
+   id("kotlin-conventions")
+}
+
+tasks.withType<AbstractTestTask>().configureEach {
+   enabled = System.getenv("CI") != "true" || System.getenv("RUNNER_OS") == "Linux"
+}

--- a/kotest-assertions/kotest-assertions-konform/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-konform/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
    id("kotest-multiplatform-library-conventions")
    id("kotest-publishing-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
    id("kotest-multiplatform-library-conventions")
    id("kotest-publishing-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-assertions/kotest-assertions-ktor/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-ktor/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
    id("kotest-js-conventions")
    id("kotest-jvm-conventions")
    id("kotest-publishing-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-arrow/build.gradle.kts
+++ b/kotest-property/kotest-property-arrow/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
    id("kotest-multiplatform-library-conventions")
    id("kotest-publishing-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-arrow/build.gradle.kts
+++ b/kotest-property/kotest-property-arrow/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
    id("kotest-multiplatform-library-conventions")
    id("kotest-publishing-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-datetime/build.gradle.kts
+++ b/kotest-property/kotest-property-datetime/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
    id("kotest-multiplatform-library-conventions")
    id("kotest-android-native-conventions")
    id("kotest-publishing-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-datetime/build.gradle.kts
+++ b/kotest-property/kotest-property-datetime/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
    id("kotest-multiplatform-library-conventions")
    id("kotest-android-native-conventions")
    id("kotest-publishing-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-lifecycle/build.gradle.kts
+++ b/kotest-property/kotest-property-lifecycle/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
    id("kotest-jvm-conventions")
    id("kotest-js-conventions")
    id("kotest-publishing-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-lifecycle/build.gradle.kts
+++ b/kotest-property/kotest-property-lifecycle/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
    id("kotest-jvm-conventions")
    id("kotest-js-conventions")
    id("kotest-publishing-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-property/kotest-property-permutations/build.gradle.kts
+++ b/kotest-property/kotest-property-permutations/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
    id("kotest-watchos-device-conventions")
    id("kotest-native-conventions")
    id("kotest-publishing-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {
@@ -27,6 +28,5 @@ kotlin {
             implementation(projects.kotestAssertions.kotestAssertionsCore)
          }
       }
-
    }
 }

--- a/kotest-property/kotest-property-permutations/build.gradle.kts
+++ b/kotest-property/kotest-property-permutations/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
    id("kotest-watchos-device-conventions")
    id("kotest-native-conventions")
    id("kotest-publishing-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-callback-order/build.gradle.kts
+++ b/kotest-tests/kotest-tests-callback-order/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-callback-order/build.gradle.kts
+++ b/kotest-tests/kotest-tests-callback-order/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-concurrency-specs/build.gradle.kts
+++ b/kotest-tests/kotest-tests-concurrency-specs/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-concurrency-specs/build.gradle.kts
+++ b/kotest-tests/kotest-tests-concurrency-specs/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-concurrency-tests/build.gradle.kts
+++ b/kotest-tests/kotest-tests-concurrency-tests/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-concurrency-tests/build.gradle.kts
+++ b/kotest-tests/kotest-tests-concurrency-tests/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-config-classname/build.gradle.kts
+++ b/kotest-tests/kotest-tests-config-classname/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-config-classname/build.gradle.kts
+++ b/kotest-tests/kotest-tests-config-classname/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-core/build.gradle.kts
+++ b/kotest-tests/kotest-tests-core/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-core/build.gradle.kts
+++ b/kotest-tests/kotest-tests-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotest-jvm-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-power-assert/build.gradle.kts
+++ b/kotest-tests/kotest-tests-power-assert/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 plugins {
    id("kotlin-conventions")
    id("kotest-jvm-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
    alias(libs.plugins.power.assert)
 }
 

--- a/kotest-tests/kotest-tests-power-assert/build.gradle.kts
+++ b/kotest-tests/kotest-tests-power-assert/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 plugins {
    id("kotlin-conventions")
    id("kotest-jvm-conventions")
+   id("jvm-only-tests-conventions")
    alias(libs.plugins.power.assert)
 }
 

--- a/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
+++ b/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotlin-conventions")
-   id("jvm-only-tests-conventions")
+   id("linux-only-tests-conventions")
 }
 
 kotlin {

--- a/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
+++ b/kotest-tests/kotest-tests-spec-parallelism/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
    id("kotlin-conventions")
+   id("jvm-only-tests-conventions")
 }
 
 kotlin {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -83,8 +83,6 @@ include(
 
    ":kotest-assertions:kotest-assertions-yaml",
 
-   // assertions used to validate code does not compile - see more https://github.com/tschuchortdev/kotlin-compile-testing
-   ":kotest-assertions:kotest-assertions-compiler",
    ":kotest-assertions:kotest-assertions-kotlinx-datetime",
 
    ":kotest-assertions:kotest-assertions-arrow",
@@ -109,79 +107,87 @@ include(
    ":kotest-property:kotest-property-arrow",
 //   ":kotest-property:kotest-property-arrow-optics",
 
-   // support for executing tests via junit platform through gradle
-   // this will also bring in the required libs for the intellij plugin
-   ":kotest-runner:kotest-runner-junit5",
-
-   ":kotest-runner:kotest-runner-junit4",
-
    // contains some common extensions not worth making a module for
    ":kotest-extensions",
-
-   // adds support for the allure reporting framework - see more https://allurereport.org/
-   ":kotest-extensions:kotest-extensions-allure",
-   ":kotest-extensions:kotest-extensions-blockhound",
-
-   // adds support for coroutine decoroutinator - see more https://github.com/Anamorphosee/stacktrace-decoroutinator
-   ":kotest-extensions:kotest-extensions-decoroutinator",
 
    ":kotest-extensions:kotest-extensions-htmlreporter",
    ":kotest-extensions:kotest-extensions-junitxml",
 
-   // adds support for mockserver - see more https://www.mock-server.com/
-   ":kotest-extensions:kotest-extensions-mockserver",
-
    // adds support for the koin DI framework - see more https://insert-koin.io/
 //   ":kotest-extensions:kotest-extensions-koin",
-
-   ":kotest-extensions:kotest-extensions-pitest",
-
-   ":kotest-extensions:kotest-extensions-spring",
-
-   // adds support for the testcontainers framework - see more https://testcontainers.com
-   ":kotest-extensions:kotest-extensions-testcontainers",
-
-   // allows overriding the .now() functionality on time classes
-   ":kotest-extensions:kotest-extensions-now",
-
-   // extensions that adapt junit extensions into kotest extensions
-   ":kotest-extensions:kotest-extensions-junit5",
-
-   // adds support for the wiremock framework - see more https://www.wiremock.io/
-   ":kotest-extensions:kotest-extensions-wiremock",
-
-
-   // the tests modules each test a piece of functionality
-   // it is useful to have separate modules so each can set their own project config that
-   // may be required as part of the tests
-   ":kotest-tests:kotest-tests-core",
-
-   // defines the order of callbacks
-   ":kotest-tests:kotest-tests-callback-order",
-
-   ":kotest-tests:kotest-tests-concurrency-tests",
-   ":kotest-tests:kotest-tests-concurrency-specs",
-   ":kotest-tests:kotest-tests-config-project",
-   ":kotest-tests:kotest-tests-config-classname",
-   ":kotest-tests:kotest-tests-config-packages",
-
-   // tests that kotest.properties on the classpath are picked up
-   ":kotest-tests:kotest-tests-config-properties",
-   ":kotest-tests:kotest-tests-htmlreporter",
-   ":kotest-tests:kotest-tests-junitxml",
-   ":kotest-tests:kotest-tests-junit-displaynameformatter",
-   ":kotest-tests:kotest-tests-multiname-test-name-sysprop",
-   ":kotest-tests:kotest-tests-power-assert",
-   ":kotest-tests:kotest-tests-spec-parallelism",
-   ":kotest-tests:kotest-tests-tagextension",
-   ":kotest-tests:kotest-tests-timeout-project",
-   ":kotest-tests:kotest-tests-timeout-sysprop",
-   ":kotest-tests:kotest-tests-test-parallelism",
-//   ":kotest-tests:kotest-tests-js",
 
    // BOM for whole kotest project
    ":kotest-bom",
 )
+
+// we can skip modules entirely that are JVM only when running on non-Linux github action CI runners, since
+// they have no platform specific code and running on any one platform is sufficient to build and publish.
+// this speeds up builds on the slower macos/windows github action runners.
+if (System.getenv("CI") != "true" || System.getenv("RUNNER_OS") == "Linux") {
+   include(
+
+      // assertions used to validate code does not compile - see more https://github.com/tschuchortdev/kotlin-compile-testing
+      ":kotest-assertions:kotest-assertions-compiler",
+
+      // adds support for the allure reporting framework - see more https://allurereport.org/
+      ":kotest-extensions:kotest-extensions-allure",
+      ":kotest-extensions:kotest-extensions-blockhound",
+
+      // adds support for coroutine decoroutinator - see more https://github.com/Anamorphosee/stacktrace-decoroutinator
+      ":kotest-extensions:kotest-extensions-decoroutinator",
+
+      // support for executing tests via junit platform through gradle
+      // this will also bring in the required libs for the intellij plugin
+      ":kotest-runner:kotest-runner-junit5",
+
+      ":kotest-runner:kotest-runner-junit4",
+
+      // adds support for mockserver - see more https://www.mock-server.com/
+      ":kotest-extensions:kotest-extensions-mockserver",
+
+      ":kotest-extensions:kotest-extensions-pitest",
+
+      ":kotest-extensions:kotest-extensions-spring",
+
+      // adds support for the testcontainers framework - see more https://testcontainers.com
+      ":kotest-extensions:kotest-extensions-testcontainers",
+
+      // allows overriding the .now() functionality on time classes
+      ":kotest-extensions:kotest-extensions-now",
+
+      // extensions that adapt junit extensions into kotest extensions
+      ":kotest-extensions:kotest-extensions-junit5",
+
+      // adds support for the wiremock framework - see more https://www.wiremock.io/
+      ":kotest-extensions:kotest-extensions-wiremock",
+
+      ":kotest-tests:kotest-tests-core",
+
+      // defines the order of callbacks
+      ":kotest-tests:kotest-tests-callback-order",
+
+      ":kotest-tests:kotest-tests-concurrency-tests",
+      ":kotest-tests:kotest-tests-concurrency-specs",
+      ":kotest-tests:kotest-tests-config-project",
+      ":kotest-tests:kotest-tests-config-classname",
+      ":kotest-tests:kotest-tests-config-packages",
+
+      // tests that kotest.properties on the classpath are picked up
+      ":kotest-tests:kotest-tests-config-properties",
+
+      ":kotest-tests:kotest-tests-htmlreporter",
+      ":kotest-tests:kotest-tests-junitxml",
+      ":kotest-tests:kotest-tests-junit-displaynameformatter",
+      ":kotest-tests:kotest-tests-multiname-test-name-sysprop",
+      ":kotest-tests:kotest-tests-power-assert",
+      ":kotest-tests:kotest-tests-spec-parallelism",
+      ":kotest-tests:kotest-tests-tagextension",
+      ":kotest-tests:kotest-tests-timeout-project",
+      ":kotest-tests:kotest-tests-timeout-sysprop",
+      ":kotest-tests:kotest-tests-test-parallelism",
+//   ":kotest-tests:kotest-tests-js",
+   )
+}
 
 develocity {
    buildScan {


### PR DESCRIPTION
For modules that are JVM only, there's no need to build and test on all runners, linux is sufficient. We don't need to test that Oracle implemented the JVM properly on all OSes :)
This should speed up the macos and windows builds significantly.
We'll still build everything on master, this is for PRs only.