### PR TITLE
Adjust logic of when AndroidInstrumentation run producer is active

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/gradle/VersionParser.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/gradle/VersionParser.kt
@@ -3,13 +3,14 @@ package io.kotest.plugin.intellij.gradle
 internal object VersionParser {
 
    fun parse(version: String): Version? {
-      // we assume x.y..... format
+      // we assume x.y.z.... format
       val tokens = version.split(".")
-      if (tokens.size < 2) return null
+      if (tokens.size < 3) return null
       val major = tokens[0].take(2).toIntOrNull() ?: return null
       val minor = tokens[1].take(2).toIntOrNull() ?: return null
-      return Version(major, minor)
+      val patch = tokens[2].take(2).toIntOrNull() ?: return null
+      return Version(major, minor, patch)
    }
 }
 
-internal data class Version(val major: Int, val minor: Int)
+internal data class Version(val major: Int, val minor: Int, val patch: Int)

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/gradle/VersionParser.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/gradle/VersionParser.kt
@@ -4,11 +4,11 @@ internal object VersionParser {
 
    fun parse(version: String): Version? {
       // we assume x.y.z.... format
-      val tokens = version.split(".")
+      val tokens = version.split('.')
       if (tokens.size < 3) return null
       val major = tokens[0].take(2).toIntOrNull() ?: return null
       val minor = tokens[1].take(2).toIntOrNull() ?: return null
-      val patch = tokens[2].take(2).toIntOrNull() ?: return null
+      val patch = tokens[2].take(2).toIntOrNull() ?: tokens[2].take(1).toIntOrNull() ?: return null
       return Version(major, minor, patch)
    }
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/mode.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/mode.kt
@@ -28,7 +28,7 @@ object RunnerModes {
 
       // if we are on Kotest 6.1 or higher, and the test runner is Gradle, then we default to the Gradle test task
       // this doesn't require the Kotest Gradle plugin to be added for JVM.
-      if (GradleUtils.isKotest61OrAbove(module) && GradleUtils.isGradleTestRunner(module)) return RunnerMode.GRADLE_TEST_TASK
+      if (GradleUtils.isKotest61OrAbove(module.project) && GradleUtils.isGradleTestRunner(module)) return RunnerMode.GRADLE_TEST_TASK
 
       // if we have the Kotest Gradle plugin, then we use the Kotest task
       if (GradleUtils.hasKotestGradlePlugin(module)) return RunnerMode.GRADLE_KOTEST_TASK

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/gradle/GradleUtilsTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/gradle/GradleUtilsTest.kt
@@ -1,0 +1,43 @@
+package io.kotest.plugin.intellij.gradle
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+
+class GradleUtilsTest {
+
+   @Test
+   fun `isKotest614OrAbove returns false for major below 6`() {
+      GradleUtils.isKotest614OrAbove(Version(5, 9, 9)) shouldBe false
+      GradleUtils.isKotest614OrAbove(Version(4, 0, 0)) shouldBe false
+   }
+
+   @Test
+   fun `isKotest614OrAbove returns false for 6_0_x`() {
+      GradleUtils.isKotest614OrAbove(Version(6, 0, 0)) shouldBe false
+      GradleUtils.isKotest614OrAbove(Version(6, 0, 9)) shouldBe false
+   }
+
+   @Test
+   fun `isKotest614OrAbove returns false for 6_1_x below patch 4`() {
+      GradleUtils.isKotest614OrAbove(Version(6, 1, 0)) shouldBe false
+      GradleUtils.isKotest614OrAbove(Version(6, 1, 3)) shouldBe false
+   }
+
+   @Test
+   fun `isKotest614OrAbove returns true for 6_1_4 and above`() {
+      GradleUtils.isKotest614OrAbove(Version(6, 1, 4)) shouldBe true
+      GradleUtils.isKotest614OrAbove(Version(6, 1, 9)) shouldBe true
+   }
+
+   @Test
+   fun `isKotest614OrAbove returns true for 6_2 and above`() {
+      GradleUtils.isKotest614OrAbove(Version(6, 2, 0)) shouldBe true
+      GradleUtils.isKotest614OrAbove(Version(6, 9, 0)) shouldBe true
+   }
+
+   @Test
+   fun `isKotest614OrAbove returns true for major 7 and above`() {
+      GradleUtils.isKotest614OrAbove(Version(7, 0, 0)) shouldBe true
+      GradleUtils.isKotest614OrAbove(Version(8, 0, 0)) shouldBe true
+   }
+}

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/gradle/VersionParserTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/gradle/VersionParserTest.kt
@@ -8,7 +8,6 @@ class VersionParserTest {
    @Test
    fun happyPath() {
       VersionParser.parse("6.1.0") shouldBe Version(6, 1, 0)
-      VersionParser.parse("6.1") shouldBe Version(6, 1, 0)
       VersionParser.parse("6.1.3") shouldBe Version(6, 1, 3)
       VersionParser.parse("12.34.45") shouldBe Version(12, 34, 45)
       VersionParser.parse("6.1.0-LOCAL") shouldBe Version(6, 1, 0)
@@ -19,6 +18,7 @@ class VersionParserTest {
    fun unhappyPath() {
       VersionParser.parse("6") shouldBe null
       VersionParser.parse("6.a") shouldBe null
+      VersionParser.parse("6.1") shouldBe null
       VersionParser.parse("6a.12") shouldBe null
       VersionParser.parse("6.1b") shouldBe null
       VersionParser.parse("") shouldBe null

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/gradle/VersionParserTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/gradle/VersionParserTest.kt
@@ -7,10 +7,12 @@ class VersionParserTest {
 
    @Test
    fun happyPath() {
-      VersionParser.parse("6.1.0") shouldBe Version(6, 1)
-      VersionParser.parse("6.1") shouldBe Version(6, 1)
-      VersionParser.parse("6.1.0-LOCAL") shouldBe Version(6, 1)
-      VersionParser.parse("6.1.0.123-SNAPSHOT") shouldBe Version(6, 1)
+      VersionParser.parse("6.1.0") shouldBe Version(6, 1, 0)
+      VersionParser.parse("6.1") shouldBe Version(6, 1, 0)
+      VersionParser.parse("6.1.3") shouldBe Version(6, 1, 3)
+      VersionParser.parse("12.34.45") shouldBe Version(12, 34, 45)
+      VersionParser.parse("6.1.0-LOCAL") shouldBe Version(6, 1, 0)
+      VersionParser.parse("6.1.0.123-SNAPSHOT") shouldBe Version(6, 1, 0)
    }
 
    @Test


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
