### PR TITLE
Overlapping partial matches causes a higher than possible match value.

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -170,7 +170,7 @@ fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
    override fun test(value: List<T>): MatcherResult {
       val comparison = SliceComparison.of(expectedSlice.toList(), value, SliceComparison.Companion.SliceType.END)
 
-      val partialMatchesDescription = describePartialMatchesInCollection(expectedSlice, value)
+      val partialMatchesDescription by lazy { describePartialMatchesInCollection(expectedSlice, value) }
 
       return MatcherResult(
          comparison.match,

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/assertions/similarity/StringDistanceCalculator.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/assertions/similarity/StringDistanceCalculator.kt
@@ -38,7 +38,20 @@ internal fun ratioOfPartialMatchesInString(
    actual: String,
 ): BigDecimal {
    val maxLength = listOf(expected, actual).maxOf { it.length }
-   val numberOfMatchedCharacters = partialMatches.sumOf { it.length }
+   val numberOfMatchedCharacters = partialMatches.filterOverlapping().sumOf { it.length }
    return BigDecimal.valueOf(numberOfMatchedCharacters.toLong())
       .divide(BigDecimal.valueOf(maxLength.toLong()), 2, RoundingMode.HALF_DOWN)
+}
+
+// In case of overlapping partial matches, we eliminate the overlapping ones and only include the longest match
+// for any given slice of the expected collection.
+private fun List<PartialCollectionMatch>.filterOverlapping(): List<PartialCollectionMatch> {
+   val sortedByLength = this.sortedBy { it.length }
+   val nonOverlappingMatches = mutableListOf<PartialCollectionMatch>()
+   for (match in sortedByLength) {
+      if (nonOverlappingMatches.all { it.rangeOfExpected.intersect(match.rangeOfExpected).isEmpty() }) {
+         nonOverlappingMatches.add(match)
+      }
+   }
+   return nonOverlappingMatches
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/DescribePartialMatchesInCollectionTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/matchers/collections/DescribePartialMatchesInCollectionTest.kt
@@ -2,6 +2,7 @@ package io.kotest.matchers.collections
 
 import io.kotest.assertions.submatching.MatchedCollectionElement
 import io.kotest.assertions.submatching.PartialCollectionMatch
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainInOrder
@@ -102,6 +103,13 @@ class DescribePartialMatchesInCollectionTest: WordSpec() {
              )
              actual.unmatchedElementsDescription shouldBe ""
              actual.indexesOfUnmatchedElements.shouldBeEmpty()
+          }
+
+          "overlapping partial matches, causing > 100% match ratio. Only use best match for any given range of expected indexes" {
+             val list = listOf("1.0.0.9/32", "1.0.0.10/32")
+             shouldNotThrowAny {
+                describePartialMatchesInCollection(listOf("1.0.0.10/32"), list)
+             }
           }
        }
 


### PR DESCRIPTION
Fixed by only including the best partial match for any given range in the expected value.

fixes #5677

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
