### PR TITLE
Support jump to source for classes in kotlin native

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
@@ -36,13 +36,13 @@ class TeamCityTestEngineListener(
    )
 
    // once a spec has completed, we want to be able to check whether any given test is
-   // a container or a leaf test, and so this map contains all test that have children
+   // a container or a leaf test, and so this map contains all tests that have children
    private val children = mutableMapOf<Descriptor, MutableList<TestCase>>()
 
    private val results = mutableMapOf<Descriptor, TestResult>()
 
-   // intellij has no method for failed suites, so if a container or spec fails we must insert
-   // a dummy "test" in order to tag the error against that
+   // intellij has no method for failed suites, so if a container or spec fails, we must insert
+   // a dummy "test" to tag the error against that
    private fun insertPlaceholder(t: Throwable, parent: Descriptor) {
 
       val (name, cause) = ExtensionExceptionExtractor.resolve(t)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/names/LocationEmbedder.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/names/LocationEmbedder.kt
@@ -11,10 +11,20 @@ object LocationEmbedder {
 
    /**
     * Since we have no control over the proxy location urls created by intellij, we will include the full
-    * test path in the display name and use the kotest intellij plugin to parse it out
-    * note: the KMP test tasks will append a context e.g. `linuxX64`, so we must put the full path first.
+    * test path in the display name and use the kotest intellij plugin to parse it out.
+    *
+    * Note: the KMP test tasks will append a context e.g. `linuxX64`, so we must put the full path first.
+    *
+    * Note2: When constructing its SMTProxy tree, for top level nodes, intellij expects a FQN, so, for
+    * specs we just display the FQN and don't mangle them.
+    *
+    * Note3: For TCSM generated trees, Intellij will parse out anything before the last period as the package name.
+    * So given a path like <kotest>com.sksamuel.Spec</kotest>Spec, Intellij will interpret <kotest>com.sksamuel as
+    * the package name. Therefore, we must replace periods.
     */
    fun embeddedTestName(descriptor: Descriptor, formattedName: String): String {
+      // https://www.ascii-code.com/
+// todo native support     return OPEN_TAG + descriptor.path().value.replace(' ', '\u00A0').replace('.', '!') + CLOSE_TAG + formattedName
       return OPEN_TAG + descriptor.path().value + CLOSE_TAG + formattedName
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityWriter.kt
@@ -4,7 +4,6 @@ import io.kotest.core.Logger
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.descriptor
 import io.kotest.core.test.TestCase
-import io.kotest.engine.names.LocationEmbedder
 import io.kotest.engine.teamcity.names.TeamCityTestNameSanitizer
 import io.kotest.engine.test.TestResult
 import io.kotest.engine.test.names.DisplayNameFormatting
@@ -177,7 +176,7 @@ internal class TeamCityWriter(
     */
    internal fun outputTestSuiteStarted(ref: SpecRef) {
       val msg = TeamCityMessageBuilder
-         .testSuiteStarted(prefix, formatting.format(ref.kclass))
+         .testSuiteStarted(prefix, specName(ref))
          .id(ref.descriptor().path().value)
          .locationHint(Locations.location(ref))
          .build()
@@ -189,18 +188,25 @@ internal class TeamCityWriter(
     */
    internal fun outputTestSuiteFinished(ref: SpecRef) {
       val msg = TeamCityMessageBuilder
-         .testSuiteFinished(prefix, formatting.format(ref.kclass))
+         .testSuiteFinished(prefix, specName(ref))
          .id(ref.descriptor().path().value)
          .build()
       println(msg)
    }
 
+   internal fun specName(ref: SpecRef): String {
+      // we ignore display name formatting for TCSM outputs, as intellij exects a FQN
+      return ref.fqn
+   }
 
    internal fun testName(testCase: TestCase): String {
-      return if (embedLocations)
-         LocationEmbedder.embeddedTestName(testCase.descriptor, formatting.format(santizeTestCaseName(testCase)))
-      else
-         formatting.format(santizeTestCaseName(testCase))
+      // todo there are some bugs to work out with TCMS nested tests, in particular around use of periods in test names
+      // so we'll punt nested test locations on native to 6.2
+      return formatting.format(santizeTestCaseName(testCase))
+//      return if (embedLocations)
+//         LocationEmbedder.embeddedTestName(testCase.descriptor, formatting.format(santizeTestCaseName(testCase)))
+//      else
+//         formatting.format(santizeTestCaseName(testCase))
    }
 
    internal fun santizeTestCaseName(testCase: TestCase): TestCase {

--- a/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/teamcity/TeamCityWriterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/teamcity/TeamCityWriterTest.kt
@@ -13,7 +13,7 @@ import io.kotest.matchers.shouldBe
 class TeamCityWriterTest : FunSpec() {
    init {
 
-      test("test name should use embedded locations when enabled") {
+      test("!test name should use embedded locations when enabled") {
          val writer = TeamCityWriter("tc", DisplayNameFormatting(null), true)
          val tc = TestCase(
             TeamCityWriterTest::class.toDescriptor().append("a"),

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
@@ -69,14 +69,14 @@ class TeamCityTestEngineListenerTest : FunSpec() {
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='123' result_status='Success']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='324' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='653' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -98,7 +98,7 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
@@ -106,7 +106,7 @@ a[testFailed name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='653' result_status='Error']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='123' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -127,13 +127,13 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testIgnored name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33' message='don|'t like it' result_status='Ignored']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='123' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -155,7 +155,7 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
@@ -165,7 +165,7 @@ a[testFailed name='Exception' id='Exception' parent_id='com.sksamuel.kotest.engi
 a[testFinished name='Exception' id='Exception' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='653' result_status='Error']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -187,7 +187,7 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
@@ -197,7 +197,7 @@ a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTes
 a[testStarted name='Exception' id='Exception' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 a[testFailed name='Exception' id='Exception' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' message='wobble']
 a[testFinished name='Exception' id='Exception' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -229,7 +229,7 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
@@ -237,7 +237,7 @@ a[testFailed name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='123' result_status='Error']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='555' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -259,14 +259,14 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(listOf(Exception("big whoop")))
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='555' result_status='Success']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='555' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 a[testStarted name='Engine exception']
 a[testFailed name='Engine exception' message='big whoop']
 a[testFinished name='Engine exception']
@@ -291,14 +291,14 @@ a[testFinished name='Engine exception']
             listener.engineFinished(listOf(Exception("big whoop"), Exception("big whoop 2")))
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='555' result_status='Success']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='555' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 a[testStarted name='Engine exception 1']
 a[testFailed name='Engine exception 1' message='big whoop']
 a[testFinished name='Engine exception 1']
@@ -332,7 +332,7 @@ a[testFinished name='Engine exception 2']
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
@@ -340,7 +340,7 @@ a[testFailed name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='555' result_status='Error']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='555' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -368,7 +368,7 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteStarted name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testStarted name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' locationHint='kotest://foo.bar.Test:33']
@@ -376,7 +376,7 @@ a[testFailed name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 a[testFinished name='c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' duration='555' result_status='Error']
 a[testSuiteFinished name='b' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='555' result_status='Success']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='324' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -401,14 +401,14 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='124' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://foo.bar.Test:12']
 a[testSuiteFinished name='a' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' duration='523' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
 
@@ -433,10 +433,10 @@ a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotes
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix durationStrategy='MANUAL']
-a[testSuiteStarted name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteStarted name='a b c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- a.b.c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' locationHint='kotest://foo.bar.Test:17']
 a[testSuiteFinished name='a b c' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- a.b.c' parent_id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a' duration='124' result_status='Success']
-a[testSuiteFinished name='TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' id='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/teamcity/TeamCityWriterJvmTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/teamcity/TeamCityWriterJvmTest.kt
@@ -15,7 +15,7 @@ import io.kotest.matchers.shouldBe
 class TeamCityWriterJvmTest : FunSpec() {
    init {
 
-      context("when embedded locations are enabled") {
+      context("!when embedded locations are enabled") {
          val writer = TeamCityWriter("tc", DisplayNameFormatting(null), true)
          val tc = TestCase(
             TeamCityWriterJvmTest::class.toDescriptor().append("a"),

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/MultiplatformJavaSuiteLocator.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/MultiplatformJavaSuiteLocator.kt
@@ -1,0 +1,49 @@
+package io.kotest.plugin.intellij.locations
+
+import com.intellij.execution.Location
+import com.intellij.execution.PsiLocation
+import com.intellij.execution.testframework.sm.runner.SMTestLocator
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.ClassUtil
+import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
+import org.jetbrains.kotlin.psi.KtClassOrObject
+
+class MultiplatformJavaSuiteLocator : SMTestLocator, DumbAware {
+
+   override fun getLocation(
+      protocol: String,
+      path: String,
+      project: Project,
+      scope: GlobalSearchScope
+   ): List<Location<PsiElement>> {
+      if (DumbService.isDumb(project)) return emptyList()
+      return findJvmLocation(project, path) ?: findKmpLocations(project, path)
+   }
+
+   private fun findJvmLocation(project: Project, path: String): List<Location<PsiElement>>? {
+      val psiClass: PsiClass? = ClassUtil.findPsiClass(
+         /* manager = */ PsiManager.getInstance(project),
+         /* name = */ path,
+      )
+      return if (psiClass == null) null else listOf(createPsiClassNavigable(psiClass))
+   }
+
+   private fun findKmpLocations(project: Project, path: String): List<Location<PsiElement>> {
+      val ktclasses = KotlinFullClassNameIndex[path, project, GlobalSearchScope.allScope(project)]
+      return ktclasses.map { createKtClassNavigable(it) }
+   }
+
+   private fun createKtClassNavigable(ktClassOrObject: KtClassOrObject): Location<PsiElement> {
+      return PsiLocation(ktClassOrObject.project, ktClassOrObject)
+   }
+
+   private fun createPsiClassNavigable(psiClass: PsiClass): Location<PsiElement> {
+      return PsiLocation(psiClass.project, psiClass)
+   }
+}

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapterTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapterTest.kt
@@ -43,4 +43,34 @@ class EmbeddedLocationSMTRunnerEventsAdapterTest {
       proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
       proxy.presentableName shouldBe "nested"
    }
+
+   @Test
+   fun shouldDetectJavaSuiteClasses() {
+      val proxy = SMTestProxy(
+         /* testName = */ "a",
+         /* isSuite = */ true,
+         /* locationUrl = */ "java:suite://io.kotest.Spec"
+      )
+      EmbeddedLocationSMTRunnerEventsAdapter().isJavaSuiteClass(proxy) shouldBe true
+   }
+
+   @Test
+   fun shouldSkipJavaSuitesThatAreNotClasses() {
+      val proxy = SMTestProxy(
+         /* testName = */ "a",
+         /* isSuite = */ true,
+         /* locationUrl = */ "java:suite://io.kotest.examples.native.KotlinTest/nested"
+      )
+      EmbeddedLocationSMTRunnerEventsAdapter().isJavaSuiteClass(proxy) shouldBe false
+   }
+
+   @Test
+   fun shouldSkipJavaTests() {
+      val proxy = SMTestProxy(
+         /* testName = */ "a",
+         /* isSuite = */ false,
+         /* locationUrl = */ "java:test://io.kotest.examples.native.KotlinTest/myTest"
+      )
+      EmbeddedLocationSMTRunnerEventsAdapter().isJavaSuiteClass(proxy) shouldBe false
+   }
 }

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/LifecycleOrderTest.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/LifecycleOrderTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.extensions.SpecExtension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.project.ProjectContext
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.TestEngineLauncher
@@ -19,7 +20,7 @@ class LifecycleOrderTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(LifecycleTests::class)
+            .withSpecRefs(SpecRef.Reference(LifecycleTests::class))
             .addExtensions(LifecycleExtension("engine"))
             .execute()
          collector.names shouldBe listOf("foo", "bar")

--- a/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
+++ b/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.config
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -17,7 +18,7 @@ class PackageConfigTest : FunSpec() {
          runBlocking {
             TestEngineLauncher()
                .withListener(collector)
-               .withClasses(BarTest::class)
+               .withSpecRefs(SpecRef.Reference(BarTest::class))
                .execute()
          }
          // if the package config isn't picked up, this test won't timeout


### PR DESCRIPTION
This gets us part of the way there to full jump to source support in KMP, it's enough for 6.1 and we'll continue to iterate for 6.2