### PR TITLE
make sure all children of an interpolated container test are marked as interpolated too

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
@@ -50,8 +50,9 @@ data class TestName(
 // components for the path, should not include prefixes
 data class TestPathEntry(val name: String)
 
-data class Test(
-   val name: TestName, // the name as entered by the user
+@ConsistentCopyVisibility
+data class Test private constructor(
+   val name: TestName, // the name as entered by the user, with interpolated propagated from parent
    val parent: Test?, // can be null if this is a root test
    val specClassName: KtClassOrObject, // the containing class name, which all tests must have
    val testType: TestType,
@@ -59,6 +60,26 @@ data class Test(
    val psi: PsiElement, // the canonical element that identifies this test
    val isDataTest: Boolean = false
 ) {
+   companion object {
+      operator fun invoke(
+         name: TestName,
+         parent: Test?,
+         specClassName: KtClassOrObject,
+         testType: TestType,
+         xdisabled: Boolean,
+         psi: PsiElement,
+         isDataTest: Boolean = false
+      ): Test {
+         // set interpolated to true if parent is interpolated but this name is not
+         // if this name is already interpolated then keep it as is - no need to do an object copy
+         val finalTestName = if (parent?.name?.interpolated == true && !name.interpolated) {
+            name.copy(interpolated = true)
+         } else {
+            name
+         }
+         return Test(finalTestName, parent, specClassName, testType, xdisabled, psi, isDataTest)
+      }
+   }
 
    // true if this test is not xdisabled and not disabled by a bang and not nested inside another disabled test
    val enabled: Boolean = !xdisabled && !name.bang && (parent == null || parent.enabled)

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/linemarker/InterpolatedTestLineMarker.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/linemarker/InterpolatedTestLineMarker.kt
@@ -26,7 +26,7 @@ import io.kotest.plugin.intellij.Test
 class InterpolatedTestLineMarker : LineMarkerProvider {
 
    private val thisTestIsInterpolatedText = "Tests with an interpolated name cannot be run using the plugin."
-   private val parentOfTestIsInterpolatedText = "Tests contained within other that have an interpolated name cannot be run using the plugin."
+   private val parentOfTestIsInterpolatedText = "Tests contained within other tests that have an interpolated name cannot be run using the plugin."
 
    // icons list https://jetbrains.design/intellij/resources/icons_list/
    private val icon = AllIcons.RunConfigurations.TestUnknown

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/TestTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/TestTest.kt
@@ -11,12 +11,13 @@ class TestTest : LightJavaCodeInsightFixtureTestCase() {
    private fun createTest(
       name: String,
       parent: Test? = null,
-      prefix: String? = null
+      prefix: String? = null,
+      testNameInterpolated : Boolean = false
    ): Test {
       val factory = KtPsiFactory(project)
       val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
       return Test(
-         name = TestName(prefix = prefix, name = name, interpolated = false),
+         name = TestName(prefix = prefix, name = name, interpolated = testNameInterpolated),
          parent = parent,
          specClassName = spec,
          testType = TestType.Test,
@@ -89,5 +90,19 @@ class TestTest : LightJavaCodeInsightFixtureTestCase() {
       """.trimIndent(), parent = parent)
 
       child.path().map { it.name } shouldBe listOf("parent multiline", "child multiline")
+   }
+
+   fun `test Test constructor should override interpolated for any child of a parent that has interpolated set to true`() {
+      val grandParentNotInterpolated = createTest("grandParentNotInterpolated", parent = null, testNameInterpolated = false)
+      val parent1NotInterpolated = createTest("parent1NotInterpolated", parent = grandParentNotInterpolated, testNameInterpolated = false)
+      val parent2Interpolated = createTest("parentt2Interpolated", parent = grandParentNotInterpolated, testNameInterpolated = true)
+      val childOfParent1 = createTest("child", parent = parent1NotInterpolated, testNameInterpolated = false)
+      val childOfParent2 = createTest("child", parent = parent2Interpolated, testNameInterpolated = false)
+
+      grandParentNotInterpolated.name.interpolated shouldBe false
+      parent1NotInterpolated.name.interpolated shouldBe false
+      parent2Interpolated.name.interpolated shouldBe true
+      childOfParent1.name.interpolated shouldBe false
+      childOfParent2.name.interpolated shouldBe true
    }
 }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
For Issue #5605
This ensures that if a container test name is considered interpolated, all its children are considered as such too (with different tooltips accordingly)

