### PR TITLE
Update IntelliJ properties documentation to reflect Gradle runner (#5599)

### DIFF
--- a/documentation/docs/intellij/props.md
+++ b/documentation/docs/intellij/props.md
@@ -6,16 +6,16 @@ slug: intellij-properties.html
 
 
 
-When running tests via the intellij runner, properties set using `gradle.properties` or in a gradle build file won't be
-picked up because the runner is not set to use Gradle.
+The IntelliJ plugin now runs tests via Gradle, which means properties defined in `gradle.properties` or Gradle build files
+are automatically available.
 
-To support runtime system properties, the Kotest framework will always look for key value pairs inside
+Additionally, the Kotest framework will always look for key-value pairs inside
 a `kotest.properties` file located on the classpath (eg, in src/main/resources).
 
 Any key value pairs located in this file will be set as a system property before any tests execute.
 
 :::tip
-Any properties specified in the `kotest.properties` file work for both command line via Gradle, and tests executed via the Intellij plugin.
+The `kotest.properties` file provides a portable way to configure Kotest consistently across the command line, Gradle, and the IntelliJ plugin.
 :::
 
 For example, after adding this file to your classpath as `kotest.properties`:
@@ -31,7 +31,7 @@ class FooTest : DescribeSpec() {
   init {
     describe("after adding kotest.properties") {
       it("foo should be set") {
-         System.getProperty("foo") shouldBe "bar"
+        System.getProperty("foo") shouldBe "bar"
       }
     }
   }
@@ -42,7 +42,7 @@ class FooTest : DescribeSpec() {
 ### Common use case
 
 It is common to disable the classpath scanning capabilities of Kotest to save some startup time, if those features are not used.
-To do this place, the following lines into the `kotest.properties` file:
+Add the following lines to the `kotest.properties` file:
 
 ```
 kotest.framework.classpath.scanning.config.disable=true
@@ -54,5 +54,5 @@ kotest.framework.classpath.scanning.autoscan.disable=true
 If you don't wish to name the file `kotest.properties`, or perhaps you want to support different files based on an environment,
 then you can use the system property `kotest.properties.filename` to set the properties filename.
 
-For example, you could launch tests with `kotest.properties.filename=cluster.prd.properties` then the key value file named
+For example, you could launch tests with `kotest.properties.filename=cluster.prd.properties` then the key-value file named
 `cluster.prd.properties` would be loaded before any tests are executed.

--- a/documentation/docs/intellij/props.md
+++ b/documentation/docs/intellij/props.md
@@ -6,7 +6,7 @@ slug: intellij-properties.html
 
 
 
-The IntelliJ plugin now runs tests via Gradle, which means properties defined in `gradle.properties` or Gradle build files
+The IntelliJ plugin runs tests via Gradle, which means properties defined in `gradle.properties` or Gradle build files
 are automatically available.
 
 Additionally, the Kotest framework will always look for key-value pairs inside

--- a/documentation/versioned_docs/version-6.1/intellij/props.md
+++ b/documentation/versioned_docs/version-6.1/intellij/props.md
@@ -6,16 +6,16 @@ slug: intellij-properties.html
 
 
 
-When running tests via the intellij runner, properties set using `gradle.properties` or in a gradle build file won't be
-picked up because the runner is not set to use Gradle.
+The IntelliJ plugin now runs tests via Gradle, which means properties defined in `gradle.properties` or Gradle build files
+are automatically available.
 
-To support runtime system properties, the Kotest framework will always look for key value pairs inside
+Additionally, the Kotest framework will always look for key-value pairs inside
 a `kotest.properties` file located on the classpath (eg, in src/main/resources).
 
 Any key value pairs located in this file will be set as a system property before any tests execute.
 
 :::tip
-Any properties specified in the `kotest.properties` file work for both command line via Gradle, and tests executed via the Intellij plugin.
+The `kotest.properties` file provides a portable way to configure Kotest consistently across the command line, Gradle, and the IntelliJ plugin.
 :::
 
 For example, after adding this file to your classpath as `kotest.properties`:
@@ -31,7 +31,7 @@ class FooTest : DescribeSpec() {
   init {
     describe("after adding kotest.properties") {
       it("foo should be set") {
-         System.getProperty("foo") shouldBe "bar"
+        System.getProperty("foo") shouldBe "bar"
       }
     }
   }
@@ -42,7 +42,7 @@ class FooTest : DescribeSpec() {
 ### Common use case
 
 It is common to disable the classpath scanning capabilities of Kotest to save some startup time, if those features are not used.
-To do this place, the following lines into the `kotest.properties` file:
+Add the following lines to the `kotest.properties` file:
 
 ```
 kotest.framework.classpath.scanning.config.disable=true
@@ -54,5 +54,5 @@ kotest.framework.classpath.scanning.autoscan.disable=true
 If you don't wish to name the file `kotest.properties`, or perhaps you want to support different files based on an environment,
 then you can use the system property `kotest.properties.filename` to set the properties filename.
 
-For example, you could launch tests with `kotest.properties.filename=cluster.prd.properties` then the key value file named
+For example, you could launch tests with `kotest.properties.filename=cluster.prd.properties` then the key-value file named
 `cluster.prd.properties` would be loaded before any tests are executed.

--- a/documentation/versioned_docs/version-6.1/intellij/props.md
+++ b/documentation/versioned_docs/version-6.1/intellij/props.md
@@ -6,7 +6,7 @@ slug: intellij-properties.html
 
 
 
-The IntelliJ plugin now runs tests via Gradle, which means properties defined in `gradle.properties` or Gradle build files
+The IntelliJ plugin runs tests via Gradle, which means properties defined in `gradle.properties` or Gradle build files
 are automatically available.
 
 Additionally, the Kotest framework will always look for key-value pairs inside


### PR DESCRIPTION
## Description

Updates the IntelliJ properties documentation to reflect that the plugin now runs tests via Gradle
(since Kotest 6.1.0).

## Related Issue

Fixes #5599

## Problem

The documentation at docs/intellij/props.md was outdated:
- Stated that gradle.properties won't be picked up when using the IntelliJ runner
- This was true before Kotest 6.1.0, but is no longer accurate

## Solution

As of Kotest 6.1.0 (#5321, #5165, #5565), the IntelliJ plugin internally runs tests via Gradle, which means:
- Properties from gradle.properties and Gradle build files are **automatically available**
- The kotest.properties file remains useful as a portable configuration method

## Changes

- Updated outdated statement about properties not being picked up
- Clarified that gradle.properties are now automatically available
- Improved tip section for better clarity and consistency
- Fixed grammar: "To do this place" → "Add"
- Standardized terminology: "key value" → "key-value"
- Fixed code indentation for better readability

## Testing

- [x] Documentation builds successfully
- [x] Content is accurate and reflects current behavior (6.1.0+)
- [x] Follows existing documentation style

## Preview

**Before**:
<img width="3538" height="2134" alt="before" src="https://github.com/user-attachments/assets/8b767656-34c5-454d-9590-857bb94afe40" />

**After**:
<img width="3548" height="2131" alt="after" src="https://github.com/user-attachments/assets/271842cc-6b0f-4ee4-b20b-3191fda71bf2" />

## Additional Context

Related commits that changed the IntelliJ plugin behavior:
- #5165
- #5321
- #5565