### PR TITLE
Allow re-registering of specs in Junit for test-retry-plugin

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -124,20 +124,20 @@ class JUnitTestEngineListener(
       logger.log { "specStarted ${ref.kclass}" }
       try {
 
-         var jdescriptor = findSpecTestDescriptor(root, ref.kclass.toDescriptor())
+         var descriptor = findSpecTestDescriptor(root, ref.kclass.toDescriptor())
 
          // usually we add the spec test descriptors when the root engine descriptor is created,
          // but when using test-retry-plugin the root is pruned and re-used, so it may not be registered yet
-         if (jdescriptor == null) {
-            jdescriptor = createSpecTestDescriptor(root, ref.kclass.toDescriptor(), ref.kclass.bestName())
-            root.addChild(jdescriptor)
-            listener.dynamicTestRegistered(jdescriptor)
+         if (descriptor == null) {
+            descriptor = createSpecTestDescriptor(root, ref.kclass.toDescriptor(), ref.kclass.bestName())
+            root.addChild(descriptor)
+            listener.dynamicTestRegistered(descriptor)
          }
 
-         descriptors[ref.kclass.toDescriptor()] = jdescriptor
+         descriptors[ref.kclass.toDescriptor()] = descriptor
 
-         logger.log { Pair(ref.kclass.bestName(), "executionStarted $jdescriptor") }
-         listener.executionStarted(jdescriptor)
+         logger.log { Pair(ref.kclass.bestName(), "executionStarted $descriptor") }
+         listener.executionStarted(descriptor)
 
       } catch (t: Throwable) {
          logger.log { Pair(ref.kclass.bestName(), "Error marking spec as started $t") }
@@ -155,7 +155,7 @@ class JUnitTestEngineListener(
          // and mark that as failed
          t != null -> {
             val descriptor = findSpecTestDescriptor(root, ref.kclass.toDescriptor())
-               ?: error("Could not find TestDescriptor for ${ref.kclass}")
+               ?: error("Could not find TestDescriptor for spec ${ref.kclass}")
             addPlaceholderTest(descriptor, t, ref.kclass)
             logger.log { Pair(ref.kclass.bestName(), "executionFinished: $descriptor $t") }
             listener.executionFinished(descriptor, TestExecutionResult.failed(t))
@@ -163,7 +163,7 @@ class JUnitTestEngineListener(
 
          else -> {
             val descriptor = findSpecTestDescriptor(root, ref.kclass.toDescriptor())
-               ?: error("Could not find TestDescriptor for ${ref.kclass}")
+               ?: error("Could not find TestDescriptor for spec ${ref.kclass}")
             logger.log { Pair(ref.kclass.bestName(), "executionFinished: $descriptor") }
             listener.executionFinished(descriptor, TestExecutionResult.successful())
          }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestEngineDescriptor.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestEngineDescriptor.kt
@@ -1,5 +1,6 @@
 package io.kotest.runner.junit.platform
 
+import io.kotest.common.reflection.bestName
 import io.kotest.core.descriptors.toDescriptor
 import io.kotest.core.extensions.Extension
 import io.kotest.core.log
@@ -14,9 +15,9 @@ class KotestEngineDescriptor internal constructor(
    val classes: List<KClass<out Spec>>,
    val extensions: List<Extension>,
 ) : EngineDescriptor(id, KotestJunitPlatformTestEngine.ENGINE_NAME) {
-   // Only reports dynamic children (see ExtensionExceptionExtractor) if there are no test classes to run,
-   // so that we can add a placeholder test for the error
-   override fun mayRegisterTests(): Boolean = classes.isEmpty()
+   // we add tests dynamically to the engine when there's an engine exception to be reported, and also
+   // some plugins like the gradle test-retry-plugin prune the root test descriptor so they are re-registered
+   override fun mayRegisterTests(): Boolean = true
 }
 
 internal data class EngineDescriptorBuilder(

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestEngineDescriptor.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestEngineDescriptor.kt
@@ -1,6 +1,5 @@
 package io.kotest.runner.junit.platform
 
-import io.kotest.common.reflection.bestName
 import io.kotest.core.descriptors.toDescriptor
 import io.kotest.core.extensions.Extension
 import io.kotest.core.log

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -1,21 +1,27 @@
 package io.kotest.runner.junit.platform
 
 import io.kotest.core.descriptors.Descriptor
+import io.kotest.core.test.TestCase
+import io.kotest.engine.test.names.DisplayNameFormatting
 import org.junit.platform.engine.TestDescriptor
 import org.junit.platform.engine.TestSource
 import org.junit.platform.engine.UniqueId
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor
 import org.junit.platform.engine.support.descriptor.ClassSource
 import org.junit.platform.engine.support.descriptor.EngineDescriptor
+import org.junit.platform.engine.support.descriptor.MethodSource
 import kotlin.jvm.optionals.getOrNull
+import kotlin.reflect.KClass
 
 /**
- * Returns the [org.junit.platform.engine.TestDescriptor] corresponding to the given spec.
- * Specs are always registered when the test suite is created, so this is expected to never fail.
+ * Finds and returns the [org.junit.platform.engine.TestDescriptor] corresponding to the
+ * given [Descriptor.SpecDescriptor] that was previously added to the engine.
+ *
+ * If the engine descriptor does not contain the spec descriptor, then null is returned.
  */
-internal fun EngineDescriptor.getSpecTestDescriptor(descriptor: Descriptor.SpecDescriptor): TestDescriptor? {
-   val id = deriveSpecUniqueId(descriptor.id)
-   return findByUniqueId(id).getOrNull()
+internal fun findSpecTestDescriptor(engine: EngineDescriptor, descriptor: Descriptor.SpecDescriptor): TestDescriptor? {
+   val id = createSpecUniqueId(engine, descriptor.id)
+   return engine.findByUniqueId(id).getOrNull()
 }
 
 /**
@@ -27,7 +33,7 @@ internal fun createSpecTestDescriptor(
    descriptor: Descriptor.SpecDescriptor,
    displayName: String,
 ): TestDescriptor {
-   val id = engine.deriveSpecUniqueId(descriptor.id)
+   val id = createSpecUniqueId(engine, descriptor.id)
    val source = ClassSource.from(descriptor.id.value)
    return object : AbstractTestDescriptor(id, displayName, source) {
       override fun getType(): TestDescriptor.Type = TestDescriptor.Type.CONTAINER
@@ -57,3 +63,27 @@ internal fun createTestTestDescriptor(
    override fun getType(): TestDescriptor.Type = type
    override fun mayRegisterTests(): Boolean = type == TestDescriptor.Type.CONTAINER
 }
+
+internal fun createTestDescriptorWithMethodSource(
+   root: EngineDescriptor,
+   testCase: TestCase,
+   type: TestDescriptor.Type,
+   formatter: DisplayNameFormatting,
+): TestDescriptor {
+   val id = createTestUniqueId(root, testCase.descriptor)
+   val testDescriptor = createTestTestDescriptor(
+      id = id,
+      displayName = formatter.format(testCase),
+      type = type,
+      // gradle-junit-platform hides tests if we don't send a source at all
+      // surefire-junit-platform (maven) needs a MethodSource in order to separate test cases from each other
+      // and produce more correct XML report with test case name.
+      source = getMethodSource(testCase.spec::class, id),
+   )
+   return testDescriptor
+}
+
+internal fun getMethodSource(kclass: KClass<*>, id: UniqueId): MethodSource = MethodSource.from(
+   /* className = */ kclass.qualifiedName,
+   /* methodName = */ id.segments.filter { it.type == Segment.Test.value }.joinToString("/") { it.value }
+)

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
@@ -29,18 +29,22 @@ internal sealed class Segment {
 }
 
 /**
- * The created [UniqueId] will have segment type [Segment.Spec] and will use the descriptor id.
+ * Creates a [UniqueId] for a spec from the given [EngineDescriptor] and [DescriptorId].
+ *
+ * The created id will have segment type [Segment.Spec].
  */
-internal fun EngineDescriptor.deriveSpecUniqueId(id: DescriptorId): UniqueId =
-   uniqueId.append(Segment.Spec.value, id.value)
+internal fun createSpecUniqueId(engine: EngineDescriptor, id: DescriptorId): UniqueId =
+   engine.uniqueId.append(Segment.Spec.value, id.value)
 
 /**
- * The created [UniqueId] will have segment type [Segment.Test] and will use the descriptor id.
+ * Creates a [UniqueId] for a test from the given [EngineDescriptor] and [Descriptor.TestDescriptor].
+ *
+ * The created id will have segment type [Segment.Test].
  */
-internal fun EngineDescriptor.deriveTestUniqueId(descriptor: Descriptor): UniqueId {
-   return when (descriptor) {
-      is Descriptor.SpecDescriptor -> deriveSpecUniqueId(descriptor.id)
-      is Descriptor.TestDescriptor -> deriveTestUniqueId(descriptor.parent)
-         .append(Segment.Test.value, descriptor.id.value)
+internal fun createTestUniqueId(engine: EngineDescriptor, descriptor: Descriptor.TestDescriptor): UniqueId {
+   val parentDescriptor = when (val parent = descriptor.parent) {
+      is Descriptor.SpecDescriptor -> createSpecUniqueId(engine, descriptor.id)
+      is Descriptor.TestDescriptor -> createTestUniqueId(engine, parent)
    }
+   return parentDescriptor.append(Segment.Test.value, descriptor.id.value)
 }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
@@ -39,7 +39,8 @@ internal fun createSpecUniqueId(engine: EngineDescriptor, id: DescriptorId): Uni
 /**
  * Creates a [UniqueId] for a test from the given [EngineDescriptor] and [Descriptor.TestDescriptor].
  *
- * The created id will have segment type [Segment.Test].
+ * The created id will have segment type [Segment.Test], and any parent tests plus the spec will
+ * be prepended to the created id.
  */
 internal fun createTestUniqueId(engine: EngineDescriptor, descriptor: Descriptor.TestDescriptor): UniqueId {
    val parentDescriptor = when (val parent = descriptor.parent) {


### PR DESCRIPTION
Fixes #3770
Fixes #3828

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
