### PR TITLE
Allow tag expressions via env vars.

### DIFF
--- a/documentation/docs/framework/tags.md
+++ b/documentation/docs/framework/tags.md
@@ -6,14 +6,14 @@ sidebar_label: Grouping Tests
 ---
 
 
-Sometimes you don't want to run all tests and Kotest provides tags to be able to determine which
+Sometimes you don't want to run all tests and Kotest provides `tags` to be able to determine which
 tests are executed at runtime. Tags are objects inheriting from `io.kotest.core.Tag`.
 
 For example, to group tests by operating system you could define the following tags:
 
 ```kotlin
 object Linux : Tag()
-object Windows: Tag()
+object Windows : Tag()
 ```
 
 Alternatively, tags can be defined using the `NamedTag` class. When using this class, observe the following rules:
@@ -22,11 +22,11 @@ Alternatively, tags can be defined using the `NamedTag` class. When using this c
 - A tag must not contain whitespace.
 - A tag must not contain ISO control characters.
 - A tag must not contain any of the following characters:
-    - !: exclamation mark
-    - (: left paren
-    - ): right paren
-    - &: ampersand
-    - |: pipe
+  - !: exclamation mark
+  - (: left paren
+  - ): right paren
+  - &: ampersand
+  - |: pipe
 
 For example:
 
@@ -34,54 +34,136 @@ For example:
 val tag = NamedTag("Linux")
 ```
 
-## Marking Tests
+:::note
+If two tag objects have the same simple name (even in different packages) they are treated as the same tag.
+:::
 
-Test cases can then be marked with tags using the `config` function:
+## Adding tags to tests
+
+### Tagging Tests
+
+Tests can be tagged at various levels. Firstly, test cases themselves can have tags added via test `config`.
+Note that any nested tags inherit tags from their parents.
 
 ```kotlin
-class MyTest : FreeSpec() {
+class MyTest : FunSpec() {
   init {
-    "should run on Windows".config(tags = setOf(Windows)) {
+    test("should run on Windows").config(tags = setOf(Windows)) {
       // ...
     }
 
-    "should run on Linux".config(tags = setOf(Linux)) {
+    test("should run on Linux").config(tags = setOf(Linux)) {
       // ...
     }
 
-    "should run on Windows and Linux".config(tags = setOf(Windows, Linux)) {
+    context("should run on Windows and Linux").config(tags = setOf(Windows, Linux)) {
+      test("and nested tests") { // implicity has windows and linux tags added
+
+      }
+    }
+  }
+}
+```
+
+### Tagging Specs
+
+Secondly, you can add tags at the spec level, either through the tags function in the spec itself, or through the @Tags
+annotation. Any tags
+added this way are applied to all tests implicitly.
+
+:::caution
+When tagging tests in this way, the spec class will still need to be instantiated in order to examine the tags on each
+test, because the test itself may define further tags. Therefore, do not rely on this if you want to avoid instantiating
+classes completely, and instead see @RequiresTag.
+:::
+
+```kotlin
+@Tags("Foo") // applied to all tests in this spec
+private class TaggedSpec : ExpectSpec() {
+  init {
+
+    tags(Windows) // applied to all tests in this spec
+
+    expect("should run on Windows") {
       // ...
     }
   }
 }
 ```
 
+:::caution
+Any tags added via @Tags do not stop the spec from being instantiated, as the engine
+needs to check for any tags added via code. If you want to avoid a spec from being instantiated completely, use
+@RequiresTag.
+:::
 
-## Running with Tags
+### @RequiresTag
 
-Then by invoking the test runner with a system property of `kotest.tags` you can control which tests are run. The expression to be
-passed in is a simple boolean expression using boolean operators: `&`, `|`, `!`, with parenthesis for association.
+Finally, you can use the @RequiresTag annotation. This only checks that all the referenced tags are present and
+if not, will skip the spec entirely. This is an important distinction, because with the other annotation - @Tags - the
+spec will still need to be instantiated in order to check for any tags added via the DSL. This can be counter-intuitive.
+
+For example, the following spec would be skipped and not instantiated unless the Linux and Mysql tags were
+specified at runtime.
+
+```kotlin
+@RequiresTag("Linux", "Mysql")
+class MyTestClass : FunSpec()
+```
+
+:::note
+Note that when you use annotations you pass the string name of the tag, not the tag instance itself.
+:::
+
+
+## Executing with Tags
+
+By invoking the test runner with a system property of `kotest.tags` or an environment variable of `KOTEST_TAGS` you can
+control which tests are run. The expression to be passed in is a simple boolean expression using boolean operators: `&`,
+`|`, `!`, with parenthesis for association.
 
 For example, `Tag1 & (Tag2 | Tag3)`
 
-Provide the simple names of tag object (without package) when you run the tests.
-Please pay attention to the use of upper case and lower case! If two tag objects have the same simple name (in different name spaces) they are treated as the same tag.
+Provide the simple names of tag object (without package) when you run the tests. Eg, a tag created as
+`val mytag = NamedTag("A")` would use the tag name `A`.
 
+:::caution
+Please pay attention to the use of upper case and lower case! Tags are case-sensitive.
+:::
 
-Example: To run only test tagged with `Linux`, but not tagged with `Database`, you would invoke
-Gradle like this:
+Example: To run only test tagged with `Linux`, but not tagged with `Database`, you would invoke Gradle
+using the environment variable (since Kotest 6.1.0).
+
+```
+KOTEST_TAGS="Linux & !Database" gradle check
+```
+
+Or using the system property from the command line.
 
 ```
 gradle test -Dkotest.tags="Linux & !Database"
 ```
 
-Tags can also be included/excluded in runtime (for example, if you're running a project configuration instead of properties) through the `RuntimeTagExtension`:
+Or by specifying the system property inside your build script.
 
 ```kotlin
-RuntimeTagExpressionExtension.expression = "Linux & !Database"
+tasks.withType<Test>().configureEach {
+  systemProperty("kotest.tags", "Linux & !Database")
+}
 ```
 
-## Tag Expression Operators
+:::tip
+Prefer the environment variable as it works on all platforms, unless you are on an earlier version of Kotest
+(prior to 6.1), or need to specify the tags in your Gradle build script rather than at the command line.
+:::
+
+:::note
+If no root tests are active at runtime, the [beforeSpec](lifecycle_hooks.md) and [afterSpec](lifecycle_hooks.md)
+callbacks will _not_ be invoked.
+:::
+
+
+### Tag Expression Operators
 
 Operators (in descending order of precedence)
 
@@ -92,36 +174,13 @@ Operators (in descending order of precedence)
 | &#124;   | or          | windows &#124; microservice |
 
 
+### Inheriting tags
 
+By default, the `@Tags` annotation will only be considered on the immediate Spec which it was applied to. However, a
+Spec can also inherit tags from superclasses and superinterfaces. To enable this, toggle `tagInheritance = true` in
+your [project config](./project_config.md)
 
-
-## Tagging All Tests
-
-You can add a tag to all tests in a spec using the tags function in the spec itself. For example:
-
-```kotlin
-class MyTestClass : FunSpec({
-
-  tags(Linux, Mysql)
-
-  test("my test") { } // automatically marked with the above tags
-})
-```
-
-:::caution
-When tagging tests in this way, the spec class will still need to be instantiated in order to examine the tags on each test, because the test itself may define further tags.
-:::
-
-:::note
-If no root tests are active at runtime, the [beforeSpec](lifecycle_hooks.md) and [afterSpec](lifecycle_hooks.md) callbacks will _not_ be invoked.
-:::
-
-## Tagging a Spec
-
-There are two annotations you can add to a spec class itself - @Tags and @RequiresTag - which accept one or more tag names as their arguments.
-
-The first tag - @Tags - will be applied to all tests in the class, however this will only stop a spec from being instantiated if we can guarantee
-that no tests would be executed (because a tag is being explicitly excluded).
+## Examples
 
 Consider the following example:
 
@@ -150,45 +209,29 @@ class MyTestClass : FunSpec({
 | kotest.tags=Linux & !Mysql | yes          | yes       | B, C are executed only, because all tests inherit `Linux` from the annotation, but A is excluded by the `Mysql` tag                                                                                                                           |
 
 
-The second tag - @RequiresTag - only checks that all the referenced tags are present and if not, will skip the spec.
-
-For example, the following spec would be skipped and not instantiated unless the Linux and Mysql tags were
-specified at runtime.
-
-```kotlin
-@RequiresTag("Linux", "Mysql")
-class MyTestClass : FunSpec()
-```
-
-
-:::note
-Note that when you use these annotations you pass the tag string name, not the tag itself. This is due to Kotlin annotations only allow "primitive" arguments
-:::
-
-### Inheriting tags
-
-By default, the `@Tags` annotation will only be considered on the immediate Spec which it was applied to. However, a Spec can also inherit tags from superclasses and superinterfaces. To enable this, toggle `tagInheritance = true` in your [project config](./project-config.html)
-
 
 ## Gradle
 
-**Special attention is needed in your gradle configuration**
+**Special attention is needed in your Gradle configuration when using system properties**
 
-To use System Properties (-Dx=y), your gradle must be configured to propagate them to the test executors, and an extra configuration must be added to your tests:
+To use System Properties (-Dx=y), Gradle must be configured to propagate them to the test executors, and an extra
+configuration must be added to your tests:
 
 Groovy:
+
 ```groovy
 test {
-    //... Other configurations ...
-    systemProperties = System.properties
+  //... Other configurations ...
+  systemProperties = System.properties
 }
 ```
 
 Kotlin Gradle DSL:
+
 ```kotlin
 val test by tasks.getting(Test::class) {
-    // ... Other configurations ...
-    systemProperties = System.getProperties().asIterable().associate { it.key.toString() to it.value }
+  // ... Other configurations ...
+  systemProperties = System.getProperties().asIterable().associate { it.key.toString() to it.value }
 }
 ```
 

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3444,6 +3444,10 @@ public final class io/kotest/engine/config/IncludeTestScopeAffixes : java/lang/E
 	public static fun values ()[Lio/kotest/engine/config/IncludeTestScopeAffixes;
 }
 
+public final class io/kotest/engine/config/KotestEngineEnvVars {
+	public static final field INSTANCE Lio/kotest/engine/config/KotestEngineEnvVars;
+}
+
 public final class io/kotest/engine/config/KotestEngineProperties {
 	public static final field INSTANCE Lio/kotest/engine/config/KotestEngineProperties;
 	public static final field INVOCATION_TIMEOUT Ljava/lang/String;
@@ -3765,8 +3769,8 @@ public final class io/kotest/engine/extensions/IncludeDescriptorFilter : io/kote
 	public fun filter (Lio/kotest/core/descriptors/Descriptor;)Lio/kotest/engine/extensions/DescriptorFilterResult;
 }
 
-public final class io/kotest/engine/extensions/SystemPropertyTagExtension : io/kotest/core/extensions/TagExtension {
-	public static final field INSTANCE Lio/kotest/engine/extensions/SystemPropertyTagExtension;
+public final class io/kotest/engine/extensions/SystemPropertyOrEnvTagExtension : io/kotest/core/extensions/TagExtension {
+	public static final field INSTANCE Lio/kotest/engine/extensions/SystemPropertyOrEnvTagExtension;
 	public fun tags ()Lio/kotest/engine/tags/TagExpression;
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/TagExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/TagExtension.kt
@@ -12,7 +12,7 @@ import io.kotest.engine.tags.TagExpression
  * Note: If multiple extensions are registered then all returned
  * [TagExpression] are combined using [TagExpression.combine], which acts like an OR.
  *
- * The [io.kotest.engine.extensions.SystemPropertyTagExtension] is automatically registered when
+ * The [io.kotest.engine.extensions.SystemPropertyOrEnvTagExtension] is automatically registered when
  * running JVM tests which includes and excludes tags using the system properties
  * 'kotest.tags.include' and 'kotest.tags.exclude'.
  *

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineEnvVars.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineEnvVars.kt
@@ -1,0 +1,9 @@
+package io.kotest.engine.config
+
+object KotestEngineEnvVars {
+
+   /**
+    * Sets the tag expression that determines included/excluded tags.
+    */
+   internal const val TAG_EXPRESSION = "KOTEST_TAGS"
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SystemPropertyOrEnvTagExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/SystemPropertyOrEnvTagExtension.kt
@@ -1,37 +1,41 @@
 package io.kotest.engine.extensions
 
-import io.kotest.common.syspropOrEnv
+import io.kotest.common.env
+import io.kotest.common.sysprop
 import io.kotest.core.NamedTag
 import io.kotest.core.Tag
 import io.kotest.core.extensions.TagExtension
+import io.kotest.engine.config.KotestEngineEnvVars
 import io.kotest.engine.config.KotestEngineProperties
 import io.kotest.engine.tags.TagExpression
 
 /**
  * This [TagExtension] includes and excludes tags using the system properties:
  * [KotestEngineProperties.TAG_EXPRESSION], [KotestEngineProperties.INCLUDE_TAGS]
- * and [KotestEngineProperties.EXCLUDE_TAGS].
+ * and [KotestEngineProperties.EXCLUDE_TAGS] or the equivalent environment variables.
  *
  * Note: If [KotestEngineProperties.TAG_EXPRESSION] is used then the other two properties will be ignored.
  *
  * This extension is registered automatically by the Kotest engine.
  *
- * On non-JVM targets this extension will have no effect.
+ * On non-JVM targets system properties have no effect, so you must use the environment variables.
  */
-object SystemPropertyTagExtension : TagExtension {
+object SystemPropertyOrEnvTagExtension : TagExtension {
 
    override fun tags(): TagExpression {
 
-      fun readTagsProperty(name: String): List<Tag> =
-         (syspropOrEnv(name) ?: "").split(',').filter { it.isNotBlank() }.map { NamedTag(it.trim()) }
-
-      val includedTags = readTagsProperty(KotestEngineProperties.INCLUDE_TAGS)
-      val excludedTags = readTagsProperty(KotestEngineProperties.EXCLUDE_TAGS)
-      val expression = syspropOrEnv(KotestEngineProperties.TAG_EXPRESSION)
+      val includedTags = readTags(KotestEngineProperties.INCLUDE_TAGS)
+      val excludedTags = readTags(KotestEngineProperties.EXCLUDE_TAGS)
+      val expression = sysprop(KotestEngineProperties.TAG_EXPRESSION) ?: env(KotestEngineEnvVars.TAG_EXPRESSION)
 
       return if (expression == null)
          TagExpression(includedTags.toSet(), excludedTags.toSet())
       else
          TagExpression(expression)
    }
+
+   private fun readTags(prop: String): List<Tag> =
+      (sysprop(prop) ?: "").split(',')
+         .filter { it.isNotBlank() }
+         .map { NamedTag(it.trim()) }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/runtime.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/runtime.kt
@@ -2,7 +2,7 @@ package io.kotest.engine.tags
 
 import io.kotest.core.extensions.TagExtension
 import io.kotest.engine.config.ProjectConfigResolver
-import io.kotest.engine.extensions.SystemPropertyTagExtension
+import io.kotest.engine.extensions.SystemPropertyOrEnvTagExtension
 
 /**
  * Returns the runtime [TagExpression]'s by invoking [TagExtension]s registered globally.
@@ -10,7 +10,7 @@ import io.kotest.engine.extensions.SystemPropertyTagExtension
 internal object TagExpressionBuilder {
 
    fun build(projectConfigResolver: ProjectConfigResolver): TagExpression {
-      val extensions = projectConfigResolver.extensions().filterIsInstance<TagExtension>() + SystemPropertyTagExtension
+      val extensions = projectConfigResolver.extensions().filterIsInstance<TagExtension>() + SystemPropertyOrEnvTagExtension
       return if (extensions.isEmpty()) TagExpression.Empty else
          extensions.map { it.tags() }
             .reduce { a, b -> a.combine(b) }

--- a/kotest-tests/kotest-tests-tags-envvar/build.gradle.kts
+++ b/kotest-tests/kotest-tests-tags-envvar/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+   id("kotest-jvm-conventions")
+}
+
+kotlin {
+   sourceSets {
+      commonTest {
+         dependencies {
+            implementation(projects.kotestFramework.kotestFrameworkEngine)
+            implementation(projects.kotestAssertions.kotestAssertionsCore)
+         }
+      }
+   }
+}
+
+tasks.withType<Test>().configureEach {
+   environment("KOTEST_TAGS", "B")
+}

--- a/kotest-tests/kotest-tests-tags-envvar/src/commonTest/kotlin/com/sksamuel/multiplatform/tags/EnvTagTest.kt
+++ b/kotest-tests/kotest-tests-tags-envvar/src/commonTest/kotlin/com/sksamuel/multiplatform/tags/EnvTagTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.multiplatform.tags
+
+import io.kotest.core.NamedTag
+import io.kotest.core.annotation.Description
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+val A = NamedTag("A")
+val B = NamedTag("B")
+
+var invoked = 0
+
+@Description("Tests that the KOTEST_TAGS env var is correctly applied on multiplatform")
+class EnvTagTest : FreeSpec() {
+   init {
+
+      afterProject {
+         invoked shouldBe 1
+      }
+
+      "A".config(tags = setOf(A)) {
+         invoked++
+      }
+
+      "B".config(tags = setOf(B)) {
+         invoked++
+      }
+   }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -189,6 +189,10 @@ if (shouldRunJvmOnlyModules) {
       ":kotest-tests:kotest-tests-junit-displaynameformatter",
 
       ":kotest-tests:kotest-tests-multiname-test-name-sysprop",
+
+      // Tests that the KOTEST_TAGS env var is correctly applied to tags at runtime
+      ":kotest-tests:kotest-tests-tags-envvar",
+
       ":kotest-tests:kotest-tests-power-assert",
       ":kotest-tests:kotest-tests-spec-parallelism",
       ":kotest-tests:kotest-tests-tagextension",


### PR DESCRIPTION
Reworked tags docs.

Fixes #4875

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
