### PR TITLE
atMost-for-int (#5210)

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -140,8 +140,10 @@ Collections: also see [inspectors](inspectors.md) which are useful ways to test 
 | `int.shouldBeBetween(x, y)`         | Asserts that the integer is between x and y, inclusive on both x and y |
 | `int.shouldBeLessThan(n)`           | Asserts that the integer is less than the given value n |
 | `int.shouldBeLessThanOrEqual(n)`    | Asserts that the integer is less or equal to than the given value n |
+| `int.shouldBeAtMost(n)`             | Asserts that the integer is less or equal to than the given value n |
 | `int.shouldBeGreaterThan(n)`        | Asserts that the integer is greater than the given value n |
 | `int.shouldBeGreaterThanOrEqual(n)` | Asserts that the integer is greater than or equal to the given value n |
+| `int.shouldBeAtLeast(n)`            | Asserts that the integer is greater than or equal to the given value n |
 | `int.shouldBeEven()`                | Asserts that the integer is even. |
 | `int.shouldBeOdd()`                 | Asserts that the integer is odd. |
 | `int.shouldBeInRange(range)`        | Asserts that the integer is included in the given range. |

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -2468,6 +2468,8 @@ public final class io/kotest/matchers/ints/IntKt {
 	public static final fun nonNegative ()Lio/kotest/matchers/Matcher;
 	public static final fun nonPositive ()Lio/kotest/matchers/Matcher;
 	public static final fun positive ()Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeAtLeast (II)I
+	public static final fun shouldBeAtMost (II)I
 	public static final fun shouldBeEven (I)I
 	public static final fun shouldBeExactly (II)I
 	public static final fun shouldBeGreaterThan (II)I
@@ -2480,6 +2482,8 @@ public final class io/kotest/matchers/ints/IntKt {
 	public static final fun shouldBeOdd (I)I
 	public static final fun shouldBePositive (I)I
 	public static final fun shouldBeZero (I)I
+	public static final fun shouldNotBeAtLeast (II)I
+	public static final fun shouldNotBeAtMost (II)I
 	public static final fun shouldNotBeEven (I)I
 	public static final fun shouldNotBeExactly (II)I
 	public static final fun shouldNotBeGreaterThan (II)I

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/int.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/int.kt
@@ -112,6 +112,11 @@ infix fun Int.shouldBeLessThanOrEqual(x: Int): Int {
    return this
 }
 
+infix fun Int.shouldBeAtMost(x: Int): Int = this.shouldBeLessThanOrEqual(x)
+infix fun Int.shouldNotBeAtMost(x: Int): Int = this.shouldBeGreaterThan(x)
+infix fun Int.shouldBeAtLeast(x: Int): Int = this.shouldBeGreaterThanOrEqual(x)
+infix fun Int.shouldNotBeAtLeast(x: Int): Int = this.shouldBeLessThan(x)
+
 infix fun Int.shouldNotBeLessThanOrEqual(x: Int): Int {
    this shouldNotBe lte(x)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/numerics/IntMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/numerics/IntMatchersTest.kt
@@ -27,6 +27,10 @@ import io.kotest.matchers.ints.beGreaterThan
 import io.kotest.matchers.ints.beGreaterThanOrEqualTo
 import io.kotest.matchers.ints.lt
 import io.kotest.matchers.ints.lte
+import io.kotest.matchers.ints.shouldBeAtLeast
+import io.kotest.matchers.ints.shouldBeAtMost
+import io.kotest.matchers.ints.shouldNotBeAtLeast
+import io.kotest.matchers.ints.shouldNotBeAtMost
 
 class IntMatchersTest : StringSpec() {
    init {
@@ -108,6 +112,36 @@ class IntMatchersTest : StringSpec() {
 
          shouldThrow<AssertionError> {
             2 shouldBe lte(1)
+         }
+      }
+
+      "shouldBeAtMost" {
+         2.shouldBeAtMost(3)
+         2.shouldBeAtMost(2)
+         shouldThrow<AssertionError> {
+            3.shouldBeAtMost(2)
+         }
+      }
+
+      "shouldNotBeAtMost" {
+         3.shouldNotBeAtMost(2)
+         shouldThrow<AssertionError> {
+            3.shouldNotBeAtMost(3)
+         }
+      }
+
+      "shouldBeAtLeast" {
+         3.shouldBeAtLeast(2)
+         2.shouldBeAtLeast(2)
+         shouldThrow<AssertionError> {
+            2.shouldBeAtLeast(3)
+         }
+      }
+
+      "shouldNotBeAtLeast" {
+         2.shouldNotBeAtLeast(3)
+         shouldThrow<AssertionError> {
+            3.shouldNotBeAtLeast(2)
          }
       }
 


### PR DESCRIPTION
add synonyms for `Int.shouldBeAtLeast` and `Int.shouldBeAtMost` which is common Kotlin verbiage