### PR TITLE
ensure nested tests within a parent are run when the parent is run with --tests filter

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/GradleClassMethodRegexTestFilterTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/GradleClassMethodRegexTestFilterTest.kt
@@ -107,6 +107,33 @@ class GradleClassMethodRegexTestFilterTest : FunSpec({
       }
    }
 
+   context("nested tests should be included when filtering to parent context without wildcard") {
+      val spec = GradleClassMethodRegexTestFilterTest::class.toDescriptor()
+      val container = spec.append("a context")
+      val nestedTest = container.append("nested test")
+      val fqn = "\\Q${GradleClassMethodRegexTestFilterTest::class.qualifiedName}\\E"
+
+      test("nested test should be INCLUDED when filtering to parent context") {
+         // This is the exact pattern gradle would generate for --tests 'FQN.a context'
+         val filter = "$fqn\\Q.a context\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter))
+            .filter(nestedTest) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("parent context should be INCLUDED when filtering to it") {
+         val filter = "$fqn\\Q.a context\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter))
+            .filter(container) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("deeply nested test should be INCLUDED when filtering to grandparent context") {
+         val deeplyNestedTest = nestedTest.append("deeply nested")
+         val filter = "$fqn\\Q.a context\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter))
+            .filter(deeplyNestedTest) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
    test("!is true when KOTEST_INCLUDE_PATTERN is set") {
       val spec = GradleClassMethodRegexTestFilterTest::class.toDescriptor()
       val container = spec.append("a context")


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

With the new gradle --tests filter, the below test
```
    "a test" - {
        "I should fail but I get ignored when 'a test' is run"{
            2 + 2 shouldBe 5
        }
    }
```
would have been completely ignored when running the context 'a test'. This change allows to run all nested tests within when a parent test is being run
