### PR TITLE
Add option to the gradle plugin to always rerun tests

### DIFF
--- a/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
+++ b/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
@@ -1,7 +1,9 @@
 public class io/kotest/framework/gradle/KotestGradleExtension {
 	public fun <init> ()V
+	public final fun getAlwaysRerunTests ()Z
 	public final fun getCustomGradleTask ()Z
 	public final fun getShowIgnoreReasons ()Z
+	public final fun setAlwaysRerunTests (Z)V
 	public final fun setCustomGradleTask (Z)V
 	public final fun setShowIgnoreReasons (Z)V
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestGradleExtension.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestGradleExtension.kt
@@ -1,5 +1,7 @@
 package io.kotest.framework.gradle
 
+import io.kotest.common.ExperimentalKotest
+
 open class KotestGradleExtension {
 
    /**
@@ -8,7 +10,10 @@ open class KotestGradleExtension {
    var customGradleTask = false
 
    /**
-    * Set to true and the Kotest engine will propagate ignore reasons to Gradle.
+    * Set to true, and the Kotest engine will propagate ignore reasons to Gradle.
     */
    var showIgnoreReasons = false
+
+   @ExperimentalKotest
+   var alwaysRerunTests = false
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -1,5 +1,6 @@
 package io.kotest.framework.gradle
 
+import io.kotest.common.ExperimentalKotest
 import io.kotest.framework.gradle.TestLauncherArgsJavaExecConfiguration.Companion.LAUNCHER_MAIN_CLASS
 import io.kotest.framework.gradle.tasks.KotestAndroidTask
 import io.kotest.framework.gradle.tasks.KotestAndroidTask.Companion.ARTIFACT_TYPE
@@ -69,6 +70,7 @@ abstract class KotestPlugin : Plugin<Project> {
 
    private val version = System.getenv("KOTEST_DEV_KSP_VERSION") ?: version()
 
+   @OptIn(ExperimentalKotest::class)
    override fun apply(project: Project) {
 
       val extension = project.extensions.create(GRADLE_EXTENSION_NAME, KotestGradleExtension::class.java)
@@ -83,6 +85,10 @@ abstract class KotestPlugin : Plugin<Project> {
          handleKotlinJvm(project)
       }
 
+      if (extension.alwaysRerunTests) {
+         configureAlwaysRerun(project)
+      }
+
       // configure Kotlin Android projects when it is not a multiplatform project
       handleAndroid(project, extension)
 
@@ -91,6 +97,12 @@ abstract class KotestPlugin : Plugin<Project> {
 
       project.gradle.taskGraph.whenReady {
          decorateGradleTestTask(project, extension)
+      }
+   }
+
+   private fun configureAlwaysRerun(project: Project) {
+      project.tasks.withType(AbstractTestTask::class.java).configureEach {
+         outputs.upToDateWhen { false }
       }
    }
 

--- a/kotest-runner/kotest-runner-junit4/src/androidMain/kotlin/io/kotest/runner/junit4/InstrumentationFilter.kt
+++ b/kotest-runner/kotest-runner-junit4/src/androidMain/kotlin/io/kotest/runner/junit4/InstrumentationFilter.kt
@@ -9,7 +9,7 @@ const val INSTRUMENTATION_INCLUDE_PATTERN_ARG = "INSTRUMENTATION_INCLUDE_PATTERN
 
 /**
  * An implementation of [TestPatternIncludeDescriptorFilter] that fetches its filter pattern
- * from Instrumentation arguments
+ * from [InstrumentationRegistry] arguments
  *
  * Android docs:
  * You can pass custom parameters (e.g., -e server_url https://api.test.com) and retrieve them within your test


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
