### PR TITLE
support for config on all methods and data test changes for all specs

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1823,15 +1823,18 @@ public abstract class io/kotest/core/spec/style/BehaviorSpec : io/kotest/core/sp
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun Context (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun Context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun Context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public final fun Given (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun Given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun Given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public final fun When (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun addContext (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun addContext (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public final fun context (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun fgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
@@ -1839,9 +1842,11 @@ public abstract class io/kotest/core/spec/style/BehaviorSpec : io/kotest/core/sp
 	public fun given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public final fun when (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun xContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xContext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -1853,20 +1858,25 @@ public final class io/kotest/core/spec/style/BehaviorSpecKt {
 
 public final class io/kotest/core/spec/style/BehaviorSpecTestFactoryConfiguration : io/kotest/core/factory/TestFactoryConfiguration, io/kotest/core/spec/style/scopes/BehaviorSpecRootScope {
 	public fun <init> ()V
+	public fun Context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun Context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun Given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun Given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun addContext (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun addContext (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
+	public fun context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun fgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xContext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -1884,12 +1894,15 @@ public abstract class io/kotest/core/spec/style/DescribeSpec : io/kotest/core/sp
 	public fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fdescribe (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun fdescribe (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fit (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun fit (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun it (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun it (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xdescribe (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xdescribe (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xit (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun xit (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
@@ -1907,12 +1920,15 @@ public final class io/kotest/core/spec/style/DescribeSpecTestFactoryConfiguratio
 	public fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fdescribe (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun fdescribe (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fit (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun fit (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun it (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun it (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xdescribe (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xdescribe (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xit (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun xit (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
@@ -2149,22 +2165,34 @@ public final class io/kotest/core/spec/style/WordSpecTestFactoryConfiguration : 
 
 public final class io/kotest/core/spec/style/scopes/BehaviorSpecContextContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
+	public final fun Context (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun Given (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun Given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun context (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fGiven (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fgiven (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
+	public final fun given (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xContext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xGiven (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xcontext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xgiven (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
+	public final fun And (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun And (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun Then (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun Then (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun When (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun When (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun and (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun and (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fWhen (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fwhen (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2173,11 +2201,13 @@ public final class io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerSc
 	public final fun then (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun when (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun when (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xAnd (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xAnd (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xThen (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun xThen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xWhen (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xand (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xand (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xthen (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun xthen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2186,40 +2216,50 @@ public final class io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerSc
 }
 
 public abstract interface class io/kotest/core/spec/style/scopes/BehaviorSpecRootScope : io/kotest/core/spec/style/scopes/RootScope {
+	public fun Context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun Context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun Given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun Given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun addContext (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun addContext (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
+	public fun context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun fgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xContext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/kotest/core/spec/style/scopes/BehaviorSpecRootScope$DefaultImpls {
+	public static fun Context (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun Context (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun Given (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun Given (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun addContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun addContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public static fun addGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun addGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
+	public static fun context (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun context (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun fGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun fgiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun given (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun given (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun xContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun xContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun xGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun xGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun xcontext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun xcontext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun xgiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun xgiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -2227,20 +2267,26 @@ public final class io/kotest/core/spec/style/scopes/BehaviorSpecRootScope$Defaul
 
 public final class io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
+	public final fun And (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun And (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun Then (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun Then (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun and (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun and (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fAnd (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fAnd (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fThen (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
+	public final fun fand (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fand (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fthen (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
 	public final fun then (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun then (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xAnd (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xAnd (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xThen (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun xThen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xand (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xand (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xthen (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;
 	public final fun xthen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2315,12 +2361,15 @@ public abstract interface class io/kotest/core/spec/style/scopes/DescribeSpecRoo
 	public fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fdescribe (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun fdescribe (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fit (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun fit (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun it (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun it (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xdescribe (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun xdescribe (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xit (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public fun xit (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
@@ -2333,24 +2382,30 @@ public final class io/kotest/core/spec/style/scopes/DescribeSpecRootScope$Defaul
 	public static fun fcontext (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun fdescribe (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun fdescribe (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun fit (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public static fun fit (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun it (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public static fun it (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun xcontext (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun xcontext (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun xdescribe (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun xdescribe (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun xit (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;
 	public static fun xit (Lio/kotest/core/spec/style/scopes/DescribeSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/kotest/core/spec/style/scopes/ExpectSpecContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
+	public final fun context (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun expect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fcontext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fexpect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fexpect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
+	public final fun xcontext (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xexpect (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xexpect (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2388,12 +2443,15 @@ public final class io/kotest/core/spec/style/scopes/ExpectSpecRootScope$DefaultI
 
 public final class io/kotest/core/spec/style/scopes/FeatureSpecContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
+	public final fun feature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun feature (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun ffeature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ffeature (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fscenario (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
 	public final fun scenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun scenario (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xfeature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xfeature (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xfscenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xscenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2426,6 +2484,7 @@ public final class io/kotest/core/spec/style/scopes/FreeSpecContainerScope : io/
 	public final fun config-KvdBJpM (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public static synthetic fun config-KvdBJpM$default (Lio/kotest/core/spec/style/scopes/FreeSpecContainerScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
+	public final fun invoke (Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun minus (Lio/kotest/core/spec/style/scopes/FreeSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun minus (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2553,6 +2612,7 @@ public final class io/kotest/core/spec/style/scopes/RootScopeKt {
 
 public final class io/kotest/core/spec/style/scopes/RootTestWithConfigBuilder {
 	public fun <init> (Lio/kotest/core/spec/style/scopes/RootScope;Lio/kotest/core/names/TestName;Lio/kotest/core/spec/style/TestXMethod;)V
+	public final fun config (Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 	public final fun config-n4j-3yA (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun config-n4j-3yA$default (Lio/kotest/core/spec/style/scopes/RootTestWithConfigBuilder;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -2135,14 +2135,25 @@ public abstract class io/kotest/core/spec/style/WordSpec : io/kotest/core/spec/D
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun When (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun When (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun config-s0vPEsQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun fWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun should (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun should (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun when (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun when (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
@@ -2152,14 +2163,25 @@ public final class io/kotest/core/spec/style/WordSpecKt {
 
 public final class io/kotest/core/spec/style/WordSpecTestFactoryConfiguration : io/kotest/core/factory/TestFactoryConfiguration, io/kotest/core/spec/style/scopes/WordSpecRootScope {
 	public fun <init> ()V
+	public fun When (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun When (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun config-s0vPEsQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun fWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun should (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun should (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun when (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun when (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
@@ -2702,27 +2724,64 @@ public final class io/kotest/core/spec/style/scopes/TestWithConfigBuilder {
 	public static synthetic fun config-ZKvTVp0$default (Lio/kotest/core/spec/style/scopes/TestWithConfigBuilder;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class io/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder {
+	public fun <init> (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/kotest/core/test/config/TestConfig;
+	public final fun copy (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public static synthetic fun copy$default (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;ILjava/lang/Object;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfig ()Lio/kotest/core/test/config/TestConfig;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class io/kotest/core/spec/style/scopes/WordSpecRootScope : io/kotest/core/spec/style/scopes/RootScope {
+	public fun When (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun When (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun config-s0vPEsQ (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public static synthetic fun config-s0vPEsQ$default (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public fun fWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun fwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun should (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun should (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun when (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun when (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun xwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public fun xwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/kotest/core/spec/style/scopes/WordSpecRootScope$DefaultImpls {
+	public static fun When (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun When (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun config (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public static fun config-s0vPEsQ (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public static synthetic fun config-s0vPEsQ$default (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public static fun fWhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun fWhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun fshould (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun fshould (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun fwhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun fwhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun should (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun should (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun when (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun when (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun xWhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun xWhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun xshould (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun xshould (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun xwhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;)V
 	public static fun xwhen (Lio/kotest/core/spec/style/scopes/WordSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
@@ -2745,15 +2804,27 @@ public final class io/kotest/core/spec/style/scopes/WordSpecTerminalScope : io/k
 public final class io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope : io/kotest/core/spec/style/scopes/AbstractContainerScope {
 	public fun <init> (Lio/kotest/core/test/TestScope;)V
 	public final fun Should (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun When (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun When (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;)Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;
+	public final fun config-0Nu1UfI (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun config-0Nu1UfI$default (Lio/kotest/core/spec/style/scopes/WordSpecWhenContainerScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun fWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
+	public final fun should (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun should (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun when (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun when (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xWhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xWhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xshould (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xshould (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun xwhen (Lio/kotest/core/spec/style/scopes/WordSpecContextConfigBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xwhen (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecContextContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecContextContainerScope.kt
@@ -43,6 +43,35 @@ class BehaviorSpecContextContainerScope(
       }
    }
 
+   suspend fun Given(name: String) =
+      addGiven(name, xmethod = TestXMethod.NONE)
+
+   suspend fun given(name: String) =
+      addGiven(name, xmethod = TestXMethod.NONE)
+
+   suspend fun fgiven(name: String) =
+      addGiven(name, xmethod = TestXMethod.FOCUSED)
+
+   suspend fun fGiven(name: String) =
+      addGiven(name, xmethod = TestXMethod.FOCUSED)
+
+   suspend fun xgiven(name: String) =
+      addGiven(name, xmethod = TestXMethod.DISABLED)
+
+   suspend fun xGiven(name: String) =
+      addGiven(name, xmethod = TestXMethod.DISABLED)
+
+   private suspend fun addGiven(
+      name: String,
+      xmethod: TestXMethod
+   ): ContainerWithConfigBuilder<BehaviorSpecGivenContainerScope> {
+      return ContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("Given: ").withDefaultAffixes().build(),
+         context = this,
+         xmethod = xmethod
+      ) { BehaviorSpecGivenContainerScope(it) }
+   }
+
    internal suspend fun context(
       name: String,
       xmethod: TestXMethod,
@@ -55,5 +84,29 @@ class BehaviorSpecContextContainerScope(
       ) {
          BehaviorSpecContextContainerScope(this).test()
       }
+   }
+
+   @Suppress("FunctionName")
+   suspend fun Context(name: String) =
+      addContext(name = name, xmethod = TestXMethod.NONE)
+
+   suspend fun context(name: String) =
+      addContext(name = name, xmethod = TestXMethod.NONE)
+
+   suspend fun xcontext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.DISABLED)
+
+   suspend fun xContext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.DISABLED)
+
+   private suspend fun addContext(
+      name: String,
+      xmethod: TestXMethod
+   ): ContainerWithConfigBuilder<BehaviorSpecContextContainerScope> {
+      return ContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("Context: ").withDefaultAffixes().build(),
+         context = this,
+         xmethod = xmethod
+      ) { BehaviorSpecContextContainerScope(it) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecGivenContainerScope.kt
@@ -56,6 +56,29 @@ class BehaviorSpecGivenContainerScope(
       }
    }
 
+   suspend fun And(name: String) =
+      addAnd(name, xmethod = TestXMethod.NONE)
+
+   suspend fun and(name: String) =
+      addAnd(name, xmethod = TestXMethod.NONE)
+
+   suspend fun xand(name: String) =
+      addAnd(name, xmethod = TestXMethod.DISABLED)
+
+   suspend fun xAnd(name: String) =
+      addAnd(name, xmethod = TestXMethod.DISABLED)
+
+   private suspend fun addAnd(
+      name: String,
+      xmethod: TestXMethod
+   ): ContainerWithConfigBuilder<BehaviorSpecGivenContainerScope> {
+      return ContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("And: ").withDefaultAffixes().build(),
+         context = this,
+         xmethod = xmethod
+      ) { BehaviorSpecGivenContainerScope(it) }
+   }
+
    suspend fun When(name: String, test: suspend BehaviorSpecWhenContainerScope.() -> Unit) =
       addWhen(name, test, xmethod = TestXMethod.NONE)
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
@@ -97,7 +97,7 @@ interface BehaviorSpecRootScope : RootScope {
 
    fun addGiven(name: String, xmethod: TestXMethod): RootContainerWithConfigBuilder<BehaviorSpecGivenContainerScope> {
       return RootContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).withPrefix("Then: ").withDefaultAffixes().build(),
+         name = TestNameBuilder.builder(name).withPrefix("Given: ").withDefaultAffixes().build(),
          context = this@BehaviorSpecRootScope,
          xmethod = xmethod,
       ) { BehaviorSpecGivenContainerScope(it) }
@@ -134,5 +134,38 @@ interface BehaviorSpecRootScope : RootScope {
          xmethod = xmethod,
          config = null
       ) { BehaviorSpecContextContainerScope(this).test() }
+   }
+
+   /**
+    * Adds a top level [BehaviorSpecContextContainerScope] to this spec.
+    */
+   @Suppress("FunctionName")
+   fun Context(name: String) =
+      addContext(name = name, xmethod = TestXMethod.NONE)
+
+   /**
+    * Adds a top level [BehaviorSpecContextContainerScope] to this spec.
+    */
+   fun context(name: String) =
+      addContext(name = name, xmethod = TestXMethod.NONE)
+
+   /**
+    * Adds a top level disabled [BehaviorSpecContextContainerScope] to this spec.
+    */
+   fun xcontext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.DISABLED)
+
+   /**
+    * Adds a top level disabled [BehaviorSpecContextContainerScope] to this spec.
+    */
+   fun xContext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.DISABLED)
+
+   fun addContext(name: String, xmethod: TestXMethod): RootContainerWithConfigBuilder<BehaviorSpecContextContainerScope> {
+      return RootContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("Context: ").withDefaultAffixes().build(),
+         context = this@BehaviorSpecRootScope,
+         xmethod = xmethod,
+      ) { BehaviorSpecContextContainerScope(it) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecWhenContainerScope.kt
@@ -57,6 +57,36 @@ class BehaviorSpecWhenContainerScope(val testScope: TestScope) :
       }
    }
 
+   suspend fun And(name: String) =
+      addAnd(name, xmethod = TestXMethod.NONE)
+
+   suspend fun and(name: String) =
+      addAnd(name, xmethod = TestXMethod.NONE)
+
+   suspend fun fand(name: String) =
+      addAnd(name, xmethod = TestXMethod.FOCUSED)
+
+   suspend fun fAnd(name: String) =
+      addAnd(name, xmethod = TestXMethod.FOCUSED)
+
+   suspend fun xand(name: String) =
+      addAnd(name, xmethod = TestXMethod.DISABLED)
+
+   suspend fun xAnd(name: String) =
+      addAnd(name, xmethod = TestXMethod.DISABLED)
+
+   private suspend fun addAnd(
+      name: String,
+      xmethod: TestXMethod
+   ): ContainerWithConfigBuilder<BehaviorSpecWhenContainerScope> {
+      return ContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("And: ").withDefaultAffixes().build(),
+         context = this,
+         xmethod = xmethod
+      ) { BehaviorSpecWhenContainerScope(it) }
+   }
+
+
    fun then(name: String) = TestWithConfigBuilder(
       TestNameBuilder.builder(name).withPrefix("Then: ").withDefaultAffixes().build(),
       this@BehaviorSpecWhenContainerScope,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
@@ -76,6 +76,25 @@ interface DescribeSpecRootScope : RootScope {
       )
    }
 
+   fun it(name: String) =
+      addIt(name = name, xmethod = TestXMethod.NONE)
+
+   fun fit(name: String) =
+      addIt(name = name, xmethod = TestXMethod.FOCUSED)
+
+
+   fun xit(name: String) =
+      addIt(name = name, xmethod = TestXMethod.DISABLED)
+
+   private fun addIt(
+      name: String,
+      xmethod: TestXMethod
+   ) = RootTestWithConfigBuilder(
+      this,
+      TestNameBuilder.builder(name).withPrefix("It: ").withDefaultAffixes().build(),
+      xmethod = TestXMethod.DISABLED
+   )
+
    private fun context(
       name: String,
       xmethod: TestXMethod,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecContainerScope.kt
@@ -51,6 +51,22 @@ class ExpectSpecContainerScope(
       ) { ExpectSpecContainerScope(this).test() }
    }
 
+   suspend fun context(name: String) =
+      addContext(name = name, xmethod = TestXMethod.NONE)
+
+   suspend fun fcontext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.FOCUSED)
+
+   suspend fun xcontext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.DISABLED)
+
+   private suspend fun addContext(name: String, xmethod: TestXMethod) =
+      ContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("Context: ").build(),
+         context = this,
+         xmethod = xmethod,
+      ) { ExpectSpecContainerScope(it) }
+
    suspend fun expect(name: String, test: suspend TestScope.() -> Unit) {
       registerExpect(name = name, xmethod = TestXMethod.NONE, test = test)
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
@@ -47,6 +47,25 @@ class FeatureSpecContainerScope(
       ) { FeatureSpecContainerScope(this).test() }
    }
 
+   suspend fun feature(name: String) =
+      addFeature(name = name, xmethod = TestXMethod.NONE)
+
+   suspend fun ffeature(name: String) =
+      addFeature(name = name, xmethod = TestXMethod.FOCUSED)
+
+   suspend fun xfeature(name: String) =
+      addFeature(name = name, xmethod = TestXMethod.DISABLED)
+
+   private suspend fun addFeature(name: String, xmethod: TestXMethod) : TestWithConfigBuilder {
+      val testName = TestNameBuilder.builder(name).withPrefix("Feature: ").build()
+      TestDslState.startTest(testName)
+      return TestWithConfigBuilder(
+         name = testName,
+         context = this,
+         xmethod = TestXMethod.NONE,
+      )
+   }
+
    suspend fun scenario(name: String, test: suspend TestScope.() -> Unit) {
       scenario(name = name, xmethod = TestXMethod.NONE, test = test)
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
@@ -56,15 +56,12 @@ class FeatureSpecContainerScope(
    suspend fun xfeature(name: String) =
       addFeature(name = name, xmethod = TestXMethod.DISABLED)
 
-   private suspend fun addFeature(name: String, xmethod: TestXMethod) : TestWithConfigBuilder {
-      val testName = TestNameBuilder.builder(name).withPrefix("Feature: ").build()
-      TestDslState.startTest(testName)
-      return TestWithConfigBuilder(
-         name = testName,
+   private suspend fun addFeature(name: String, xmethod: TestXMethod) =
+      ContainerWithConfigBuilder(
+         name = TestNameBuilder.builder(name).withPrefix("Feature: ").build(),
          context = this,
-         xmethod = TestXMethod.NONE,
-      )
-   }
+         xmethod = xmethod,
+      ) { FeatureSpecContainerScope(it) }
 
    suspend fun scenario(name: String, test: suspend TestScope.() -> Unit) {
       scenario(name = name, xmethod = TestXMethod.NONE, test = test)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
@@ -106,6 +106,22 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
    }
 
    /**
+    * Adds the contained config and test to this scope as a leaf test.
+    *
+    * E.g.
+    * ```
+    * "this test".config(...) { }
+    * ```
+    */
+   suspend infix operator fun FreeSpecContextConfigBuilder.invoke(test: suspend FreeSpecTerminalScope.() -> Unit) {
+      registerContainer(
+         name = TestNameBuilder.builder(name).build(),
+         xmethod = TestXMethod.NONE,
+         config = config
+      ) { FreeSpecTerminalScope(this).test() }
+   }
+
+   /**
     * Starts a config builder, which can be added to the scope by invoking [minus] on the returned value.
     *
     * E.g.

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootTestWithConfigBuilder.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/RootTestWithConfigBuilder.kt
@@ -18,6 +18,13 @@ class RootTestWithConfigBuilder(
 ) {
 
    fun config(
+      config: TestConfig,
+      test: suspend TestScope.() -> Unit,
+   ) {
+      context.addTest(testName = name, xmethod = xmethod, config = config, test = test)
+   }
+
+   fun config(
       enabled: Boolean? = null,
       invocations: Int? = null,
       tags: Set<Tag>? = null,
@@ -50,6 +57,6 @@ class RootTestWithConfigBuilder(
          retries = retries,
          retryDelay = retryDelay,
       )
-      context.addTest(testName = name, xmethod = xmethod, config = config, test = test)
+      config(config, test)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
@@ -1,7 +1,15 @@
 package io.kotest.core.spec.style.scopes
 
+import io.kotest.core.Tag
+import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.names.TestNameBuilder
 import io.kotest.core.spec.style.TestXMethod
+import io.kotest.core.test.EnabledIf
+import io.kotest.core.test.TestCaseSeverityLevel
+import io.kotest.core.test.config.TestConfig
+import kotlin.time.Duration
+
+data class WordSpecContextConfigBuilder(val name: String, val config: TestConfig)
 
 interface WordSpecRootScope : RootScope {
 
@@ -71,5 +79,104 @@ interface WordSpecRootScope : RootScope {
          xmethod = xmethod,
          config = null,
       ) { WordSpecWhenContainerScope(this).test() }
+   }
+
+   /**
+    * Starts a config builder, which can be added to the scope by invoking [`when`] or [should] on the returned value.
+    *
+    * E.g.
+    *
+    * ```
+    * "this test".config(...) `when` { }
+    * ```
+    */
+   fun String.config(
+      enabled: Boolean? = null,
+      invocations: Int? = null,
+      threads: Int? = null,
+      tags: Set<Tag>? = null,
+      timeout: Duration? = null,
+      extensions: List<TestCaseExtension>? = null,
+      enabledIf: EnabledIf? = null,
+      invocationTimeout: Duration? = null,
+      severity: TestCaseSeverityLevel? = null,
+      failfast: Boolean? = null,
+      blockingTest: Boolean? = null,
+      coroutineTestScope: Boolean? = null,
+   ): WordSpecContextConfigBuilder {
+      val config = TestConfig(
+         enabled = enabled,
+         tags = tags ?: emptySet(),
+         extensions = extensions,
+         timeout = timeout,
+         invocationTimeout = invocationTimeout,
+         enabledIf = enabledIf,
+         invocations = invocations,
+         severity = severity,
+         failfast = failfast,
+         blockingTest = blockingTest,
+         coroutineTestScope = coroutineTestScope,
+      )
+      return config(config)
+   }
+
+   /**
+    * Starts a config builder, which can be added to the scope by invoking [`when`] or [should] on the returned value.
+    *
+    * E.g.
+    *
+    * ```
+    * "this test".config(...) `when` { }
+    * ```
+    */
+   fun String.config(
+      config: TestConfig,
+   ): WordSpecContextConfigBuilder {
+      return WordSpecContextConfigBuilder(this, config)
+   }
+
+   @Suppress("FunctionName")
+   infix fun WordSpecContextConfigBuilder.When(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.NONE, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.fWhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.FOCUSED, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.xWhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.DISABLED, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.`when`(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.NONE, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.fwhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.FOCUSED, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.xwhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.DISABLED, this.config, test)
+
+   private fun addWhen(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecWhenContainerScope.() -> Unit) {
+      addContainer(
+         testName = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         xmethod = xmethod,
+         config = config
+      ) { WordSpecWhenContainerScope(this).test() }
+   }
+
+
+   infix fun WordSpecContextConfigBuilder.should(test: suspend WordSpecShouldContainerScope.() -> Unit) =
+      addShould(this.name, TestXMethod.NONE, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.fshould(test: suspend WordSpecShouldContainerScope.() -> Unit) =
+      addShould(this.name, TestXMethod.FOCUSED, this.config, test)
+
+   infix fun WordSpecContextConfigBuilder.xshould(test: suspend WordSpecShouldContainerScope.() -> Unit) =
+      addShould(this.name, TestXMethod.DISABLED, this.config, test)
+
+   private fun addShould(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecShouldContainerScope.() -> Unit) {
+      addContainer(
+         testName = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         xmethod = xmethod,
+         config = config
+      ) { WordSpecShouldContainerScope(this).test() }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
@@ -1,10 +1,16 @@
 package io.kotest.core.spec.style.scopes
 
+import io.kotest.core.Tag
+import io.kotest.core.extensions.TestCaseExtension
 import io.kotest.core.names.TestName
 import io.kotest.core.names.TestNameBuilder
 import io.kotest.core.spec.KotestTestScope
 import io.kotest.core.spec.style.TestXMethod
+import io.kotest.core.test.EnabledIf
+import io.kotest.core.test.TestCaseSeverityLevel
 import io.kotest.core.test.TestScope
+import io.kotest.core.test.config.TestConfig
+import kotlin.time.Duration
 
 @Suppress("FunctionName")
 @KotestTestScope
@@ -66,5 +72,94 @@ class WordSpecWhenContainerScope(
          config = null
       ) { WordSpecShouldContainerScope(this).test() }
    }
+
+   /**
+    * Adds a configured test to this scope as a leaf test.
+    *
+    * E.g.
+    * ```
+    * "this test".config(...) `when` { }
+    * ```
+    */
+   suspend fun String.config(
+      enabled: Boolean? = null,
+      invocations: Int? = null,
+      tags: Set<Tag>? = null,
+      timeout: Duration? = null,
+      extensions: List<TestCaseExtension>? = null,
+      enabledIf: EnabledIf? = null,
+      invocationTimeout: Duration? = null,
+      severity: TestCaseSeverityLevel? = null,
+      failfast: Boolean? = null,
+      blockingTest: Boolean? = null,
+      coroutineTestScope: Boolean? = null,
+   ) : WordSpecContextConfigBuilder {
+      val config = TestConfig(
+         enabled = enabled,
+         tags = tags ?: emptySet(),
+         extensions = extensions,
+         timeout = timeout,
+         invocationTimeout = invocationTimeout,
+         enabledIf = enabledIf,
+         invocations = invocations,
+         severity = severity,
+         failfast = failfast,
+         blockingTest = blockingTest,
+         coroutineTestScope = coroutineTestScope,
+      )
+      return config(config)
+   }
+
+   fun String.config(
+      config: TestConfig,
+   ): WordSpecContextConfigBuilder {
+      return WordSpecContextConfigBuilder(this, config)
+   }
+
+   @Suppress("FunctionName")
+   suspend infix fun WordSpecContextConfigBuilder.When(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.NONE, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.fWhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.FOCUSED, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.xWhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.DISABLED, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.`when`(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.NONE, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.fwhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.FOCUSED, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.xwhen(test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      addWhen(this.name, TestXMethod.DISABLED, this.config, test)
+
+   private suspend fun addWhen(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecWhenContainerScope.() -> Unit) =
+      registerContainer(
+         name = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         xmethod = xmethod,
+         config = config
+      ) { WordSpecWhenContainerScope(this).test() }
+
+
+
+   suspend infix fun WordSpecContextConfigBuilder.should(test: suspend WordSpecShouldContainerScope.() -> Unit) =
+      addShould(this.name, TestXMethod.NONE, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.fshould(test: suspend WordSpecShouldContainerScope.() -> Unit) =
+      addShould(this.name, TestXMethod.FOCUSED, this.config, test)
+
+   suspend infix fun WordSpecContextConfigBuilder.xshould(test: suspend WordSpecShouldContainerScope.() -> Unit) =
+      addShould(this.name, TestXMethod.DISABLED, this.config, test)
+
+   private suspend fun addShould(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecShouldContainerScope.() -> Unit) {
+      registerContainer(
+         name = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         xmethod = xmethod,
+         config = config
+      ) { WordSpecShouldContainerScope(this).test() }
+   }
+
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecContextContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecContextContainerScope.kt
@@ -229,7 +229,7 @@ suspend fun <T> BehaviorSpecContextContainerScope.withContexts(
    test: suspend BehaviorSpecContextContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t), xmethod = TestXMethod.NONE) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -244,7 +244,7 @@ suspend fun <T> BehaviorSpecContextContainerScope.withGivens(
    test: suspend BehaviorSpecGivenContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      given(nameFn(t), xmethod = TestXMethod.NONE) { this.test(t) }
+      given(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -271,7 +271,7 @@ suspend fun <T> BehaviorSpecContextContainerScope.withContexts(
    data: Map<String, T>,
    test: suspend BehaviorSpecContextContainerScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> this.context(name, xmethod = TestXMethod.NONE) { this.test(t) } }
+   data.forEach { (name, t) -> context(name).config() { this.test(t) } }
 }
 
 /**
@@ -284,5 +284,5 @@ suspend fun <T> BehaviorSpecContextContainerScope.withGivens(
    data: Map<String, T>,
    test: suspend BehaviorSpecGivenContainerScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> given(name, xmethod = TestXMethod.NONE) { this.test(t) } }
+   data.forEach { (name, t) -> given(name).config() { this.test(t) } }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecGivenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecGivenContainerScope.kt
@@ -295,7 +295,7 @@ suspend fun <T> BehaviorSpecGivenContainerScope.withAnds(
    ts: Iterable<T>,
    test: suspend BehaviorSpecGivenContainerScope.(T) -> Unit
 ) {
-   ts.forEach { t -> and(nameFn(t)) { this.test(t) } }
+   ts.forEach { t -> and(nameFn(t)).config() { this.test(t) } }
 }
 
 /**
@@ -308,7 +308,7 @@ suspend fun <T> BehaviorSpecGivenContainerScope.withWhens(
    ts: Iterable<T>,
    test: suspend BehaviorSpecWhenContainerScope.(T) -> Unit
 ) {
-   ts.forEach { t -> `when`(nameFn(t)) { this.test(t) } }
+   ts.forEach { t -> `when`(nameFn(t)).config() { this.test(t) } }
 }
 
 /**
@@ -321,7 +321,7 @@ suspend fun <T> BehaviorSpecGivenContainerScope.withThens(
    ts: Iterable<T>,
    test: suspend TestScope.(T) -> Unit
 ) {
-   ts.forEach { t -> then(nameFn(t)) { this.test(t) } }
+   ts.forEach { t -> then(nameFn(t)).config() { this.test(t) } }
 }
 
 /**
@@ -347,7 +347,7 @@ suspend fun <T> BehaviorSpecGivenContainerScope.withAnds(
    data: Map<String, T>,
    test: suspend BehaviorSpecGivenContainerScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> and(name) { this.test(t) } }
+   data.forEach { (name, t) -> and(name).config() { this.test(t) } }
 }
 
 /**
@@ -360,7 +360,7 @@ suspend fun <T> BehaviorSpecGivenContainerScope.withWhens(
    data: Map<String, T>,
    test: suspend BehaviorSpecWhenContainerScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> `when`(name) { this.test(t) } }
+   data.forEach { (name, t) -> `when`(name).config() { this.test(t) } }
 }
 
 /**
@@ -373,5 +373,5 @@ suspend fun <T> BehaviorSpecGivenContainerScope.withThens(
    data: Map<String, T>,
    test: suspend TestScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> then(name) { this.test(t) } }
+   data.forEach { (name, t) -> then(name).config() { this.test(t) } }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecRoot.kt
@@ -212,7 +212,7 @@ fun <T> BehaviorSpecRootScope.withContexts(
    test: suspend BehaviorSpecContextContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -227,7 +227,7 @@ fun <T> BehaviorSpecRootScope.withGivens(
    test: suspend BehaviorSpecGivenContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      given(nameFn(t)) { this.test(t) }
+      given(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -251,7 +251,7 @@ fun <T> BehaviorSpecRootScope.withContexts(
    test: suspend BehaviorSpecContextContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ fun <T> BehaviorSpecRootScope.withGivens(
    test: suspend BehaviorSpecGivenContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      given(name) { this.test(t) }
+      given(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/behaviorSpecWhenContainerScope.kt
@@ -209,7 +209,7 @@ suspend fun <T> BehaviorSpecWhenContainerScope.withAnds(
    ts: Iterable<T>,
    test: suspend BehaviorSpecWhenContainerScope.(T) -> Unit
 ) {
-   ts.forEach { t -> and(nameFn(t)) { this.test(t) } }
+   ts.forEach { t -> and(nameFn(t)).config() { this.test(t) } }
 }
 
 /**
@@ -221,7 +221,7 @@ suspend fun <T> BehaviorSpecWhenContainerScope.withThens(
    ts: Iterable<T>,
    test: suspend TestScope.(T) -> Unit
 ) {
-   ts.forEach { t -> then(nameFn(t)) { this.test(t) } }
+   ts.forEach { t -> then(nameFn(t)).config() { this.test(t) } }
 }
 
 /**
@@ -245,7 +245,7 @@ suspend fun <T> BehaviorSpecWhenContainerScope.withAnds(
    data: Map<String, T>,
    test: suspend BehaviorSpecWhenContainerScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> and(name) { this.test(t) } }
+   data.forEach { (name, t) -> and(name).config() { this.test(t) } }
 }
 
 /**
@@ -257,5 +257,5 @@ suspend fun <T> BehaviorSpecWhenContainerScope.withThens(
    data: Map<String, T>,
    test: suspend TestScope.(T) -> Unit
 ) {
-   data.forEach { (name, t) -> then(name) { this.test(t) } }
+   data.forEach { (name, t) -> then(name).config() { this.test(t) } }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/describeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/describeSpecContainerScope.kt
@@ -271,7 +271,7 @@ suspend fun <T> DescribeSpecContainerScope.withContexts(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -285,7 +285,7 @@ suspend fun <T> DescribeSpecContainerScope.withDescribes(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      describe(nameFn(t)) { this.test(t) }
+      describe(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -299,7 +299,7 @@ suspend fun <T> DescribeSpecContainerScope.withIts(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      it(nameFn(t)) { this.test(t) }
+      it(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -325,7 +325,7 @@ suspend fun <T> DescribeSpecContainerScope.withContexts(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -339,7 +339,7 @@ suspend fun <T> DescribeSpecContainerScope.withDescribes(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      describe(name) { this.test(t) }
+      describe(name).config() { this.test(t) }
    }
 }
 
@@ -350,6 +350,6 @@ suspend fun <T> DescribeSpecContainerScope.withDescribes(
 @JvmName("withItsMap")
 suspend fun <T> DescribeSpecContainerScope.withIts(data: Map<String, T>, test: suspend TestScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      it(name) { this.test(t) }
+      it(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/describeSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/describeSpecRoot.kt
@@ -261,7 +261,7 @@ fun <T> DescribeSpecRootScope.withContexts(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -276,7 +276,7 @@ fun <T> DescribeSpecRootScope.withDescribes(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      describe(nameFn(t)) { this.test(t) }
+      describe(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -291,7 +291,7 @@ fun <T> DescribeSpecRootScope.withIts(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      it(nameFn(t)) { this.test(t) }
+      it(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -309,7 +309,7 @@ fun <T> DescribeSpecRootScope.withData(data: Map<String, T>, test: suspend Descr
  */
 fun <T> DescribeSpecRootScope.withContexts(data: Map<String, T>, test: suspend DescribeSpecContainerScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -322,7 +322,7 @@ fun <T> DescribeSpecRootScope.withDescribes(
    test: suspend DescribeSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      describe(name) { this.test(t) }
+      describe(name).config() { this.test(t) }
    }
 }
 
@@ -332,6 +332,6 @@ fun <T> DescribeSpecRootScope.withDescribes(
  */
 fun <T> DescribeSpecRootScope.withIts(data: Map<String, T>, test: suspend TestScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      it(name) { this.test(t) }
+      it(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/expectSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/expectSpecContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> ExpectSpecContainerScope.withContexts(
    test: suspend ExpectSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> ExpectSpecContainerScope.withExpects(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      expect(nameFn(t)) { this.test(t) }
+      expect(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> ExpectSpecContainerScope.withContexts(
    test: suspend ExpectSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ suspend fun <T> ExpectSpecContainerScope.withExpects(
    test: suspend TestScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      expect(name) { this.test(t) }
+      expect(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/expectSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/expectSpecRoot.kt
@@ -212,7 +212,7 @@ fun <T> ExpectSpecRootScope.withContexts(
    test: suspend ExpectSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -227,7 +227,7 @@ fun <T> ExpectSpecRootScope.withExpects(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      expect(nameFn(t)) { this.test(t) }
+      expect(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -251,7 +251,7 @@ fun <T> ExpectSpecRootScope.withContexts(
    test: suspend ExpectSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ fun <T> ExpectSpecRootScope.withExpects(
    test: suspend TestScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      expect(name) { this.test(t) }
+      expect(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/featureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/featureSpecContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> FeatureSpecContainerScope.withFeatures(
    test: suspend FeatureSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      feature(nameFn(t)).config() { FeatureSpecContainerScope(this).test(t) }
+      feature(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> FeatureSpecContainerScope.withFeatures(
    test: suspend FeatureSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      feature(name).config() { FeatureSpecContainerScope(this).test(t) }
+      feature(name).config() { this.test(t) }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/featureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/featureSpecContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> FeatureSpecContainerScope.withFeatures(
    test: suspend FeatureSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      feature(nameFn(t)) { this.test(t) }
+      feature(nameFn(t)).config() { FeatureSpecContainerScope(this).test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> FeatureSpecContainerScope.withScenarios(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      scenario(nameFn(t)) { this.test(t) }
+      scenario(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> FeatureSpecContainerScope.withFeatures(
    test: suspend FeatureSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      feature(name) { this.test(t) }
+      feature(name).config() { FeatureSpecContainerScope(this).test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ suspend fun <T> FeatureSpecContainerScope.withScenarios(
    test: suspend TestScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      scenario(name) { this.test(t) }
+      scenario(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/featureSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/featureSpecRoot.kt
@@ -150,7 +150,7 @@ fun <T> FeatureSpecRootScope.withFeatures(
    test: suspend FeatureSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      feature(nameFn(t)) { this.test(t) }
+      feature(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -168,6 +168,6 @@ fun <T> FeatureSpecRootScope.withData(data: Map<String, T>, test: suspend Featur
  */
 fun <T> FeatureSpecRootScope.withFeatures(data: Map<String, T>, test: suspend FeatureSpecContainerScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      feature(name) { this.test(t) }
+      feature(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/freeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/freeSpecContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> FreeSpecContainerScope.withContexts(
    test: suspend FreeSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).minus { test(t) }
+      nameFn(t).config().minus { test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> FreeSpecContainerScope.withTests(
    test: suspend FreeSpecTerminalScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).invoke { test(t) }
+      nameFn(t).config() { FreeSpecTerminalScope(this).test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> FreeSpecContainerScope.withContexts(
    test: suspend FreeSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.minus { test(t) }
+      name.config().minus { test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ suspend fun <T> FreeSpecContainerScope.withTests(
    test: suspend FreeSpecTerminalScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.invoke { test(t) }
+      name.config() { FreeSpecTerminalScope(this).test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/freeSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/freeSpecRoot.kt
@@ -212,7 +212,7 @@ fun <T> FreeSpecRootScope.withContexts(
    test: suspend FreeSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).minus { this.test(t) }
+      nameFn(t).config().minus { this.test(t) }
    }
 }
 
@@ -227,7 +227,7 @@ fun <T> FreeSpecRootScope.withTests(
    test: suspend FreeSpecTerminalScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).invoke { this.test(t) }
+      nameFn(t).config() { FreeSpecTerminalScope(this).test(t) }
    }
 }
 
@@ -251,7 +251,7 @@ fun <T> FreeSpecRootScope.withContexts(
    test: suspend FreeSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.minus { this.test(t) }
+      name.config().minus { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ fun <T> FreeSpecRootScope.withTests(
    test: suspend FreeSpecTerminalScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.invoke { this.test(t) }
+      name.config() { FreeSpecTerminalScope(this).test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/funSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/funSpecContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> FunSpecContainerScope.withContexts(
    test: suspend FunSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> FunSpecContainerScope.withTests(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      test(nameFn(t)) { this.test(t) }
+      test(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -247,7 +247,7 @@ suspend fun <T> FunSpecContainerScope.withContexts(
    test: suspend FunSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -258,6 +258,6 @@ suspend fun <T> FunSpecContainerScope.withContexts(
 @JvmName("withTestsMap")
 suspend fun <T> FunSpecContainerScope.withTests(data: Map<String, T>, test: suspend TestScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      test(name) { this.test(t) }
+      test(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/funSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/funSpecRoot.kt
@@ -203,7 +203,7 @@ fun <T> FunSpecRootScope.withContexts(
    test: suspend FunSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -218,7 +218,7 @@ fun <T> FunSpecRootScope.withTests(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      test(nameFn(t)) { this.test(t) }
+      test(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -236,7 +236,7 @@ fun <T> FunSpecRootScope.withData(data: Map<String, T>, test: suspend FunSpecCon
  */
 fun <T> FunSpecRootScope.withContexts(data: Map<String, T>, test: suspend FunSpecContainerScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -246,6 +246,6 @@ fun <T> FunSpecRootScope.withContexts(data: Map<String, T>, test: suspend FunSpe
  */
 fun <T> FunSpecRootScope.withTests(data: Map<String, T>, test: suspend TestScope.(T) -> Unit) {
    data.forEach { (name, t) ->
-      test(name) { this.test(t) }
+      test(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/shouldSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/shouldSpecContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> ShouldSpecContainerScope.withContexts(
    test: suspend ShouldSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> ShouldSpecContainerScope.withShoulds(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      should(nameFn(t)) { this.test(t) }
+      should(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> ShouldSpecContainerScope.withContexts(
    test: suspend ShouldSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ suspend fun <T> ShouldSpecContainerScope.withShoulds(
    test: suspend TestScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      should(name) { this.test(t) }
+      should(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/shouldSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/shouldSpecRoot.kt
@@ -212,7 +212,7 @@ fun <T> ShouldSpecRootScope.withContexts(
    test: suspend ShouldSpecContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      context(nameFn(t)) { this.test(t) }
+      context(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -227,7 +227,7 @@ fun <T> ShouldSpecRootScope.withShoulds(
    test: suspend TestScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      should(nameFn(t)) { this.test(t) }
+      should(nameFn(t)).config() { this.test(t) }
    }
 }
 
@@ -251,7 +251,7 @@ fun <T> ShouldSpecRootScope.withContexts(
    test: suspend ShouldSpecContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      context(name) { this.test(t) }
+      context(name).config() { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ fun <T> ShouldSpecRootScope.withShoulds(
    test: suspend TestScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      should(name) { this.test(t) }
+      should(name).config() { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/stringSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/stringSpecRoot.kt
@@ -127,7 +127,7 @@ fun <T> StringSpecRootScope.withData(
    test: suspend StringSpecScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).invoke { this.test(t) }
+      nameFn(t).config() { StringSpecScope(this).test(t) }
    }
 }
 
@@ -150,7 +150,7 @@ fun <T> StringSpecRootScope.withData(
    test: suspend StringSpecScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.invoke { this.test(t) }
+      name.config() { StringSpecScope(this).test(t) }
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/wordSpecRoot.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/wordSpecRoot.kt
@@ -212,7 +212,7 @@ fun <T> WordSpecRootScope.withWhens(
    test: suspend WordSpecWhenContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t) `when` { this.test(t) }
+      nameFn(t).config() `when` { this.test(t) }
    }
 }
 
@@ -227,7 +227,7 @@ fun <T> WordSpecRootScope.withShoulds(
    test: suspend WordSpecShouldContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t) should { this.test(t) }
+      nameFn(t).config() should { this.test(t) }
    }
 }
 
@@ -251,7 +251,7 @@ fun <T> WordSpecRootScope.withWhens(
    test: suspend WordSpecWhenContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name `when` { this.test(t) }
+      name.config() `when` { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ fun <T> WordSpecRootScope.withShoulds(
    test: suspend WordSpecShouldContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name should { this.test(t) }
+      name.config() should { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/wordSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/wordSpecWhenContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> WordSpecWhenContainerScope.withWhens(
    test: suspend WordSpecWhenContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t) `when` { this.test(t) }
+      nameFn(t).config() `when` { WordSpecWhenContainerScope(this).test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> WordSpecWhenContainerScope.withShoulds(
    test: suspend WordSpecShouldContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t) should { this.test(t) }
+      nameFn(t).config() should { WordSpecShouldContainerScope(this).test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> WordSpecWhenContainerScope.withWhens(
    test: suspend WordSpecWhenContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name `when` { this.test(t) }
+      name.config() `when` { WordSpecWhenContainerScope(this).test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ suspend fun <T> WordSpecWhenContainerScope.withShoulds(
    test: suspend WordSpecShouldContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name should { this.test(t) }
+      name.config() should { WordSpecShouldContainerScope(this).test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/wordSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/datatest/wordSpecWhenContainerScope.kt
@@ -210,7 +210,7 @@ suspend fun <T> WordSpecWhenContainerScope.withWhens(
    test: suspend WordSpecWhenContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).config() `when` { WordSpecWhenContainerScope(this).test(t) }
+      nameFn(t).config() `when` { this.test(t) }
    }
 }
 
@@ -224,7 +224,7 @@ suspend fun <T> WordSpecWhenContainerScope.withShoulds(
    test: suspend WordSpecShouldContainerScope.(T) -> Unit
 ) {
    ts.forEach { t ->
-      nameFn(t).config() should { WordSpecShouldContainerScope(this).test(t) }
+      nameFn(t).config() should { this.test(t) }
    }
 }
 
@@ -250,7 +250,7 @@ suspend fun <T> WordSpecWhenContainerScope.withWhens(
    test: suspend WordSpecWhenContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.config() `when` { WordSpecWhenContainerScope(this).test(t) }
+      name.config() `when` { this.test(t) }
    }
 }
 
@@ -264,6 +264,6 @@ suspend fun <T> WordSpecWhenContainerScope.withShoulds(
    test: suspend WordSpecShouldContainerScope.(T) -> Unit
 ) {
    data.forEach { (name, t) ->
-      name.config() should { WordSpecShouldContainerScope(this).test(t) }
+      name.config() should { this.test(t) }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/styles/FeatureSpecDataTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/styles/FeatureSpecDataTest.kt
@@ -39,7 +39,7 @@ class FeatureSpecDataTest : FeatureSpec() {
       afterSpec {
          afterTestCounter shouldBe 111
          beforeAnyCounter shouldBe 111
-         beforeEachCounter shouldBe 87
+         beforeEachCounter shouldBe 36
          beforeTestCounter shouldBe 111
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/styles/FeatureSpecDataTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/styles/FeatureSpecDataTest.kt
@@ -39,7 +39,7 @@ class FeatureSpecDataTest : FeatureSpec() {
       afterSpec {
          afterTestCounter shouldBe 111
          beforeAnyCounter shouldBe 111
-         beforeEachCounter shouldBe 36
+         beforeEachCounter shouldBe 87
          beforeTestCounter shouldBe 111
       }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Adds support to call any spec method with a config attached - used this in data tests for all specs.
Will be supporting the use-case of adding tags for data tests in https://github.com/kotest/kotest/pull/5574