### PR TITLE
Clarify empty collection assertion behavior + tests

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1185,8 +1185,6 @@ public final class io/kotest/matchers/collections/BoundsKt {
 public final class io/kotest/matchers/collections/CollectionMatchersKt {
 	public static final fun beSorted ()Lio/kotest/matchers/Matcher;
 	public static final fun beSortedBy (Lkotlin/jvm/functions/Function1;)Lio/kotest/matchers/Matcher;
-	public static final fun existInOrder (Ljava/util/List;)Lio/kotest/matchers/Matcher;
-	public static final fun existInOrder ([Lkotlin/jvm/functions/Function1;)Lio/kotest/matchers/Matcher;
 	public static final fun haveSize (I)Lio/kotest/matchers/Matcher;
 	public static final fun matchEach (Ljava/util/List;)Lio/kotest/matchers/Matcher;
 	public static final fun matchEach (Ljava/util/List;Lkotlin/jvm/functions/Function2;)Lio/kotest/matchers/Matcher;
@@ -1385,6 +1383,11 @@ public final class io/kotest/matchers/collections/EmptyKt {
 	public static final fun shouldNotBeEmpty ([Ljava/lang/Object;)[Ljava/lang/Object;
 	public static final fun shouldNotBeEmpty ([S)[S
 	public static final fun shouldNotBeEmpty ([Z)[Z
+}
+
+public final class io/kotest/matchers/collections/ExistInOrderKt {
+	public static final fun existInOrder (Ljava/util/List;)Lio/kotest/matchers/Matcher;
+	public static final fun existInOrder ([Lkotlin/jvm/functions/Function1;)Lio/kotest/matchers/Matcher;
 }
 
 public final class io/kotest/matchers/collections/IncreasingKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -8,11 +8,22 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.errorCollector
 import io.kotest.matchers.neverNullMatcher
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> existInOrder(vararg ps: (T) -> Boolean): Matcher<Collection<T>?> = existInOrder(ps.asList())
 
 /**
  * Assert that a collections contains a subsequence that matches the given subsequence of predicates, possibly with
  * values in between.
+ *
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> = neverNullMatcher { actual ->
    require(predicates.isNotEmpty()) { "predicates must not be empty" }
@@ -45,11 +56,36 @@ fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> 
 
 fun <T> haveSize(size: Int): Matcher<Collection<T>> = haveSizeMatcher(size)
 
-
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> beSorted(): Matcher<List<T>> = sorted()
+
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> sorted(): Matcher<List<T>> = sortedBy { it }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T, E : Comparable<E>> beSortedBy(transform: (T) -> E): Matcher<List<T>> = sortedBy(transform)
+
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T, E : Comparable<E>> sortedBy(transform: (T) -> E): Matcher<List<T>> = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       val failure =

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/CollectionMatchers.kt
@@ -8,52 +8,6 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.errorCollector
 import io.kotest.matchers.neverNullMatcher
 
-/**
- * Note that if `this` is empty, this assertion will pass.
- * because there are no elements in it that _do not_ fail the test.
- *
- * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
- */
-fun <T> existInOrder(vararg ps: (T) -> Boolean): Matcher<Collection<T>?> = existInOrder(ps.asList())
-
-/**
- * Assert that a collections contains a subsequence that matches the given subsequence of predicates, possibly with
- * values in between.
- *
- * Note that if `this` is empty, this assertion will pass.
- * because there are no elements in it that _do not_ fail the test.
- *
- * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
- */
-fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> = neverNullMatcher { actual ->
-   require(predicates.isNotEmpty()) { "predicates must not be empty" }
-
-   var subsequenceIndex = 0
-   val actualIterator = actual.iterator()
-
-   while (actualIterator.hasNext() && subsequenceIndex < predicates.size) {
-      if (predicates[subsequenceIndex](actualIterator.next())) subsequenceIndex += 1
-   }
-
-   val passed = subsequenceIndex == predicates.size
-
-   val predicateMatchedOutOfOrderDescription = {
-      val predicateMatchedOutOfOrderIndexes = if (passed) emptyList() else {
-         actual.mapIndexedNotNull { index, element ->
-            if (predicates[subsequenceIndex](element)) index else null
-         }
-      }
-      if (predicateMatchedOutOfOrderIndexes.isEmpty()) "" else
-         ",\nbut found element(s) matching the predicate out of order at index(es): ${predicateMatchedOutOfOrderIndexes.print().value}"
-   }
-
-   MatcherResult(
-      passed,
-      { "${actual.print().value} did not match the predicates in order. Predicate at index $subsequenceIndex did not match.${predicateMatchedOutOfOrderDescription()}" },
-      { "${actual.print().value} should not match the predicates in order" }
-   )
-}
-
 fun <T> haveSize(size: Int): Matcher<Collection<T>> = haveSizeMatcher(size)
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -12,7 +12,10 @@ import io.kotest.matchers.should
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun ByteArray.shouldHaveUpperBound(value: Byte): ByteArray {
    asList() should haveUpperBound(value, "ByteArray")
@@ -22,7 +25,10 @@ infix fun ByteArray.shouldHaveUpperBound(value: Byte): ByteArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun ShortArray.shouldHaveUpperBound(value: Short): ShortArray {
    asList() should haveUpperBound(value, "ShortArray")
@@ -32,7 +38,10 @@ infix fun ShortArray.shouldHaveUpperBound(value: Short): ShortArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun CharArray.shouldHaveUpperBound(value: Char): CharArray {
    asList() should haveUpperBound(value, "CharArray")
@@ -42,7 +51,10 @@ infix fun CharArray.shouldHaveUpperBound(value: Char): CharArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun IntArray.shouldHaveUpperBound(value: Int): IntArray {
    asList() should haveUpperBound(value, "IntArray")
@@ -52,7 +64,10 @@ infix fun IntArray.shouldHaveUpperBound(value: Int): IntArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun LongArray.shouldHaveUpperBound(value: Long): LongArray {
    asList() should haveUpperBound(value, "LongArray")
@@ -62,7 +77,10 @@ infix fun LongArray.shouldHaveUpperBound(value: Long): LongArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun FloatArray.shouldHaveUpperBound(value: Float): FloatArray {
    asList() should haveUpperBound(value, "FloatArray")
@@ -72,7 +90,10 @@ infix fun FloatArray.shouldHaveUpperBound(value: Float): FloatArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun DoubleArray.shouldHaveUpperBound(value: Double): DoubleArray {
    asList() should haveUpperBound(value, "DoubleArray")
@@ -82,7 +103,10 @@ infix fun DoubleArray.shouldHaveUpperBound(value: Double): DoubleArray {
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(value: T): Array<T> {
    asList() should haveUpperBound(value, "Array")
@@ -92,7 +116,10 @@ infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(value: T): Array<T> 
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(value: T): I {
    this should haveUpperBound(value, null)
@@ -102,7 +129,10 @@ infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(value: T):
 /**
  * Verifies that all elements are less than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 fun <T : Comparable<T>, C : Collection<T>> haveUpperBound(value: T): Matcher<C> = haveUpperBound(value, null)
 
@@ -124,7 +154,10 @@ private fun <T : Comparable<T>, I : Iterable<T>> haveUpperBound(t: T, name: Stri
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun ByteArray.shouldHaveLowerBound(value: Byte): ByteArray {
    asList() should haveLowerBound(value, "ByteArray")
@@ -134,7 +167,10 @@ infix fun ByteArray.shouldHaveLowerBound(value: Byte): ByteArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun ShortArray.shouldHaveLowerBound(value: Short): ShortArray {
    asList() should haveLowerBound(value, "ShortArray")
@@ -144,7 +180,10 @@ infix fun ShortArray.shouldHaveLowerBound(value: Short): ShortArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun CharArray.shouldHaveLowerBound(value: Char): CharArray {
    asList() should haveLowerBound(value, "CharArray")
@@ -154,7 +193,10 @@ infix fun CharArray.shouldHaveLowerBound(value: Char): CharArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun IntArray.shouldHaveLowerBound(value: Int): IntArray {
    asList() should haveLowerBound(value, "IntArray")
@@ -164,7 +206,10 @@ infix fun IntArray.shouldHaveLowerBound(value: Int): IntArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun LongArray.shouldHaveLowerBound(value: Long): LongArray {
    asList() should haveLowerBound(value, "LongArray")
@@ -174,7 +219,10 @@ infix fun LongArray.shouldHaveLowerBound(value: Long): LongArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun FloatArray.shouldHaveLowerBound(value: Float): FloatArray {
    asList() should haveLowerBound(value, "FloatArray")
@@ -184,7 +232,10 @@ infix fun FloatArray.shouldHaveLowerBound(value: Float): FloatArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun DoubleArray.shouldHaveLowerBound(value: Double): DoubleArray {
    asList() should haveLowerBound(value, "DoubleArray")
@@ -194,7 +245,10 @@ infix fun DoubleArray.shouldHaveLowerBound(value: Double): DoubleArray {
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(value: T): Array<T> {
    asList() should haveLowerBound(value, "Array")
@@ -204,13 +258,22 @@ infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(value: T): Array<T> 
 /**
  * Verifies that all elements are greater than or equal to [value].
  *
- * Passes if `this` is empty.
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
 infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(value: T): I {
    this should haveLowerBound(value, null)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>, C : Collection<T>> haveLowerBound(t: T): Matcher<C> = haveLowerBound(t, null)
 
 private fun <T : Comparable<T>, I : Iterable<T>> haveLowerBound(t: T, name: String?): Matcher<I> = object : Matcher<I> {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/existInOrder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/existInOrder.kt
@@ -1,0 +1,38 @@
+package io.kotest.matchers.collections
+
+import io.kotest.assertions.print.print
+import io.kotest.matchers.Matcher
+import io.kotest.matchers.MatcherResult
+import io.kotest.matchers.MatcherResult.Companion.invoke
+import io.kotest.matchers.neverNullMatcher
+
+fun <T> existInOrder(vararg ps: (T) -> Boolean): Matcher<Collection<T>?> = existInOrder(ps.asList())
+
+fun <T> existInOrder(predicates: List<(T) -> Boolean>): Matcher<Collection<T>?> = neverNullMatcher { actual ->
+   require(predicates.isNotEmpty()) { "predicates must not be empty" }
+
+   var subsequenceIndex = 0
+   val actualIterator = actual.iterator()
+
+   while (actualIterator.hasNext() && subsequenceIndex < predicates.size) {
+      if (predicates[subsequenceIndex](actualIterator.next())) subsequenceIndex += 1
+   }
+
+   val passed = subsequenceIndex == predicates.size
+
+   val predicateMatchedOutOfOrderDescription = {
+      val predicateMatchedOutOfOrderIndexes = if (passed) emptyList() else {
+         actual.mapIndexedNotNull { index, element ->
+            if (predicates[subsequenceIndex](element)) index else null
+         }
+      }
+      if (predicateMatchedOutOfOrderIndexes.isEmpty()) "" else
+         ",\nbut found element(s) matching the predicate out of order at index(es): ${predicateMatchedOutOfOrderIndexes.print().value}"
+   }
+
+   MatcherResult(
+      passed,
+      { "${actual.print().value} did not match the predicates in order. Predicate at index $subsequenceIndex did not match.${predicateMatchedOutOfOrderDescription()}" },
+      { "${actual.print().value} should not match the predicates in order" }
+   )
+}

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/increasing.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/increasing.kt
@@ -6,21 +6,45 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeStrictlyIncreasing(): I {
    toList().shouldBeStrictlyIncreasing()
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> Array<T>.shouldBeStrictlyIncreasing(): Array<T> {
    asList().shouldBeStrictlyIncreasing()
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> Sequence<T>.shouldBeStrictlyIncreasing(): Sequence<T> {
    asIterable().shouldBeStrictlyIncreasing()
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> List<T>.shouldBeStrictlyIncreasing(): List<T> {
    this should beStrictlyIncreasing()
    return this
@@ -51,16 +75,34 @@ fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeMonotonicallyIncreasing(): I 
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> Array<T>.shouldBeMonotonicallyIncreasing(): Array<T> {
    asList().shouldBeMonotonicallyIncreasing()
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> Sequence<T>.shouldBeMonotonicallyIncreasing(): Sequence<T> {
    asIterable().shouldBeMonotonicallyIncreasing()
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> List<T>.shouldBeMonotonicallyIncreasing(): List<T> {
    this should beMonotonicallyIncreasing()
    return this
@@ -86,21 +128,45 @@ fun <T : Comparable<T>> List<T>.shouldNotBeMonotonicallyIncreasing(): List<T> {
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T> List<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): List<T> {
    this should beMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T> Sequence<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldBeMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T, I : Iterable<T>> I.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): I {
    toList().shouldBeMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T> Array<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeMonotonicallyIncreasingWith(comparator)
    return this
@@ -126,21 +192,45 @@ infix fun <T> Sequence<T>.shouldNotBeMonotonicallyIncreasingWith(comparator: Com
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T> List<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): List<T> {
    this should beStrictlyIncreasingWith(comparator)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T, I : Iterable<T>> I.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): I {
    toList().shouldBeStrictlyIncreasingWith(comparator)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T> Array<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeStrictlyIncreasingWith(comparator)
    return this
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T> Sequence<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldBeStrictlyIncreasingWith(comparator)
    return this
@@ -166,15 +256,40 @@ infix fun <T> Sequence<T>.shouldNotBeStrictlyIncreasingWith(comparator: Comparat
    return this
 }
 
-
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> beStrictlyIncreasing(): Matcher<List<T>> = strictlyIncreasing()
+
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> strictlyIncreasing(): Matcher<List<T>> = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       return testStrictlyIncreasingWith(value) { a, b -> a.compareTo(b) }
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> beStrictlyIncreasingWith(comparator: Comparator<in T>): Matcher<List<T>> = strictlyIncreasingWith(comparator)
+
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> strictlyIncreasingWith(comparator: Comparator<in T>): Matcher<List<T>> = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       return testStrictlyIncreasingWith(value, comparator)
@@ -199,6 +314,12 @@ private fun <T> testStrictlyIncreasingWith(value: List<T>, comparator: Comparato
    )
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> beMonotonicallyIncreasing(): Matcher<List<T>> = monotonicallyIncreasing()
 fun <T : Comparable<T>> monotonicallyIncreasing(): Matcher<List<T>> = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
@@ -206,9 +327,21 @@ fun <T : Comparable<T>> monotonicallyIncreasing(): Matcher<List<T>> = object : M
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> beMonotonicallyIncreasingWith(comparator: Comparator<in T>): Matcher<List<T>> =
    monotonicallyIncreasingWith(comparator)
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> monotonicallyIncreasingWith(comparator: Comparator<in T>): Matcher<List<T>> = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       return testMonotonicallyIncreasingWith(value, comparator)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -23,6 +23,12 @@ Sequence<T>.count() may run through the whole sequence (sequences from `generate
 For now, the documentation should mention that infinite sequences will cause these matchers never to halt.
 */
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> Sequence<T>.shouldContainOnlyNulls() = this should containOnlyNulls()
 fun <T> Sequence<T>.shouldNotContainOnlyNulls() = this shouldNot containOnlyNulls()
 fun <T> containOnlyNulls() = object : Matcher<Sequence<T>> {
@@ -70,7 +76,14 @@ fun <T, S : Sequence<T>> haveElementAt(index: Int, element: T) = object : Matche
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> Sequence<T>.shouldContainNoNulls() = this should containNoNulls()
+
 fun <T> Sequence<T>.shouldNotContainNoNulls() = this shouldNot containNoNulls()
 fun <T> containNoNulls() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>) =
@@ -209,8 +222,20 @@ fun <T : Comparable<T>, C : Sequence<T>> haveUpperBound(t: T) = object : Matcher
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 infix fun <T : Comparable<T>, C : Sequence<T>> C.shouldHaveLowerBound(t: T) = this should haveLowerBound(t)
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>, C : Sequence<T>> haveLowerBound(t: T) = object : Matcher<C> {
    override fun test(value: C): MatcherResult {
       val elementBelowLowerBound = value.withIndex().firstOrNull { it.value < t }
@@ -225,11 +250,17 @@ fun <T : Comparable<T>, C : Sequence<T>> haveLowerBound(t: T) = object : Matcher
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> Sequence<T>.shouldBeUnique() = this should beUnique()
+
 fun <T> Sequence<T>.shouldNotBeUnique() = this shouldNot beUnique()
 fun <T> beUnique() = object : Matcher<Sequence<T>> {
    val delegate = beUniqueByEquals<T>("Sequence")
-
    override fun test(value: Sequence<T>): MatcherResult = delegate.test(value.asIterable())
 }
 
@@ -241,10 +272,30 @@ fun <T> containDuplicates() = object : Matcher<Sequence<T>> {
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> Sequence<T>.shouldBeSorted() = this should beSorted()
+
 fun <T : Comparable<T>> Sequence<T>.shouldNotBeSorted() = this shouldNot beSorted()
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> beSorted(): Matcher<Sequence<T>> = sorted()
+
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T : Comparable<T>> sorted(): Matcher<Sequence<T>> = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
       val valueAsList = value.toList()
@@ -476,7 +527,14 @@ fun <T> containAll(ts: List<T>): Matcher<Sequence<T>> = object : Matcher<Sequenc
    }
 }
 
+/**
+ * Note that if `this` is empty, this assertion will pass.
+ * because there are no elements in it that _do not_ fail the test.
+ *
+ * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
+ */
 fun <T> Sequence<T>.shouldMatchEach(vararg assertions: (T) -> Unit) = toList().shouldMatchEach(assertions.toList())
+
 infix fun <T> Sequence<T>.shouldMatchEach(assertions: List<(T) -> Unit>) = toList().shouldMatchEach(assertions)
 fun <T> Sequence<T>.shouldMatchEach(expected: Sequence<T>, asserter: (T, T) -> Unit) =
    toList().shouldMatchEach(expected.toList(), asserter)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BoundsTest.kt
@@ -118,6 +118,10 @@ class BoundsTest : WordSpec() {
             shouldThrowAny { 1..3 shouldHaveUpperBound 2 }
                .shouldHaveMessage(msg("Range"))
          }
+
+         "pass for empty collection" {
+            emptyList<Int>().shouldHaveUpperBound(0)
+         }
       }
 
       "haveLowerBound" should {
@@ -229,6 +233,10 @@ class BoundsTest : WordSpec() {
          "fail for Range" {
             shouldThrowAny { 1..3 shouldHaveLowerBound 2 }
                .shouldHaveMessage(msg("Range"))
+         }
+
+         "pass for empty collection" {
+            emptyList<Int>().shouldHaveUpperBound(0)
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -901,9 +901,6 @@ expected:<2> but was:<3>""")
                { it == 2 }
             )
          }
-         "pass on empty collections" {
-            emptyList<Int>().shouldExistInOrder({ true })
-         }
       }
 
       "Contain any" should {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -34,6 +34,7 @@ import io.kotest.matchers.collections.shouldContainNoNulls
 import io.kotest.matchers.collections.shouldContainNull
 import io.kotest.matchers.collections.shouldContainOnlyNulls
 import io.kotest.matchers.collections.shouldExist
+import io.kotest.matchers.collections.shouldExistInOrder
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveAtMostSize
 import io.kotest.matchers.collections.shouldHaveElementAt
@@ -899,6 +900,9 @@ expected:<2> but was:<3>""")
                { it == 2 },
                { it == 2 }
             )
+         }
+         "pass on empty collections" {
+            emptyList<Int>().shouldExistInOrder({ true })
          }
       }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/IncreasingDecreasingTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/IncreasingDecreasingTest.kt
@@ -100,6 +100,14 @@ class IncreasingDecreasingTest : WordSpec() {
             sequenceOf(1, 2, 2, 3).shouldNotBeStrictlyIncreasingWith(comparator)
             sequenceOf(6, 5).shouldNotBeStrictlyIncreasingWith(comparator)
          }
+         "pass for empty collections" {
+            emptyList<Int>().shouldBeMonotonicallyIncreasing()
+            emptyList<Int>().shouldBeStrictlyIncreasing()
+            emptyArray<Int>().shouldBeMonotonicallyIncreasing()
+            emptyArray<Int>().shouldBeStrictlyIncreasing()
+            emptySet<Int>().shouldBeMonotonicallyIncreasing()
+            emptySet<Int>().shouldBeStrictlyIncreasing()
+         }
       }
 
       "shouldBeDecreasing" should {
@@ -172,6 +180,14 @@ class IncreasingDecreasingTest : WordSpec() {
             sequenceOf(-4, 2, 3).shouldBeStrictlyDecreasingWith(comparator)
             sequenceOf(-4, 2, 2, 3).shouldNotBeStrictlyDecreasingWith(comparator)
             sequenceOf(6, 5).shouldNotBeStrictlyDecreasingWith(comparator)
+         }
+         "pass for empty collections" {
+            emptyList<Int>().shouldBeMonotonicallyDecreasing()
+            emptyList<Int>().shouldBeStrictlyDecreasing()
+            emptyArray<Int>().shouldBeMonotonicallyDecreasing()
+            emptyArray<Int>().shouldBeStrictlyDecreasing()
+            emptySet<Int>().shouldBeMonotonicallyDecreasing()
+            emptySet<Int>().shouldBeStrictlyDecreasing()
          }
       }
    }


### PR DESCRIPTION
Re: https://github.com/kotest/kotest/issues/4384

Our current behavior is to "pass" assertions that operate on empty collections (eg, empty list should be sorted). Whether that is correct or not is subjective and open to debate. However, given that this issue has been open for 15 months; given that the current behavior has been around for a decade and would be a breaking change; and given that the Kotlin SDK has the same behavior for its any/all methods, let's document this and move on.

Closes #4384

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
