### PR TITLE
introduce full support for multiline and trimming tests

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
@@ -42,7 +42,7 @@ data class TestName(
     * Returns a flattened name that can be used for a single line ui component
     */
    fun displayName(): String {
-      val flattened = name.trim().replace("\n", "")
+      val flattened = name.trim().replace("\\s+".toRegex(), " ")
       return if (prefix == null) flattened else "$prefix$flattened"
    }
 }
@@ -73,8 +73,8 @@ data class Test(
     * The full path to this test is all parents plus this test
     */
    fun path(): List<TestPathEntry> = when (parent) {
-      null -> listOf(TestPathEntry(name.name))
-      else -> parent.path() + TestPathEntry(name.name)
+      null -> listOf(TestPathEntry(name.displayName()))
+      else -> parent.path() + TestPathEntry(name.displayName())
    }
 
    /**

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
@@ -42,11 +42,12 @@ data class TestName(
     * Returns a flattened name that can be used for a single line ui component
     */
    fun displayName(): String {
-      val flattened = name.trim().replace("\\s+".toRegex(), " ")
+      val flattened = name.flattenTestName()
       return if (prefix == null) flattened else "$prefix$flattened"
    }
 }
 
+private fun String.flattenTestName() = this.trim().replace("\\s+".toRegex(), " ")
 // components for the path, should not include prefixes
 data class TestPathEntry(val name: String)
 
@@ -73,8 +74,8 @@ data class Test(
     * The full path to this test is all parents plus this test
     */
    fun path(): List<TestPathEntry> = when (parent) {
-      null -> listOf(TestPathEntry(name.displayName()))
-      else -> parent.path() + TestPathEntry(name.displayName())
+      null -> listOf(TestPathEntry(name.name.flattenTestName()))
+      else -> parent.path() + TestPathEntry(name.name.flattenTestName())
    }
 
    /**

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/TestNameTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/TestNameTest.kt
@@ -1,0 +1,66 @@
+package io.kotest.plugin.intellij
+
+import io.kotest.matchers.shouldBe
+import junit.framework.TestCase
+
+class TestNameTest : TestCase() {
+
+   fun `test displayName should flatten multiline test name to single line`() {
+      val testName = TestName(null, """
+         this is a test
+         that spans multiple
+         lines
+      """.trimIndent(), interpolated = false)
+
+      testName.displayName() shouldBe "this is a test that spans multiple lines"
+   }
+
+   fun `test displayName should collapse multiple spaces to single space`() {
+      val testName = TestName(null, "this    has     many    spaces", interpolated = false)
+
+      testName.displayName() shouldBe "this has many spaces"
+   }
+
+   fun `test displayName should trim leading and trailing whitespace`() {
+      val testName = TestName(null, "   trimmed name   ", interpolated = false)
+
+      testName.displayName() shouldBe "trimmed name"
+   }
+
+   fun `test displayName should include prefix when provided`() {
+      val testName = TestName("Given: ", "a condition", interpolated = false)
+
+      testName.displayName() shouldBe "Given: a condition"
+   }
+
+   fun `test displayName should handle tabs and newlines`() {
+      val testName = TestName(null, "test\twith\ttabs\nand\nnewlines", interpolated = false)
+
+      testName.displayName() shouldBe "test with tabs and newlines"
+   }
+
+   fun `test displayName should handle empty lines in multiline string`() {
+      val testName = TestName(null, """
+         first line
+
+         third line
+      """.trimIndent(), interpolated = false)
+
+      testName.displayName() shouldBe "first line third line"
+   }
+
+   fun `test displayName with prefix and multiline name`() {
+      val testName = TestName("When: ", """
+         something
+         happens
+      """.trimIndent(), interpolated = false)
+
+      testName.displayName() shouldBe "When: something happens"
+   }
+
+   fun `test displayName should preserve single spaces between words`() {
+      val testName = TestName(null, "normal test name", interpolated = false)
+
+      testName.displayName() shouldBe "normal test name"
+   }
+}

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/TestTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/TestTest.kt
@@ -1,0 +1,93 @@
+package io.kotest.plugin.intellij
+
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+// odd class name, but the data class is called Test :/
+class TestTest : LightJavaCodeInsightFixtureTestCase() {
+
+   private fun createTest(
+      name: String,
+      parent: Test? = null,
+      prefix: String? = null
+   ): Test {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
+      return Test(
+         name = TestName(prefix = prefix, name = name, interpolated = false),
+         parent = parent,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+   }
+
+   fun `test path should flatten multiline test name to single line`() {
+      val test = createTest("""
+         this is a test
+         that spans multiple
+         lines
+      """.trimIndent())
+
+      test.path().map { it.name } shouldBe listOf("this is a test that spans multiple lines")
+   }
+
+   fun `test path should collapse multiple spaces to single space`() {
+      val test = createTest("this    has     many    spaces")
+
+      test.path().map { it.name } shouldBe listOf("this has many spaces")
+   }
+
+   fun `test path should trim leading and trailing whitespace`() {
+      val test = createTest("   trimmed name   ")
+
+      test.path().map { it.name } shouldBe listOf("trimmed name")
+   }
+
+   fun `test path should not include prefix`() {
+      val test = createTest("a condition", prefix = "Given: ")
+
+      test.path().map { it.name } shouldBe listOf("a condition")
+   }
+
+   fun `test path should handle tabs and newlines`() {
+      val test = createTest("test\twith\ttabs\nand\nnewlines")
+
+      test.path().map { it.name } shouldBe listOf("test with tabs and newlines")
+   }
+
+   fun `test path should handle empty lines in multiline string`() {
+      val test = createTest("""
+         first line
+
+         third line
+      """.trimIndent())
+
+      test.path().map { it.name } shouldBe listOf("first line third line")
+   }
+
+   fun `test path should include parent path entries`() {
+      val grandparent = createTest("grandparent test")
+      val parent = createTest("parent test", parent = grandparent)
+      val child = createTest("child test", parent = parent)
+
+      child.path().map { it.name } shouldBe listOf("grandparent test", "parent test", "child test")
+   }
+
+   fun `test path should flatten all entries in nested hierarchy`() {
+      val parent = createTest("""
+         parent
+         multiline
+      """.trimIndent())
+      val child = createTest("""
+         child
+         multiline
+      """.trimIndent(), parent = parent)
+
+      child.path().map { it.name } shouldBe listOf("parent multiline", "child multiline")
+   }
+}


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
With the new `GradleMultiplatformJvmTestTaskRunProducer` we had lost the possibility to run tests whose names
- span over multiple lines
- have extra spaces

this should fix it