### PR TITLE
ensure alwaysRerunTests is evaluated before deciding if to apply

### DIFF
--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -87,7 +87,8 @@ abstract class KotestPlugin : Plugin<Project> {
          handleKotlinJvm(project)
       }
 
-      configureAlwaysRerun(project, extension)
+      // configure test tasks to always rerun when the extension property is set, this overrides gradle up-to-date checks
+      configureAlwaysRerunTestTasks(project, extension)
 
       // configure Kotlin Android projects when it is not a multiplatform project
       handleAndroid(project, extension)
@@ -130,7 +131,7 @@ abstract class KotestPlugin : Plugin<Project> {
    }
 
    @OptIn(ExperimentalKotest::class)
-   private fun configureAlwaysRerun(project: Project, extension: KotestGradleExtension) {
+   private fun configureAlwaysRerunTestTasks(project: Project, extension: KotestGradleExtension) {
       project.afterEvaluate {
          if (extension.alwaysRerunTests) {
             project.tasks.withType(AbstractTestTask::class.java).configureEach {

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -87,9 +87,7 @@ abstract class KotestPlugin : Plugin<Project> {
          handleKotlinJvm(project)
       }
 
-      if (extension.alwaysRerunTests) {
-         configureAlwaysRerun(project)
-      }
+      configureAlwaysRerun(project, extension)
 
       // configure Kotlin Android projects when it is not a multiplatform project
       handleAndroid(project, extension)
@@ -131,9 +129,14 @@ abstract class KotestPlugin : Plugin<Project> {
       }
    }
 
-   private fun configureAlwaysRerun(project: Project) {
-      project.tasks.withType(AbstractTestTask::class.java).configureEach {
-         outputs.upToDateWhen { false }
+   @OptIn(ExperimentalKotest::class)
+   private fun configureAlwaysRerun(project: Project, extension: KotestGradleExtension) {
+      project.afterEvaluate {
+         if (extension.alwaysRerunTests) {
+            project.tasks.withType(AbstractTestTask::class.java).configureEach {
+               outputs.upToDateWhen { false }
+            }
+         }
       }
    }
 


### PR DESCRIPTION
The new `alwaysRerunTests` property was not being read during the apply - this solution works, and I suspect we'll have to do the same for `powerAssert` 