### PR TITLE
Add truncateTestNamesInGradle option to Gradle plugin

### DIFF
--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemPropertiesExtensions.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemPropertiesExtensions.kt
@@ -8,7 +8,7 @@ import io.kotest.extensions.system.OverrideMode.SetOrError
 import java.util.Properties
 
 /**
- * Changes System Properties with chosen key and value
+ * Changes System Properties with a given key and value
  *
  * This is a helper function for code that uses System Properties. It changes the specific [key] from [System.getProperties]
  * with the specified [value], only during the execution of [block].
@@ -26,7 +26,7 @@ inline fun <T> withSystemProperty(key: String, value: String?, mode: OverrideMod
 }
 
 /**
- * Changes System Properties with chosen key and value
+ * Changes System Properties with a given key and value
  *
  * This is a helper function for code that uses System Properties. It changes the specific key from [System.getProperties]
  * with the specified value, only during the execution of [block].

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/names/LocationEmbedder.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/names/LocationEmbedder.kt
@@ -23,7 +23,6 @@ object LocationEmbedder {
     * the package name. Therefore, we must replace periods.
     */
    fun embeddedTestName(descriptor: Descriptor, formattedName: String): String {
-      // https://www.ascii-code.com/
 // todo native support     return OPEN_TAG + descriptor.path().value.replace(' ', '\u00A0').replace('.', '!') + CLOSE_TAG + formattedName
       return OPEN_TAG + descriptor.path().value + CLOSE_TAG + formattedName
    }

--- a/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
+++ b/kotest-framework/kotest-framework-plugin-gradle/api/kotest-framework-plugin-gradle.api
@@ -4,6 +4,7 @@ public abstract class io/kotest/framework/gradle/KotestGradleExtension {
 	public abstract fun getCustomGradleTask ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnablePowerAssert ()Lorg/gradle/api/provider/Property;
 	public abstract fun getShowIgnoreReasons ()Lorg/gradle/api/provider/Property;
+	public abstract fun getTruncateTestNamesInGradle ()Lorg/gradle/api/provider/Property;
 }
 
 public abstract class io/kotest/framework/gradle/KotestPlugin : org/gradle/api/Plugin {

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestGradleExtension.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestGradleExtension.kt
@@ -26,4 +26,12 @@ abstract class KotestGradleExtension {
     */
    @ExperimentalKotest
    abstract val enablePowerAssert: Property<Boolean>
+
+   /**
+    * Set to true, and Kotest will truncate container (parent) test display names when running via Gradle.
+    * This can help avoid excessively long file paths in test reports when Gradle generates a directory
+    * for every level of the test hierarchy (Gradle 9.3+).
+    * Spec names (class names) are never truncated.
+    */
+   abstract val truncateTestNamesInGradle: Property<Boolean>
 }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -65,6 +65,7 @@ abstract class KotestPlugin : Plugin<Project> {
 
       internal const val KOTEST_INCLUDE_PATTERN = "KOTEST_INCLUDE_PATTERN"
       internal const val KOTEST_SHOW_IGNORE_REASONS = "KOTEST_SHOW_IGNORE_REASONS"
+      internal const val KOTEST_TRUNCATE_TEST_NAMES = "KOTEST_TRUNCATE_TEST_NAMES"
       internal const val IDEA_ACTIVE_ENV = "IDEA_ACTIVE"
       internal const val IDEA_ACTIVE_SYSPROP = "idea.active"
       internal const val FAIL_ON_NO_DISCOVERED_TESTS = "failOnNoDiscoveredTests"
@@ -158,6 +159,10 @@ abstract class KotestPlugin : Plugin<Project> {
 
          if (extension.showIgnoreReasons.getOrElse(false)) {
             setEnvVar(task, KOTEST_SHOW_IGNORE_REASONS, "true")
+         }
+
+         if (extension.truncateTestNamesInGradle.getOrElse(false)) {
+            setEnvVar(task, KOTEST_TRUNCATE_TEST_NAMES, "true")
          }
       }
 

--- a/kotest-runner/kotest-runner-junit-platform/build.gradle.kts
+++ b/kotest-runner/kotest-runner-junit-platform/build.gradle.kts
@@ -37,3 +37,8 @@ kotlin {
 
    }
 }
+
+tasks.withType<Test>().configureEach {
+   // Required by kotest-extensions-system's withEnvironment to modify System.getenv() in tests
+   jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+}

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -17,7 +17,7 @@ import kotlin.jvm.optionals.getOrNull
 import kotlin.reflect.KClass
 
 internal const val TRUNCATE_TEST_NAMES_ENV = "KOTEST_TRUNCATE_TEST_NAMES"
-internal const val MAX_TRUNCATED_NAME_LENGTH = 64
+internal const val MAX_TRUNCATED_NAME_LENGTH = 48
 
 /**
  * Finds and returns the [org.junit.platform.engine.TestDescriptor] corresponding to the

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/descriptors.kt
@@ -1,6 +1,5 @@
 package io.kotest.runner.junit.platform
 
-import io.kotest.common.env
 import io.kotest.common.isIntellij
 import io.kotest.core.descriptors.Descriptor
 import io.kotest.core.test.TestCase
@@ -83,7 +82,7 @@ internal fun createTestDescriptorWithMethodSource(
          LocationEmbedder.embeddedTestName(testCase.descriptor, formatter.format(testCase))
       else {
          val name = formatter.format(testCase)
-         if (type == TestDescriptor.Type.CONTAINER && env(TRUNCATE_TEST_NAMES_ENV) == "true")
+         if (type == TestDescriptor.Type.CONTAINER && isTruncateTestNamesEnabled())
             truncateTestName(name)
          else
             name
@@ -106,6 +105,17 @@ internal fun getMethodSource(kclass: KClass<*>, id: UniqueId): MethodSource = Me
    /* className = */ kclass.java.name,
    /* methodName = */ id.segments.filter { it.type == Segment.Test.value }.joinToString("/") { it.value }
 )
+
+/**
+ * Returns true if test name truncation is enabled.
+ *
+ * Checks both the JVM system property and the environment variable with the same key
+ * ([TRUNCATE_TEST_NAMES_ENV]) so that the feature can be activated via either mechanism.
+ * System properties are checked first because they work on all platforms (including Windows,
+ * where modifying environment variables at runtime is unreliable).
+ */
+internal fun isTruncateTestNamesEnabled(): Boolean =
+   System.getProperty(TRUNCATE_TEST_NAMES_ENV) == "true" || System.getenv(TRUNCATE_TEST_NAMES_ENV) == "true"
 
 internal fun truncateTestName(name: String): String =
    if (name.length <= MAX_TRUNCATED_NAME_LENGTH) name

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/CreateTestDescriptorWithMethodSourceTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/CreateTestDescriptorWithMethodSourceTest.kt
@@ -8,7 +8,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
 import io.kotest.engine.test.names.DisplayNameFormatting
-import io.kotest.extensions.system.withEnvironment
+import io.kotest.extensions.system.withSystemProperty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.platform.engine.TestDescriptor
@@ -122,7 +122,7 @@ class CreateTestDescriptorWithMethodSourceTest : FunSpec({
       }
 
       test("CONTAINER display name is truncated when env var is set") {
-         withEnvironment(TRUNCATE_TEST_NAMES_ENV, "true") {
+         withSystemProperty(TRUNCATE_TEST_NAMES_ENV, "true") {
             val descriptor = createTestDescriptorWithMethodSource(
                root = root,
                testCase = longNameTestCase,
@@ -143,7 +143,7 @@ class CreateTestDescriptorWithMethodSourceTest : FunSpec({
             TestType.Test,
             parent = longNameTestCase,
          )
-         withEnvironment(TRUNCATE_TEST_NAMES_ENV, "true") {
+         withSystemProperty(TRUNCATE_TEST_NAMES_ENV, "true") {
             val descriptor = createTestDescriptorWithMethodSource(
                root = root,
                testCase = longLeafTestCase,
@@ -155,7 +155,7 @@ class CreateTestDescriptorWithMethodSourceTest : FunSpec({
       }
 
       test("short CONTAINER display name is not truncated even when env var is set") {
-         withEnvironment(TRUNCATE_TEST_NAMES_ENV, "true") {
+         withSystemProperty(TRUNCATE_TEST_NAMES_ENV, "true") {
             val descriptor = createTestDescriptorWithMethodSource(
                root = root,
                testCase = containerTestCase,
@@ -169,4 +169,3 @@ class CreateTestDescriptorWithMethodSourceTest : FunSpec({
 })
 
 private class DummySpec : FunSpec({})
-

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/TruncateTestNameTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/TruncateTestNameTest.kt
@@ -1,0 +1,42 @@
+package io.kotest.runner.junit.platform
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class TruncateTestNameTest : FunSpec({
+
+   test("name shorter than max length is returned unchanged") {
+      truncateTestName("short name") shouldBe "short name"
+   }
+
+   test("empty string is returned unchanged") {
+      truncateTestName("") shouldBe ""
+   }
+
+   test("name exactly at max length is returned unchanged") {
+      val name = "a".repeat(MAX_TRUNCATED_NAME_LENGTH)
+      truncateTestName(name) shouldBe name
+   }
+
+   test("name one character over max length is truncated with ellipsis") {
+      val name = "a".repeat(MAX_TRUNCATED_NAME_LENGTH + 1)
+      val truncated = truncateTestName(name)
+      truncated shouldBe "a".repeat(MAX_TRUNCATED_NAME_LENGTH - 3) + "..."
+      truncated.length shouldBe MAX_TRUNCATED_NAME_LENGTH
+   }
+
+   test("long name is truncated to max length with ellipsis") {
+      val name = "a".repeat(MAX_TRUNCATED_NAME_LENGTH * 2)
+      val truncated = truncateTestName(name)
+      truncated.length shouldBe MAX_TRUNCATED_NAME_LENGTH
+      truncated.endsWith("...") shouldBe true
+   }
+
+   test("truncated name ends with ellipsis") {
+      val name = "Given a user is logged in and has an active subscription with premium features enabled"
+      val truncated = truncateTestName(name)
+      truncated.length shouldBe MAX_TRUNCATED_NAME_LENGTH
+      truncated.endsWith("...") shouldBe true
+      truncated shouldBe name.take(MAX_TRUNCATED_NAME_LENGTH - 3) + "..."
+   }
+})


### PR DESCRIPTION
## Summary

Fixes #5644.

Gradle 9.3+ generates a directory for every level of the test hierarchy in test reports. With verbose BDD-style test descriptions (e.g. \`Context > Given > When > Then\`), the resulting file paths can exceed limits on some CI systems (e.g. Azure Pipelines' 399-character path limit).

This PR adds a \`truncateTestNamesInGradle\` boolean option to \`KotestGradleExtension\` that, when enabled, truncates container (parent) test display names to at most 48 characters in Gradle test reports.

- Adds \`truncateTestNamesInGradle: Property<Boolean>\` to \`KotestGradleExtension\` (defaults to \`false\`)
- When \`true\`, the Gradle plugin sets the \`KOTEST_TRUNCATE_TEST_NAMES\` environment variable on the test task
- The JUnit platform test engine listener checks this env var and truncates container test names to 48 characters (appending \`...\` if truncated)
- Spec names (class names) are **never** truncated
- Leaf tests are **never** truncated
- No effect when running in IntelliJ

## Usage

```kotlin
// build.gradle.kts
kotest {
    truncateTestNamesInGradle = true
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)