### PR TITLE
docs: fix typo in property test shrinking documentation

### DIFF
--- a/documentation/docs/proptest/shrinking.md
+++ b/documentation/docs/proptest/shrinking.md
@@ -12,7 +12,7 @@ Built-in generators generally have a default Shrinker defined by the framework, 
 
 ## Shrinking for built-in generators
 Built-in generators (see [Generators List](genslist.md)) have a default Shrinker defined by the framework.
-A shrink function takes as input the value that failed the test and returns a list of new values on which Kotest can appy the test.
+A shrink function takes as input the value that failed the test and returns a list of new values on which Kotest can apply the test.
 The exact behaviour depends on the data type.
 For instance, a string could be shrunk by dropping the first or last character while for integers we could decrement or halve the value.
 In addition, shrink behaviour is defined for edge cases such as an empty string or the integer 0.

--- a/documentation/versioned_docs/version-6.0/proptest/shrinking.md
+++ b/documentation/versioned_docs/version-6.0/proptest/shrinking.md
@@ -12,7 +12,7 @@ Built-in generators generally have a default Shrinker defined by the framework, 
 
 ## Shrinking for built-in generators
 Built-in generators (see [Generators List](genslist.md)) have a default Shrinker defined by the framework.
-A shrink function takes as input the value that failed the test and returns a list of new values on which Kotest can appy the test.
+A shrink function takes as input the value that failed the test and returns a list of new values on which Kotest can apply the test.
 The exact behaviour depends on the data type.
 For instance, a string could be shrunk by dropping the first or last character while for integers we could decrement or halve the value.
 In addition, shrink behaviour is defined for edge cases such as an empty string or the integer 0.


### PR DESCRIPTION
  ## Description
  Fixed a typo in the property test shrinking documentation.

  ## Changes
  - Fixed typo: `appy` → `apply` in `documentation/docs/proptest/shrinking.md:15`
  - Applied the same fix to `documentation/versioned_docs/version-6.0/proptest/shrinking.md:15`