### PR TITLE
Fix multiple --tests arguments not finding any tests

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/CombinedGradleDescriptorFilter.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/CombinedGradleDescriptorFilter.kt
@@ -1,0 +1,26 @@
+package io.kotest.runner.junit.platform.gradle
+
+import io.kotest.core.descriptors.Descriptor
+import io.kotest.engine.extensions.filter.DescriptorFilter
+import io.kotest.engine.extensions.filter.DescriptorFilterResult
+
+/**
+ * A [DescriptorFilter] that combines both regex-based and nested-test-based filters with OR logic.
+ *
+ * This is used when multiple `--tests` arguments contain a mix of simple patterns and nested test patterns.
+ * A descriptor is included if it matches ANY of the regex patterns OR ANY of the nested test args.
+ */
+internal class CombinedGradleDescriptorFilter(
+   regexPatterns: Set<String>,
+   nestedArgs: Set<NestedTestArg>,
+) : DescriptorFilter {
+
+   private val regexFilter = GradleClassMethodRegexTestFilter(regexPatterns)
+   private val nestedFilter = NestedTestsArgDescriptorFilter(nestedArgs)
+
+   override fun filter(descriptor: Descriptor): DescriptorFilterResult {
+      if (regexFilter.filter(descriptor) is DescriptorFilterResult.Include) return DescriptorFilterResult.Include
+      if (nestedFilter.filter(descriptor) is DescriptorFilterResult.Include) return DescriptorFilterResult.Include
+      return DescriptorFilterResult.Exclude(null)
+   }
+}

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterAdapterTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterAdapterTest.kt
@@ -1,0 +1,86 @@
+package io.kotest.runner.junit.platform.gradle
+
+import io.kotest.core.descriptors.Descriptor
+import io.kotest.core.descriptors.DescriptorId
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.extensions.filter.DescriptorFilterResult
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests that multiple --tests filters are correctly combined with OR logic.
+ *
+ * When Gradle receives multiple --tests arguments (e.g., --tests TestA --tests TestB),
+ * each becomes a separate pattern. All patterns must be combined with OR logic so that
+ * a test is included if it matches ANY pattern.
+ *
+ * Regression test for https://github.com/kotest/kotest/issues/5678
+ */
+class ClassMethodNameFilterAdapterTest : FunSpec({
+
+   context("multiple regex patterns should use OR logic") {
+
+      test("spec matching any of the patterns should be INCLUDED") {
+         val specA = Descriptor.SpecDescriptor(DescriptorId("com.example.TestA"))
+         val specB = Descriptor.SpecDescriptor(DescriptorId("com.example.TestB"))
+
+         // Simulate two --tests patterns combined into a single filter
+         val filter = GradleClassMethodRegexTestFilter(
+            setOf("\\Qcom.example.TestA\\E", "\\Qcom.example.TestB\\E")
+         )
+
+         filter.filter(specA) shouldBe DescriptorFilterResult.Include
+         filter.filter(specB) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("spec matching none of the patterns should be EXCLUDED") {
+         val specC = Descriptor.SpecDescriptor(DescriptorId("com.example.TestC"))
+
+         val filter = GradleClassMethodRegexTestFilter(
+            setOf("\\Qcom.example.TestA\\E", "\\Qcom.example.TestB\\E")
+         )
+
+         filter.filter(specC) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+   }
+
+   context("CombinedGradleDescriptorFilter should use OR logic across both filter types") {
+
+      test("spec matching regex pattern should be INCLUDED even when nested filter does not match") {
+         val spec = Descriptor.SpecDescriptor(DescriptorId("com.example.TestA"))
+         val nestedArg = NestedTestArg("com.example", "TestB", listOf("context", "nested"))
+
+         val filter = CombinedGradleDescriptorFilter(
+            regexPatterns = setOf("\\Qcom.example.TestA\\E"),
+            nestedArgs = setOf(nestedArg),
+         )
+
+         filter.filter(spec) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("nested test matching nested arg should be INCLUDED even when regex filter does not match") {
+         val spec = Descriptor.SpecDescriptor(DescriptorId("com.example.TestB"))
+         val context = spec.append("context")
+         val nested = context.append("nested")
+         val nestedArg = NestedTestArg("com.example", "TestB", listOf("context", "nested"))
+
+         val filter = CombinedGradleDescriptorFilter(
+            regexPatterns = setOf("\\Qcom.example.TestA\\E"),
+            nestedArgs = setOf(nestedArg),
+         )
+
+         filter.filter(nested) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("descriptor matching neither type should be EXCLUDED") {
+         val spec = Descriptor.SpecDescriptor(DescriptorId("com.example.TestC"))
+         val nestedArg = NestedTestArg("com.example", "TestB", listOf("context", "nested"))
+
+         val filter = CombinedGradleDescriptorFilter(
+            regexPatterns = setOf("\\Qcom.example.TestA\\E"),
+            nestedArgs = setOf(nestedArg),
+         )
+
+         filter.filter(spec) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+   }
+})


### PR DESCRIPTION
## Summary

Fixes #5678

- `ClassMethodNameFilterAdapter.adapt()` was creating a separate `DescriptorFilter` for each extracted `--tests` pattern
- Since the engine applies `DescriptorFilter`s with AND semantics, using multiple `--tests` arguments (e.g., `--tests TestA --tests TestB`) caused no tests to be found because each test had to match ALL patterns simultaneously
- Group all patterns into a single filter per type (regex-based and nested-test-based) so they are combined with OR logic within the filter
- When both types are present, use a `CombinedGradleDescriptorFilter` that applies OR across both filter types

## Test plan

- [x] Added `ClassMethodNameFilterAdapterTest` verifying OR logic for multiple regex patterns
- [x] Added tests for `CombinedGradleDescriptorFilter` verifying OR logic across mixed filter types
- [x] All existing `GradleClassMethodRegexTestFilterTest`, `NestedTestsArgParserTest`, and `NestedTestsArgDescriptorFilterTest` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)