### PR TITLE
Only show JUnit ignore reasons if enabled

### DIFF
--- a/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
+++ b/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
@@ -1,7 +1,9 @@
 public class io/kotest/framework/gradle/KotestGradleExtension {
 	public fun <init> ()V
 	public final fun getCustomGradleTask ()Z
+	public final fun getShowIgnoreReasons ()Z
 	public final fun setCustomGradleTask (Z)V
+	public final fun setShowIgnoreReasons (Z)V
 }
 
 public abstract class io/kotest/framework/gradle/KotestPlugin : org/gradle/api/Plugin {

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestGradleExtension.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestGradleExtension.kt
@@ -6,4 +6,9 @@ open class KotestGradleExtension {
     * Set to true and the Gradle plugin will create "kotest" test tasks
     */
    var customGradleTask = false
+
+   /**
+    * Set to true and the Kotest engine will propagate ignore reasons to Gradle.
+    */
+   var showIgnoreReasons = false
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -61,6 +61,7 @@ abstract class KotestPlugin : Plugin<Project> {
       private val unsupportedTargets = listOf("metadata")
 
       internal const val KOTEST_INCLUDE_PATTERN = "KOTEST_INCLUDE_PATTERN"
+      internal const val KOTEST_SHOW_IGNORE_REASONS = "KOTEST_SHOW_IGNORE_REASONS"
       internal const val IDEA_ACTIVE_ENV = "IDEA_ACTIVE"
       internal const val IDEA_ACTIVE_SYSPROP = "idea.active"
       internal const val FAIL_ON_NO_DISCOVERED_TESTS = "failOnNoDiscoveredTests"
@@ -70,8 +71,8 @@ abstract class KotestPlugin : Plugin<Project> {
 
    override fun apply(project: Project) {
 
-      val kotestExtension = project.extensions.create(GRADLE_EXTENSION_NAME, KotestGradleExtension::class.java)
-      if (kotestExtension.customGradleTask) {
+      val extension = project.extensions.create(GRADLE_EXTENSION_NAME, KotestGradleExtension::class.java)
+      if (extension.customGradleTask) {
 
          project.tasks.register(KOTEST_TASK_NAME) {
             group = JavaBasePlugin.VERIFICATION_GROUP
@@ -83,22 +84,22 @@ abstract class KotestPlugin : Plugin<Project> {
       }
 
       // configure Kotlin Android projects when it is not a multiplatform project
-      handleAndroid(project, kotestExtension)
+      handleAndroid(project, extension)
 
       // configures Kotlin multiplatform projects
-      handleMultiplatform(project, kotestExtension)
+      handleMultiplatform(project, extension)
 
       project.gradle.taskGraph.whenReady {
-         decorateGradleTestTask(project)
+         decorateGradleTestTask(project, extension)
       }
    }
 
    /**
-    * Forwards the --tests arg and test filters from the Gradle test tasks to Kotest in the form
+    * Forwards the tests arg and test filters from the Gradle test tasks to Kotest in the form
     * of environment variables that Kotest picks up and applies via a descriptor filter.
     * This allows us to run specific tests using the regular Gradle task.
     */
-   private fun decorateGradleTestTask(project: Project) {
+   private fun decorateGradleTestTask(project: Project, extension: KotestGradleExtension) {
       project.tasks.withType(AbstractTestTask::class.java).configureEach {
          doFirst {
 
@@ -119,8 +120,8 @@ abstract class KotestPlugin : Plugin<Project> {
 
             when (this) {
                is KotlinNativeTest -> Unit
-                  // saves the user having to set this manually
-                  // Caused by: java.lang.IllegalStateException: The value for task ':linuxX64Test' property 'failOnNoDiscoveredTests' is final and cannot be changed any further.
+               // saves the user having to set this manually
+               // Caused by: java.lang.IllegalStateException: The value for task ':linuxX64Test' property 'failOnNoDiscoveredTests' is final and cannot be changed any further.
 //                  if (hasProperty(FAIL_ON_NO_DISCOVERED_TESTS)) {
 //                     setProperty(FAIL_ON_NO_DISCOVERED_TESTS, false)
 //                  }
@@ -130,6 +131,10 @@ abstract class KotestPlugin : Plugin<Project> {
             // isn't available when we're inside the engine, so we propagate an env variable to do the same thing
             if (System.getProperty(IDEA_ACTIVE_SYSPROP) != null) {
                setEnvVar(this, IDEA_ACTIVE_ENV, "true")
+            }
+
+            if (extension.showIgnoreReasons) {
+               setEnvVar(this, KOTEST_SHOW_IGNORE_REASONS, "true")
             }
          }
       }
@@ -164,7 +169,7 @@ abstract class KotestPlugin : Plugin<Project> {
    }
 
    private fun configureJvmTask(sourceSetName: String, project: Project, target: String?) {
-      // gradle best practice is to only apply to this project, and users add the plugin to each subproject
+      // Gradle's best practice is to only apply to this project, and users add the plugin to each subproject
       // see https://docs.gradle.org/current/userguide/isolated_projects.html
       val jvmKotest = project.tasks.register(JVM_KOTEST_NAME, KotestJvmTask::class) {
 

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -109,12 +109,7 @@ abstract class KotestPlugin : Plugin<Project> {
             }
 
             if (includes.isNotEmpty()) {
-
                val pattern = includes.joinToString(";")
-
-               project.logger.warn("Detected gradle includes $name: $includes")
-               project.logger.warn("Setting env var to " + includes.joinToString(";"))
-
                setEnvVar(this, KOTEST_INCLUDE_PATTERN, pattern)
             }
 
@@ -141,6 +136,7 @@ abstract class KotestPlugin : Plugin<Project> {
    }
 
    private fun setEnvVar(task: Task, name: String, value: String) {
+      task.project.logger.info("Setting environment variable $name=$value for task ${task.name}")
       when (task) {
          is KotlinJsTest -> task.environment(name, value)
          is KotlinNativeTest -> task.environment(name, value, false)

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -1,5 +1,6 @@
 package io.kotest.runner.junit.platform
 
+import io.kotest.common.env
 import io.kotest.common.reflection.bestName
 import io.kotest.core.Logger
 import io.kotest.core.descriptors.Descriptor
@@ -178,7 +179,7 @@ class JUnitTestEngineListener(
       logger.log { Pair(kclass.bestName(), "Spec is being flagged as ignored") }
       val testDescriptor = findTestDescriptorForSpec(root, Descriptor.SpecDescriptor(DescriptorId(kclass.java.name)))
       if (testDescriptor != null)
-         listener.executionSkipped(testDescriptor, reason ?: "")
+         listener.executionSkipped(testDescriptor, reasonIfEnabled(reason))
    }
 
    private fun reset() {
@@ -272,7 +273,13 @@ class JUnitTestEngineListener(
       results[testCase.descriptor] = TestResult.Ignored(reason)
 
       logger.log { Pair(testCase.name.name, "executionSkipped: $testDescriptor") }
-      listener.executionSkipped(testDescriptor, reason ?: "")
+      listener.executionSkipped(testDescriptor, reasonIfEnabled(reason))
+   }
+
+   private fun reasonIfEnabled(reason: String?): String? {
+      if (reason == null) return null
+      if (env("KOTEST_SHOW_IGNORE_REASONS") == "true") return reason
+      return null
    }
 
    private fun startParents(testCase: TestCase) {

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -276,17 +276,17 @@ class JUnitTestEngineListener(
       listener.executionSkipped(testDescriptor, reasonIfEnabled(reason))
    }
 
-   private fun reasonIfEnabled(reason: String?): String? {
-      if (reason == null) return null
+   private fun reasonIfEnabled(reason: String?): String {
+      if (reason == null) return ""
       if (env("KOTEST_SHOW_IGNORE_REASONS") == "true") return reason
-      return null
+      return ""
    }
 
    private fun startParents(testCase: TestCase) {
       val parent = testCase.parent
       if (parent != null) {
          startParents(parent)
-         // when starting parents, type must be CONTAINER
+         // when starting parents, the type must be CONTAINER
          startTestIfNotStarted(parent, TestDescriptor.Type.CONTAINER)
       }
    }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/JUnitTestEngineListenerTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/JUnitTestEngineListenerTest.kt
@@ -93,10 +93,7 @@ class JUnitTestEngineListenerTest : FunSpec({
       val listener = JUnitTestEngineListener(track, root, DisplayNameFormatting(null))
       listener.specIgnored(MySpec::class, "disabled foo")
       track.events shouldBe listOf(
-         EventTrackingEngineExecutionListener.Event.ExecutionSkipped(
-            "MySpec",
-            "disabled foo"
-         )
+         EventTrackingEngineExecutionListener.Event.ExecutionSkipped("MySpec", "")
       )
    }
 
@@ -159,7 +156,7 @@ class JUnitTestEngineListenerTest : FunSpec({
             "com.sksamuel.kotest.runner.junit5.MySpec",
             "foo"
          ),
-         EventTrackingEngineExecutionListener.Event.ExecutionSkipped("foo", "secret!"),
+         EventTrackingEngineExecutionListener.Event.ExecutionSkipped("foo", ""),
          EventTrackingEngineExecutionListener.Event.ExecutionFinished(
             "MySpec",
             TestExecutionResult.Status.SUCCESSFUL
@@ -240,7 +237,7 @@ class JUnitTestEngineListenerTest : FunSpec({
             "com.sksamuel.kotest.runner.junit5.MySpec",
             "foo/bar"
          ),
-         EventTrackingEngineExecutionListener.Event.ExecutionSkipped("bar", "secret!"),
+         EventTrackingEngineExecutionListener.Event.ExecutionSkipped("bar", ""),
          EventTrackingEngineExecutionListener.Event.ExecutionFinished("foo", TestExecutionResult.Status.SUCCESSFUL),
          EventTrackingEngineExecutionListener.Event.ExecutionFinished(
             "MySpec",
@@ -412,7 +409,7 @@ class EventTrackingEngineExecutionListener : EngineExecutionListener {
    sealed interface Event {
       data class TestCaseRegistered(val descriptor: String, val className: String, val methodName: String) : Event
       data class TestRegistered(val descriptor: String, val type: TestDescriptor.Type) : Event
-      data class ExecutionSkipped(val descriptor: String, val reason: String?) : Event
+      data class ExecutionSkipped(val descriptor: String, val reason: String) : Event
       data class ExecutionStarted(val descriptor: String) : Event
       data class ExecutionFinished(val descriptor: String, val status: TestExecutionResult.Status) : Event
    }


### PR DESCRIPTION
New option in the kotest plugin to enable this if so desired

Closes #5190 