### PR TITLE
add-atLeast-atMost-for-BigDecimal 

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -178,21 +178,23 @@ Collections: also see [inspectors](inspectors.md) which are useful ways to test 
 | `double.shouldBeNaN()`                          | Asserts that the double is the Not-a-Number constant NaN |
 | `double.shouldBeZero()`                         | Asserts that the double is zero |
 
-| BigDecimal                                  |                                                                            |
-|---------------------------------------------|----------------------------------------------------------------------------|
-| `bigDecimal.shouldHavePrecision(n)`         | Asserts that the bigDecimal precision is equals than the given value n     |
-| `bigDecimal.shouldHaveScale(n)`             | Asserts that the bigDecimal scale is equals than the given value n         |
-| `bigDecimal.shouldBePositive()`             | Asserts that the bigDecimal is positive                                    |
-| `bigDecimal.shouldBeNegative()`             | Asserts that the bigDecimal is negative                                    |
-| `bigDecimal.shouldNotBePositive()`          | Asserts that the bigDecimal is not positive                                |
-| `bigDecimal.shouldNotBeNegative()`          | Asserts that the bigDecimal is not negative                                |
-| `bigDecimal.shouldBeZero()`                 | Asserts that the bigDecimal is zero                                        |
-| `bigDecimal.shouldBeLessThan(n)`            | Asserts that the bigDecimal is less than the given value n                 |
-| `bigDecimal.shouldBeLessThanOrEquals(n)`    | Asserts that the bigDecimal is less than or equal to n                     |
-| `bigDecimal.shouldBeGreaterThan(n)`         | Asserts that the bigDecimal is greater than the given value n              |
-| `bigDecimal.shouldBeGreaterThanOrEquals(n)` | Asserts that the bigDecimal is greater than or equals to the given value n |
-| `bigDecimal.shouldBeInRange(r)`             | Asserts that the bigDecimal is in the given range                          |
-| `bigDecimal.shouldBeEqualIgnoringScale(r)`  | Asserts that the bigDecimal is equal to the given value n ignoring scale   |
+| BigDecimal                                          |                                                                            |
+|-----------------------------------------------------|----------------------------------------------------------------------------|
+| `bigDecimal.shouldHavePrecision(n)`                 | Asserts that the bigDecimal precision is equals than the given value n     |
+| `bigDecimal.shouldHaveScale(n)`                     | Asserts that the bigDecimal scale is equals than the given value n         |
+| `bigDecimal.shouldBePositive()`                     | Asserts that the bigDecimal is positive                                    |
+| `bigDecimal.shouldBeNegative()`                     | Asserts that the bigDecimal is negative                                    |
+| `bigDecimal.shouldNotBePositive()`                  | Asserts that the bigDecimal is not positive                                |
+| `bigDecimal.shouldNotBeNegative()`                  | Asserts that the bigDecimal is not negative                                |
+| `bigDecimal.shouldBeZero()`                         | Asserts that the bigDecimal is zero                                        |
+| `bigDecimal.shouldBeLessThan(n)`                    | Asserts that the bigDecimal is less than the given value n                 |
+| `bigDecimal.shouldBeLessThanOrEqual(n)`             | Asserts that the bigDecimal is less than or equal to n                     |
+| `bigDecimal.shouldBeAtMost(n)`                      | Asserts that the bigDecimal is less than or equal to n                     |
+| `bigDecimal.shouldBeGreaterThan(n)`                 | Asserts that the bigDecimal is greater than the given value n              |
+| `bigDecimal.shouldBeGreaterThanOrEqual(n)`          | Asserts that the bigDecimal is greater than or equals to the given value n |
+| `bigDecimal.shouldBeAtLeast(n)`                     | Asserts that the bigDecimal is greater than or equals to the given value n |
+| `bigDecimal.shouldBeInRange(r)`                     | Asserts that the bigDecimal is in the given range                          |
+| `bigDecimal.shouldBeEqualIgnoringScale(r)`          | Asserts that the bigDecimal is equal to the given value n ignoring scale   |
 | `bigDecimal.shouldBe(value plusOrMinus(tolerance))` | Asserts that the bigDecimal is equal to the given value within a tolerance range. |
 
 | Channels                                          ||

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1025,22 +1025,30 @@ public final class io/kotest/matchers/bigdecimal/BigDecimalToleranceKt {
 public final class io/kotest/matchers/bigdecimal/MatchersKt {
 	public static final fun beEqualIgnoringScale (Ljava/math/BigDecimal;)Lio/kotest/matchers/Matcher;
 	public static final fun beInClosedRange (Lkotlin/ranges/ClosedRange;)Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeAtLeast (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
+	public static final fun shouldBeAtMost (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBeEqualIgnoringScale (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)V
 	public static final fun shouldBeGreaterThan (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
+	public static final fun shouldBeGreaterThanOrEqual (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBeGreaterThanOrEquals (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBeInRange (Ljava/math/BigDecimal;Lkotlin/ranges/ClosedRange;)V
 	public static final fun shouldBeLessThan (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
+	public static final fun shouldBeLessThanOrEqual (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBeLessThanOrEquals (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBeNegative (Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBePositive (Ljava/math/BigDecimal;)Ljava/lang/Object;
 	public static final fun shouldBeZero (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldHavePrecision (Ljava/math/BigDecimal;I)I
 	public static final fun shouldHaveScale (Ljava/math/BigDecimal;I)I
+	public static final fun shouldNotBeAtLeast (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
+	public static final fun shouldNotBeAtMost (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBeEqualIgnoringScale (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)V
 	public static final fun shouldNotBeGreaterThan (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
+	public static final fun shouldNotBeGreaterThanOrEqual (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBeGreaterThanOrEquals (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBeInRange (Ljava/math/BigDecimal;Lkotlin/ranges/ClosedRange;)V
 	public static final fun shouldNotBeLessThan (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
+	public static final fun shouldNotBeLessThanOrEqual (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBeLessThanOrEquals (Ljava/math/BigDecimal;Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBeNegative (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;
 	public static final fun shouldNotBePositive (Ljava/math/BigDecimal;)Ljava/math/BigDecimal;

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/matchers.kt
@@ -24,14 +24,38 @@ infix fun BigDecimal.shouldHaveScale(scale: Int) = this.scale() shouldBe scale
 infix fun BigDecimal.shouldNotHaveScale(scale: Int) = this.scale() shouldNotBe scale
 
 infix fun BigDecimal.shouldBeLessThan(other: BigDecimal) = this shouldBe lt(other)
-infix fun BigDecimal.shouldBeLessThanOrEquals(other: BigDecimal) = this shouldBe lte(other)
+@Deprecated(
+   "use Kotest's shouldBeLessThanOrEqual",
+   ReplaceWith("shouldBeLessThanOrEqual", "io.kotest.matchers.bigdecimal")
+)
+infix fun BigDecimal.shouldBeLessThanOrEquals(other: BigDecimal) = this.shouldBeLessThanOrEqual(other)
+infix fun BigDecimal.shouldBeAtMost(other: BigDecimal) = this.shouldBeLessThanOrEqual(other)
+infix fun BigDecimal.shouldBeLessThanOrEqual(other: BigDecimal) = this shouldBe lte(other)
 infix fun BigDecimal.shouldNotBeLessThan(other: BigDecimal) = this shouldNotBe lt(other)
-infix fun BigDecimal.shouldNotBeLessThanOrEquals(other: BigDecimal) = this shouldNotBe lte(other)
+@Deprecated(
+   "use Kotest's shouldNotBeLessThanOrEqual",
+   ReplaceWith("shouldNotBeLessThanOrEqual", "io.kotest.matchers.bigdecimal")
+)
+infix fun BigDecimal.shouldNotBeLessThanOrEquals(other: BigDecimal) = this.shouldNotBeLessThanOrEqual(other)
+infix fun BigDecimal.shouldNotBeAtMost(other: BigDecimal) = this.shouldNotBeLessThanOrEqual(other)
+infix fun BigDecimal.shouldNotBeLessThanOrEqual(other: BigDecimal) = this shouldNotBe lte(other)
 
 infix fun BigDecimal.shouldBeGreaterThan(other: BigDecimal) = this shouldBe gt(other)
-infix fun BigDecimal.shouldBeGreaterThanOrEquals(other: BigDecimal) = this shouldBe gte(other)
+@Deprecated(
+   "use Kotest's shouldBeGreaterThanOrEqual",
+   ReplaceWith("shouldBeGreaterThanOrEqual", "io.kotest.matchers.bigdecimal")
+)
+infix fun BigDecimal.shouldBeGreaterThanOrEquals(other: BigDecimal) = this.shouldBeGreaterThanOrEqual(other)
+infix fun BigDecimal.shouldBeAtLeast(other: BigDecimal) = this.shouldBeGreaterThanOrEqual(other)
+infix fun BigDecimal.shouldBeGreaterThanOrEqual(other: BigDecimal) = this shouldBe gte(other)
 infix fun BigDecimal.shouldNotBeGreaterThan(other: BigDecimal) = this shouldNotBe gt(other)
-infix fun BigDecimal.shouldNotBeGreaterThanOrEquals(other: BigDecimal) = this shouldNotBe gte(other)
+@Deprecated(
+   "use Kotest's shouldNotBeGreaterThanOrEqual",
+   ReplaceWith("shouldNotBeGreaterThanOrEqual", "io.kotest.matchers.bigdecimal")
+)
+infix fun BigDecimal.shouldNotBeGreaterThanOrEquals(other: BigDecimal) = this.shouldNotBeGreaterThanOrEqual(other)
+infix fun BigDecimal.shouldNotBeAtLeast(other: BigDecimal) = this.shouldNotBeGreaterThanOrEqual(other)
+infix fun BigDecimal.shouldNotBeGreaterThanOrEqual(other: BigDecimal) = this shouldNotBe gte(other)
 
 @Deprecated("use <T: Comparable<T>> shouldBeIn",
    ReplaceWith("this shouldBeIn (range)", "io.kotest.matchers.ranges.shouldBeIn")

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/bigdecimal/BigDecimalMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/bigdecimal/BigDecimalMatchersTest.kt
@@ -2,18 +2,22 @@ package com.sksamuel.kotest.matchers.bigdecimal
 
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.bigdecimal.shouldBeAtLeast
+import io.kotest.matchers.bigdecimal.shouldBeAtMost
 import io.kotest.matchers.bigdecimal.shouldBeGreaterThan
-import io.kotest.matchers.bigdecimal.shouldBeGreaterThanOrEquals
+import io.kotest.matchers.bigdecimal.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.bigdecimal.shouldBeLessThan
-import io.kotest.matchers.bigdecimal.shouldBeLessThanOrEquals
+import io.kotest.matchers.bigdecimal.shouldBeLessThanOrEqual
 import io.kotest.matchers.bigdecimal.shouldBeNegative
 import io.kotest.matchers.bigdecimal.shouldBePositive
 import io.kotest.matchers.bigdecimal.shouldBeZero
 import io.kotest.matchers.bigdecimal.shouldHavePrecision
+import io.kotest.matchers.bigdecimal.shouldNotBeAtLeast
+import io.kotest.matchers.bigdecimal.shouldNotBeAtMost
 import io.kotest.matchers.bigdecimal.shouldNotBeGreaterThan
-import io.kotest.matchers.bigdecimal.shouldNotBeGreaterThanOrEquals
+import io.kotest.matchers.bigdecimal.shouldNotBeGreaterThanOrEqual
 import io.kotest.matchers.bigdecimal.shouldNotBeLessThan
-import io.kotest.matchers.bigdecimal.shouldNotBeLessThanOrEquals
+import io.kotest.matchers.bigdecimal.shouldNotBeLessThanOrEqual
 import io.kotest.matchers.bigdecimal.shouldNotBeNegative
 import io.kotest.matchers.bigdecimal.shouldNotBePositive
 import io.kotest.matchers.ranges.shouldBeIn
@@ -70,13 +74,21 @@ class BigDecimalMatchersTest : StringSpec() {
          BigDecimal.ONE shouldNotBeGreaterThan BigDecimal.TEN
          BigDecimal.TEN shouldNotBeGreaterThan BigDecimal.TEN
       }
-      "shouldBeGreaterThanOrEquals" {
-         BigDecimal.ONE shouldBeGreaterThanOrEquals BigDecimal.ZERO
-         BigDecimal.ONE shouldBeGreaterThanOrEquals BigDecimal.ONE
-         BigDecimal.TEN shouldBeGreaterThanOrEquals BigDecimal.ONE
-         BigDecimal.TEN shouldBeGreaterThanOrEquals BigDecimal.TEN
-         BigDecimal.ONE shouldNotBeGreaterThanOrEquals BigDecimal.TEN
-         BigDecimal.ZERO shouldNotBeGreaterThanOrEquals BigDecimal.ONE
+      "shouldBeGreaterThanOrEqual" {
+         BigDecimal.ONE shouldBeGreaterThanOrEqual BigDecimal.ZERO
+         BigDecimal.ONE shouldBeGreaterThanOrEqual BigDecimal.ONE
+         BigDecimal.TEN shouldBeGreaterThanOrEqual BigDecimal.ONE
+         BigDecimal.TEN shouldBeGreaterThanOrEqual BigDecimal.TEN
+         BigDecimal.ONE shouldNotBeGreaterThanOrEqual BigDecimal.TEN
+         BigDecimal.ZERO shouldNotBeGreaterThanOrEqual BigDecimal.ONE
+      }
+      "shouldBeAtLeast" {
+         BigDecimal.ONE shouldBeAtLeast BigDecimal.ZERO
+         BigDecimal.ONE shouldBeAtLeast BigDecimal.ONE
+         BigDecimal.TEN shouldBeAtLeast BigDecimal.ONE
+         BigDecimal.TEN shouldBeAtLeast BigDecimal.TEN
+         BigDecimal.ONE shouldNotBeAtLeast BigDecimal.TEN
+         BigDecimal.ZERO shouldNotBeAtLeast BigDecimal.ONE
       }
       "shouldBeLessThan" {
          BigDecimal.ZERO shouldBeLessThan BigDecimal.ONE
@@ -85,13 +97,21 @@ class BigDecimalMatchersTest : StringSpec() {
          BigDecimal.TEN shouldNotBeLessThan BigDecimal.ONE
          BigDecimal.TEN shouldNotBeLessThan BigDecimal.TEN
       }
-      "shouldBeLessThanOrEquals" {
-         BigDecimal.ZERO shouldBeLessThanOrEquals BigDecimal.ONE
-         BigDecimal.ONE shouldBeLessThanOrEquals BigDecimal.ONE
-         BigDecimal.ONE shouldBeLessThanOrEquals BigDecimal.TEN
-         BigDecimal.TEN shouldBeLessThanOrEquals BigDecimal.TEN
-         BigDecimal.TEN shouldNotBeLessThanOrEquals BigDecimal.ONE
-         BigDecimal.ONE shouldNotBeLessThanOrEquals BigDecimal.ZERO
+      "shouldBeLessThanOrEqual" {
+         BigDecimal.ZERO shouldBeLessThanOrEqual BigDecimal.ONE
+         BigDecimal.ONE shouldBeLessThanOrEqual BigDecimal.ONE
+         BigDecimal.ONE shouldBeLessThanOrEqual BigDecimal.TEN
+         BigDecimal.TEN shouldBeLessThanOrEqual BigDecimal.TEN
+         BigDecimal.TEN shouldNotBeLessThanOrEqual BigDecimal.ONE
+         BigDecimal.ONE shouldNotBeLessThanOrEqual BigDecimal.ZERO
+      }
+      "shouldBeAtMost" {
+         BigDecimal.ZERO shouldBeAtMost BigDecimal.ONE
+         BigDecimal.ONE shouldBeAtMost BigDecimal.ONE
+         BigDecimal.ONE shouldBeAtMost BigDecimal.TEN
+         BigDecimal.TEN shouldBeAtMost BigDecimal.TEN
+         BigDecimal.TEN shouldNotBeAtMost BigDecimal.ONE
+         BigDecimal.ONE shouldNotBeAtMost BigDecimal.ZERO
       }
       "shouldBeInRange" {
          BigDecimal.ZERO shouldBeIn BigDecimal(-1)..BigDecimal(1)


### PR DESCRIPTION
* add standard Kotlin verbiage `atLeast/atMost` for `BigDecimal` matchers.
* deprecate non-standard matchers `shouldBeLessThanOrEquals` in favor of `shouldBeLessThanOrEqual` which is consistent with matchers for all other types

