### PR TITLE
Removing deprecated EqualityMatcherResult

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/InvokeMatcher.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/InvokeMatcher.kt
@@ -4,9 +4,7 @@ import io.kotest.assertions.Actual
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.Expected
 import io.kotest.assertions.collectOrThrow
-import io.kotest.assertions.print.print
 
-@Suppress("DEPRECATION")
 fun <T> invokeMatcher(t: T, matcher: Matcher<T>): T {
    assertionCounter.inc()
    val result = matcher.test(t)
@@ -19,15 +17,6 @@ fun <T> invokeMatcher(t: T, matcher: Matcher<T>): T {
                .withValues(
                   expected = Expected(result.expected),
                   actual = Actual(result.actual)
-               ).build()
-         )
-
-         is EqualityMatcherResult -> errorCollector.collectOrThrow(
-            AssertionErrorBuilder.create()
-               .withMessage(result.failureMessage() + "\n")
-               .withValues(
-                  expected = Expected(result.expected().print()),
-                  actual = Actual(result.actual().print())
                ).build()
          )
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/properties/properties.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/properties/properties.kt
@@ -3,7 +3,7 @@ package io.kotest.matchers.properties
 import io.kotest.assertions.eq.EqCompare
 import io.kotest.assertions.print.print
 import io.kotest.assertions.withClue
-import io.kotest.matchers.EqualityMatcherResult
+import io.kotest.matchers.ComparisonMatcherResult
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
@@ -36,10 +36,10 @@ fun <T> haveValue(expected: T) = object : Matcher<KProperty0<T>> {
       val prependMessage = { "Assertion failed for property '${value.name}'" }
       val actual = value.get()
 
-      return EqualityMatcherResult(
+      return ComparisonMatcherResult(
          passed = EqCompare.compare(actual, expected, false) == null,
-         actual = actual,
-         expected = expected,
+         actual = actual.print(),
+         expected = expected.print(),
          failureMessageFn = prependMessage,
          negatedFailureMessageFn = { prependMessage() + "\n${expected.print().value} should not equal ${actual.print().value}" },
       )

--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -167,16 +167,6 @@ public final class io/kotest/matchers/ComparisonMatcherResult : io/kotest/matche
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/kotest/matchers/EqualityMatcherResult : io/kotest/matchers/MatcherResult {
-	public static final field Companion Lio/kotest/matchers/EqualityMatcherResult$Companion;
-	public abstract fun actual ()Ljava/lang/Object;
-	public abstract fun expected ()Ljava/lang/Object;
-}
-
-public final class io/kotest/matchers/EqualityMatcherResult$Companion {
-	public final fun invoke (ZLjava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lio/kotest/matchers/EqualityMatcherResult;
-}
-
 public final class io/kotest/matchers/ErrorCollectionMode : java/lang/Enum {
 	public static final field Hard Lio/kotest/matchers/ErrorCollectionMode;
 	public static final field Soft Lio/kotest/matchers/ErrorCollectionMode;

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/Matcher.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/Matcher.kt
@@ -123,27 +123,3 @@ data class ComparisonMatcherResult(
    override fun failureMessage(): String = failureMessageFn()
    override fun negatedFailureMessage(): String = negatedFailureMessageFn()
 }
-
-@Deprecated("Use ComparisonMatcherResult")
-interface EqualityMatcherResult : MatcherResult {
-
-   fun actual(): Any?
-
-   fun expected(): Any?
-
-   companion object {
-      operator fun invoke(
-         passed: Boolean,
-         actual: Any?,
-         expected: Any?,
-         failureMessageFn: () -> String,
-         negatedFailureMessageFn: () -> String,
-      ): EqualityMatcherResult = object : EqualityMatcherResult {
-         override fun passed(): Boolean = passed
-         override fun failureMessage(): String = failureMessageFn()
-         override fun negatedFailureMessage(): String = negatedFailureMessageFn()
-         override fun actual(): Any? = actual
-         override fun expected(): Any? = expected
-      }
-   }
-}


### PR DESCRIPTION
## Summary
- Replaced all uses of the deprecated `EqualityMatcherResult` with `ComparisonMatcherResult`
- Updated `properties.kt` to use `ComparisonMatcherResult` with `Printed` values instead of raw values
- Removed the `EqualityMatcherResult` interface branch from `InvokeMatcher.kt`
- Deleted the `EqualityMatcherResult` interface and companion object from `Matcher.kt`
- Updated the API file to reflect the removal

## Test plan
- ✅ All existing tests pass
- ✅ Ran full test suite with `./gradlew test`
- ✅ Ran assertions-core tests with `./gradlew :kotest-assertions:kotest-assertions-core:jvmTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)