### PR TITLE
Migrate to Test Containers version 2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ mockserver = "5.15.0"
 fuel = "2.3.1"
 konform = "0.10.0"
 arrow = "2.1.2"
-testcontainers = "1.21.3"
+testcontainers = "2.0.2"
 asm = "9.8"
 nmcp = "1.0.2"
 kotlin-poet = "2.2.0"
@@ -143,9 +143,9 @@ hikari = { module = "com.zaxxer:HikariCP", version = "6.3.3" }
 kafka-client = { module = "org.apache.kafka:kafka-clients", version = "3.9.0" }
 
 testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "testcontainers" }
-testcontainers-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainers" }
-testcontainers-mysql = { module = "org.testcontainers:mysql", version.ref = "testcontainers" }
+testcontainers-jdbc = { module = "org.testcontainers:testcontainers-jdbc", version.ref = "testcontainers" }
+testcontainers-kafka = { module = "org.testcontainers:testcontainers-kafka", version.ref = "testcontainers" }
+testcontainers-mysql = { module = "org.testcontainers:testcontainers-mysql", version.ref = "testcontainers" }
 
 mysql-driver = { module = "mysql:mysql-connector-java", version = "8.0.33" }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
+++ b/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
@@ -8,6 +8,33 @@ public abstract class io/kotest/extensions/testcontainers/AbstractContainerExten
 	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/GenericContainer;
 }
 
+public final class io/kotest/extensions/testcontainers/ComposeContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener {
+	public fun <init> (Lorg/testcontainers/containers/ComposeContainer;)V
+	public fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/ComposeContainer;
+}
+
+public final class io/kotest/extensions/testcontainers/ComposeContainerSpecExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/TestListener {
+	public fun <init> (Lorg/testcontainers/containers/ComposeContainer;)V
+	public fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterContainer (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterEach (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun afterTest (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun beforeAny (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun beforeContainer (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun beforeEach (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun beforeInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun beforeSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/ComposeContainer;
+	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class io/kotest/extensions/testcontainers/ContainerExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/AfterTestListener, io/kotest/core/listeners/BeforeSpecListener, io/kotest/core/listeners/BeforeTestListener {
 	public fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/ContainerLifecycleMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/ContainerLifecycleMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -108,25 +135,11 @@ public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerExte
 	public static synthetic fun toDataSource$default (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/zaxxer/hikari/HikariDataSource;
 }
 
-public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener, io/kotest/core/listeners/TestListener {
+public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener {
 	public fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;)V
-	public fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterContainer (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterEach (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterTest (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeAny (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeContainer (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeEach (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun mount (Lkotlin/jvm/functions/Function1;)Lcom/zaxxer/hikari/HikariDataSource;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public fun mount (Lkotlin/jvm/functions/Function1;)Ljavax/sql/DataSource;
-	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterSpecListener {
@@ -379,25 +392,11 @@ public final class io/kotest/extensions/testcontainers/TestContainerHikariConfig
 	public final fun setDbInitScripts (Ljava/util/List;)V
 }
 
-public final class io/kotest/extensions/testcontainers/TestContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener, io/kotest/core/listeners/TestListener {
+public final class io/kotest/extensions/testcontainers/TestContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener {
 	public fun <init> (Lorg/testcontainers/containers/GenericContainer;)V
-	public fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterContainer (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterEach (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun afterTest (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeAny (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeContainer (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeEach (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeInvocation (Lio/kotest/core/test/TestCase;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun beforeTest (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun finalizeSpec (Lkotlin/reflect/KClass;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/GenericContainer;
-	public fun prepareSpec (Lkotlin/reflect/KClass;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/extensions/testcontainers/TestContainerSpecExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/TestListener {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/AbstractContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/AbstractContainerExtension.kt
@@ -6,7 +6,7 @@ import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.spec.Spec
 import org.testcontainers.containers.GenericContainer
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 abstract class AbstractContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerSpecExtension.kt
@@ -1,0 +1,34 @@
+package io.kotest.extensions.testcontainers
+
+import io.kotest.core.extensions.MountableExtension
+import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.Spec
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
+import org.testcontainers.containers.ComposeContainer
+
+/**
+ * A Kotest [MountableExtension] for [ComposeContainer]s that will launch the container
+ * upon first install, and close after the spec has completed.
+ *
+ * Note: This extension requires Kotest 6.0+
+ *
+ * @param container the specific test container type
+ */
+class ComposeContainerSpecExtension(
+   private val container: ComposeContainer,
+) : MountableExtension<ComposeContainer, ComposeContainer>, AfterSpecListener, TestListener {
+
+   override fun mount(configure: ComposeContainer.() -> Unit): ComposeContainer {
+      configure(container)
+      container.start()
+      return container
+   }
+
+   override suspend fun afterSpec(spec: Spec) {
+      runInterruptible(Dispatchers.IO) {
+         container.stop()
+      }
+   }
+}

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerExtension.kt
@@ -53,7 +53,7 @@ import org.testcontainers.containers.GenericContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class ContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerLifecycleMode.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerLifecycleMode.kt
@@ -3,7 +3,7 @@ package io.kotest.extensions.testcontainers
 /**
  * Determines the lifetime of a test container installed in a Kotest extension.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 enum class ContainerLifecycleMode {
 
    /**

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainerExtension.kt
@@ -48,7 +48,7 @@ import java.io.File
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class DockerComposeContainerExtension<T : DockerComposeContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainersExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainersExtension.kt
@@ -15,7 +15,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
 import java.util.Optional
 import org.testcontainers.containers.DockerComposeContainer
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class DockerComposeContainersExtension<T : DockerComposeContainer<*>>(
    private val container: T,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
@@ -3,32 +3,32 @@ package io.kotest.extensions.testcontainers
 import io.kotest.core.TestConfiguration
 import org.testcontainers.lifecycle.Startable
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> T.perTest(): StartablePerTestListener<T> = StartablePerTestListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> T.perSpec(): StartablePerSpecListener<T> = StartablePerSpecListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> T.perProject(): StartablePerProjectListener<T> = StartablePerProjectListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> T.perProject(containerName: String): StartablePerProjectListener<T> =
    StartablePerProjectListener<T>(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> TestConfiguration.configurePerTest(startable: T): T {
    extension(StartablePerTestListener(startable))
    return startable
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> TestConfiguration.configurePerSpec(startable: T): T {
    extension(StartablePerSpecListener(startable))
    return startable
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 fun <T : Startable> TestConfiguration.configurePerProject(startable: T, containerName: String): T {
    extension(StartablePerProjectListener(startable))
    return startable

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
@@ -50,7 +50,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class JdbcDatabaseContainerExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,
@@ -130,6 +130,7 @@ class JdbcDatabaseContainerExtension(
  *
  * @param configure a thunk to configure the [HikariConfig] used to create the datasource.
  */
+@Deprecated("Will be removed in 6.2")
 fun JdbcDatabaseContainer<*>.toDataSource(configure: HikariConfig.() -> Unit = {}): HikariDataSource {
    val config = HikariConfig()
    config.jdbcUrl = jdbcUrl

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
@@ -36,12 +36,12 @@ class JdbcDatabaseContainerProjectExtension(
       lock.lockInterruptibly()
       val t = ref.get()
       if (t == null) {
+         container.start()
          val config = HikariConfig()
          config.jdbcUrl = container.jdbcUrl
          config.username = container.username
          config.password = container.password
          config.configure()
-         container.start()
          val ds = HikariDataSource(config)
          ref.set(ds)
       }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
@@ -4,7 +4,6 @@ import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.core.extensions.MountableExtension
 import io.kotest.core.listeners.AfterProjectListener
-import io.kotest.core.listeners.TestListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import org.testcontainers.containers.JdbcDatabaseContainer
@@ -28,7 +27,7 @@ import javax.sql.DataSource
  */
 class JdbcDatabaseContainerProjectExtension(
    private val container: JdbcDatabaseContainer<*>,
-) : MountableExtension<HikariConfig, DataSource>, AfterProjectListener, TestListener {
+) : MountableExtension<HikariConfig, DataSource>, AfterProjectListener {
 
    private val ref = AtomicReference<HikariDataSource>(null)
    private val lock = ReentrantLock()

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension.kt
@@ -6,7 +6,7 @@ import io.kotest.core.extensions.MountableExtension
 import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.spec.Spec
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import org.testcontainers.containers.JdbcDatabaseContainer
 import javax.sql.DataSource
 
@@ -41,7 +41,7 @@ class JdbcDatabaseContainerSpecExtension(
    }
 
    override suspend fun afterSpec(spec: Spec) {
-      withContext(Dispatchers.IO) {
+      runInterruptible(Dispatchers.IO) {
          container.stop()
       }
    }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcTestContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcTestContainerExtension.kt
@@ -31,7 +31,7 @@ import javax.sql.DataSource
  *
  * @since 1.1.0
  */
-@Deprecated("Use JdbcTestContainerProjectExtension or JdbcTestContainerSpecExtension instead")
+@Deprecated("Use JdbcTestContainerProjectExtension or JdbcTestContainerSpecExtension instead. Will be removed in 6.2")
 class JdbcTestContainerExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/LifecycleMode.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/LifecycleMode.kt
@@ -1,6 +1,6 @@
 package io.kotest.extensions.testcontainers
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 enum class LifecycleMode {
    Spec, EveryTest, Leaf, Root
 }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ProjectContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ProjectContainerExtension.kt
@@ -53,7 +53,7 @@ import org.testcontainers.containers.GenericContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class ProjectContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ResourceLoader.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ResourceLoader.kt
@@ -11,25 +11,25 @@ import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 
-@Deprecated("use Flyway or another db migration tool")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
 sealed interface Resource {
    data class Classpath(val resource: String) : Resource
    data class File(val path: Path) : Resource
 }
 
-@Deprecated("use Flyway or another db migration tool")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
 fun Resource.endsWith(name: String): Boolean = when (this) {
    is Resource.Classpath -> this.resource.endsWith(name)
    is Resource.File -> this.path.name.endsWith(name)
 }
 
-@Deprecated("use Flyway or another db migration tool")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
 fun Resource.loadToReader(): BufferedReader = when (this) {
    is Resource.Classpath -> javaClass.getResourceAsStream(this.resource)?.bufferedReader() ?: error("$this was not found on classpath")
    is Resource.File -> Files.newBufferedReader(this.path)
 }
 
-@Deprecated("use Flyway or another db migration tool")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
 class ResourceLoader {
 
    private fun Path.getDirContentsOrItself(): List<Path> {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SettableDataSource.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SettableDataSource.kt
@@ -6,7 +6,7 @@ import java.sql.Connection
 import java.util.logging.Logger
 import javax.sql.DataSource
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class SettableDataSource(private var ds: HikariDataSource?) : DataSource {
 
    private fun getDs(): DataSource = ds ?: error("DataSource is not ready")

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedTestContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedTestContainerExtension.kt
@@ -35,7 +35,7 @@ import org.testcontainers.containers.GenericContainer
  *
  * @since 1.3.0
  */
-@Deprecated("use ContainerExtension")
+@Deprecated("use ContainerExtension. Will be removed in 6.2")
 class SharedTestContainerExtension<T : GenericContainer<*>, U>(
    private val container: T,
    private val beforeTest: suspend (T) -> Unit = {},

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
@@ -19,7 +19,7 @@ import org.testcontainers.lifecycle.Startable
  * @see
  * [StartablePerTestListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class StartablePerProjectListener<T : Startable>(private val startable: T) : TestListener, ProjectListener {
 
    @Deprecated("The containerName arg is no longer used")

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerSpecListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerSpecListener.kt
@@ -22,7 +22,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
  * @see
  * [StartablePerTestListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class StartablePerSpecListener<T : Startable>(private val startable: T) : TestListener {
    private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerTestListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerTestListener.kt
@@ -19,7 +19,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
  *
  * @see[StartablePerSpecListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class StartablePerTestListener<T : Startable>(private val startable: T) : TestListener {
 
    private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerExtension.kt
@@ -14,7 +14,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.lifecycle.TestLifecycleAware
 import java.util.Optional
 
-@Deprecated("use ContainerExtension")
+@Deprecated("use ContainerExtension. Will be removed in 6.2")
 class TestContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,
@@ -29,7 +29,7 @@ class TestContainerExtension<T : GenericContainer<*>>(
    }
 
    override fun mount(configure: T.() -> Unit): T {
-      (container as T).configure()
+      container.configure()
       if (lifecycleMode == LifecycleMode.Spec) {
          container.start()
       }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
@@ -6,6 +6,8 @@ import io.kotest.core.listeners.TestListener
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.testcontainers.containers.GenericContainer
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.locks.ReentrantLock
 
 /**
  * A Kotest [MountableExtension] for [GenericContainer]s that will launch the container
@@ -20,9 +22,18 @@ class TestContainerProjectExtension<T : GenericContainer<*>>(
    private val container: T,
 ) : MountableExtension<T, T>, AfterProjectListener, TestListener {
 
+   private val ref = AtomicReference<T>(null)
+   private val lock = ReentrantLock()
+
    override fun mount(configure: T.() -> Unit): T {
-      configure(container)
-      container.start()
+      lock.lockInterruptibly()
+      val t = ref.get()
+      if (t == null) {
+         configure(container)
+         container.start()
+         ref.set(container)
+      }
+      lock.unlock()
       return container
    }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestLifecycleAwareListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestLifecycleAwareListener.kt
@@ -9,7 +9,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
 import java.net.URLEncoder
 import java.util.Optional
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 class TestLifecycleAwareListener(startable: Startable) : TestListener {
    private val testLifecycleAware = startable as? TestLifecycleAware
 
@@ -22,7 +22,7 @@ class TestLifecycleAwareListener(startable: Startable) : TestListener {
    }
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
 internal fun TestCase.toTestDescription() = object : TestDescription {
 
    override fun getFilesystemFriendlyName(): String {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka.kt
@@ -15,6 +15,7 @@ import java.util.UUID
 /**
  * Creates a [KafkaProducer] for the given [KafkaContainer] with a String serializer for both keys and values.
  */
+@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
 fun KafkaContainer.createStringStringProducer(
    configure: Properties.() -> Unit = {},
 ): KafkaProducer<String, String> {
@@ -24,6 +25,7 @@ fun KafkaContainer.createStringStringProducer(
 /**
  * Creates a [KafkaProducer] for the given [KafkaContainer] with the given serializers.
  */
+@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
 fun <K, V> KafkaContainer.createProducer(
    kserializer: Serializer<K>,
    vserializer: Serializer<V>,
@@ -38,6 +40,7 @@ fun <K, V> KafkaContainer.createProducer(
 /**
  * Creates a [KafkaConsumer] for the given [KafkaContainer] with a String deserializer for both keys and values.
  */
+@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
 fun KafkaContainer.createStringStringConsumer(
    configure: Properties.() -> Unit = {},
 ): KafkaConsumer<String, String> {
@@ -47,6 +50,7 @@ fun KafkaContainer.createStringStringConsumer(
 /**
  * Creates a [KafkaConsumer] for the given [KafkaContainer] with the given deserializers.
  */
+@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
 fun <K, V> KafkaContainer.createConsumer(
    kserializer: Deserializer<K>,
    vserializer: Deserializer<V>,
@@ -62,6 +66,7 @@ fun <K, V> KafkaContainer.createConsumer(
 /**
  * Creates a [AdminClient] for the given [KafkaContainer].
  */
+@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
 fun KafkaContainer.createAdminClient(configure: Properties.() -> Unit = {}): AdminClient {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/KafkaContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/KafkaContainerExtension.kt
@@ -17,7 +17,7 @@ import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 import java.util.Properties
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 class KafkaContainerExtension(
    container: KafkaContainer,
    mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,
@@ -29,7 +29,7 @@ class KafkaContainerExtension(
    ) : this(KafkaContainer(image), mode)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.admin(configure: Properties.() -> Unit = {}): Admin {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -37,7 +37,7 @@ fun KafkaContainer.admin(configure: Properties.() -> Unit = {}): Admin {
    return Admin.create(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.producer(configure: Properties.() -> Unit = {}): KafkaProducer<Bytes, Bytes> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -47,7 +47,7 @@ fun KafkaContainer.producer(configure: Properties.() -> Unit = {}): KafkaProduce
    return KafkaProducer<Bytes, Bytes>(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.stringStringProducer(configure: Properties.() -> Unit = {}): KafkaProducer<String, String> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -57,7 +57,7 @@ fun KafkaContainer.stringStringProducer(configure: Properties.() -> Unit = {}): 
    return KafkaProducer<String, String>(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.consumer(configure: Properties.() -> Unit = {}): KafkaConsumer<Bytes, Bytes> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -69,7 +69,7 @@ fun KafkaContainer.consumer(configure: Properties.() -> Unit = {}): KafkaConsume
    return KafkaConsumer<Bytes, Bytes>(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.stringStringConsumer(configure: Properties.() -> Unit = {}): KafkaConsumer<String, String> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/kafka.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/kafka.kt
@@ -12,14 +12,14 @@ import org.testcontainers.containers.KafkaContainer
 import java.util.Properties
 import java.util.UUID
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.createStringStringProducer(
    configure: Properties.() -> Unit = {},
 ): KafkaProducer<String, String> {
    return createProducer(StringSerializer(), StringSerializer(), configure)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun <K, V> KafkaContainer.createProducer(
    kserializer: Serializer<K>,
    vserializer: Serializer<V>,
@@ -31,14 +31,14 @@ fun <K, V> KafkaContainer.createProducer(
    return KafkaProducer(props, kserializer, vserializer)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.createStringStringConsumer(
    configure: Properties.() -> Unit = {},
 ): KafkaConsumer<String, String> {
    return createConsumer(StringDeserializer(), StringDeserializer(), configure)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun <K, V> KafkaContainer.createConsumer(
    kserializer: Deserializer<K>,
    vserializer: Deserializer<V>,
@@ -51,7 +51,7 @@ fun <K, V> KafkaContainer.createConsumer(
    return KafkaConsumer(props, kserializer, vserializer)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
 fun KafkaContainer.createAdminClient(configure: Properties.() -> Unit = {}): AdminClient {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmTest/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtensionTest.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmTest/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtensionTest.kt
@@ -7,7 +7,7 @@ import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.mysql.MySQLContainer
 
 private val mysql = MySQLContainer("mysql:8.0.26").apply {
    withInitScript("init.sql")


### PR DESCRIPTION
Updates to test containers v2.
Added support for ComposeContainers.
Removed unused TestListener interfaces.
Clarified deprecation notices.
Uses runInterruptible instead of withContext for blocking ops.

Fixes #5200 