### PR TITLE
Enhance documentation for countdown latches usage

### DIFF
--- a/documentation/docs/assertions/eventually.md
+++ b/documentation/docs/assertions/eventually.md
@@ -30,7 +30,7 @@ Some common approaches to these problems are:
   iterations, handle certain exceptions and fail on others, ensure the total time taken has not exceeded the max and so
   on.
 
-* Use countdown latches and block threads until the latches are released by the non-deterministic operation. This can
+* Use countdown latches and block threads until the latches are released by the non-deterministic operation - [kotest's parallelRunner implementation shows how to do that](https://github.com/kotest/kotest/blob/master/documentation/docs/framework/race_conditions.md). This can
   work well if you are able to inject the latches in the appropriate places, but just like callbacks, it isn't always
   possible to have the code to be tested integrate with a latch.
 


### PR DESCRIPTION
Added a reference to kotest's parallelRunner implementation for countdown latches.


