### PR TITLE
Restrict runner modules and now/junit5 extensions to Linux-only builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,25 +82,24 @@ dependencies {
    nmcpAggregation(projects.kotestProperty.kotestPropertyDatetime)
    nmcpAggregation(projects.kotestProperty.kotestPropertyLifecycle)
    nmcpAggregation(projects.kotestProperty.kotestPropertyPermutations)
-   nmcpAggregation(projects.kotestExtensions.kotestExtensionsJunit5)
-   nmcpAggregation(projects.kotestExtensions.kotestExtensionsNow)
-
    // Linux-only modules: only included in the build when running on a Linux runner (or locally).
    // Use findProject so this gracefully no-ops when the module is absent from settings.
    findProject(":kotest-extensions:kotest-extensions-allure")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-blockhound")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-decoroutinator")?.let { nmcpAggregation(it) }
+   findProject(":kotest-extensions:kotest-extensions-junit5")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-mockserver")?.let { nmcpAggregation(it) }
+   findProject(":kotest-extensions:kotest-extensions-now")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-pitest")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-spring")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-testcontainers")?.let { nmcpAggregation(it) }
    findProject(":kotest-extensions:kotest-extensions-wiremock")?.let { nmcpAggregation(it) }
 
    // Runners
-   nmcpAggregation(projects.kotestRunner.kotestRunnerJunitPlatform)
-   nmcpAggregation(projects.kotestRunner.kotestRunnerJunit4)
-   nmcpAggregation(projects.kotestRunner.kotestRunnerJunit5)
-   nmcpAggregation(projects.kotestRunner.kotestRunnerJunit6)
+   findProject(":kotest-runner:kotest-runner-junit-platform")?.let { nmcpAggregation(it) }
+   findProject(":kotest-runner:kotest-runner-junit4")?.let { nmcpAggregation(it) }
+   findProject(":kotest-runner:kotest-runner-junit5")?.let { nmcpAggregation(it) }
+   findProject(":kotest-runner:kotest-runner-junit6")?.let { nmcpAggregation(it) }
 
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,8 @@ dependencies {
    nmcpAggregation(projects.kotestProperty.kotestPropertyDatetime)
    nmcpAggregation(projects.kotestProperty.kotestPropertyLifecycle)
    nmcpAggregation(projects.kotestProperty.kotestPropertyPermutations)
+
+
    // Linux-only modules: only included in the build when running on a Linux runner (or locally).
    // Use findProject so this gracefully no-ops when the module is absent from settings.
    findProject(":kotest-extensions:kotest-extensions-allure")?.let { nmcpAggregation(it) }
@@ -96,10 +98,12 @@ dependencies {
    findProject(":kotest-extensions:kotest-extensions-wiremock")?.let { nmcpAggregation(it) }
 
    // Runners
-   findProject(":kotest-runner:kotest-runner-junit-platform")?.let { nmcpAggregation(it) }
    findProject(":kotest-runner:kotest-runner-junit4")?.let { nmcpAggregation(it) }
-   findProject(":kotest-runner:kotest-runner-junit5")?.let { nmcpAggregation(it) }
    findProject(":kotest-runner:kotest-runner-junit6")?.let { nmcpAggregation(it) }
+
+   // Runners
+   nmcpAggregation(projects.kotestRunner.kotestRunnerJunitPlatform)
+   nmcpAggregation(projects.kotestRunner.kotestRunnerJunit5)
 
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -110,22 +110,8 @@ include(
    ":kotest-extensions:kotest-extensions-htmlreporter",
    ":kotest-extensions:kotest-extensions-junitxml",
 
-   // allows overriding the .now() functionality on time classes
-   ":kotest-extensions:kotest-extensions-now",
-
-   // extensions that adapt junit extensions into kotest extensions
-   ":kotest-extensions:kotest-extensions-junit5",
-
-
    // adds support for the koin DI framework - see more https://insert-koin.io/
    ":kotest-extensions:kotest-extensions-koin",
-
-   ":kotest-runner:kotest-runner-junit4",
-   ":kotest-runner:kotest-runner-junit5",
-   ":kotest-runner:kotest-runner-junit6",
-
-   // shared support executing tests via JUnit Platform
-   ":kotest-runner:kotest-runner-junit-platform",
 
    // BOM for whole kotest project
    ":kotest-bom",
@@ -247,6 +233,19 @@ if (shouldRunLinuxOnlyModules) {
 
       // adds support for the wiremock framework - see more https://www.wiremock.io/
       ":kotest-extensions:kotest-extensions-wiremock",
+
+      // allows overriding the .now() functionality on time classes
+      ":kotest-extensions:kotest-extensions-now",
+
+      // extensions that adapt junit extensions into kotest extensions
+      ":kotest-extensions:kotest-extensions-junit5",
+
+      ":kotest-runner:kotest-runner-junit4",
+      ":kotest-runner:kotest-runner-junit5",
+      ":kotest-runner:kotest-runner-junit6",
+
+      // shared support executing tests via JUnit Platform
+      ":kotest-runner:kotest-runner-junit-platform",
    )
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -119,6 +119,7 @@ include(
 
 /** Is the build currently running on CI? */
 private val isCI = System.getenv("CI").toBoolean()
+private val isLocal = !isCI
 
 /** Is the build currently running on a GitHub actions Linux runner? */
 private val isLinuxRunner = System.getenv("RUNNER_OS") == "Linux"
@@ -126,10 +127,10 @@ private val isLinuxRunner = System.getenv("RUNNER_OS") == "Linux"
 private val isMaster = System.getenv("GITHUB_REF_NAME") == "master"
 
 /** we only include JVM-only modules if it's a non-CI build, or if it's a master build, or if it's using a linux runner */
-private val shouldRunJvmOnlyModules = !isCI || isMaster || isLinuxRunner
+private val shouldRunJvmOnlyModules = isLocal || isMaster || isLinuxRunner
 
 /** we only include Linux-only modules if it's a non-CI build or if it's using a linux runner */
-private val shouldRunLinuxOnlyModules = !isCI || isLinuxRunner
+private val shouldRunLinuxOnlyModules = isLocal || isLinuxRunner
 
 /**
  * These modules only have JVM source sets. We don't need to run them on all OSes for PRs as we can

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -113,6 +113,12 @@ include(
    // adds support for the koin DI framework - see more https://insert-koin.io/
    ":kotest-extensions:kotest-extensions-koin",
 
+   // shared support executing tests via JUnit Platform
+   ":kotest-runner:kotest-runner-junit-platform",
+
+   // runs tests on junit5 but also used by other modules to run kotest's own tests
+   ":kotest-runner:kotest-runner-junit5",
+
    // BOM for whole kotest project
    ":kotest-bom",
 )
@@ -242,11 +248,7 @@ if (shouldRunLinuxOnlyModules) {
       ":kotest-extensions:kotest-extensions-junit5",
 
       ":kotest-runner:kotest-runner-junit4",
-      ":kotest-runner:kotest-runner-junit5",
       ":kotest-runner:kotest-runner-junit6",
-
-      // shared support executing tests via JUnit Platform
-      ":kotest-runner:kotest-runner-junit-platform",
    )
 }
 


### PR DESCRIPTION
Move kotest-extensions-now, kotest-extensions-junit5, and all four runner modules (junit4, junit5, junit6, junit-platform) into the shouldRunLinuxOnlyModules block in settings.gradle.kts.

Switch their nmcpAggregation entries in build.gradle.kts from type-safe project accessors to findProject() so they no-op cleanly when the modules are absent on non-Linux CI runners.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
