### PR TITLE
handle duplicate test names in `InstancePerLeaf` and `InstancePerTest` (issue #5261)

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/isolation/DescribeSpecInstancePerLeafTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/isolation/DescribeSpecInstancePerLeafTest.kt
@@ -217,3 +217,20 @@ class InstancePerLeafTest7 : DescribeSpec({
       }
    }
 })
+
+/**
+ * A test to demonstrate that in InstancePerLeaf mode, tests with the same name do not clash.
+ */
+class InstancePerLeafTest8 : DescribeSpec({
+
+   isolationMode = IsolationMode.InstancePerLeaf
+
+   describe("describe") {
+      it("tests with the same name") {
+         1 + 1 shouldBe 2
+      }
+      it("tests with the same name") {
+         1 + 1 shouldBe 2
+      }
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/isolation/DescribeSpecInstancePerTestTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/isolation/DescribeSpecInstancePerTestTest.kt
@@ -1,0 +1,22 @@
+package com.sksamuel.kotest.engine.spec.isolation
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * A test to demonstrate that in InstancePerTest mode, tests with the same name do not get squashed into one test only.
+ */
+class InstancePerTestTest1 : DescribeSpec({
+
+   isolationMode = IsolationMode.InstancePerTest
+
+   describe("describe") {
+      it("tests with the same name") {
+         1 + 1 shouldBe 2
+      }
+      it("tests with the same name") {
+         1 + 1 shouldBe 2
+      }
+   }
+})


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
Addresses https://github.com/kotest/kotest/issues/5261 but as I addresses it I noticed that `InstancePerTest` would merge tests with the same name, so added a de-duplicator there too