### PR TITLE
Makes `beBoolean` matcher public

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1065,6 +1065,7 @@ public final class io/kotest/matchers/bigdecimal/ToleranceMatcher : io/kotest/ma
 }
 
 public final class io/kotest/matchers/booleans/BooleanMatchersKt {
+	public static final fun beBoolean (Z)Lio/kotest/matchers/Matcher;
 	public static final fun beFalse ()Lio/kotest/matchers/Matcher;
 	public static final fun beTrue ()Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeFalse (Ljava/lang/Boolean;)Z

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
@@ -7,22 +7,6 @@ import io.kotest.matchers.shouldNot
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
-private fun booleanMatcher(expected: Boolean) = object : Matcher<Boolean?> {
-   override fun test(value: Boolean?) = MatcherResult(
-      value == expected,
-      { "$value should equal $expected" },
-      { "$value should not equal $expected" }
-   )
-}
-/**
- * Match that verifies a given [Boolean] is `true`.
- */
-fun beTrue() = booleanMatcher(true)
-/**
- * Match that verifies a given [Boolean] is `false`.
- */
-fun beFalse() = booleanMatcher(false)
-
 /**
  * Asserts that this [Boolean] is true
  *
@@ -118,4 +102,22 @@ fun Boolean?.shouldBeFalse(): Boolean {
 fun Boolean?.shouldNotBeFalse(): Boolean? {
    this shouldNot beFalse()
    return this
+}
+
+/**
+ * Match that verifies a given [Boolean] is `true`.
+ */
+fun beTrue() = beBoolean(true)
+
+/**
+ * Match that verifies a given [Boolean] is `false`.
+ */
+fun beFalse() = beBoolean(false)
+
+fun beBoolean(expected: Boolean) = object : Matcher<Boolean?> {
+   override fun test(value: Boolean?) = MatcherResult(
+      value == expected,
+      { "$value should equal $expected" },
+      { "$value should not equal $expected" }
+   )
 }


### PR DESCRIPTION
- Renames matcher
- Removes private modifier
- Move matcher to the end of the file
