### PR TITLE
Added backwards compatible methods for nondeterministic testing

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -302,6 +302,7 @@ public final class io/kotest/assertions/nondeterministic/ContinuallyConfiguratio
 }
 
 public final class io/kotest/assertions/nondeterministic/ContinuallyKt {
+	public static final fun continually (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun continually (Lio/kotest/assertions/nondeterministic/ContinuallyConfiguration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun continually-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun continuallyConfig (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/nondeterministic/ContinuallyConfiguration;
@@ -361,6 +362,7 @@ public final class io/kotest/assertions/nondeterministic/EventuallyConfiguration
 }
 
 public final class io/kotest/assertions/nondeterministic/EventuallyKt {
+	public static final fun eventually (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventually (Lio/kotest/assertions/nondeterministic/EventuallyConfiguration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventually (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventually-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -449,6 +451,7 @@ public final class io/kotest/assertions/nondeterministic/UntilConfigurationBuild
 }
 
 public final class io/kotest/assertions/nondeterministic/UntilKt {
+	public static final fun until (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun until (Lio/kotest/assertions/nondeterministic/UntilConfiguration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun until-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun untilConfig (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/nondeterministic/UntilConfiguration;

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/continually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/continually.kt
@@ -24,6 +24,20 @@ suspend fun <T> continually(
 }
 
 /**
+ * Runs the [test] function continually for the given [durationMs] in milliseconds, failing if an exception is
+ * thrown during any invocation.
+ *
+ * To supply more options to continually, use the overload that accepts a [ContinuallyConfiguration].
+ */
+suspend fun <T> continually(
+   durationMs: Long,
+   test: suspend () -> T,
+): T {
+   val config = continuallyConfig<T> { this.duration = durationMs.milliseconds }
+   return continually(config, test)
+}
+
+/**
  * Runs the [test] function continually using the given [config], failing if an exception is
  * thrown during any invocation.
  */

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/continually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/continually.kt
@@ -33,8 +33,7 @@ suspend fun <T> continually(
    durationMs: Long,
    test: suspend () -> T,
 ): T {
-   val config = continuallyConfig<T> { this.duration = durationMs.milliseconds }
-   return continually(config, test)
+   return continually(durationMs.milliseconds, test)
 }
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
@@ -12,7 +12,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeMark
 
 /**
- * Runs a function [test] until it doesn't throw as long as the specified duration hasn't passed.
+ * Runs a function [test] until it doesn't throw as long as the default duration hasn't passed.
  *
  * To supply more options to eventually, use the overload that accepts an [EventuallyConfiguration].
  */
@@ -24,7 +24,7 @@ suspend fun <T> eventually(
 }
 
 /**
- * Runs a function [test] until it doesn't throw as long as the specified duration hasn't passed.
+ * Runs a function [test] until it doesn't throw as long as the specified [duration] hasn't passed.
  *
  * To supply more options to eventually, use the overload that accepts an [EventuallyConfiguration].
  */
@@ -33,6 +33,19 @@ suspend fun <T> eventually(
    test: suspend () -> T,
 ): T {
    val config = eventuallyConfig { this.duration = duration }
+   return eventually(config, test)
+}
+
+/**
+ * Runs a function [test] until it doesn't throw as long as the specified [durationMs] in milliseconds hasn't passed.
+ *
+ * To supply more options to eventually, use the overload that accepts an [EventuallyConfiguration].
+ */
+suspend fun <T> eventually(
+   durationMs: Long,
+   test: suspend () -> T,
+): T {
+   val config = eventuallyConfig { this.duration = durationMs.milliseconds }
    return eventually(config, test)
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
@@ -45,8 +45,7 @@ suspend fun <T> eventually(
    durationMs: Long,
    test: suspend () -> T,
 ): T {
-   val config = eventuallyConfig { this.duration = durationMs.milliseconds }
-   return eventually(config, test)
+   return eventually(durationMs.milliseconds, test)
 }
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
@@ -7,7 +7,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Runs a function [test] until it returns true, as long as the specified duration hasn't passed.
+ * Runs a function [test] until it returns true, as long as the specified [duration] hasn't passed.
  *
  * To supply more options to until, use the overload that accepts an [UntilConfiguration].
  */
@@ -16,6 +16,19 @@ suspend fun until(
    test: suspend () -> Boolean,
 ) {
    val config = untilConfig { this.duration = duration }
+   until(config, test)
+}
+
+/**
+ * Runs a function [test] until it returns true, as long as the specified [durationMs] hasn't passed.
+ *
+ * To supply more options to until, use the overload that accepts an [UntilConfiguration].
+ */
+suspend fun until(
+   durationMs: Long,
+   test: suspend () -> Boolean,
+) {
+   val config = untilConfig { this.duration = durationMs.milliseconds }
    until(config, test)
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
@@ -28,8 +28,7 @@ suspend fun until(
    durationMs: Long,
    test: suspend () -> Boolean,
 ) {
-   val config = untilConfig { this.duration = durationMs.milliseconds }
-   until(config, test)
+   until(durationMs.milliseconds, test)
 }
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/UntilTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/UntilTest.kt
@@ -23,6 +23,15 @@ class UntilTest : FunSpec({
       attempts shouldBe 1
    }
 
+   test("until with immediate pass for millis") {
+      var attempts = 0
+      until(1000) {
+         attempts++
+         nonConstantTrue() shouldBe true
+      }
+      attempts shouldBe 1
+   }
+
    test("until should exit as soon as predicate passes") {
       until(1.days) {
          nonConstantTrue() shouldBe true


### PR DESCRIPTION
Am updating one of my other projects and noticed the 5.x era versions that accept a Long have gone away, so adding back to aid anyone upgrading.