### PR TITLE
Add regression test for afterSpec not firing when spec excluded by tag

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/raceConditions/ParallelRunnerTest.kt
@@ -3,6 +3,7 @@ package io.kotest.raceConditions
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.test.config.TestConfig
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.raceConditions.ParallelRunner.Companion.runInParallel
 import io.mockk.clearAllMocks
@@ -15,9 +16,9 @@ import java.time.LocalDateTime
 class ParallelRunnerTest: StringSpec() {
    init {
       /*
-      A typical race condition - two tasks mutate shared state without synchronization
+      A typical race condition - two tasks mutate a shared state without synchronization
        */
-      "two tasks share one mutable state, both make the same decision at the same time" {
+      "two tasks share one mutable state, both make the same decision at the same time".config(TestConfig(retries = 3)) {
          val box = Box(maxCapacity = 2)
          box.addItem("apple")
          runInParallel({ runner: ParallelRunner ->
@@ -39,7 +40,7 @@ class ParallelRunnerTest: StringSpec() {
          box.items() shouldContainExactlyInAnyOrder listOf("apple", "banana", "orange")
       }
 
-      "demo for mockkStatic".config(enabled = true) {
+      "demo for mockkStatic".config(TestConfig(retries = 3)) {
          runInParallel({ runner: ParallelRunner ->
             timedPrint("Before mock on same thread: ${LocalDateTime.now()}")
             runner.await()
@@ -64,7 +65,7 @@ Time: 2022-04-27T12:34:56, Thread: 50, After mock on same thread: 2022-04-27T12:
           */
       }
 
-      "demo for mockkStatic - can remock".config(enabled = true) {
+      "demo for mockkStatic - can remock".config(TestConfig(retries = 3)) {
          runInParallel({ runner: ParallelRunner ->
             mockkStatic(LocalDateTime::class)
             val localTime = LocalDateTime.of(2022, 4, 27, 12, 34, 56)

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -2099,6 +2099,7 @@ public abstract class io/kotest/core/spec/style/StringSpec : io/kotest/core/spec
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 	public fun config-4xH7vM4 (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
@@ -2109,6 +2110,7 @@ public final class io/kotest/core/spec/style/StringSpecKt {
 
 public final class io/kotest/core/spec/style/StringSpecTestFactoryConfiguration : io/kotest/core/factory/TestFactoryConfiguration, io/kotest/core/spec/style/scopes/StringSpecRootScope {
 	public fun <init> ()V
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 	public fun config-4xH7vM4 (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
@@ -2682,12 +2684,14 @@ public final class io/kotest/core/spec/style/scopes/ShouldSpecRootScope$DefaultI
 }
 
 public abstract interface class io/kotest/core/spec/style/scopes/StringSpecRootScope : io/kotest/core/spec/style/scopes/RootScope {
+	public fun config (Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 	public fun config-4xH7vM4 (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun config-4xH7vM4$default (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun invoke (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 }
 
 public final class io/kotest/core/spec/style/scopes/StringSpecRootScope$DefaultImpls {
+	public static fun config (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/String;Lio/kotest/core/test/config/TestConfig;Lkotlin/jvm/functions/Function2;)V
 	public static fun config-4xH7vM4 (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun config-4xH7vM4$default (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Set;Lkotlin/time/Duration;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/time/Duration;Lio/kotest/core/test/TestCaseSeverityLevel;Lkotlin/jvm/functions/Function1;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public static fun invoke (Lio/kotest/core/spec/style/scopes/StringSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/StringSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/StringSpecRootScope.kt
@@ -70,7 +70,20 @@ interface StringSpecRootScope : RootScope {
       addTest(
          testName = TestNameBuilder.builder(this).build(),
          xmethod = TestXMethod.NONE,
-         config = null
+         config = null,
+      ) {
+         StringSpecScope(this).test()
+      }
+   }
+
+   /**
+    * Adds a String Spec test using the supplied [TestConfig].
+    */
+   fun String.config(config: TestConfig, test: suspend TestScope.() -> Unit) {
+      addTest(
+         testName = TestNameBuilder.builder(this).build(),
+         xmethod = TestXMethod.NONE,
+         config = config,
       ) {
          StringSpecScope(this).test()
       }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
@@ -109,7 +109,7 @@ data class TestConfig(
    // if left to null, then the default provided by a spec or the project config will be used
    val retries: Int? = null,
 
-   // if set to a non-null value then this is the delay between retries
+   // if set to a non-null value, then this is the delay between retries
    // if left to null, then the default provided by a spec or the project config will be used
    val retryDelay: Duration? = null,
 ) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/test/config/TestConfig.kt
@@ -27,17 +27,18 @@ data class TestConfig(
    val invocations: Int? = null,
 
    /**
-    * The timeout for a test case and all it's invocations. For example, if this value was set to 800ms,
-    * and invocations was 1 (which is the default and typical value), then that single invocation has
-    * the full 800ms to complete. But if invocations was 2 for example, then the 800ms would apply to
-    * the total time across both those invocations.
+    * The timeout for a test case and all it's invocations.
+    *
+    * For example, if this value was set to 800ms, and invocations were 1 (which is the default and typical value),
+    * then that single invocation has the full 800ms to complete. But if invocations were instead set to 3 then the
+    * 800ms would apply to the total time across all three invocations.
     *
     * To set a timeout per invocation see [invocationTimeout].
     */
    val timeout: Duration? = null,
 
    /**
-    * This timeout applies to individual invocations of a test case. If invocations is 1, then this
+    * This timeout applies to individual invocations of a test case. If invocations are 1, then this
     * has the same effect as timeout. To set a timeout across all invocations then see [timeout].
     */
    val invocationTimeout: Duration? = null,
@@ -108,7 +109,7 @@ data class TestConfig(
    // if left to null, then the default provided by a spec or the project config will be used
    val retries: Int? = null,
 
-   // if set to to a non null value then this is the delay between retries
+   // if set to a non-null value then this is the delay between retries
    // if left to null, then the default provided by a spec or the project config will be used
    val retryDelay: Duration? = null,
 ) {


### PR DESCRIPTION
Verifies #5169 

Verifies that afterSpec callbacks (inline DSL, AfterSpecListener extension, and function override) are not invoked when a spec is filtered out by tag exclusion.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
