### PR TITLE
Update code snippet for eventually with retries to match described scenario

### DIFF
--- a/documentation/docs/assertions/eventually.md
+++ b/documentation/docs/assertions/eventually.md
@@ -118,7 +118,7 @@ we retry the operation 10 times, or until 8 seconds has expired.
 
 ```kotlin
 val config = eventuallyConfig {
-  initialDelay = 8.seconds
+  duration = 8.seconds
   retries = 10
 }
 

--- a/documentation/versioned_docs/version-5.7.x/assertions/eventually.md
+++ b/documentation/versioned_docs/version-5.7.x/assertions/eventually.md
@@ -118,7 +118,7 @@ we retry the operation 10 times, or until 8 seconds has expired.
 
 ```kotlin
 val config = eventuallyConfig {
-  initialDelay = 8.seconds
+  duration = 8.seconds
   retries = 10
 }
 

--- a/documentation/versioned_docs/version-5.8.x/assertions/eventually.md
+++ b/documentation/versioned_docs/version-5.8.x/assertions/eventually.md
@@ -118,7 +118,7 @@ we retry the operation 10 times, or until 8 seconds has expired.
 
 ```kotlin
 val config = eventuallyConfig {
-  initialDelay = 8.seconds
+  duration = 8.seconds
   retries = 10
 }
 

--- a/documentation/versioned_docs/version-5.9.x/assertions/eventually.md
+++ b/documentation/versioned_docs/version-5.9.x/assertions/eventually.md
@@ -118,7 +118,7 @@ we retry the operation 10 times, or until 8 seconds has expired.
 
 ```kotlin
 val config = eventuallyConfig {
-  initialDelay = 8.seconds
+  duration = 8.seconds
   retries = 10
 }
 

--- a/documentation/versioned_docs/version-6.0/assertions/eventually.md
+++ b/documentation/versioned_docs/version-6.0/assertions/eventually.md
@@ -118,7 +118,7 @@ we retry the operation 10 times, or until 8 seconds has expired.
 
 ```kotlin
 val config = eventuallyConfig {
-  initialDelay = 8.seconds
+  duration = 8.seconds
   retries = 10
 }
 


### PR DESCRIPTION
Given scenario that `retry the operation 10 times, or until 8 seconds has expired` the code snippet should use `retries` with **`duration`** instead of `retries` with ~~`initialDelay`~~