### PR TITLE
Allow re-registering of specs in Junit for test-retry-plugin

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -119,9 +119,13 @@ class JUnitTestEngineListener(
       logger.log { "specStarted ${ref.kclass}" }
       try {
 
-         // descriptor must definitely exist for a started spec
-         val descriptor = findTestDescriptorForSpec(root, ref.kclass.toDescriptor())
-         descriptors[ref.kclass.toDescriptor()] = descriptor ?: error("Could not find TestDescriptor for ${ref.kclass}")
+         var descriptor = findTestDescriptorForSpec(root, ref.kclass.toDescriptor())
+         if (descriptor == null) {
+            descriptor = createSpecTestDescriptor(root, ref.kclass.toDescriptor(), ref.kclass.bestName())
+            root.addChild(descriptor)
+            listener.dynamicTestRegistered(descriptor)
+         }
+         descriptors[ref.kclass.toDescriptor()] = descriptor
 
          logger.log { Pair(ref.kclass.bestName(), "executionStarted $descriptor") }
          listener.executionStarted(descriptor)

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestEngineDescriptor.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestEngineDescriptor.kt
@@ -14,9 +14,9 @@ class KotestEngineDescriptor internal constructor(
    val classes: List<KClass<out Spec>>,
    val extensions: List<Extension>,
 ) : EngineDescriptor(id, KotestJunitPlatformTestEngine.ENGINE_NAME) {
-   // Only reports dynamic children (see ExtensionExceptionExtractor) if there are no test classes to run,
-   // so that we can add a placeholder test for the error
-   override fun mayRegisterTests(): Boolean = classes.isEmpty()
+   // we add tests dynamically to the engine when there's an engine exception to be reported, and also
+   // some plugins like the gradle test-retry-plugin prune the root test descriptor so they are re-registered
+   override fun mayRegisterTests(): Boolean = true
 }
 
 internal data class EngineDescriptorBuilder(

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -70,7 +70,7 @@ internal fun createTestDescriptorWithMethodSource(
    type: TestDescriptor.Type,
    formatter: DisplayNameFormatting,
 ): TestDescriptor {
-   val id = createTestUniqueId(root.uniqueId, testCase.descriptor)
+   val id = createUniqueIdForTest(root.uniqueId, testCase.descriptor)
    val testDescriptor = createTestTestDescriptor(
       id = id,
       displayName = formatter.format(testCase),

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -14,8 +14,10 @@ import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.KClass
 
 /**
- * Returns the [org.junit.platform.engine.TestDescriptor] corresponding to the given spec.
- * Specs are always registered when the test suite is created, so this is expected to never fail.
+ * Finds and returns the [org.junit.platform.engine.TestDescriptor] corresponding to the
+ * given [Descriptor.SpecDescriptor] that was previously added to the engine.
+ *
+ * If the engine descriptor does not contain the spec descriptor, then null is returned.
  */
 internal fun findTestDescriptorForSpec(root: EngineDescriptor, descriptor: Descriptor.SpecDescriptor): TestDescriptor? {
    val id = createUniqueIdForSpec(root, descriptor.id)

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.KClass
  * Specs are always registered when the test suite is created, so this is expected to never fail.
  */
 internal fun findTestDescriptorForSpec(root: EngineDescriptor, descriptor: Descriptor.SpecDescriptor): TestDescriptor? {
-   val id = root.deriveSpecUniqueId(descriptor.id)
+   val id = createUniqueIdForSpec(root, descriptor.id)
    return root.findByUniqueId(id).getOrNull()
 }
 
@@ -31,7 +31,7 @@ internal fun createSpecTestDescriptor(
    descriptor: Descriptor.SpecDescriptor,
    displayName: String,
 ): TestDescriptor {
-   val id = root.deriveSpecUniqueId(descriptor.id)
+   val id = createUniqueIdForSpec(root, descriptor.id)
    val source = ClassSource.from(descriptor.id.value)
    return object : AbstractTestDescriptor(id, displayName, source) {
       override fun getType(): TestDescriptor.Type = TestDescriptor.Type.CONTAINER

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -20,7 +20,7 @@ import kotlin.reflect.KClass
  * If the engine descriptor does not contain the spec descriptor, then null is returned.
  */
 internal fun findTestDescriptorForSpec(root: EngineDescriptor, descriptor: Descriptor.SpecDescriptor): TestDescriptor? {
-   val id = createUniqueIdForSpec(root, descriptor.id)
+   val id = createUniqueIdForSpec(root.uniqueId, descriptor.id)
    return root.findByUniqueId(id).getOrNull()
 }
 
@@ -33,7 +33,7 @@ internal fun createSpecTestDescriptor(
    descriptor: Descriptor.SpecDescriptor,
    displayName: String,
 ): TestDescriptor {
-   val id = createUniqueIdForSpec(root, descriptor.id)
+   val id = createUniqueIdForSpec(root.uniqueId, descriptor.id)
    val source = ClassSource.from(descriptor.id.value)
    return object : AbstractTestDescriptor(id, displayName, source) {
       override fun getType(): TestDescriptor.Type = TestDescriptor.Type.CONTAINER
@@ -70,7 +70,7 @@ internal fun createTestDescriptorWithMethodSource(
    type: TestDescriptor.Type,
    formatter: DisplayNameFormatting,
 ): TestDescriptor {
-   val id = root.deriveTestUniqueId(testCase.descriptor)
+   val id = createTestUniqueId(root.uniqueId, testCase.descriptor)
    val testDescriptor = createTestTestDescriptor(
       id = id,
       displayName = formatter.format(testCase),

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
@@ -29,18 +29,23 @@ internal sealed class Segment {
 }
 
 /**
- * The created [UniqueId] will have segment type [Segment.Spec] and will use the descriptor id.
+ * Creates a [UniqueId] for a spec from the given [EngineDescriptor] and [DescriptorId].
+ *
+ * The created id will have segment type [Segment.Spec].
  */
-internal fun createUniqueIdForSpec(root: EngineDescriptor, id: DescriptorId): UniqueId =
-   root.uniqueId.append(Segment.Spec.value, id.value)
+internal fun createUniqueIdForSpec(engineId: UniqueId, id: DescriptorId): UniqueId =
+   engineId.append(Segment.Spec.value, id.value)
 
 /**
- * The created [UniqueId] will have segment type [Segment.Test] and will use the descriptor id.
+ * Creates a [UniqueId] for a test from the given [EngineDescriptor] and [Descriptor.TestDescriptor].
+ *
+ * The created id will have segment type [Segment.Test], and any parent tests plus the spec will
+ * be prepended to the created id.
  */
-internal fun EngineDescriptor.deriveTestUniqueId(descriptor: Descriptor): UniqueId {
-   return when (descriptor) {
-      is Descriptor.SpecDescriptor -> createUniqueIdForSpec(this, descriptor.id)
-      is Descriptor.TestDescriptor -> deriveTestUniqueId(descriptor.parent)
-         .append(Segment.Test.value, descriptor.id.value)
+internal fun createTestUniqueId(engineId: UniqueId, descriptor: Descriptor.TestDescriptor): UniqueId {
+   val parentDescriptor = when (val parent = descriptor.parent) {
+      is Descriptor.SpecDescriptor -> createUniqueIdForSpec(engineId, parent.id)
+      is Descriptor.TestDescriptor -> createTestUniqueId(engineId, parent)
    }
+   return parentDescriptor.append(Segment.Test.value, descriptor.id.value)
 }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
@@ -31,10 +31,10 @@ internal fun createUniqueIdForSpec(engineId: UniqueId, id: DescriptorId): Unique
  * The created id will have segment type [Segment.Test], and any parent tests plus the spec will
  * be prepended to the created id.
  */
-internal fun createTestUniqueId(engineId: UniqueId, descriptor: Descriptor.TestDescriptor): UniqueId {
+internal fun createUniqueIdForTest(engineId: UniqueId, descriptor: Descriptor.TestDescriptor): UniqueId {
    val parentDescriptor = when (val parent = descriptor.parent) {
       is Descriptor.SpecDescriptor -> createUniqueIdForSpec(engineId, parent.id)
-      is Descriptor.TestDescriptor -> createTestUniqueId(engineId, parent)
+      is Descriptor.TestDescriptor -> createUniqueIdForTest(engineId, parent)
    }
    return parentDescriptor.append(Segment.Test.value, descriptor.id.value)
 }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
@@ -31,15 +31,15 @@ internal sealed class Segment {
 /**
  * The created [UniqueId] will have segment type [Segment.Spec] and will use the descriptor id.
  */
-internal fun EngineDescriptor.deriveSpecUniqueId(id: DescriptorId): UniqueId =
-   uniqueId.append(Segment.Spec.value, id.value)
+internal fun createUniqueIdForSpec(root: EngineDescriptor, id: DescriptorId): UniqueId =
+   root.uniqueId.append(Segment.Spec.value, id.value)
 
 /**
  * The created [UniqueId] will have segment type [Segment.Test] and will use the descriptor id.
  */
 internal fun EngineDescriptor.deriveTestUniqueId(descriptor: Descriptor): UniqueId {
    return when (descriptor) {
-      is Descriptor.SpecDescriptor -> deriveSpecUniqueId(descriptor.id)
+      is Descriptor.SpecDescriptor -> createUniqueIdForSpec(this, descriptor.id)
       is Descriptor.TestDescriptor -> deriveTestUniqueId(descriptor.parent)
          .append(Segment.Test.value, descriptor.id.value)
    }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/uniqueids.kt
@@ -5,17 +5,6 @@ import io.kotest.core.descriptors.DescriptorId
 import org.junit.platform.engine.UniqueId
 import org.junit.platform.engine.support.descriptor.EngineDescriptor
 
-/**
- * Returns a new [UniqueId] by appending this [descriptor] to the receiver.
- */
-internal fun UniqueId.append(descriptor: Descriptor): UniqueId {
-   val segment = when (descriptor) {
-      is Descriptor.SpecDescriptor -> Segment.Spec
-      is Descriptor.TestDescriptor -> Segment.Test
-   }
-   return this.append(segment.value, descriptor.id.value)
-}
-
 internal sealed class Segment {
    abstract val value: String
 

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit/platform/UniqueIdTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit/platform/UniqueIdTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.descriptors.toDescriptor
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.runner.junit.platform.Segment
-import io.kotest.runner.junit.platform.createTestUniqueId
+import io.kotest.runner.junit.platform.createUniqueIdForTest
 import io.kotest.runner.junit.platform.createUniqueIdForSpec
 import org.junit.platform.engine.UniqueId
 
@@ -20,7 +20,7 @@ class UniqueIdTest : FunSpec() {
       test("createTestUniqueId should handle rooot tests") {
          val root = UniqueId.forEngine("kotest")
          val testDescriptor = UniqueIdTest::class.toDescriptor().append("a")
-         createTestUniqueId(root, testDescriptor) shouldBe
+         createUniqueIdForTest(root, testDescriptor) shouldBe
             root.append(Segment.Spec.value, "com.sksamuel.kotest.runner.junit.platform.UniqueIdTest")
                .append(Segment.Test.value, "a")
       }
@@ -28,7 +28,7 @@ class UniqueIdTest : FunSpec() {
       test("createTestUniqueId should handle nested tests") {
          val root = UniqueId.forEngine("kotest")
          val testDescriptor = UniqueIdTest::class.toDescriptor().append("a").append("b")
-         createTestUniqueId(root, testDescriptor) shouldBe
+         createUniqueIdForTest(root, testDescriptor) shouldBe
             root.append(Segment.Spec.value, "com.sksamuel.kotest.runner.junit.platform.UniqueIdTest")
                .append(Segment.Test.value, "a")
                .append(Segment.Test.value, "b")

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit/platform/UniqueIdTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit/platform/UniqueIdTest.kt
@@ -1,0 +1,37 @@
+package com.sksamuel.kotest.runner.junit.platform
+
+import io.kotest.core.descriptors.toDescriptor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit.platform.Segment
+import io.kotest.runner.junit.platform.createTestUniqueId
+import io.kotest.runner.junit.platform.createUniqueIdForSpec
+import org.junit.platform.engine.UniqueId
+
+class UniqueIdTest : FunSpec() {
+   init {
+
+      test("createUniqueIdForSpec") {
+         val root = UniqueId.forEngine("kotest")
+         createUniqueIdForSpec(root, UniqueIdTest::class.toDescriptor().id) shouldBe
+            root.append(Segment.Spec.value, "com.sksamuel.kotest.runner.junit.platform.UniqueIdTest")
+      }
+
+      test("createTestUniqueId should handle rooot tests") {
+         val root = UniqueId.forEngine("kotest")
+         val testDescriptor = UniqueIdTest::class.toDescriptor().append("a")
+         createTestUniqueId(root, testDescriptor) shouldBe
+            root.append(Segment.Spec.value, "com.sksamuel.kotest.runner.junit.platform.UniqueIdTest")
+               .append(Segment.Test.value, "a")
+      }
+
+      test("createTestUniqueId should handle nested tests") {
+         val root = UniqueId.forEngine("kotest")
+         val testDescriptor = UniqueIdTest::class.toDescriptor().append("a").append("b")
+         createTestUniqueId(root, testDescriptor) shouldBe
+            root.append(Segment.Spec.value, "com.sksamuel.kotest.runner.junit.platform.UniqueIdTest")
+               .append(Segment.Test.value, "a")
+               .append(Segment.Test.value, "b")
+      }
+   }
+}

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit/platform/UniqueIdTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit/platform/UniqueIdTest.kt
@@ -17,7 +17,7 @@ class UniqueIdTest : FunSpec() {
             root.append(Segment.Spec.value, "com.sksamuel.kotest.runner.junit.platform.UniqueIdTest")
       }
 
-      test("createTestUniqueId should handle rooot tests") {
+      test("createTestUniqueId should handle root tests") {
          val root = UniqueId.forEngine("kotest")
          val testDescriptor = UniqueIdTest::class.toDescriptor().append("a")
          createUniqueIdForTest(root, testDescriptor) shouldBe

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DynamicSpecRegistrationTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DynamicSpecRegistrationTest.kt
@@ -1,12 +1,15 @@
 package com.sksamuel.kotest.runner.junit5
 
 import io.kotest.core.annotation.Issue
+import io.kotest.core.descriptors.DescriptorId
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.test.names.DisplayNameFormatting
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.runner.junit.platform.EngineDescriptorBuilder
 import io.kotest.runner.junit.platform.JUnitTestEngineListener
+import io.kotest.runner.junit.platform.createUniqueIdForSpec
 import org.junit.platform.engine.EngineExecutionListener
 import org.junit.platform.engine.TestDescriptor
 import org.junit.platform.engine.TestExecutionResult
@@ -18,23 +21,30 @@ class DynamicSpecRegistrationTest : FunSpec() {
    init {
       test("JUnitTestEngineListener should dynamically register spec if not currently registered") {
 
-         var registered = false
+         var registered: TestDescriptor? = null
+         var started: TestDescriptor? = null
 
          val engineExecutionListener = object : EngineExecutionListener {
             override fun executionFinished(testDescriptor: TestDescriptor, testExecutionResult: TestExecutionResult) {}
             override fun reportingEntryPublished(testDescriptor: TestDescriptor?, entry: ReportEntry?) {}
             override fun executionSkipped(testDescriptor: TestDescriptor?, reason: String?) {}
-            override fun executionStarted(testDescriptor: TestDescriptor?) {}
+            override fun executionStarted(testDescriptor: TestDescriptor?) {
+               started = testDescriptor
+            }
+
             override fun dynamicTestRegistered(testDescriptor: TestDescriptor?) {
-               registered = true
+               registered = testDescriptor
             }
          }
 
-         val root = EngineDescriptorBuilder.builder(UniqueId.forEngine("kotest")).build()
+         val rootId = UniqueId.forEngine("kotest")
+         val root = EngineDescriptorBuilder.builder(rootId).build()
          val listener = JUnitTestEngineListener(engineExecutionListener, root, DisplayNameFormatting(null))
          listener.specStarted(SpecRef.Reference(DynamicSpecRegistrationTest::class))
 
-         registered shouldBe true
+         val specId = createUniqueIdForSpec(root, DescriptorId(DynamicSpecRegistrationTest::class.java.name))
+         registered.shouldNotBeNull().uniqueId shouldBe specId
+         started.shouldNotBeNull().uniqueId shouldBe specId
       }
    }
 }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DynamicSpecRegistrationTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DynamicSpecRegistrationTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.kotest.runner.junit5
+
+import io.kotest.core.annotation.Issue
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.test.names.DisplayNameFormatting
+import io.kotest.matchers.shouldBe
+import io.kotest.runner.junit.platform.EngineDescriptorBuilder
+import io.kotest.runner.junit.platform.JUnitTestEngineListener
+import org.junit.platform.engine.EngineExecutionListener
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.TestExecutionResult
+import org.junit.platform.engine.UniqueId
+import org.junit.platform.engine.reporting.ReportEntry
+
+@Issue("https://github.com/kotest/kotest/issues/3770")
+class DynamicSpecRegistrationTest : FunSpec() {
+   init {
+      test("JUnitTestEngineListener should dynamically register spec if not currently registered") {
+
+         var registered = false
+
+         val engineExecutionListener = object : EngineExecutionListener {
+            override fun executionFinished(testDescriptor: TestDescriptor, testExecutionResult: TestExecutionResult) {}
+            override fun reportingEntryPublished(testDescriptor: TestDescriptor?, entry: ReportEntry?) {}
+            override fun executionSkipped(testDescriptor: TestDescriptor?, reason: String?) {}
+            override fun executionStarted(testDescriptor: TestDescriptor?) {}
+            override fun dynamicTestRegistered(testDescriptor: TestDescriptor?) {
+               registered = true
+            }
+         }
+
+         val root = EngineDescriptorBuilder.builder(UniqueId.forEngine("kotest")).build()
+         val listener = JUnitTestEngineListener(engineExecutionListener, root, DisplayNameFormatting(null))
+         listener.specStarted(SpecRef.Reference(DynamicSpecRegistrationTest::class))
+
+         registered shouldBe true
+      }
+   }
+}

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DynamicSpecRegistrationTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DynamicSpecRegistrationTest.kt
@@ -42,7 +42,7 @@ class DynamicSpecRegistrationTest : FunSpec() {
          val listener = JUnitTestEngineListener(engineExecutionListener, root, DisplayNameFormatting(null))
          listener.specStarted(SpecRef.Reference(DynamicSpecRegistrationTest::class))
 
-         val specId = createUniqueIdForSpec(root, DescriptorId(DynamicSpecRegistrationTest::class.java.name))
+         val specId = createUniqueIdForSpec(root.uniqueId, DescriptorId(DynamicSpecRegistrationTest::class.java.name))
          registered.shouldNotBeNull().uniqueId shouldBe specId
          started.shouldNotBeNull().uniqueId shouldBe specId
       }


### PR DESCRIPTION
Fixes https://github.com/kotest/kotest/issues/3770
Fixes https://github.com/kotest/kotest/issues/3828