### PR TITLE
SpringExtension now supports test class inheritance

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionInheritanceTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionInheritanceTest.kt
@@ -1,0 +1,30 @@
+package io.kotest.extensions.spring
+
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ContextConfiguration
+
+/**
+ * Tests that @ApplyExtension on a base spec class is inherited by subclasses.
+ * This addresses the issue where SpringExtension needs to be available for constructor injection.
+ */
+@SpringBootTest
+@ContextConfiguration(classes = [Components::class])
+@ApplyExtension(SpringExtension::class)
+open class BaseSpringSpec : DescribeSpec()
+
+class SpringExtensionInheritanceTest(
+   @Autowired private val service: UserService
+) : BaseSpringSpec() {
+
+   init {
+      describe("SpringExtension inheritance") {
+         it("should autowire constructor parameters from base class annotation") {
+            service.repository.findUser().name shouldBe "system_user"
+         }
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/SpecRefExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/SpecRefExecutor.kt
@@ -2,6 +2,8 @@ package io.kotest.engine.spec.execution
 
 import io.kotest.common.KotestTesting
 import io.kotest.common.platform
+import io.kotest.common.reflection.IncludingSuperclasses
+import io.kotest.common.reflection.IncludingAnnotations
 import io.kotest.common.reflection.annotation
 import io.kotest.common.reflection.bestName
 import io.kotest.common.reflection.instantiations
@@ -78,7 +80,7 @@ internal class SpecRefExecutor(
    private suspend fun applyExtensions(ref: SpecRef) {
       try {
 
-         val classes = ref.kclass.annotation<ApplyExtension>()?.extensions?.toList() ?: emptyList()
+         val classes = ref.kclass.annotation<ApplyExtension>(IncludingAnnotations, IncludingSuperclasses)?.extensions?.toList() ?: emptyList()
          val extensions = classes.map { instantiations.newInstanceNoArgConstructorOrObjectInstance(it) }
          logger.log { Pair(ref.kclass.bestName(), "Applying extensions: $extensions") }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
# Context
https://github.com/kotest/kotest/issues/5666

# Changes
- `applyExtensions` now searches for both annotations and superclasses
- Added small Spring test to test for `SpringExtension` being applied to the superclass