### PR TITLE
re-enable location hints for TeamCity

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -4573,6 +4573,7 @@ public final class io/kotest/engine/teamcity/TeamCityMessage {
 	public final fun exception (Ljava/lang/Throwable;Z)Lio/kotest/engine/teamcity/TeamCityMessage;
 	public static synthetic fun exception$default (Lio/kotest/engine/teamcity/TeamCityMessage;Ljava/lang/Throwable;ZILjava/lang/Object;)Lio/kotest/engine/teamcity/TeamCityMessage;
 	public final fun expected (Ljava/lang/String;)V
+	public final fun locationHint (Ljava/lang/String;)V
 	public final fun message (Ljava/lang/String;)V
 	public final fun name (Ljava/lang/String;)V
 	public final fun out (Ljava/lang/String;)V
@@ -4587,6 +4588,7 @@ public final class io/kotest/engine/teamcity/TeamCityMessage$Attributes {
 	public static final field DURATION Ljava/lang/String;
 	public static final field EXPECTED Ljava/lang/String;
 	public static final field INSTANCE Lio/kotest/engine/teamcity/TeamCityMessage$Attributes;
+	public static final field LOCATION_HINT Ljava/lang/String;
 	public static final field MESSAGE Ljava/lang/String;
 	public static final field NAME Ljava/lang/String;
 	public static final field OUT Ljava/lang/String;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
@@ -10,6 +10,7 @@ import io.kotest.engine.errors.ExtensionExceptionExtractor
 import io.kotest.engine.extensions.MultipleExceptions
 import io.kotest.engine.teamcity.TeamCityMessage
 import io.kotest.engine.teamcity.TeamCityPathRenderer
+import io.kotest.engine.teamcity.Locations
 import io.kotest.engine.test.TestResult
 import io.kotest.engine.test.names.DisplayNameFormatting
 import kotlin.reflect.KClass
@@ -64,6 +65,7 @@ class TeamCityTestEngineListener(
    override suspend fun specStarted(ref: SpecRef) {
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_SUITE_STARTED) {
          name(renderer.testPath(ref))
+         locationHint(Locations.location(ref))
       }.output()
    }
 
@@ -91,12 +93,14 @@ class TeamCityTestEngineListener(
       if (testCase.type == TestType.Test)
          TeamCityMessage(prefix, TeamCityMessage.Types.TEST_STARTED) {
             name(renderer.testPath(testCase))
+            locationHint(Locations.location(testCase.source))
          }.output()
    }
 
    override suspend fun testIgnored(testCase: TestCase, reason: String?) {
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_IGNORED) {
          name(testCase.descriptor.path().value)
+         locationHint(Locations.location(testCase.source))
          message(reason)
          result(TestResult.Ignored(reason))
       }.output()

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityMessage.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityMessage.kt
@@ -50,6 +50,7 @@ class TeamCityMessage(
       const val DETAILS = "details"
       const val MESSAGE = "message"
       const val RESULT_STATUS = "result_status"
+      const val LOCATION_HINT = "locationHint"
    }
 
    object Types {
@@ -132,6 +133,10 @@ class TeamCityMessage(
    private fun escapeColonsIn(value: String) = when (escapeColons) {
       true -> value.replace(":", "\u02D0")
       false -> value
+   }
+
+   fun locationHint(value: String?) {
+      if (value != null) attribute(Attributes.LOCATION_HINT, value)
    }
 
    fun duration(duration: Duration) =

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
@@ -67,8 +67,8 @@ class TeamCityTestEngineListenerTest : FunSpec() {
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Success']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
@@ -92,8 +92,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFailed name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' message='boom' result_status='Error']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='653' result_status='Error']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
@@ -117,8 +117,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testIgnored name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' message='don|'t like it' result_status='Ignored']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testIgnored name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' locationHint='kotest://foo.bar.Test:33' message='don|'t like it' result_status='Ignored']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
@@ -141,8 +141,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Success']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ Exception']
 a[testFailed name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ Exception']
@@ -169,8 +169,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Success']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest ⇢ Exception']
 a[testFailed name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest ⇢ Exception']
@@ -207,8 +207,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFailed name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' message='well this is a' result_status='Error']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Error']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
@@ -233,8 +233,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(listOf(Exception("big whoop")))
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='555' result_status='Success']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 a[testStarted name='Exception']
@@ -261,8 +261,8 @@ a[testFinished name='Exception']
             listener.engineFinished(listOf(Exception("big whoop"), Exception("big whoop 2")))
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='555' result_status='Success']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 a[testStarted name='Exception']
@@ -295,9 +295,9 @@ a[testFinished name='Exception']
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
@@ -323,8 +323,8 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             listener.engineFinished(emptyList())
          }
          output shouldBe """a[enteredTheMatrix]
-a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
-a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a b c']
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a b c' locationHint='kotest://foo.bar.Test:17']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a b c' duration='124' result_status='Success']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
fixes https://github.com/kotest/kotest/issues/5676
Re-enables locationHint in TeamCity - this is not needed by the `gradle` producers, but still needed by the `idea`'s ones