### PR TITLE
Support Java21 SequencedSet in shouldContainsExactly

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/assertions/eq/isOrderedSet.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/assertions/eq/isOrderedSet.kt
@@ -5,7 +5,13 @@ import java.util.SortedSet
 /**
  * JVM-specific: Allows TreeSet to be considered ordered for iterable comparisons
  */
-actual fun isOrderedSet(item: Iterable<*>) =
-   item is LinkedHashSet ||
+actual fun isOrderedSet(item: Iterable<*>): Boolean {
+   return item is LinkedHashSet ||
       item is SortedSet ||
-      (item is Set && item.size <= 1)
+      (item is Set && item.size <= 1) ||
+      isJavaSequencedSet(item::class.java)
+}
+
+private fun isJavaSequencedSet(clazz: Class<out Iterable<*>>): Boolean {
+   return clazz.name == $$"java.util.Collections$UnmodifiableSequencedSet"
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/eq/IsOrderedSetTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/eq/IsOrderedSetTest.kt
@@ -1,0 +1,22 @@
+package com.sksamuel.kotest.assertions.eq
+
+import io.kotest.assertions.eq.isOrderedSet
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class IsOrderedSetTest : FunSpec() {
+   init {
+      test("supports LinkedHashSet") {
+         isOrderedSet(java.util.LinkedHashSet(listOf(1, 2, 3))) shouldBe true
+      }
+      test("supports SortedSet") {
+         isOrderedSet(sortedSetOf(1, 2, 3)) shouldBe true
+      }
+      test("supports empty set") {
+         isOrderedSet(emptySet<Int>()) shouldBe true
+      }
+      test("fails for list") {
+         isOrderedSet(listOf(1, 2, 3)) shouldBe false
+      }
+   }
+}

--- a/kotest-tests/kotest-tests-assertions-java21/build.gradle.kts
+++ b/kotest-tests/kotest-tests-assertions-java21/build.gradle.kts
@@ -1,0 +1,30 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+plugins {
+   id("kotlin-conventions")
+}
+
+kotlin {
+   jvm()
+   jvmToolchain { languageVersion = JavaLanguageVersion.of(21) }
+   sourceSets {
+      jvmTest {
+         dependencies {
+            implementation(projects.kotestFramework.kotestFrameworkEngine)
+            implementation(projects.kotestRunner.kotestRunnerJunit5)
+            implementation(projects.kotestAssertions.kotestAssertionsCore)
+         }
+      }
+   }
+}
+
+tasks.withType<KotlinJvmCompile>().configureEach {
+   compilerOptions {
+      jvmTarget.set(JvmTarget.JVM_21)
+   }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+   options.release.set(21)
+}

--- a/kotest-tests/kotest-tests-assertions-java21/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/jdk21/ShouldContainExactlyTest.kt
+++ b/kotest-tests/kotest-tests-assertions-java21/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/jdk21/ShouldContainExactlyTest.kt
@@ -1,0 +1,15 @@
+package com.sksamuel.kotest.assertions.jdk21
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import java.util.Collections
+
+class ShouldContainExactlyTest : FunSpec() {
+   init {
+      test("support Java21 unmodifiableSequencedSet") {
+         Collections.unmodifiableSequencedSet(linkedSetOf("a", "b", "c")).shouldContainExactly("a", "b", "c")
+         Collections.unmodifiableSequencedSet(linkedSetOf("a", "b", "c")).shouldContainExactlyInAnyOrder("c", "b", "a")
+      }
+   }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -171,6 +171,9 @@ if (shouldRunJvmOnlyModules) {
 
       ":kotest-tests:kotest-tests-core",
 
+      // tests for Java APIs added in JDK21
+      ":kotest-tests:kotest-tests-assertions-java21",
+
       // defines the order of callbacks
       ":kotest-tests:kotest-tests-callback-order",
 


### PR DESCRIPTION
Fixes #3996

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
