### PR TITLE
Updating arrow extension docs to point to correct artifact

### DIFF
--- a/documentation/docs/assertions/arrow.md
+++ b/documentation/docs/assertions/arrow.md
@@ -5,13 +5,11 @@ sidebar_label: Arrow
 ---
 
 
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-arrow)](https://search.maven.org/artifact/io.kotest.extensions/kotest-assertions-arrow)
-
 This page lists all current matchers in the Kotest arrow matchers extension library.
 
 :::note
-The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently of the main Kotest project.
-Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
+The `kotest-assertions-arrow` module has moved to the `io.kotest` group. Please update your dependency to
+`io.kotest:kotest-assertions-arrow`, and use the version matching your kotest version.
 :::
 
 :::note

--- a/documentation/versioned_docs/version-6.0/assertions/arrow.md
+++ b/documentation/versioned_docs/version-6.0/assertions/arrow.md
@@ -4,14 +4,11 @@ slug: arrow.html
 sidebar_label: Arrow
 ---
 
-
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-arrow)](https://search.maven.org/artifact/io.kotest.extensions/kotest-assertions-arrow)
-
 This page lists all current matchers in the Kotest arrow matchers extension library.
 
 :::note
-The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently of the main Kotest project.
-Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
+The `kotest-assertions-arrow` module has moved to the `io.kotest` group. Please update your dependency to
+`io.kotest:kotest-assertions-arrow`, and use the version matching your kotest version.
 :::
 
 :::note

--- a/documentation/versioned_docs/version-6.1/assertions/arrow.md
+++ b/documentation/versioned_docs/version-6.1/assertions/arrow.md
@@ -4,14 +4,11 @@ slug: arrow.html
 sidebar_label: Arrow
 ---
 
-
-[![Latest Release](https://img.shields.io/maven-central/v/io.kotest.extensions/kotest-assertions-arrow)](https://search.maven.org/artifact/io.kotest.extensions/kotest-assertions-arrow)
-
 This page lists all current matchers in the Kotest arrow matchers extension library.
 
 :::note
-The following module is needed: `io.kotest.extensions:kotest-assertions-arrow` which is versioned independently of the main Kotest project.
-Search maven central for latest version [here](https://central.sonatype.com/search?q=io.kotest.extensions:kotest-assertions-arrow).
+The `kotest-assertions-arrow` module has moved to the `io.kotest` group. Please update your dependency to
+`io.kotest:kotest-assertions-arrow`, and use the version matching your kotest version.
 :::
 
 :::note


### PR DESCRIPTION
Partially fixes #5668

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
