### PR TITLE
reintroduce io.kotest.matchers classes and interfaces

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
+++ b/kotest-assertions/kotest-assertions-shared/api/kotest-assertions-shared.api
@@ -186,6 +186,18 @@ public final class io/kotest/matchers/Aliases_jvmKt {
 	public static final fun getErrorCollectorContextElement ()Lkotlin/coroutines/CoroutineContext$Element;
 }
 
+public abstract interface class io/kotest/matchers/AssertionCounter : io/kotest/assertions/AssertionCounter {
+}
+
+public final class io/kotest/matchers/AssertionCounter$DefaultImpls {
+	public static fun getAndReset (Lio/kotest/matchers/AssertionCounter;)I
+	public static fun inc (Lio/kotest/matchers/AssertionCounter;I)V
+}
+
+public class io/kotest/matchers/BasicErrorCollector : io/kotest/assertions/BasicErrorCollector {
+	public fun <init> ()V
+}
+
 public final class io/kotest/matchers/DiffableMatcherResult : io/kotest/matchers/MatcherResult {
 	public final fun component1 ()Z
 	public final fun component2 ()Lkotlin/jvm/functions/Function0;
@@ -203,6 +215,9 @@ public final class io/kotest/matchers/DiffableMatcherResult : io/kotest/matchers
 	public fun negatedFailureMessage ()Ljava/lang/String;
 	public fun passed ()Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/kotest/matchers/ErrorCollector : io/kotest/assertions/ErrorCollector {
 }
 
 public abstract interface class io/kotest/matchers/Matcher {

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/aliases.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/matchers/aliases.kt
@@ -3,7 +3,7 @@ package io.kotest.matchers
 import io.kotest.assertions.BasicErrorCollector
 
 @Deprecated("Use io.kotest.assertions.AssertionCounter. Will be removed in a future release.")
-typealias AssertionCounter = io.kotest.assertions.AssertionCounter
+interface AssertionCounter : io.kotest.assertions.AssertionCounter
 
 @Deprecated("Use io.kotest.assertions.assertionCounter. Will be removed in a future release.")
 val assertionCounter: io.kotest.assertions.AssertionCounter get() = io.kotest.assertions.assertionCounter
@@ -12,10 +12,10 @@ val assertionCounter: io.kotest.assertions.AssertionCounter get() = io.kotest.as
 typealias ErrorCollectionMode = io.kotest.assertions.ErrorCollectionMode
 
 @Deprecated("Use io.kotest.assertions.ErrorCollector. Will be removed in a future release.")
-typealias ErrorCollector = io.kotest.assertions.ErrorCollector
+interface ErrorCollector : io.kotest.assertions.ErrorCollector
 
 @Deprecated("Use io.kotest.assertions.errorCollector. Will be removed in a future release.")
 val errorCollector: io.kotest.assertions.ErrorCollector get() = io.kotest.assertions.errorCollector
 
 @Deprecated("Use io.kotest.assertions.BasicErrorCollector. Will be removed in a future release.")
-typealias BasicErrorCollector = BasicErrorCollector
+open class BasicErrorCollector : BasicErrorCollector()


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Unable to re-introduce:
- ErrorCollectionMode: this is an enum and it cannot implement from another ENUM 

tries to address https://github.com/kotest/kotest/issues/5732