### PR TITLE
Escape single quotes in GradleTestFilterBuilder

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilder.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilder.kt
@@ -33,9 +33,21 @@ data class GradleTestFilterBuilder(
          }
          if (test != null) {
             append(".")
-            append(test.path().joinToString(" -- ") { it.name })
+            append(test.path().joinToString(" -- ") { it.name.escapeSingleQuotes() })
          }
          append("'")
       }
    }
 }
+
+/**
+ * Escapes single quotes for use inside a single-quoted shell argument.
+ *
+ * A single quote cannot appear inside a single-quoted string, so we close the
+ * quoted string, emit a backslash-escaped single quote, then reopen the quoted
+ * string: `'` → `'\''`.
+ *
+ * For example, the test name `it's a test` becomes `it'\''s a test`, which
+ * when wrapped in outer single quotes produces `'it'\''s a test'`.
+ */
+private fun String.escapeSingleQuotes(): String = replace("'", "'\\''")

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilderTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilderTest.kt
@@ -73,4 +73,67 @@ class GradleTestFilterBuilderTest : BasePlatformTestCase() {
          .build(true) shouldBe "--tests 'MyTestClass.foo -- bar'"
    }
 
+   fun testSingleQuoteInTestNameIsEscaped() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
+      val test = Test(
+         name = TestName(prefix = null, name = "it's a test", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MyTestClass.it'\\''s a test'"
+   }
+
+   fun testSingleQuoteInNestedTestNameIsEscaped() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
+      val root = Test(
+         name = TestName(prefix = null, name = "parent's context", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Container,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      val test = Test(
+         name = TestName(prefix = null, name = "child's test", interpolated = false),
+         parent = root,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MyTestClass.parent'\\''s context -- child'\\''s test'"
+   }
+
+   fun testMultipleSingleQuotesInTestNameAreAllEscaped() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
+      val test = Test(
+         name = TestName(prefix = null, name = "it's 'special'", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(false) shouldBe "'MyTestClass.it'\\''s '\\''special'\\'''"
+   }
+
 }


### PR DESCRIPTION
## Summary

- Test names containing single quotes (e.g. `"it's a test"`) produced invalid shell syntax when wrapped in single quotes for the `--tests` filter argument
- Adds a `String.escapeSingleQuotes()` helper that replaces `'` with `'\''` — the standard shell technique for escaping single quotes inside a single-quoted string
- Adds three new tests covering: a single quote in a top-level test name, single quotes in a nested test name, and multiple single quotes in a test name

## Test plan

- [x] `testSingleQuoteInTestNameIsEscaped` — `"it's a test"` → `'MyTestClass.it'\''s a test'`
- [x] `testSingleQuoteInNestedTestNameIsEscaped` — parent/child both containing `'`
- [x] `testMultipleSingleQuotesInTestNameAreAllEscaped` — multiple quotes in one name
- [x] All 7 tests in `GradleTestFilterBuilderTest` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)