### PR TITLE
Add IC-261 (IntelliJ 2026.1 EAP) build target for the intellij plugin

### DIFF
--- a/.github/workflows/master_intellij_plugin.yml
+++ b/.github/workflows/master_intellij_plugin.yml
@@ -13,7 +13,7 @@ jobs:
 
       strategy:
          matrix:
-            product: [ "IC-242", "IC-243", "IC-251", "IC-252" ]
+            product: [ "IC-251", "IC-252", "IC-253", "IC-261" ]
          max-parallel: 10
          fail-fast: false
 
@@ -26,6 +26,10 @@ jobs:
             with:
                java-version: "21"
                distribution: "temurin"
+
+         -  name: Override Kotlin version for IC-261
+            if: matrix.product == 'IC-261'
+            run: sed -i 's/^kotlin = .*/kotlin = "2.3.10"/' gradle/libs.versions.toml
 
          -  name: Run tests
             run: ./gradlew :kotest-intellij-plugin:check

--- a/.github/workflows/pr_intellij_plugin.yml
+++ b/.github/workflows/pr_intellij_plugin.yml
@@ -12,7 +12,7 @@ jobs:
 
       strategy:
          matrix:
-            product: [ "IC-251", "IC-252", "IC-253" ]
+            product: [ "IC-251", "IC-252", "IC-253", "IC-261" ]
          max-parallel: 10
          fail-fast: false
 
@@ -25,6 +25,10 @@ jobs:
             with:
                java-version: "21"
                distribution: "temurin"
+
+         -  name: Override Kotlin version for IC-261
+            if: matrix.product == 'IC-261'
+            run: sed -i 's/^kotlin = .*/kotlin = "2.3.10"/' gradle/libs.versions.toml
 
          -  name: Run tests
             run: ./gradlew :kotest-intellij-plugin:check

--- a/.github/workflows/release_intellij_plugin.yml
+++ b/.github/workflows/release_intellij_plugin.yml
@@ -8,7 +8,7 @@ jobs:
 
       strategy:
          matrix:
-            product: [ "IC-251", "IC-252", "IC-253" ]
+            product: [ "IC-251", "IC-252", "IC-253", "IC-261" ]
          max-parallel: 1
 
       runs-on: ubuntu-latest
@@ -22,6 +22,10 @@ jobs:
             with:
                java-version: "21"
                distribution: "temurin"
+
+         -  name: Override Kotlin version for IC-261
+            if: matrix.product == 'IC-261'
+            run: sed -i 's/^kotlin = .*/kotlin = "2.3.10"/' gradle/libs.versions.toml
 
          -  name: deploy to jetbrains
             run: ./gradlew --stacktrace publishPlugin

--- a/kotest-intellij-plugin/build.gradle.kts
+++ b/kotest-intellij-plugin/build.gradle.kts
@@ -59,6 +59,15 @@ val descriptors = listOf(
       jdkTarget = JavaVersion.VERSION_21,
       androidVersion = "253.28294.334",
    ),
+   PluginDescriptor(
+      since = "261.*", // this version is 2026.1.x
+      until = "262.*",
+      sdkVersion = "261-EAP-SNAPSHOT",
+      sourceFolder = "IC-261",
+      useInstaller = false,
+      jdkTarget = JavaVersion.VERSION_21,
+      androidVersion = "261.20869.38",
+   ),
 )
 
 val productName = System.getenv("PRODUCT_NAME") ?: "IC-251"

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
@@ -2,13 +2,13 @@ package io.kotest.plugin.intellij.actions
 
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiDocumentManager
 import io.kotest.plugin.intellij.psi.enclosingSpec
 import io.kotest.plugin.intellij.psi.specStyle
 import io.kotest.plugin.intellij.Test
 import io.kotest.plugin.intellij.TestElement
-import org.jetbrains.kotlin.idea.refactoring.hostEditor
 
 enum class Direction {
    Previous, Next
@@ -18,7 +18,7 @@ abstract class NavigateToTestAction(private val direction: Direction) : AnAction
    override fun actionPerformed(e: AnActionEvent) {
 
       val project = e.project ?: return
-      val editor = e.dataContext.hostEditor ?: return
+      val editor = e.dataContext.getData(CommonDataKeys.EDITOR) ?: return
       val offset = editor.caretModel.offset
 
       val file = PsiDocumentManager.getInstance(project).getPsiFile(editor.document) ?: return

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeModel.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/toolwindow/treeModel.kt
@@ -9,8 +9,8 @@ import io.kotest.plugin.intellij.TestElement
 import io.kotest.plugin.intellij.psi.callbacks
 import io.kotest.plugin.intellij.psi.includes
 import io.kotest.plugin.intellij.psi.specStyle
+import com.intellij.openapi.module.ModuleManager
 import org.jetbrains.kotlin.idea.facet.KotlinFacet
-import org.jetbrains.kotlin.idea.util.projectStructure.allModules
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import javax.swing.tree.DefaultMutableTreeNode
 import javax.swing.tree.DefaultTreeModel
@@ -54,7 +54,7 @@ fun createTreeModel(
       val allModulesNode = DefaultMutableTreeNode(allModulesDescriptor)
       root.add(allModulesNode)
 
-      project.allModules()
+      ModuleManager.getInstance(project).modules.toList()
          .filter { it.isKotlin() }
          .filter { it.name.endsWith("jvmTest") || it.name.endsWith("test") }
          .forEach {


### PR DESCRIPTION
- Add PluginDescriptor for IC-261 using 261-EAP-SNAPSHOT SDK and Android plugin 261.20869.38
- Update all three CI workflows to include IC-261 in the build matrix
- Fix master_intellij_plugin.yml which still referenced removed IC-242/IC-243 targets
- Override Kotlin to 2.3.10 for IC-261 builds since IC-261 bundles Kotlin 2.3 (metadata 2.4.0) which is incompatible with the project's Kotlin 2.2.x compiler
- Replace deprecated K1 APIs flagged as errors in IC-261:
  - project.allModules() -> ModuleManager.getInstance(project).modules.toList()
  - e.dataContext.hostEditor -> e.dataContext.getData(CommonDataKeys.EDITOR)

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
