### PR TITLE
Fix default productName back to IC-253

### DIFF
--- a/kotest-intellij-plugin/build.gradle.kts
+++ b/kotest-intellij-plugin/build.gradle.kts
@@ -78,7 +78,7 @@ val descriptors = listOf(
    ),
 )
 
-val productName = System.getenv("PRODUCT_NAME") ?: "IC-261"
+val productName = System.getenv("PRODUCT_NAME") ?: "IC-253"
 val descriptor: PluginDescriptor = descriptors.first { it.sourceFolder == productName }
 val jvmTargetVersion: String = System.getenv("JVM_TARGET") ?: descriptor.jdkTarget.majorVersion
 


### PR DESCRIPTION
## Summary

- Commit `d6efb45e` (PR #5708) accidentally changed the fallback `PRODUCT_NAME` from `IC-253` to `IC-261` while adding the `extraBundledPlugins` fix
- This causes CI `gradle-check` jobs (which don't set `PRODUCT_NAME`) to compile the IntelliJ plugin against the IC-261 EAP snapshot
- The IC-261 EAP bundles Kotlin with metadata version 2.4.0, which is incompatible with the project's Kotlin 2.2.x compiler, causing compilation failure
- The dedicated IC-261 build jobs explicitly set `PRODUCT_NAME=IC-261` and override the Kotlin version to 2.3.10, so those are unaffected

## Test plan

- [x] `PRODUCT_NAME=IC-253 ./gradlew :kotest-intellij-plugin:test` — passes
- [x] `gradle-check` CI jobs should now build against IC-253 (the stable platform) instead of IC-261 EAP

🤖 Generated with [Claude Code](https://claude.com/claude-code)