### PR TITLE
Clarify default poll interval in continually documentation

### DIFF
--- a/documentation/docs/assertions/continually.md
+++ b/documentation/docs/assertions/continually.md
@@ -33,7 +33,7 @@ class MyTests: ShouldSpec() {
 
      val config = continuallyConfig<Unit> {
         duration = 60.seconds
-        intervalFn = DurationFn { 50.milliseconds }
+        interval = 50.milliseconds
      }
 
       continually(config) {

--- a/documentation/docs/assertions/continually.md
+++ b/documentation/docs/assertions/continually.md
@@ -24,13 +24,19 @@ class MyTests : ShouldSpec() {
 }
 ```
 
-The function passed to the `continually` block is executed every 10 milliseconds. We can specify the poll interval if we prefer:
+By default, the function passed to the `continually` block is executed every 25 milliseconds. We can explicitly set the poll interval. In the following example we set it to 50 milliseconds:
 
 ```kotlin
 class MyTests: ShouldSpec() {
   init {
     should("pass for 60 seconds") {
-      continually(60.seconds, 5.seconds) {
+
+     val config = continuallyConfig<Unit> {
+        duration = 60.seconds
+        intervalFn = DurationFn { 50.milliseconds }
+     }
+
+      continually(config) {
         // code here that should succeed and continue to succeed for 60 seconds
       }
     }


### PR DESCRIPTION
Updated the documentation to clarify the default poll interval for the continually block and how to set it explicitly. Currently the docs don't match the actual implementation.


