### PR TITLE
Fix multiple `--tests` issue

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterAdapter.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterAdapter.kt
@@ -54,7 +54,7 @@ internal object ClassMethodNameFilterAdapter {
          ClassMethodNameFilterUtils.reset(request.postFilters())
       }
 
-      val descriptionFilter = when {
+      val descriptorFilter = when {
          nestedArgs.isEmpty() -> GradleClassMethodRegexTestFilter(regexPatterns)
          regexPatterns.isEmpty() -> NestedTestsArgDescriptorFilter(nestedArgs)
          else -> object : DescriptorFilter {
@@ -72,6 +72,6 @@ internal object ClassMethodNameFilterAdapter {
          }
       }
 
-      return listOf(descriptionFilter)
+      return listOf(descriptorFilter)
    }
 }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterAdapter.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterAdapter.kt
@@ -2,7 +2,9 @@
 
 package io.kotest.runner.junit.platform.gradle
 
+import io.kotest.core.descriptors.Descriptor
 import io.kotest.engine.extensions.filter.DescriptorFilter
+import io.kotest.engine.extensions.filter.DescriptorFilterResult
 import io.kotest.runner.junit.platform.postFilters
 import org.junit.platform.engine.EngineDiscoveryRequest
 import org.junit.platform.launcher.PostDiscoveryFilter
@@ -28,18 +30,48 @@ internal object ClassMethodNameFilterAdapter {
     * If no post-filters are present, this will return an empty list.
     */
    internal fun adapt(request: EngineDiscoveryRequest): List<DescriptorFilter> {
-      return ClassMethodNameFilterUtils.extractIncludePatterns(request.postFilters())
-         .map { filter ->
-            val nestedTestArg = NestedTestsArgParser.parse(filter)
-            if (nestedTestArg != null) {
-               // HACK since we have a tests filter with a nested test name, we will clear the list of post-filters
-               // so Gradle doesn't do any filtering - otherwise, Gradle will incorrectly filter out the nested
-               // test as it doesn't understand the kotest format
-               // note - this implementation assumes that if we have one nested post-filter, then there are no others
-               ClassMethodNameFilterUtils.reset(request.postFilters())
-               NestedTestsArgDescriptorFilter(setOf(nestedTestArg))
-            } else
-               GradleClassMethodRegexTestFilter(setOf(filter))
+      val patterns = ClassMethodNameFilterUtils.extractIncludePatterns(request.postFilters())
+      if (patterns.isEmpty()) {
+         return emptyList()
+      }
+
+      val nestedArgs = mutableSetOf<NestedTestArg>()
+      val regexPatterns = mutableSetOf<String>()
+
+      for (filter in patterns) {
+         val nestedTestArg = NestedTestsArgParser.parse(filter)
+         if (nestedTestArg != null) {
+            nestedArgs.add(nestedTestArg)
+         } else {
+            regexPatterns.add(filter)
          }
+      }
+
+      if (nestedArgs.isNotEmpty()) {
+         // HACK since we have a tests filter with a nested test name, we will clear the list of post-filters
+         // so Gradle doesn't do any filtering - otherwise, Gradle will incorrectly filter out the nested
+         // test as it doesn't understand the kotest format
+         ClassMethodNameFilterUtils.reset(request.postFilters())
+      }
+
+      val descriptionFilter = when {
+         nestedArgs.isEmpty() -> GradleClassMethodRegexTestFilter(regexPatterns)
+         regexPatterns.isEmpty() -> NestedTestsArgDescriptorFilter(nestedArgs)
+         else -> object : DescriptorFilter {
+            override fun filter(descriptor: Descriptor): DescriptorFilterResult {
+               val descriptorFilters = listOf(
+                  GradleClassMethodRegexTestFilter(regexPatterns),
+                  NestedTestsArgDescriptorFilter(nestedArgs),
+               )
+               return if (descriptorFilters.any { it.filter(descriptor) == DescriptorFilterResult.Include }) {
+                  DescriptorFilterResult.Include
+               } else {
+                  DescriptorFilterResult.Exclude(null)
+               }
+            }
+         }
+      }
+
+      return listOf(descriptionFilter)
    }
 }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtils.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtils.kt
@@ -13,7 +13,7 @@ import java.util.regex.Pattern
  * [org.gradle.api.internal.tasks.testing.junitplatform.ClassMethodNameFilter] which is an
  * implementation of PostDiscoveryFilter. It is also used by the test retry plugin.
  *
- * But ClassMethodNameFilter, as the name implies, only handles clases and methods.
+ * But ClassMethodNameFilter, as the name implies, only handles classes and methods.
  * Kotest is more advanced, and JUnit5 Platform allows for hierarchical tests, so this is a limitation
  * of Gradle not implementing the spec fully. See https://github.com/gradle/gradle/issues/4912
  *


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

close #5678

**NOT TEST** (i'd like maintainers to do that 🙏 )

- ClassMethodNameFilterAdapter.adapt() was creating a separate DescriptorFilter for each extracted --tests pattern
- Since the engine applies DescriptorFilters with AND semantics, using multiple --tests arguments (e.g., --tests TestA --tests TestB) caused no tests to be found because each test had to match ALL patterns simultaneously
- Group all patterns into a single filter per type (regex-based and nested-test-based) so they are combined with OR logic within the filter
