### PR TITLE
atMost-for-long (#5212)

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -157,7 +157,7 @@ Collections: also see [inspectors](inspectors.md) which are useful ways to test 
 | `long.shouldBeAtMost(n)`             | Asserts that the long is less or equal to than the given value n |
 | `long.shouldBeGreaterThan(n)`        | Asserts that the long is greater than the given value n |
 | `long.shouldBeGreaterThanOrEqual(n)` | Asserts that the long is greater than or equal to the given value n |
-| `long.shouldBeAtMost(n)`             | Asserts that the long is greater than or equal to the given value n |
+| `long.shouldBeAtLeast(n)`             | Asserts that the long is greater than or equal to the given value n |
 | `long.shouldBeInRange(range)`        | Asserts that the long is included in the given range. |
 | `long.shouldBeEven()`                | Asserts that the long is even. |
 | `long.shouldBeOdd()`                 | Asserts that the long is odd. |

--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -154,8 +154,10 @@ Collections: also see [inspectors](inspectors.md) which are useful ways to test 
 | `long.shouldBeBetween(x, y)`         | Asserts that the long is between x and y, inclusive on both x and y |
 | `long.shouldBeLessThan(n)`           | Asserts that the long is less than the given value n |
 | `long.shouldBeLessThanOrEqual(n)`    | Asserts that the long is less or equal to than the given value n |
+| `long.shouldBeAtMost(n)`             | Asserts that the long is less or equal to than the given value n |
 | `long.shouldBeGreaterThan(n)`        | Asserts that the long is greater than the given value n |
 | `long.shouldBeGreaterThanOrEqual(n)` | Asserts that the long is greater than or equal to the given value n |
+| `long.shouldBeAtMost(n)`             | Asserts that the long is greater than or equal to the given value n |
 | `long.shouldBeInRange(range)`        | Asserts that the long is included in the given range. |
 | `long.shouldBeEven()`                | Asserts that the long is even. |
 | `long.shouldBeOdd()`                 | Asserts that the long is odd. |

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -2542,6 +2542,8 @@ public final class io/kotest/matchers/longs/LongKt {
 	public static final fun nonNegativeL ()Lio/kotest/matchers/Matcher;
 	public static final fun nonPositiveL ()Lio/kotest/matchers/Matcher;
 	public static final fun positiveL ()Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeAtLeast (JJ)J
+	public static final fun shouldBeAtMost (JJ)J
 	public static final fun shouldBeEven (J)J
 	public static final fun shouldBeExactly (JJ)J
 	public static final fun shouldBeGreaterThan (JJ)J
@@ -2554,6 +2556,8 @@ public final class io/kotest/matchers/longs/LongKt {
 	public static final fun shouldBeOdd (J)J
 	public static final fun shouldBePositive (J)J
 	public static final fun shouldBeZero (J)J
+	public static final fun shouldNotBeAtLeast (JJ)J
+	public static final fun shouldNotBeAtMost (JJ)J
 	public static final fun shouldNotBeEven (J)J
 	public static final fun shouldNotBeExactly (JJ)J
 	public static final fun shouldNotBeGreaterThan (JJ)J

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/long.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/long.kt
@@ -139,6 +139,11 @@ infix fun Long.shouldNotBeGreaterThanOrEqual(x: Long): Long {
    return this
 }
 
+infix fun Long.shouldBeAtMost(x: Long): Long = this.shouldBeLessThanOrEqual(x)
+infix fun Long.shouldNotBeAtMost(x: Long): Long = this.shouldBeGreaterThan(x)
+infix fun Long.shouldBeAtLeast(x: Long): Long = this.shouldBeGreaterThanOrEqual(x)
+infix fun Long.shouldNotBeAtLeast(x: Long): Long = this.shouldBeLessThan(x)
+
 infix fun Long.shouldBeExactly(x: Long): Long {
    this shouldBe exactly(x)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/numerics/LongMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/numerics/LongMatchersTest.kt
@@ -19,6 +19,10 @@ import io.kotest.data.row
 import io.kotest.data.table
 import io.kotest.matchers.comparables.between
 import io.kotest.matchers.comparables.shouldBeBetween
+import io.kotest.matchers.longs.shouldBeAtLeast
+import io.kotest.matchers.longs.shouldBeAtMost
+import io.kotest.matchers.longs.shouldNotBeAtLeast
+import io.kotest.matchers.longs.shouldNotBeAtMost
 
 class LongMatchersTest : StringSpec() {
   init {
@@ -75,6 +79,36 @@ class LongMatchersTest : StringSpec() {
         2L should beLessThanOrEqualTo(1L)
       }
     }
+
+    "shouldBeAtMost" {
+       1L shouldBeAtMost 1L
+       1L shouldBeAtMost 2L
+       shouldThrow<AssertionError> {
+          2L shouldBeAtMost 1L
+       }
+    }
+
+     "shouldNotBeAtMost" {
+        1L shouldNotBeAtMost 0L
+        shouldThrow<AssertionError> {
+           2L shouldNotBeAtMost 3L
+        }
+     }
+
+     "shouldBeAtLeast" {
+        1L shouldBeAtLeast 0L
+        1L shouldBeAtLeast 1L
+        shouldThrow<AssertionError> {
+           2L shouldBeAtLeast 3L
+        }
+     }
+
+     "shouldNotBeAtLeast" {
+        1L shouldBeAtLeast 0L
+        shouldThrow<AssertionError> {
+           2L shouldNotBeAtLeast 1L
+        }
+     }
 
     "greaterThan" {
       1L should beGreaterThanOrEqualTo(0L)


### PR DESCRIPTION
add Kotlin's common verbiage `shouldBeAtMost`/`shouldBeAtLeast` for `Long`
