### PR TITLE
Fix shrinker treating assume() skips as failures

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/shrink.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/shrink.kt
@@ -2,6 +2,7 @@ package io.kotest.property.internal
 
 import io.kotest.assertions.print.print
 import io.kotest.common.stacktrace.stacktraces
+import io.kotest.engine.IterationSkippedException
 import io.kotest.property.PropertyContext
 import io.kotest.property.PropertyTesting
 import io.kotest.property.RTree
@@ -83,6 +84,11 @@ suspend fun <A> doStep(
             test(candidate)
             if (PropertyTesting.shouldPrintShrinkSteps)
                sb.append("Shrink #${counter.count}: ${candidate.print().value} pass\n")
+         } catch (_: IterationSkippedException) {
+            // A skipped iteration (from assume()) is not a failure — the shrunk value does not
+            // satisfy the precondition so it is not a valid counterexample. Treat it as a pass.
+            if (PropertyTesting.shouldPrintShrinkSteps)
+               sb.append("Shrink #${counter.count}: ${candidate.print().value} skip\n")
          } catch (t: Throwable) {
             if (PropertyTesting.shouldPrintShrinkSteps)
                sb.append("Shrink #${counter.count}: ${candidate.print().value} fail\n")

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/AssumeShrinkingTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/AssumeShrinkingTest.kt
@@ -1,0 +1,45 @@
+package com.sksamuel.kotest.property.shrinking
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.IterationSkippedException
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.property.RTree
+import io.kotest.property.ShrinkingMode
+import io.kotest.property.assume
+import io.kotest.property.internal.doShrinking
+
+/**
+ * Regression tests for https://github.com/kotest/kotest/issues/5693
+ *
+ * The shrinker must not treat an IterationSkippedException (raised by assume()) as a test failure.
+ * A shrunk candidate that fails an assumption is not a valid counterexample and should be skipped,
+ * not used as the "smallest failing case".
+ */
+class AssumeShrinkingTest : FunSpec() {
+   init {
+      test("doShrinking should treat assume() failures as passes, not as test failures") {
+         // Manual shrink tree: initial value 10, shrink candidates are 0, 3, and 7.
+         // assume() requires n >= 5, so candidates 0 and 3 trigger IterationSkippedException.
+         // Candidate 7 is the genuine smallest failure (passes assumption, fails property).
+         val result = doShrinking(
+            RTree({ 10 }, lazy {
+               listOf(
+                  RTree({ 0 }),  // fails assume(n >= 5) → IterationSkippedException
+                  RTree({ 3 }),  // fails assume(n >= 5) → IterationSkippedException
+                  RTree({ 7 }),  // passes assume, fails property (n > 5)
+               )
+            }),
+            ShrinkingMode.Unbounded
+         ) { n: Int ->
+            assume(n >= 5)
+            if (n > 5) throw AssertionError("n must not exceed 5, but was $n")
+         }
+
+         // Before the fix, 0 was reported (IterationSkippedException treated as failure).
+         // After the fix, 7 is correctly reported as the smallest genuine counterexample.
+         result.shrink shouldBe 7
+         result.cause.shouldBeInstanceOf<AssertionError>()
+      }
+   }
+}


### PR DESCRIPTION
## Summary

Fixes #5693.

The shrinker in `doStep()` caught all `Throwable`s as test failures. Since `assume()` throws `IterationSkippedException` (a `Throwable`), a shrunk candidate that simply failed the property's precondition was treated as a genuine counterexample. The shrinker would then descend into it and eventually report a meaningless minimal value (e.g. empty string or `0`) that only fails the assumption, not the actual property.

**Fix:** Add a `catch (_: IterationSkippedException)` clause before the general `catch (t: Throwable)` in `doStep()`. A skipped iteration is treated as a pass — not a valid counterexample — so the shrinker moves on to the next candidate.

## Changes

- `kotest-property/.../internal/shrink.kt` — catch `IterationSkippedException` separately and treat it as a pass during shrinking
- `kotest-property/.../shrinking/AssumeShrinkingTest.kt` — regression test: verifies that candidates failing `assume()` are skipped, and the smallest genuine failure is returned

## Test plan

- [x] New regression test `AssumeShrinkingTest` verifies the fixed behaviour directly via `doShrinking` with a controlled shrink tree
- [x] All existing shrinking tests pass (`com.sksamuel.kotest.property.shrinking.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)