### PR TITLE
Fixed a bunch of warnings around test enginer launcher usage

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTestLevelTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTestLevelTest.kt
@@ -14,7 +14,7 @@ class AssertSoftlyTestLevelTest : FunSpec() {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(AssertSoftlyAtTestLevel::class)
+            .withSpecRefs(SpecRef.Reference(AssertSoftlyAtTestLevel::class))
             .execute()
          listener.tests.size shouldBe 2
          listener.errors shouldBe true

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTestLevelTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/AssertSoftlyTestLevelTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.matchers
 
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3408,30 +3408,6 @@ public final class io/kotest/engine/TestAbortedException : java/lang/Throwable {
 	public final fun getReason ()Ljava/lang/String;
 }
 
-public final class io/kotest/engine/TestEngineLauncher {
-	public fun <init> ()V
-	public fun <init> (Ljava/util/List;Lio/kotest/core/config/AbstractProjectConfig;Ljava/util/List;Lio/kotest/engine/tags/TagExpression;Lio/kotest/engine/extensions/ExtensionRegistry;)V
-	public final fun addExtension (Lio/kotest/core/extensions/Extension;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun addExtensions (Ljava/util/List;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun addExtensions ([Lio/kotest/core/extensions/Extension;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun copy (Ljava/util/List;Lio/kotest/core/config/AbstractProjectConfig;Ljava/util/List;Lio/kotest/engine/tags/TagExpression;Lio/kotest/engine/extensions/ExtensionRegistry;)Lio/kotest/engine/TestEngineLauncher;
-	public static synthetic fun copy$default (Lio/kotest/engine/TestEngineLauncher;Ljava/util/List;Lio/kotest/core/config/AbstractProjectConfig;Ljava/util/List;Lio/kotest/engine/tags/TagExpression;Lio/kotest/engine/extensions/ExtensionRegistry;ILjava/lang/Object;)Lio/kotest/engine/TestEngineLauncher;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun execute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun hashCode ()I
-	public final fun promise ()Ljava/lang/Object;
-	public fun toString ()Ljava/lang/String;
-	public final fun withConsoleListener ()Lio/kotest/engine/TestEngineLauncher;
-	public final fun withListener (Lio/kotest/engine/listener/TestEngineListener;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withListeners (Ljava/util/Collection;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withNoOpListener ()Lio/kotest/engine/TestEngineLauncher;
-	public final fun withProjectConfig (Lio/kotest/core/config/AbstractProjectConfig;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withSpecRefs (Ljava/util/List;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withSpecRefs ([Lio/kotest/core/spec/SpecRef;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withTagExpression (Lio/kotest/engine/tags/TagExpression;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withTeamCityListener ()Lio/kotest/engine/TestEngineLauncher;
-}
-
 public final class io/kotest/engine/concurrency/ConcurrencyOrder : java/lang/Enum {
 	public static final field IsolateFirst Lio/kotest/engine/concurrency/ConcurrencyOrder;
 	public static final field IsolateLast Lio/kotest/engine/concurrency/ConcurrencyOrder;

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3421,8 +3421,6 @@ public final class io/kotest/engine/TestEngineLauncher {
 	public fun hashCode ()I
 	public final fun promise ()Ljava/lang/Object;
 	public fun toString ()Ljava/lang/String;
-	public final fun withClasses (Ljava/util/List;)Lio/kotest/engine/TestEngineLauncher;
-	public final fun withClasses ([Lkotlin/reflect/KClass;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withConsoleListener ()Lio/kotest/engine/TestEngineLauncher;
 	public final fun withListener (Lio/kotest/engine/listener/TestEngineListener;)Lio/kotest/engine/TestEngineLauncher;
 	public final fun withListeners (Ljava/util/Collection;)Lio/kotest/engine/TestEngineLauncher;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
@@ -55,7 +55,6 @@ class FunSpecContainerScope(
    /**
     * Adds a container test to this context expecting config.
     */
-   @ExperimentalKotest
    fun context(name: String): ContainerWithConfigBuilder<FunSpecContainerScope> {
       return ContainerWithConfigBuilder(
          name = TestNameBuilder.builder(name).build(),

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
@@ -1,6 +1,5 @@
 package io.kotest.core.spec.style.scopes
 
-import io.kotest.common.ExperimentalKotest
 import io.kotest.core.names.TestNameBuilder
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.spec.style.TestXMethod

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/TestEngineLauncher.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/TestEngineLauncher.kt
@@ -2,13 +2,12 @@
 
 package io.kotest.engine
 
+import io.kotest.common.KotestInternal
 import io.kotest.common.isIntellij
-import io.kotest.common.reflection.bestName
 import io.kotest.core.Logger
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.project.TestSuite
-import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecRef
 import io.kotest.engine.extensions.DefaultExtensionRegistry
 import io.kotest.engine.extensions.ExtensionRegistry
@@ -23,14 +22,13 @@ import io.kotest.engine.listener.TeamCityTestEngineListener
 import io.kotest.engine.listener.TestEngineListener
 import io.kotest.engine.listener.ThreadSafeTestEngineListener
 import io.kotest.engine.tags.TagExpression
-import kotlin.reflect.KClass
 
 /**
  * A builder class for creating and executing tests via a [TestEngine].
  *
- * Entry point for tests generated through the compiler plugins, and so the
- * public api cannot have breaking changes.
+ * This API is considered internal and should be used by other Kotest components only.
  */
+@KotestInternal
 data class TestEngineLauncher(
    private val listeners: List<TestEngineListener>,
    private val config: AbstractProjectConfig?,
@@ -82,14 +80,6 @@ data class TestEngineLauncher(
    fun withNoOpListener(): TestEngineLauncher {
       return withListener(NoopTestEngineListener)
    }
-
-   @Suppress("DEPRECATION")
-   @Deprecated("use withSpecRefs. Deprecated since 6.1")
-   fun withClasses(vararg specs: KClass<out Spec>): TestEngineLauncher = withClasses(specs.toList())
-
-   @Deprecated("use withSpecRefs. Deprecated since 6.1")
-   fun withClasses(specs: List<KClass<out Spec>>): TestEngineLauncher =
-      withSpecRefs(specs.map { SpecRef.Reference(it, it.bestName()) })
 
    fun withSpecRefs(vararg refs: SpecRef): TestEngineLauncher = withSpecRefs(refs.toList())
    fun withSpecRefs(refs: List<SpecRef>): TestEngineLauncher {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/DescriptorFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/DescriptorFilterTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.descriptors.Descriptor
+import io.kotest.core.spec.SpecRef
 import io.kotest.engine.extensions.filter.DescriptorFilter
 import io.kotest.engine.extensions.filter.DescriptorFilterResult
 import io.kotest.core.spec.style.FunSpec
@@ -36,7 +37,7 @@ class DescriptorFilterTest : FunSpec() {
 
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(SillySpec::class)
+            .withSpecRefs(SpecRef.Reference(SillySpec::class))
             .withProjectConfig(c)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvocationThreadErrorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvocationThreadErrorTest.kt
@@ -15,7 +15,7 @@ class InvocationThreadErrorTest : FunSpec({
       val listener = CollectingTestEngineListener()
       TestEngineLauncher()
          .withListener(listener)
-         .withClasses(InvocationErrorsTests::class)
+         .withSpecRefs(SpecRef.Reference(InvocationErrorsTests::class))
          .execute()
       listener.tests.keys.map { it.name.name } shouldBe setOf(
          "multiple invocations",

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvocationThreadErrorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/InvocationThreadErrorTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/IsolatedAnnotationTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/IsolatedAnnotationTest.kt
@@ -18,7 +18,7 @@ class IsolatedAnnotationTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(MyIsolatedSpec::class)
+            .withSpecRefs(SpecRef.Reference(MyIsolatedSpec::class))
             .execute()
          collector.tests.shouldHaveSize(1)
          collector.tests.mapKeys { it.key.descriptor.id }[DescriptorId("a")]!!.isSuccess shouldBe true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/IsolatedAnnotationTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/IsolatedAnnotationTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.descriptors.DescriptorId
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/NoClassDefFoundTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/NoClassDefFoundTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -15,7 +16,8 @@ class NoClassDefFoundTest : FunSpec() {
    init {
       test("java.lang.NoClassDefFoundError should be caught") {
          val listener = CollectingTestEngineListener()
-         TestEngineLauncher().withListener(listener).withClasses(SomeSpec1::class, SomeSpec2::class).execute()
+         TestEngineLauncher().withListener(listener)
+            .withSpecRefs(SpecRef.Reference(SomeSpec1::class), SpecRef.Reference(SomeSpec2::class)).execute()
          listener.specs.shouldHaveSize(2)
          listener.specs[SomeSpec1::class]!!.errorOrNull.shouldBeInstanceOf<SpecInstantiationException>()
          listener.specs[SomeSpec2::class]!!.errorOrNull.shouldBeInstanceOf<SpecInstantiationException>()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -18,7 +19,7 @@ private var includeTest = false
 @EnabledIf(LinuxOnlyGithubCondition::class)
 class PrivateClassesIngoreOptionTest : FunSpec() {
    init {
-      test("private class should be ignore") {
+      test("private class should be ignored") {
          includeTest = true // causes the error test to be included when this engine runs
          val p = object : AbstractProjectConfig() {
             override val ignorePrivateClasses = true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/PrivateClassesAreIgnoredTest.kt
@@ -26,7 +26,7 @@ class PrivateClassesIngoreOptionTest : FunSpec() {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(PrivateClassesAreIgnoredTest::class)
+            .withSpecRefs(SpecRef.Reference(PrivateClassesAreIgnoredTest::class))
             .withProjectConfig(p)
             .execute()
          listener.errors shouldBe false

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/SpecInstantiationErrorCapturedTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/SpecInstantiationErrorCapturedTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/SpecInstantiationErrorCapturedTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/SpecInstantiationErrorCapturedTest.kt
@@ -16,7 +16,7 @@ class SpecInstantiationErrorCapturedTest : FunSpec() {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(SpecInstantiationFailureSpec::class)
+            .withSpecRefs(SpecRef.Reference(SpecInstantiationFailureSpec::class))
             .execute()
          listener.specs.shouldHaveSize(1)
          listener.specs[SpecInstantiationFailureSpec::class]!!.errorOrNull.shouldBeInstanceOf<SpecInstantiationException>()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/active/LauncherTestFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/active/LauncherTestFilterTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.active
 
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.descriptors.Descriptor
+import io.kotest.core.spec.SpecRef
 import io.kotest.engine.extensions.filter.DescriptorFilter
 import io.kotest.engine.extensions.filter.DescriptorFilterResult
 import io.kotest.core.spec.style.FunSpec

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/active/LauncherTestFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/active/LauncherTestFilterTest.kt
@@ -34,7 +34,7 @@ class LauncherTestFilterTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(MyTestClass::class)
+            .withSpecRefs(SpecRef.Reference(MyTestClass::class))
             .addExtensions(filter)
             .execute()
       }
@@ -55,7 +55,7 @@ class LauncherTestFilterTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(MyTestClass::class)
+            .withSpecRefs(SpecRef.Reference(MyTestClass::class))
             .addExtensions(filter)
             .execute()
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/GlobalAssertionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/GlobalAssertionTest.kt
@@ -54,7 +54,7 @@ class GlobalAssertionTest : FunSpec({
 
       TestEngineLauncher().withListener(collector)
          .withProjectConfig(c)
-         .withClasses(ShouldThrowSoftlyTest::class)
+         .withSpecRefs(SpecRef.Reference(ShouldThrowSoftlyTest::class))
          .execute()
 
       collector.result("shouldThrow")!!.isSuccess shouldBe false
@@ -72,7 +72,7 @@ class GlobalAssertionTest : FunSpec({
 
       TestEngineLauncher().withListener(collector)
          .withProjectConfig(c)
-         .withClasses(FooTest::class)
+         .withSpecRefs(SpecRef.Reference(FooTest::class))
          .execute()
 
       collector.result("Should log for 1")?.isSuccess shouldBe true
@@ -88,7 +88,7 @@ class GlobalAssertionTest : FunSpec({
 
       TestEngineLauncher().withListener(collector)
          .withProjectConfig(c)
-         .withClasses(FooTest::class)
+         .withSpecRefs(SpecRef.Reference(FooTest::class))
          .execute()
 
       collector.result("a dummy test with no assertion")?.isSuccess shouldBe true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/GlobalAssertionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/GlobalAssertionTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.config
 
 import io.kotest.assertions.throwables.shouldThrowSoftly
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/KotestPropertiesTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/KotestPropertiesTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.config
 
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.config.KotestEngineProperties

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/KotestPropertiesTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/KotestPropertiesTest.kt
@@ -15,7 +15,7 @@ class KotestPropertiesTest : FunSpec() {
          withSystemProperty(KotestEngineProperties.PROPERTIES_FILENAME, "/test.kotest.properties") {
             TestEngineLauncher()
                .withListener(NoopTestEngineListener)
-               .withClasses(C::class)
+               .withSpecRefs(SpecRef.Reference(C::class))
                .execute()
             value shouldBe 123
          }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/ProjectWideFailFastTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/ProjectWideFailFastTest.kt
@@ -20,7 +20,7 @@ class ProjectWideFailFastTest : FunSpec() {
       runBlocking {
          TestEngineLauncher().withListener(listener)
             .withProjectConfig(c)
-            .withClasses(A::class, B::class)
+            .withSpecRefs(SpecRef.Reference(A::class, B::class))
             .execute()
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/ProjectWideFailFastTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/ProjectWideFailFastTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.engine.config
 
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -20,7 +21,7 @@ class ProjectWideFailFastTest : FunSpec() {
       runBlocking {
          TestEngineLauncher().withListener(listener)
             .withProjectConfig(c)
-            .withSpecRefs(SpecRef.Reference(A::class, B::class))
+            .withSpecRefs(SpecRef.Reference(A::class), SpecRef.Reference(B::class))
             .execute()
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.coroutines
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineDebugTest.kt
@@ -24,7 +24,7 @@ class CoroutineDebugTest : FunSpec() {
          val output = captureStandardOut {
             TestEngineLauncher()
                .withListener(NoopTestEngineListener)
-               .withClasses(Wibble::class)
+               .withSpecRefs(SpecRef.Reference(Wibble::class))
                .withProjectConfig(p)
                .execute()
                .errors.shouldBeEmpty()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineExceptionTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.coroutines
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
@@ -20,7 +21,7 @@ class CoroutineExceptionTest : FunSpec({
 
    test("exception in coroutine") {
 
-      var _result: TestResult? = null
+      @Suppress("LocalVariableName") var _result: TestResult? = null
 
       val listener = object : AbstractTestEngineListener() {
          override suspend fun testFinished(testCase: TestCase, result: TestResult) {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/coroutines/CoroutineExceptionTest.kt
@@ -32,7 +32,7 @@ class CoroutineExceptionTest : FunSpec({
 
       TestEngineLauncher()
          .withListener(listener)
-         .withClasses(FailingCoroutineTest::class)
+         .withSpecRefs(SpecRef.Reference(FailingCoroutineTest::class))
          .execute()
 
       _result?.isError shouldBe true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/ConstructorExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/ConstructorExtensionTest.kt
@@ -25,7 +25,7 @@ class ConstructorExtensionTest : FunSpec() {
          val collector = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(collector)
-            .withClasses(DummySpec::class)
+            .withSpecRefs(SpecRef.Reference(DummySpec::class))
             .withProjectConfig(c)
             .execute()
 
@@ -38,7 +38,7 @@ class ConstructorExtensionTest : FunSpec() {
          val collector = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(collector)
-            .withClasses(FunkySpec::class)
+            .withSpecRefs(SpecRef.Reference(FunkySpec::class))
             .execute()
 
          // if the extension isn't applied, it would fail to instantiate the class

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/ConstructorExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/ConstructorExtensionTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.extensions.ConstructorExtension
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -29,7 +30,7 @@ class ConstructorExtensionTest : FunSpec() {
             .withProjectConfig(c)
             .execute()
 
-         // the extension was applied then the instantiation will fail
+         // the extension was applied, then the instantiation will fail
          collector.specs[DummySpec::class]!!.errorOrNull shouldBe IllegalStateException("THWACK!")
       }
 
@@ -54,7 +55,7 @@ private class DummySpec : FunSpec() {
 }
 
 private class ErroringConstructorExtension : ConstructorExtension {
-   override fun <T : Spec> instantiate(clazz: KClass<T>): Spec? {
+   override fun <T : Spec> instantiate(clazz: KClass<T>): Spec {
       error("THWACK!")
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/InstantiationListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/InstantiationListenerTest.kt
@@ -21,7 +21,7 @@ class InstantiationListenerTest : FunSpec() {
 
          TestEngineLauncher()
             .withListener(NoopTestEngineListener)
-            .withClasses(DummySpec7::class)
+            .withSpecRefs(SpecRef.Reference(DummySpec7::class))
             .withProjectConfig(c)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/InstantiationListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/InstantiationListenerTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.extensions
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.InstantiationListener
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/errors/ExtensionErrorsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/errors/ExtensionErrorsTest.kt
@@ -3,13 +3,14 @@ package com.sksamuel.kotest.engine.extensions.errors
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.extensions.ExtensionException
 import io.kotest.engine.extensions.MultipleExceptions
 import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.engine.test.TestResult
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.types.shouldBeInstanceOf

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/errors/ExtensionErrorsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/errors/ExtensionErrorsTest.kt
@@ -20,7 +20,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("beforeSpec function overrides should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(BeforeSpecFunctionOverrideError::class)
+            .withSpecRefs(SpecRef.Reference(BeforeSpecFunctionOverrideError::class))
             .execute()
          val error = collector.specs.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.BeforeSpecException>()
@@ -29,7 +29,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("beforeSpec DSL errors should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(BeforeSpecDSLError::class)
+            .withSpecRefs(SpecRef.Reference(BeforeSpecDSLError::class))
             .execute()
          val error = collector.specs.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.BeforeSpecException>()
@@ -38,7 +38,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("multiple beforeSpec should be collected") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MultipleBeforeSpecErrors::class)
+            .withSpecRefs(SpecRef.Reference(MultipleBeforeSpecErrors::class))
             .execute()
          val error = collector.specs.values.first().errorOrNull
          error.shouldBeInstanceOf<MultipleExceptions>()
@@ -49,7 +49,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("afterSpec function overrides should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(AfterSpecFunctionOverrideError::class)
+            .withSpecRefs(SpecRef.Reference(AfterSpecFunctionOverrideError::class))
             .execute()
          val error = collector.specs.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.AfterSpecException>()
@@ -58,7 +58,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("afterSpec DSL errors should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(AfterSpecDSLError::class)
+            .withSpecRefs(SpecRef.Reference(AfterSpecDSLError::class))
             .execute()
          val error = collector.specs.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.AfterSpecException>()
@@ -67,7 +67,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("multiple afterSpec should be collected") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MultipleAfterSpecErrors::class)
+            .withSpecRefs(SpecRef.Reference(MultipleAfterSpecErrors::class))
             .execute()
          val error = collector.specs.values.first().errorOrNull
          error.shouldBeInstanceOf<MultipleExceptions>()
@@ -78,7 +78,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("beforeTest function overrides should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(BeforeTestFunctionOverrideError::class)
+            .withSpecRefs(SpecRef.Reference(BeforeTestFunctionOverrideError::class))
             .execute()
          val error = collector.tests.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.BeforeAnyException>()
@@ -87,7 +87,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("beforeTest DSL errors should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(BeforeTestDSLError::class)
+            .withSpecRefs(SpecRef.Reference(BeforeTestDSLError::class))
             .execute()
          val error = collector.tests.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.BeforeAnyException>()
@@ -96,7 +96,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("multiple beforeTest errors should be collected") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MultipleBeforeTestErrors::class)
+            .withSpecRefs(SpecRef.Reference(MultipleBeforeTestErrors::class))
             .execute()
          val error = collector.tests.values.first().errorOrNull
          error.shouldBeInstanceOf<MultipleExceptions>()
@@ -107,7 +107,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("afterTest function overrides should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(AfterTestFunctionOverrideError::class)
+            .withSpecRefs(SpecRef.Reference(AfterTestFunctionOverrideError::class))
             .execute()
          val error = collector.tests.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.AfterAnyException>()
@@ -116,7 +116,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("afterTest DSL errors should be wrapped") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(AfterTestDSLError::class)
+            .withSpecRefs(SpecRef.Reference(AfterTestDSLError::class))
             .execute()
          val error = collector.tests.values.first().errorOrNull
          error.shouldBeInstanceOf<ExtensionException.AfterAnyException>()
@@ -125,7 +125,7 @@ class ExtensionErrorsTest : FunSpec() {
       test("multiple afterTest errors should be collected") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MultipleAfterTestErrors::class)
+            .withSpecRefs(SpecRef.Reference(MultipleAfterTestErrors::class))
             .execute()
          val error = collector.tests.values.first().errorOrNull
          error.shouldBeInstanceOf<MultipleExceptions>()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectDslTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectDslTest.kt
@@ -26,7 +26,7 @@ class AfterProjectDslTest : FunSpec({
 
       TestEngineLauncher()
          .withListener(NoopTestEngineListener)
-         .withClasses(DummySpec6::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec6::class))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectDslTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectDslTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectListenerTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.AfterProjectListener
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/AfterProjectListenerTest.kt
@@ -26,7 +26,7 @@ class AfterProjectListenerTest : FunSpec({
       }
 
       TestEngineLauncher().withListener(NoopTestEngineListener)
-         .withClasses(DummySpec4::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec4::class))
          .withProjectConfig(c)
          .execute()
 
@@ -48,7 +48,7 @@ class AfterProjectListenerTest : FunSpec({
       }
 
       TestEngineLauncher().withListener(NoopTestEngineListener)
-         .withClasses(DummySpec4::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec4::class))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeAndAfterProjectConfigCallbackTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeAndAfterProjectConfigCallbackTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.extensions.project
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.TestEngineLauncher
@@ -32,7 +33,10 @@ class BeforeAndAfterProjectConfigCallbackTest : WordSpec() {
             TestEngineLauncher()
                .withListener(NoopTestEngineListener)
                // two classes so we know these callbacks are only invoked once
-               .withClasses(A::class, B::class)
+               .withSpecRefs(
+                  SpecRef.Reference(A::class),
+                  SpecRef.Reference(B::class),
+               )
                .withProjectConfig(config)
                .execute()
             beforeAfterProject shouldBe "beforeabafter"

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeProjectListenerExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeProjectListenerExceptionTest.kt
@@ -37,7 +37,7 @@ class BeforeProjectListenerExceptionTest : FunSpec({
       }
 
       TestEngineLauncher().withListener(listener)
-         .withClasses(DummySpec3::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec3::class))
          .withProjectConfig(c)
          .execute()
 
@@ -73,7 +73,7 @@ class BeforeProjectListenerExceptionTest : FunSpec({
       }
 
       TestEngineLauncher().withListener(listener)
-         .withClasses(DummySpec3::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec3::class))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeProjectListenerExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeProjectListenerExceptionTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.extensions.ExtensionException

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeProjectListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/BeforeProjectListenerTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.BeforeProjectListener
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener
@@ -26,7 +27,7 @@ class BeforeProjectListenerTest : FunSpec({
       }
 
       TestEngineLauncher().withListener(NoopTestEngineListener)
-         .withClasses(DummySpec5::class)
+         .withSpecRefs(SpecRef.Reference((DummySpec5::class)))
          .withProjectConfig(c)
          .execute()
 
@@ -46,7 +47,7 @@ class BeforeProjectListenerTest : FunSpec({
       }
 
       TestEngineLauncher().withListener(NoopTestEngineListener)
-         .withClasses(DummySpec5::class)
+         .withSpecRefs(SpecRef.Reference((DummySpec5::class)))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/ProjectExtensionEngineResultTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/ProjectExtensionEngineResultTest.kt
@@ -47,7 +47,7 @@ class ProjectExtensionEngineResultTest : FunSpec({
 
       TestEngineLauncher()
          .withListener(listener)
-         .withClasses(PassingProjectTest::class)
+         .withSpecRefs(SpecRef.Reference(PassingProjectTest::class))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/ProjectExtensionEngineResultTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/ProjectExtensionEngineResultTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.ProjectExtension
 import io.kotest.core.project.ProjectContext
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.AbstractTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/ProjectListenerExactlyOnceTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/project/ProjectListenerExactlyOnceTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.BeforeProjectListener
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.TestEngineLauncher
@@ -49,7 +50,7 @@ class ProjectListenerExactlyOnceTest : WordSpec() {
 
             TestEngineLauncher()
                .withListener(NoopTestEngineListener)
-               .withClasses(MyTest1::class, MyTest2::class)
+               .withSpecRefs(SpecRef.Reference(MyTest1::class), SpecRef.Reference(MyTest2::class))
                .withProjectConfig(c)
                .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AfterProjectListenerExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AfterProjectListenerExceptionTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.ProjectListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.extensions.ExtensionException

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AfterProjectListenerExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AfterProjectListenerExceptionTest.kt
@@ -40,7 +40,7 @@ class AfterProjectListenerExceptionTest : FunSpec({
 
       TestEngineLauncher()
          .withListener(listener)
-         .withClasses(DummySpec7::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec7::class))
          .withProjectConfig(c)
          .execute()
 
@@ -77,7 +77,7 @@ class AfterProjectListenerExceptionTest : FunSpec({
 
       TestEngineLauncher()
          .withListener(listener)
-         .withClasses(DummySpec7::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec7::class))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AnnotationExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/AnnotationExtensionTest.kt
@@ -10,11 +10,12 @@ import io.kotest.core.listeners.BeforeSpecListener
 import io.kotest.core.listeners.BeforeTestListener
 import io.kotest.core.listeners.PrepareSpecListener
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener
+import io.kotest.engine.test.TestResult
 import io.kotest.matchers.shouldBe
 import kotlin.reflect.KClass
 
@@ -35,7 +36,7 @@ class AnnotationExtensionTest : FunSpec() {
 
       test("a spec annotated with ApplyExtension should have that extension applied") {
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(MyAnnotatedSpec1::class)
+            .withSpecRefs(SpecRef.Reference(MyAnnotatedSpec1::class))
             .execute()
          instantiations.shouldBe(1)
          beforeSpec.shouldBe(1)
@@ -49,7 +50,7 @@ class AnnotationExtensionTest : FunSpec() {
 
       test("a spec annotated with multiple ApplyExtension's should have all extensions applied") {
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(MyAnnotatedSpec2::class)
+            .withSpecRefs(SpecRef.Reference(MyAnnotatedSpec2::class))
             .execute()
          instantiations.shouldBe(2)
          beforeSpec.shouldBe(2)
@@ -63,8 +64,10 @@ class AnnotationExtensionTest : FunSpec() {
 
       test("ApplyExtension should only apply to the spec they are annotating") {
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(MyAnnotatedSpec1::class, NotAnnotatedSpec::class)
-            .execute()
+            .withSpecRefs(
+               SpecRef.Reference(MyAnnotatedSpec1::class),
+               SpecRef.Reference(NotAnnotatedSpec::class)
+            ).execute()
          instantiations.shouldBe(1)
          beforeSpec.shouldBe(1)
          afterSpec.shouldBe(1)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/PostInstantiationExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/PostInstantiationExtensionTest.kt
@@ -22,7 +22,7 @@ class PostInstantiationExtensionTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(MySpec::class)
+            .withSpecRefs(SpecRef.Reference(MySpec::class))
             .withProjectConfig(p)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/PostInstantiationExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/PostInstantiationExtensionTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.Isolate
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.PostInstantiationExtension
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecExtensionTest.kt
@@ -31,7 +31,7 @@ class SpecExtensionTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(SpecInterceptSingleInstance::class)
+            .withSpecRefs(SpecRef.Reference(SpecInterceptSingleInstance::class))
             .withProjectConfig(c)
             .execute()
 
@@ -53,7 +53,7 @@ class SpecExtensionTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(SpecInterceptInstancePerRoot::class)
+            .withSpecRefs(SpecRef.Reference(SpecInterceptInstancePerRoot::class))
             .withProjectConfig(c)
             .execute()
 
@@ -73,7 +73,7 @@ class SpecExtensionTest : FunSpec() {
          val collecting = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(collecting)
-            .withClasses(SpecInterceptInstancePerRoot::class)
+            .withSpecRefs(SpecRef.Reference(SpecInterceptInstancePerRoot::class))
             .withProjectConfig(c)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/SpecExtensionTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.SpecExtension
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/afterspec/AfterSpecListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/afterspec/AfterSpecListenerTest.kt
@@ -9,6 +9,7 @@ import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withTests
 import io.kotest.engine.TestEngineLauncher
@@ -35,7 +36,7 @@ class AfterSpecListenerTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MyPopulatedSpec2::class)
+            .withSpecRefs(SpecRef.Reference((MyPopulatedSpec2::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -48,7 +49,7 @@ class AfterSpecListenerTest : FunSpec() {
       test("AfterSpecListener's exceptions should be propagated to specExit") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MyErrorSpec2::class)
+            .withSpecRefs(SpecRef.Reference((MyErrorSpec2::class)))
             .execute()
          collector.specs.size shouldBe 1
          collector.specs[MyErrorSpec2::class]!!.errorOrNull.shouldBeInstanceOf<ExtensionException.AfterSpecException>()
@@ -63,7 +64,7 @@ class AfterSpecListenerTest : FunSpec() {
          counter.set(0)
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(MyEmptySpec2::class)
+            .withSpecRefs(SpecRef.Reference((MyEmptySpec2::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -78,7 +79,7 @@ class AfterSpecListenerTest : FunSpec() {
          counter.set(0)
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(NoActiveTestsSpec2::class)
+            .withSpecRefs(SpecRef.Reference((NoActiveTestsSpec2::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -87,7 +88,7 @@ class AfterSpecListenerTest : FunSpec() {
 
       test("inline afterSpec functions should be invoked") {
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(InlineAfterSpec::class)
+            .withSpecRefs(SpecRef.Reference((InlineAfterSpec::class)))
             .execute()
          inlineAfterSpec.shouldBeTrue()
       }
@@ -103,7 +104,7 @@ class AfterSpecListenerTest : FunSpec() {
             }
             TestEngineLauncher().withListener(collector)
                .withProjectConfig(config)
-               .withClasses(InlineAfterSpecError::class)
+               .withSpecRefs(SpecRef.Reference((InlineAfterSpecError::class)))
                .execute()
             collector.specs.size.shouldBe(1)
             collector.specs[InlineAfterSpecError::class]!!.errorOrNull.shouldBeInstanceOf<ExtensionException.AfterSpecException>()
@@ -121,7 +122,7 @@ class AfterSpecListenerTest : FunSpec() {
             }
             TestEngineLauncher().withListener(listener)
                .withProjectConfig(config)
-               .withClasses(AfterSpecFunctionOverrideWithError::class)
+               .withSpecRefs(SpecRef.Reference((AfterSpecFunctionOverrideWithError::class)))
                .execute()
             listener.specs.size shouldBe 1
             listener.specs.values.first().isError.shouldBeTrue()
@@ -144,7 +145,7 @@ class AfterSpecListenerTest : FunSpec() {
             }
             TestEngineLauncher().withListener(listener)
                .withProjectConfig(config)
-               .withClasses(NestedSpec::class)
+               .withSpecRefs(SpecRef.Reference((NestedSpec::class)))
                .execute()
             counter.get() shouldBe instances
          }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/beforespec/BeforeSpecIsolatedTestModeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/beforespec/BeforeSpecIsolatedTestModeTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.extensions.install
 import io.kotest.core.listeners.BeforeSpecListener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/beforespec/BeforeSpecIsolatedTestModeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/beforespec/BeforeSpecIsolatedTestModeTest.kt
@@ -19,7 +19,7 @@ class BeforeSpecIsolatedTestModeTest : FunSpec({
 
       val collector = CollectingTestEngineListener()
       TestEngineLauncher().withListener(collector)
-         .withClasses(ParallelTests::class)
+         .withSpecRefs(SpecRef.Reference(ParallelTests::class))
          .execute()
 
       collector.tests.values.size shouldBe 20

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/beforespec/BeforeSpecListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/beforespec/BeforeSpecListenerTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.extensions.install
 import io.kotest.core.listeners.BeforeSpecListener
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
@@ -24,6 +25,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
 
+@Suppress("DEPRECATION")
 @EnabledIf(LinuxOnlyGithubCondition::class)
 @Isolate
 class BeforeSpecListenerTest : FunSpec() {
@@ -41,7 +43,7 @@ class BeforeSpecListenerTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecTests::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecTests::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -55,7 +57,7 @@ class BeforeSpecListenerTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecOverrideMethodTests::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecOverrideMethodTests::class)))
             .execute()
 
          listener.specs.size shouldBe 1
@@ -68,7 +70,7 @@ class BeforeSpecListenerTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecInlineTest::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecInlineTest::class)))
             .execute()
 
          listener.specs.size shouldBe 1
@@ -81,11 +83,11 @@ class BeforeSpecListenerTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecInlineOrderFunSpecTest::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecInlineOrderFunSpecTest::class)))
             .execute()
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecInlineOrderDescribeSpecTest::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecInlineOrderDescribeSpecTest::class)))
             .execute()
 
          a shouldBe "spectest1test2spectestinner"
@@ -95,7 +97,7 @@ class BeforeSpecListenerTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecInlineWithTestInterceptor::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecInlineWithTestInterceptor::class)))
             .execute()
 
          b shouldBe "beforeSpecintercepttest"
@@ -105,7 +107,7 @@ class BeforeSpecListenerTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(BeforeSpecByReturningExtensionsTest::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecByReturningExtensionsTest::class)))
             .execute()
 
          listener.specs.size shouldBe 1
@@ -121,7 +123,7 @@ class BeforeSpecListenerTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(BeforeSpecNoTests::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecNoTests::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -135,7 +137,7 @@ class BeforeSpecListenerTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(BeforeSpecErrorNoTests::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecErrorNoTests::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -149,7 +151,7 @@ class BeforeSpecListenerTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(BeforeSpecDisabledOnlyTests::class)
+            .withSpecRefs(SpecRef.Reference((BeforeSpecDisabledOnlyTests::class)))
             .withProjectConfig(c)
             .execute()
 
@@ -169,7 +171,7 @@ class BeforeSpecListenerTest : FunSpec() {
             }
             TestEngineLauncher().withListener(listener)
                .withProjectConfig(config)
-               .withClasses(BeforeSpecFunctionOverrideWithError::class)
+               .withSpecRefs(SpecRef.Reference((BeforeSpecFunctionOverrideWithError::class)))
                .execute()
             listener.specs.size shouldBe 1
             listener.specs.values.first().isError.shouldBeTrue()
@@ -190,7 +192,7 @@ class BeforeSpecListenerTest : FunSpec() {
             }
             TestEngineLauncher().withListener(listener)
                .withProjectConfig(config)
-               .withClasses(BeforeSpecInlineWithError::class)
+               .withSpecRefs(SpecRef.Reference((BeforeSpecInlineWithError::class)))
                .execute()
             listener.specs.size shouldBe 1
             listener.specs.values.first().isError.shouldBeTrue()
@@ -212,7 +214,7 @@ class BeforeSpecListenerTest : FunSpec() {
             }
             TestEngineLauncher().withListener(listener)
                .withProjectConfig(config)
-               .withClasses(NestedSpec::class)
+               .withSpecRefs(SpecRef.Reference((NestedSpec::class)))
                .execute()
             counter.get() shouldBe instances
          }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/finalizespec/FinalizeSpecListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/finalizespec/FinalizeSpecListenerTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.listeners.FinalizeSpecListener
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/finalizespec/FinalizeSpecListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/spec/finalizespec/FinalizeSpecListenerTest.kt
@@ -43,7 +43,7 @@ class FinalizeSpecTest : FunSpec() {
          }
          counter.set(0)
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(FinalizeSpec::class)
+            .withSpecRefs(SpecRef.Reference(FinalizeSpec::class))
             .withProjectConfig(c)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/IgnoredTestListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/IgnoredTestListenerTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.extensions.test
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.listeners.IgnoredTestListener
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/IgnoredTestListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/test/IgnoredTestListenerTest.kt
@@ -25,7 +25,7 @@ class IgnoredTestListenerTest : FunSpec({
    test("ignored listener should be fired for all combinations of ingored tests") {
       TestEngineLauncher()
          .withListener(NoopTestEngineListener)
-         .withClasses(IgnoredTests::class)
+         .withSpecRefs(SpecRef.Reference(IgnoredTests::class))
          .addExtensions(ignoredTestListener)
          .execute()
       ignoredTests shouldBe setOf(

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/AbortedExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/AbortedExceptionTest.kt
@@ -18,7 +18,7 @@ class AbortedExceptionTest : FreeSpec({
       val collector = CollectingTestEngineListener()
 
       TestEngineLauncher().withListener(collector)
-         .withClasses(DummySpec::class)
+         .withSpecRefs(SpecRef.Reference(DummySpec::class))
          .execute()
 
       collector.tests.toList().shouldMatchEach(

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/AbortedExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/AbortedExceptionTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.interceptors
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/SystemPropertyFiltersTests.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/interceptors/SystemPropertyFiltersTests.kt
@@ -6,6 +6,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestScope
 import io.kotest.engine.config.KotestEngineProperties
@@ -31,7 +32,7 @@ private val testSuite = listOf<KClass<out Spec>>(
    NearFutureSciFiTests::class,
    BarTests::class,
    FooTests::class,
-)
+).map { SpecRef.Reference(it) }
 
 /**
  * Test that the filter expressions in [KotestEngineProperties.FILTER_TESTS] and
@@ -52,7 +53,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "",
             KotestEngineProperties.FILTER_TESTS to ""
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
       numberOfTestsRunShouldBe(13)
    }
 
@@ -62,7 +63,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "*DistantFutureSciFiTests",
             KotestEngineProperties.FILTER_TESTS to ""
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
       numberOfTestsRunShouldBe(7)
    }
 
@@ -72,7 +73,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "*FutureSciFiTests",
             KotestEngineProperties.FILTER_TESTS to ""
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
       numberOfTestsRunShouldBe(9)
    }
 
@@ -83,7 +84,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "*NearFutureSciFiTests",
             KotestEngineProperties.FILTER_TESTS to "Daedalus*"
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
 
       numberOfTestsRunShouldBe(1)
    }
@@ -95,7 +96,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "",
             KotestEngineProperties.FILTER_TESTS to "trek tests*"
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
 
       numberOfTestsRunShouldBe(3)
    }
@@ -107,7 +108,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "com.sksamuel.kotest.engine.interceptors.filters1.*",
             KotestEngineProperties.FILTER_TESTS to ""
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
 
       numberOfTestsRunShouldBe(2)
    }
@@ -119,7 +120,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "",
             KotestEngineProperties.FILTER_TESTS to "expanse tests*"
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
 
       numberOfTestsRunShouldBe(4)
    }
@@ -131,7 +132,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "",
             KotestEngineProperties.FILTER_TESTS to "*anse tes*"
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
 
       numberOfTestsRunShouldBe(4)
    }
@@ -143,7 +144,7 @@ class SystemPropertyTestFiltersTests : FunSpec({
             KotestEngineProperties.FILTER_SPECS to "",
             KotestEngineProperties.FILTER_TESTS to "*BC-304"
          )
-      ) { TestEngineLauncher().withClasses(testSuite).execute() }
+      ) { TestEngineLauncher().withSpecRefs(testSuite).execute() }
 
       numberOfTestsRunShouldBe(2)
       executed.shouldContainExactly("Daedalus BC-304", "Odyssey BC-304")

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/objects/ObjectTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/objects/ObjectTest.kt
@@ -11,7 +11,7 @@ class ObjectSpecTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(MyObjectSpec::class)
+            .withSpecRefs(SpecRef.Reference(MyObjectSpec::class))
             .execute()
          collector.result("foo")!!.isSuccess shouldBe true
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/objects/ObjectTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/objects/ObjectTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.objects
 
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecInitializationErrorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecInitializationErrorTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.spec
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecInitializationErrorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecInitializationErrorTest.kt
@@ -15,7 +15,7 @@ class SpecInitializationErrorTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(FieldInitErrorSpec::class)
+            .withSpecRefs(SpecRef.Reference(FieldInitErrorSpec::class))
             .execute()
          collector.specs[FieldInitErrorSpec::class]!!.errorOrNull.shouldBeInstanceOf<SpecInstantiationException>()
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecResultDurationTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecResultDurationTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.spec
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecResultDurationTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/SpecResultDurationTest.kt
@@ -15,7 +15,7 @@ class SpecResultDurationTest : FunSpec() {
       test("spec finished callback should include construction time in duration") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(Wobble::class)
+            .withSpecRefs(SpecRef.Reference(Wobble::class))
             .execute()
          listener.specs.values.first().duration.inWholeMicroseconds.shouldBeGreaterThan(1000)
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/TempDirTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/TempDirTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.spec
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -21,7 +22,7 @@ class TempDirTest : FunSpec({
       val collector = CollectingTestEngineListener()
       TestEngineLauncher()
          .withListener(collector)
-         .withClasses(TempDirPassSpec::class)
+         .withSpecRefs(SpecRef.Reference((TempDirPassSpec::class)))
          .execute()
 
       // check the tests passed so we know the dir was created
@@ -33,7 +34,7 @@ class TempDirTest : FunSpec({
    test("temp dir should be kept after the spec is completed because of keepOnFailure") {
       TestEngineLauncher()
          .withListener(NoopTestEngineListener)
-         .withClasses(TempDirFailSpec::class)
+         .withSpecRefs(SpecRef.Reference((TempDirFailSpec::class)))
          .execute()
       dir2!!.shouldExist()
    }
@@ -44,7 +45,7 @@ class TempDirTest : FunSpec({
 
       TestEngineLauncher()
          .withListener(collector)
-         .withClasses(TempDirSymLink::class)
+         .withSpecRefs(SpecRef.Reference((TempDirSymLink::class)))
          .execute()
 
       // check the tests passed so we know the dir was created

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecIgnoresTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecIgnoresTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.spec.annotation
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.engine.TestEngineLauncher
@@ -18,7 +19,7 @@ class AnnotationSpecIgnoresTest : DescribeSpec({
          val listener = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(AnnotationSpecWithBangTest::class)
+            .withSpecRefs(SpecRef.Reference((AnnotationSpecWithBangTest::class)))
             .execute()
          listener.tests
             .mapKeys { it.key.name.name }
@@ -29,7 +30,7 @@ class AnnotationSpecIgnoresTest : DescribeSpec({
          val listener = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(AnnotationSpecAtIgnoreTest::class)
+            .withSpecRefs(SpecRef.Reference((AnnotationSpecAtIgnoreTest::class)))
             .execute()
          listener.tests
             .mapKeys { it.key.name.name }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecNestedTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecNestedTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.spec.annotation
 
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecNestedTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecNestedTest.kt
@@ -13,7 +13,7 @@ class AnnotationSpecNestedTest : FunSpec() {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(AnnotationSpecWithNested::class)
+            .withSpecRefs(SpecRef.Reference(AnnotationSpecWithNested::class))
             .execute()
          listener.tests.shouldHaveSize(2)
          listener.tests.keys.map { it.name.name }.toSet() shouldBe setOf("foo", "bar")

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecTest.kt
@@ -17,27 +17,27 @@ class AnnotationSpecTest : DescribeSpec({
 
       it("should detect public and private methods annotated with @Test") {
          val listener = CollectingTestEngineListener()
-         TestEngineLauncher().withListener(listener).withClasses(AnnotationSpecClass::class).execute()
+         TestEngineLauncher().withListener(listener).withSpecRefs(SpecRef.Reference(AnnotationSpecClass::class)).execute()
          listener.tests.shouldHaveSize(2)
       }
 
       it("should support throwing exceptions with @Test(expected=foo)") {
          val listener = CollectingTestEngineListener()
-         TestEngineLauncher().withListener(listener).withClasses(AnnotationSpecWithExceptions::class).execute()
+         TestEngineLauncher().withListener(listener).withSpecRefs(SpecRef.Reference(AnnotationSpecWithExceptions::class)).execute()
          val ds = listener.tests.mapKeys { it.key.descriptor.id }
          ds[DescriptorId("test1")]?.isSuccess shouldBe true
       }
 
       it("should fail on unexpected exception") {
          val listener = CollectingTestEngineListener()
-         TestEngineLauncher().withListener(listener).withClasses(AnnotationSpecWithExceptions::class).execute()
+         TestEngineLauncher().withListener(listener).withSpecRefs(SpecRef.Reference(AnnotationSpecWithExceptions::class)).execute()
          val ds = listener.tests.mapKeys { it.key.descriptor.id }
          ds[DescriptorId("test2")]?.isFailure shouldBe true
       }
 
       it("should fail on expected exception that wasn't thrown") {
          val listener = CollectingTestEngineListener()
-         TestEngineLauncher().withListener(listener).withClasses(AnnotationSpecWithExceptions::class).execute()
+         TestEngineLauncher().withListener(listener).withSpecRefs(SpecRef.Reference(AnnotationSpecWithExceptions::class)).execute()
          val ds = listener.tests.mapKeys { it.key.descriptor.id }
          ds[DescriptorId("test3")]?.isFailure shouldBe true
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/annotation/AnnotationSpecTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.spec.annotation
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.descriptors.DescriptorId
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/LateRootTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/LateRootTestDefinitionTest.kt
@@ -24,7 +24,7 @@ class LateRootTestDefinitionTest : FunSpec() {
       test("expect spec") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(ExpectSpecWithExtraRootTests::class)
+            .withSpecRefs(SpecRef.Reference(ExpectSpecWithExtraRootTests::class))
             .execute()
          listener.result("foo")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
       }
@@ -32,7 +32,7 @@ class LateRootTestDefinitionTest : FunSpec() {
       test("feature spec") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(FeatureSpecWithExtraRootTests::class)
+            .withSpecRefs(SpecRef.Reference(FeatureSpecWithExtraRootTests::class))
             .execute()
          listener.result("foo")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
       }
@@ -40,7 +40,7 @@ class LateRootTestDefinitionTest : FunSpec() {
       test("free spec") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(FreeSpecWithExtraRootTests::class)
+            .withSpecRefs(SpecRef.Reference(FreeSpecWithExtraRootTests::class))
             .execute()
          listener.result("foo")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
       }
@@ -48,7 +48,7 @@ class LateRootTestDefinitionTest : FunSpec() {
       test("fun spec") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(FunSpecWithExtraRootTests::class)
+            .withSpecRefs(SpecRef.Reference(FunSpecWithExtraRootTests::class))
             .execute()
          listener.result("foo")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
       }
@@ -56,7 +56,7 @@ class LateRootTestDefinitionTest : FunSpec() {
       test("should spec") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(ShouldSpecWithExtraRootTests::class)
+            .withSpecRefs(SpecRef.Reference(ShouldSpecWithExtraRootTests::class))
             .execute()
          listener.result("foo")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/LateRootTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/LateRootTestDefinitionTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.names.TestNameBuilder
 import io.kotest.core.spec.InvalidDslException
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.core.spec.style.FeatureSpec
 import io.kotest.core.spec.style.FreeSpec

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/UnfinishedTestDefinitionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/UnfinishedTestDefinitionTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.spec.dsl
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.core.spec.style.FeatureSpec
@@ -23,42 +24,42 @@ class UnfinishedTestDefinitionTest : FunSpec() {
 
       test("fun spec") {
          val result = TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(FunSpecUnfinishedTestDefinitionTest::class)
+            .withSpecRefs(SpecRef.Reference((FunSpecUnfinishedTestDefinitionTest::class)))
             .execute()
          result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished test") }
       }
 
       test("fun spec with override") {
          val result = TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(FunSpecUnfinishedTestWithDuplicatedLeafNamesDefinitionTest::class)
+            .withSpecRefs(SpecRef.Reference((FunSpecUnfinishedTestWithDuplicatedLeafNamesDefinitionTest::class)))
             .execute()
          result.errors.forAtLeastOne { it.message!!.shouldContain("abc") }
       }
 
       test("describe spec") {
          val result = TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(DescribeSpecUnfinishedTestDefinitionTest::class)
+            .withSpecRefs(SpecRef.Reference((DescribeSpecUnfinishedTestDefinitionTest::class)))
             .execute()
          result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished it") }
       }
 
       test("should spec") {
          val result = TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(ShouldSpecUnfinishedTestDefinitionTest::class)
+            .withSpecRefs(SpecRef.Reference((ShouldSpecUnfinishedTestDefinitionTest::class)))
             .execute()
          result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished should") }
       }
 
       test("feature spec") {
          val result = TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(FeatureSpecUnfinishedTestDefinitionTest::class)
+            .withSpecRefs(SpecRef.Reference((FeatureSpecUnfinishedTestDefinitionTest::class)))
             .execute()
          result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished scenario") }
       }
 
       test("expect spec") {
          val result = TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(ExpectSpecUnfinishedTestDefinitionTest::class)
+            .withSpecRefs(SpecRef.Reference((ExpectSpecUnfinishedTestDefinitionTest::class)))
             .execute()
          result.errors.forAtLeastOne { it.message!!.shouldContain("unfinished expect") }
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/aftereach/AfterEachPlacementRestrictionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/dsl/aftereach/AfterEachPlacementRestrictionTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.Description
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.InvalidDslException
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.core.spec.style.FunSpec
@@ -22,7 +23,7 @@ class AfterEachPlacementRestrictionTest : FunSpec() {
       test("FunSpec") {
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(FunSpecWithAfterEach::class)
+            .withSpecRefs(SpecRef.Reference((FunSpecWithAfterEach::class)))
             .execute()
          listener.result("foo1")!!.isSuccess.shouldBeTrue()
          listener.result("foo2")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
@@ -32,7 +33,7 @@ class AfterEachPlacementRestrictionTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(ShouldSpecWithAfterEach::class)
+            .withSpecRefs(SpecRef.Reference((ShouldSpecWithAfterEach::class)))
             .execute()
          listener.result("foo1")!!.isSuccess.shouldBeTrue()
          listener.result("foo2")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
@@ -42,7 +43,7 @@ class AfterEachPlacementRestrictionTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(ExpectSpecWithAfterEach::class)
+            .withSpecRefs(SpecRef.Reference((ExpectSpecWithAfterEach::class)))
             .execute()
          listener.result("foo1")!!.isSuccess.shouldBeTrue()
          listener.result("foo2")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
@@ -52,7 +53,7 @@ class AfterEachPlacementRestrictionTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(WordSpecWithAfterEach::class)
+            .withSpecRefs(SpecRef.Reference((WordSpecWithAfterEach::class)))
             .execute()
          listener.result("foo1")!!.isSuccess.shouldBeTrue()
          listener.result("foo2")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()
@@ -62,7 +63,7 @@ class AfterEachPlacementRestrictionTest : FunSpec() {
 
          val listener = CollectingTestEngineListener()
          TestEngineLauncher().withListener(listener)
-            .withClasses(FreeSpecWithAfterEach::class)
+            .withSpecRefs(SpecRef.Reference((FreeSpecWithAfterEach::class)))
             .execute()
          listener.result("foo1")!!.isSuccess.shouldBeTrue()
          listener.result("foo2")!!.errorOrNull!!.shouldBeInstanceOf<InvalidDslException>()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/examples/DescribeSpecExample.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/examples/DescribeSpecExample.kt
@@ -23,7 +23,7 @@ class DescribeSpecExampleTest : FunSpec({
 
       val duration = testTimeSource().measureTime {
          TestEngineLauncher().withListener(collector)
-            .withClasses(DescribeSpecExample::class)
+            .withSpecRefs(SpecRef.Reference(DescribeSpecExample::class))
             .execute()
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/examples/DescribeSpecExample.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/examples/DescribeSpecExample.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.common.testTimeSource
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/ApplyExtensionsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/interceptor/ApplyExtensionsTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.extensions.ApplyExtension
 import io.kotest.core.extensions.TestCaseExtension
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.TestEngineLauncher
@@ -23,7 +24,7 @@ class ApplyExtensionsTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(MyAnnotatedSpec1::class)
+            .withSpecRefs(SpecRef.Reference((MyAnnotatedSpec1::class)))
             .execute()
 
          // if apply extension was not applied, it would fail to intercept the failing test
@@ -36,7 +37,7 @@ class ApplyExtensionsTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(MyAnnotatedSpec2::class)
+            .withSpecRefs(SpecRef.Reference((MyAnnotatedSpec2::class)))
             .execute()
 
          // if apply extension was not applied, it would fail to intercept the failing test
@@ -49,7 +50,7 @@ class ApplyExtensionsTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(MyAnnotatedSpec3::class)
+            .withSpecRefs(SpecRef.Reference((MyAnnotatedSpec3::class)))
             .execute()
 
          // if apply extension was not applied, it would fail to intercept the failing test
@@ -61,7 +62,7 @@ class ApplyExtensionsTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(MyAnnotatedSpec4::class)
+            .withSpecRefs(SpecRef.Reference((MyAnnotatedSpec4::class)))
             .execute()
          collector.specs.toList()
             .first().second.errorOrNull.shouldNotBeNull().message shouldContain "Cannot use private class"

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/sorts/DefaultSpecExecutionOrderExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/sorts/DefaultSpecExecutionOrderExtensionTest.kt
@@ -115,7 +115,11 @@ class DefaultSpecExecutionOrderExtensionTest : DescribeSpec({
 
          TestEngineLauncher()
             .withListener(listener)
-            .withClasses(ASpec::class, ZSpec::class, YSpec::class)
+            .withSpecRefs(
+               SpecRef.Reference(ASpec::class),
+               SpecRef.Reference(ZSpec::class),
+               SpecRef.Reference(YSpec::class)
+            )
             .withProjectConfig(c)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/BehaviorSpecTreeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/BehaviorSpecTreeTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.spec.tree
 import io.kotest.core.descriptors.DescriptorPath
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/BehaviorSpecTreeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/BehaviorSpecTreeTest.kt
@@ -16,7 +16,7 @@ class BehaviorSpecTreeTest : FunSpec() {
       test("BehaviorSpec should nest tests properly") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MyBehaviorSpecTree::class)
+            .withSpecRefs(SpecRef.Reference(MyBehaviorSpecTree::class))
             .execute()
          collector.tests.mapKeys { it.key.descriptor.path() }.keys shouldBe setOf(
             DescriptorPath("com.sksamuel.kotest.engine.spec.tree.MyBehaviorSpecTree/a -- b -- c"),

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/FreeSpecTreeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/FreeSpecTreeTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.spec.tree
 import io.kotest.core.descriptors.DescriptorPath
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/FreeSpecTreeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/tree/FreeSpecTreeTest.kt
@@ -16,7 +16,7 @@ class FreeSpecTreeTest : FunSpec() {
       test("free spec should nest context's properly") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MyFreeSpec::class)
+            .withSpecRefs(SpecRef.Reference(MyFreeSpec::class))
             .execute()
          collector.tests.mapKeys { it.key.descriptor.path() }.keys shouldBe setOf(
             DescriptorPath("com.sksamuel.kotest.engine.spec.tree.MyFreeSpec/a"),

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/BehaviorSpecTagTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/BehaviorSpecTagTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.engine.tags
 
 import io.kotest.core.Tag
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
@@ -15,7 +16,7 @@ class BehaviorSpecTagTest : FunSpec() {
          withSystemProperty("kotest.tags", "!MyTagABC") {
             TestEngineLauncher()
                .withListener(listener)
-               .withClasses(ThenTagTest::class)
+               .withSpecRefs(SpecRef.Reference((ThenTagTest::class)))
                .execute()
          }
          listener.tests.toList().first { it.first.name.name == "a" }.second.isSuccess shouldBe true
@@ -29,7 +30,7 @@ class BehaviorSpecTagTest : FunSpec() {
          withSystemProperty("kotest.tags", "MyTagABC") {
             TestEngineLauncher()
                .withListener(listener)
-               .withClasses(GivenTagTest::class)
+               .withSpecRefs(SpecRef.Reference((GivenTagTest::class)))
                .execute()
          }
          listener.tests.toList().first { it.first.name.name == "a" }.second.isSuccess shouldBe true
@@ -43,7 +44,7 @@ class BehaviorSpecTagTest : FunSpec() {
          withSystemProperty("kotest.tags", "!MyTagABC") {
             TestEngineLauncher()
                .withListener(listener)
-               .withClasses(GivenTagTest::class)
+               .withSpecRefs(SpecRef.Reference((GivenTagTest::class)))
                .execute()
          }
          listener.tests.toList().first { it.first.name.name == "a" }.second.isIgnored shouldBe true
@@ -57,7 +58,7 @@ class BehaviorSpecTagTest : FunSpec() {
          withSystemProperty("kotest.tags", "!MyTagABC") {
             TestEngineLauncher()
                .withListener(listener)
-               .withClasses(WhenTagTest::class)
+               .withSpecRefs(SpecRef.Reference((WhenTagTest::class)))
                .execute()
          }
          listener.tests.toList().first { it.first.name.name == "a" }.second.isSuccess shouldBe true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/ExcludeTagExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/ExcludeTagExtensionTest.kt
@@ -7,6 +7,7 @@ import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.TagExtension
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/ExcludeTagExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/ExcludeTagExtensionTest.kt
@@ -37,7 +37,7 @@ class ExcludeTagExtensionTest : FunSpec() {
          }
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(ExcludedSpec::class)
+            .withSpecRefs(SpecRef.Reference(ExcludedSpec::class))
             .withProjectConfig(c)
             .execute()
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/RequiresTagTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/RequiresTagTest.kt
@@ -5,6 +5,7 @@ import io.kotest.engine.tags.TagExpression
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.RequiresTag
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.ExpectSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
@@ -25,7 +26,7 @@ class RequiresTagTest : FunSpec({
          TestEngineLauncher()
             .withListener(collector)
             .withTagExpression(TagExpression("Foo"))
-            .withClasses(TaggedSpec::class)
+            .withSpecRefs(SpecRef.Reference((TaggedSpec::class)))
             .execute()
 
          collector
@@ -39,7 +40,7 @@ class RequiresTagTest : FunSpec({
          val collector = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(collector)
-            .withClasses(TaggedSpec::class)
+            .withSpecRefs(SpecRef.Reference((TaggedSpec::class)))
             .withTagExpression(TagExpression("UnrelatedTag"))
             .execute()
 
@@ -57,7 +58,7 @@ class RequiresTagTest : FunSpec({
 
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(TaggedSpec::class)
+            .withSpecRefs(SpecRef.Reference((TaggedSpec::class)))
             .withTagExpression(TagExpression.Empty)
             .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/RuntimeTagExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/RuntimeTagExtensionTest.kt
@@ -11,6 +11,7 @@ import io.kotest.core.extensions.RuntimeTagExtension
 import io.kotest.core.extensions.TagExtension
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
@@ -38,7 +39,7 @@ class RuntimeTagExtensionTest : StringSpec() {
             override val extensions = listOf(RuntimeTagExtension(included = emptySet(), excluded = setOf(MyRuntimeExcludedTag)))
          }
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(TestWithTag::class)
+            .withSpecRefs(SpecRef.Reference((TestWithTag::class)))
             .withProjectConfig(c)
             .execute()
             .errors.shouldBeEmpty()
@@ -49,7 +50,7 @@ class RuntimeTagExtensionTest : StringSpec() {
             override val extensions = listOf(RuntimeTagExpressionExtension("!MyRuntimeExcludedTag"))
          }
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(TestWithTag::class)
+            .withSpecRefs(SpecRef.Reference((TestWithTag::class)))
             .withProjectConfig(c)
             .execute()
             .errors.shouldBeEmpty()
@@ -60,7 +61,7 @@ class RuntimeTagExtensionTest : StringSpec() {
             override val extensions = listOf(FooTagExtension)
          }
          TestEngineLauncher().withListener(NoopTestEngineListener)
-            .withClasses(TestWithListenerAndTag::class)
+            .withSpecRefs(SpecRef.Reference((TestWithListenerAndTag::class)))
             .withProjectConfig(c)
             .execute()
          counter.get() shouldBe 0

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagExtensionTest.kt
@@ -30,7 +30,7 @@ class TagExtensionTest : StringSpec() {
 
             val collector = CollectingTestEngineListener()
             TestEngineLauncher().withListener(collector)
-               .withClasses(TestWithTags::class)
+               .withSpecRefs(SpecRef.Reference(TestWithTags::class))
                .withProjectConfig(c)
                .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagExtensionTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.TagExtension
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.extensions.tags.SpecifiedTagsTagExtension

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagFilteredDiscoveryExtensionExampleTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagFilteredDiscoveryExtensionExampleTest.kt
@@ -28,7 +28,7 @@ class TagFilteredDiscoveryExtensionExampleTest : StringSpec() {
          }
          TestEngineLauncher().withListener(collector)
             .withProjectConfig(c)
-            .withClasses(ShouldBeExcluded::class)
+            .withSpecRefs(SpecRef.Reference(ShouldBeExcluded::class))
             .execute()
 
          collector.errors.shouldBeFalse()

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagFilteredDiscoveryExtensionExampleTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagFilteredDiscoveryExtensionExampleTest.kt
@@ -8,6 +8,7 @@ import io.kotest.core.annotation.Tags
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.extensions.Extension
 import io.kotest.core.extensions.TagExtension
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/FailFastTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/FailFastTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.test
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
@@ -19,7 +20,7 @@ class FailFastTest : FunSpec() {
          val listener = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(FailFastFunSpec::class)
+            .withSpecRefs(SpecRef.Reference((FailFastFunSpec::class)))
             .execute()
 
          val results = listener.tests.mapKeys { it.key.name.name }
@@ -40,7 +41,7 @@ class FailFastTest : FunSpec() {
          val listener = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(FailFastFreeSpec::class)
+            .withSpecRefs(SpecRef.Reference((FailFastFreeSpec::class)))
             .execute()
 
          val results = listener.tests.mapKeys { it.key.name.name }
@@ -61,7 +62,7 @@ class FailFastTest : FunSpec() {
          val listener = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(listener)
-            .withClasses(GrandfatherFailFastFreeSpec::class)
+            .withSpecRefs(SpecRef.Reference(GrandfatherFailFastFreeSpec::class))
             .execute()
 
          val results = listener.tests.mapKeys { it.key.name.name }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/RetryTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/RetryTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.test
 
 import io.kotest.assertions.withClue
 import io.kotest.common.testTimeSource
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.config.DefaultTestConfig

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/RetryTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/RetryTest.kt
@@ -34,7 +34,7 @@ class RetryTests : FunSpec() {
          val collector = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(collector)
-            .withClasses(InnerRetryTest::class)
+            .withSpecRefs(SpecRef.Reference(InnerRetryTest::class))
             .execute()
 
          checkResults(collector, 4)
@@ -44,7 +44,7 @@ class RetryTests : FunSpec() {
          val collector = CollectingTestEngineListener()
 
          TestEngineLauncher().withListener(collector)
-            .withClasses(InnerRetryWithSpecDefaultTest::class)
+            .withSpecRefs(SpecRef.Reference(InnerRetryWithSpecDefaultTest::class))
             .execute()
 
          checkResults(collector, 1)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/EnabledIfErrorsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/EnabledIfErrorsTest.kt
@@ -11,7 +11,7 @@ class EnabledIfErrorsTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(EnabledIfFailues::class)
+            .withSpecRefs(SpecRef.Reference(EnabledIfFailues::class))
             .execute()
 
          collector.result("a")!!.isIgnored shouldBe true

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/EnabledIfErrorsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/EnabledIfErrorsTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.test.enabled
 
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/IgnoredTestReasonTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/IgnoredTestReasonTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.descriptors.Descriptor
 import io.kotest.core.extensions.EnabledExtension
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.ShouldSpec
@@ -20,7 +21,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("enabledOrReasonIf should report the reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(EnabledOrReasonIfSpec::class)
+            .withSpecRefs(SpecRef.Reference((EnabledOrReasonIfSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "wobble"
       }
@@ -36,7 +37,7 @@ class IgnoredTestReasonTest : FunSpec() {
          }
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(MyFunSpec::class)
+            .withSpecRefs(SpecRef.Reference((MyFunSpec::class)))
             .withProjectConfig(c)
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "wibble"
@@ -45,7 +46,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("xdisabled in fun spec should report the reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(XReasonFunSpec::class)
+            .withSpecRefs(SpecRef.Reference((XReasonFunSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "Disabled by xmethod"
       }
@@ -53,7 +54,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("xdisabled in describe spec should report the reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(XReasonDescribeSpec::class)
+            .withSpecRefs(SpecRef.Reference((XReasonDescribeSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "Disabled by xmethod"
       }
@@ -61,7 +62,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("xdisabled in should spec should report the reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(XReasonShouldSpec::class)
+            .withSpecRefs(SpecRef.Reference((XReasonShouldSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "Disabled by xmethod"
       }
@@ -69,7 +70,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("enabled should report some reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(EnabledSpec::class)
+            .withSpecRefs(SpecRef.Reference((EnabledSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "Disabled by enabled flag in config"
       }
@@ -77,7 +78,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("enabledIf should report some reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(EnabledIfSpec::class)
+            .withSpecRefs(SpecRef.Reference((EnabledIfSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "Disabled by enabledIf flag in config"
       }
@@ -85,7 +86,7 @@ class IgnoredTestReasonTest : FunSpec() {
       test("bang should report some reason for skipping") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(BangSpec::class)
+            .withSpecRefs(SpecRef.Reference((BangSpec::class)))
             .execute()
          collector.testResult("a").reasonOrNull shouldBe "Disabled by bang"
       }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/names/DefaultDisplayNameFormatterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/names/DefaultDisplayNameFormatterTest.kt
@@ -190,7 +190,7 @@ class DefaultDisplayNameFormatterTest : FunSpec() {
             TestEngineLauncher()
                .withListener(collector)
                .withProjectConfig(c)
-               .withClasses(TaggedSpec::class)
+               .withSpecRefs(SpecRef.Reference(TaggedSpec::class))
                .withTagExpression(TagExpression.Empty)
                .execute()
          }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/names/DefaultDisplayNameFormatterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/names/DefaultDisplayNameFormatterTest.kt
@@ -20,6 +20,7 @@ import io.kotest.engine.config.IncludeTestScopeAffixes
 import io.kotest.engine.config.ProjectConfigResolver
 import io.kotest.engine.config.TestConfigResolver
 import io.kotest.core.descriptors.toDescriptor
+import io.kotest.core.spec.SpecRef
 import io.kotest.engine.listener.TeamCityTestEngineListener
 import io.kotest.engine.tags.TagExpression
 import io.kotest.engine.test.names.DefaultDisplayNameFormatter

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
@@ -30,7 +30,7 @@ class ContainerTimeoutTest : FunSpec() {
             TestEngineLauncher()
                .withListener(collector)
                .withProjectConfig(c)
-               .withClasses(NestedTimeout::class)
+               .withSpecRefs(SpecRef.Reference(NestedTimeout::class))
                .execute()
 
             collector.names.shouldContainExactly("a")

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/ContainerTimeoutTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.asClue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/EngineTimeoutTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.engine.test.timeout
 import io.kotest.assertions.asClue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
@@ -19,7 +20,7 @@ class EngineTimeoutTest : FunSpec() {
       test("timeouts should be applied by the engine to suspend delays") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(DannyDelay::class)
+            .withSpecRefs(SpecRef.Reference((DannyDelay::class)))
             .execute()
          collector.names shouldBe listOf("a")
          collector.result("a").asClue { result ->
@@ -30,7 +31,7 @@ class EngineTimeoutTest : FunSpec() {
       test("timeouts should be applied by the engine to suspend inside launched coroutines") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(LarryLauncher::class)
+            .withSpecRefs(SpecRef.Reference((LarryLauncher::class)))
             .execute()
          collector.names shouldBe listOf("a")
          collector.result("a").asClue { result ->
@@ -41,7 +42,7 @@ class EngineTimeoutTest : FunSpec() {
       test("timeouts should be applied by the engine to blocked threads") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(BillyBlocked::class)
+            .withSpecRefs(SpecRef.Reference((BillyBlocked::class)))
             .execute()
          collector.names shouldBe listOf("a")
          collector.result("a").asClue { result ->

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.asClue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.datatest.withData

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/GlobalTimeoutTest.kt
@@ -31,7 +31,7 @@ class GlobalTimeoutTest : FunSpec() {
             val collector = CollectingTestEngineListener()
 
             TestEngineLauncher().withListener(collector)
-               .withClasses(TestTimeouts::class)
+               .withSpecRefs(SpecRef.Reference(TestTimeouts::class))
                .withProjectConfig(c)
                .execute()
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceedingTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceedingTimeoutTest.kt
@@ -21,7 +21,7 @@ class TestInvocationTimeoutExceedingTimeoutTest : FunSpec() {
       test("invocation timeout shouldn't exceed test timeout") {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(SpecWithInvalidInvocationTimeout::class)
+            .withSpecRefs(SpecRef.Reference(SpecWithInvalidInvocationTimeout::class))
             .execute()
 
          collector.specs.getValue(SpecWithInvalidInvocationTimeout::class).errorOrNull

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceedingTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestInvocationTimeoutExceedingTimeoutTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/WithTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/WithTimeoutTest.kt
@@ -18,7 +18,7 @@ class WithTimeoutTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(WithTimeoutSpec::class)
+            .withSpecRefs(SpecRef.Reference(WithTimeoutSpec::class))
             .execute()
          collector.result("a")!!.errorOrNull!!.message shouldBe """Timed out waiting for 1000 ms"""
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/WithTimeoutTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/WithTimeoutTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.engine.test.timeout
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestingRepeatedNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestingRepeatedNameTest.kt
@@ -1,5 +1,6 @@
 package io.kotest.datatest
 
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.StringSpec
@@ -14,7 +15,7 @@ class DataTestingRepeatedTestNameTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(RepeatedNamesDescribeSpec::class)
+            .withSpecRefs(SpecRef.Reference((RepeatedNamesDescribeSpec::class)))
             .execute()
 
          collector.names shouldBe listOf(
@@ -33,7 +34,7 @@ class DataTestingRepeatedTestNameTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(RepeatedNamesDescribeSpecRoot::class)
+            .withSpecRefs(SpecRef.Reference((RepeatedNamesDescribeSpecRoot::class)))
             .execute()
 
          collector.names shouldBe listOf(
@@ -51,7 +52,7 @@ class DataTestingRepeatedTestNameTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(RepeatedNamesFunSpec::class)
+            .withSpecRefs(SpecRef.Reference((RepeatedNamesFunSpec::class)))
             .execute()
 
          collector.names shouldBe listOf(
@@ -70,7 +71,7 @@ class DataTestingRepeatedTestNameTest : FunSpec() {
 
          val collector = CollectingTestEngineListener()
          TestEngineLauncher().withListener(collector)
-            .withClasses(RepeatedNamesRootFunSpec::class)
+            .withSpecRefs(SpecRef.Reference((RepeatedNamesRootFunSpec::class)))
             .execute()
 
          collector.names shouldBe listOf(

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/UnstableTestNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/UnstableTestNameTest.kt
@@ -47,7 +47,7 @@ class UnstableTestNameTest : FunSpec() {
             TestEngineLauncher()
                .withProjectConfig(config)
                .withListener(listener)
-               .withClasses(NonDataClassesTest::class)
+               .withSpecRefs(SpecRef.Reference(NonDataClassesTest::class))
                .execute()
 
             results shouldBe listOf(

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/UnstableTestNameTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/UnstableTestNameTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
 import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/LifecycleOrderTest.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/LifecycleOrderTest.kt
@@ -19,7 +19,7 @@ class LifecycleOrderTest : FunSpec() {
          val collector = CollectingTestEngineListener()
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(LifecycleTests::class)
+            .withSpecRefs(SpecRef.Reference(LifecycleTests::class))
             .addExtensions(LifecycleExtension("engine"))
             .execute()
          collector.names shouldBe listOf("foo", "bar")

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/LifecycleOrderTest.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/LifecycleOrderTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.extensions.SpecExtension
 import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.project.ProjectContext
 import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-tests/kotest-tests-config-classname/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/SystemPropertyConfigClassTest.kt
+++ b/kotest-tests/kotest-tests-config-classname/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/SystemPropertyConfigClassTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.config.classname
 
 import io.kotest.core.annotation.Description
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-tests/kotest-tests-config-classname/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/SystemPropertyConfigClassTest.kt
+++ b/kotest-tests/kotest-tests-config-classname/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/SystemPropertyConfigClassTest.kt
@@ -17,7 +17,7 @@ class SystemPropertyConfigClassTest : FunSpec() {
          counter.set(0)
          TestEngineLauncher()
             .withListener(collector)
-            .withClasses(FooTest::class)
+            .withSpecRefs(SpecRef.Reference(FooTest::class))
             .execute()
          counter.get() shouldBe 5
       }

--- a/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
+++ b/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.config
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener

--- a/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
+++ b/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
@@ -17,7 +17,7 @@ class PackageConfigTest : FunSpec() {
          runBlocking {
             TestEngineLauncher()
                .withListener(collector)
-               .withClasses(BarTest::class)
+               .withSpecRefs(SpecRef.Reference(BarTest::class))
                .execute()
          }
          // if the package config isn't picked up, this test won't timeout

--- a/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
+++ b/kotest-tests/kotest-tests-config-packages/src/jvmTest/kotlin/com/sksamuel/kotest/config/PackageConfigTest.kt
@@ -21,7 +21,7 @@ class PackageConfigTest : FunSpec() {
                .withSpecRefs(SpecRef.Reference(BarTest::class))
                .execute()
          }
-         // if the package config isn't picked up, this test won't timeout
+         // if the package config isn't picked up, this test would not timeout
          collector.result("bar")?.errorOrNull?.message shouldBe "Test 'bar' did not complete within 22ms"
       }
    }

--- a/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/DefaultFqnConfigClassTest.kt
+++ b/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/DefaultFqnConfigClassTest.kt
@@ -14,7 +14,7 @@ class DefaultFqnConfigClassTest : FunSpec() {
          invocations.set(0)
          TestEngineLauncher()
             .withListener(NoopTestEngineListener)
-            .withClasses(BarTest::class)
+            .withSpecRefs(SpecRef.Reference(BarTest::class))
             .execute()
          invocations.get() shouldBe 5
       }

--- a/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/DefaultFqnConfigClassTest.kt
+++ b/kotest-tests/kotest-tests-config-project/src/jvmTest/kotlin/com/sksamuel/kotest/config/classname/DefaultFqnConfigClassTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.config.classname
 
 import io.kotest.core.annotation.Description
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.NoopTestEngineListener

--- a/kotest-tests/kotest-tests-timeout-project/src/jvmTest/kotlin/com/sksamuel/kotest/timeout/ProjectTimeoutTest.kt
+++ b/kotest-tests/kotest-tests-timeout-project/src/jvmTest/kotlin/com/sksamuel/kotest/timeout/ProjectTimeoutTest.kt
@@ -25,7 +25,7 @@ class ProjectTimeoutTest : FunSpec({
       // each test takes 5, but 3 tests, so we should easily hit project limit
       val result = TestEngineLauncher()
          .withListener(NoopTestEngineListener)
-         .withClasses(ProjectTimeoutSampleSpec::class)
+         .withSpecRefs(SpecRef.Reference(ProjectTimeoutSampleSpec::class))
          .withProjectConfig(c)
          .execute()
 

--- a/kotest-tests/kotest-tests-timeout-project/src/jvmTest/kotlin/com/sksamuel/kotest/timeout/ProjectTimeoutTest.kt
+++ b/kotest-tests/kotest-tests-timeout-project/src/jvmTest/kotlin/com/sksamuel/kotest/timeout/ProjectTimeoutTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.timeout
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.interceptors.ProjectTimeoutException

--- a/kotest-tests/kotest-tests-timeout-sysprop/src/jvmTest/kotlin/io/kotest/engine/timeout/SystemPropertyTimeoutTest.kt
+++ b/kotest-tests/kotest-tests-timeout-sysprop/src/jvmTest/kotlin/io/kotest/engine/timeout/SystemPropertyTimeoutTest.kt
@@ -2,6 +2,7 @@ package io.kotest.engine.timeout
 
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.config.KotestEngineProperties
 import io.kotest.engine.TestEngineLauncher

--- a/kotest-tests/kotest-tests-timeout-sysprop/src/jvmTest/kotlin/io/kotest/engine/timeout/SystemPropertyTimeoutTest.kt
+++ b/kotest-tests/kotest-tests-timeout-sysprop/src/jvmTest/kotlin/io/kotest/engine/timeout/SystemPropertyTimeoutTest.kt
@@ -19,7 +19,7 @@ class SystemPropertyTimeoutTest : FunSpec() {
             val collector = CollectingTestEngineListener()
             TestEngineLauncher()
                .withListener(collector)
-               .withClasses(TimeoutTest::class)
+               .withSpecRefs(SpecRef.Reference(TimeoutTest::class))
                .execute()
             collector.tests.mapKeys { it.key.name.name }["a"]?.isError shouldBe true
          }
@@ -30,7 +30,7 @@ class SystemPropertyTimeoutTest : FunSpec() {
             val collector = CollectingTestEngineListener()
             TestEngineLauncher()
                .withListener(collector)
-               .withClasses(TimeoutTest::class)
+               .withSpecRefs(SpecRef.Reference(TimeoutTest::class))
                .execute()
             collector.tests.mapKeys { it.key.name.name }["a"]?.isError shouldBe true
          }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
