### PR TITLE
Precise Gradle configuration needed for pitest extension

### DIFF
--- a/documentation/versioned_docs/version-6.1/extensions/pitest.md
+++ b/documentation/versioned_docs/version-6.1/extensions/pitest.md
@@ -17,7 +17,7 @@ After [configuring](https://gradle-pitest-plugin.solidsoft.info/) Pitest,
 add the `io.kotest:kotest-extensions-pitest` module to your dependencies as well:
 
 ```kotlin
-    testImplementation("io.kotest:kotest-extensions-pitest:<version>")
+    pitest("io.kotest:kotest-extensions-pitest:<version>")
 ```
 
 :::note


### PR DESCRIPTION
This is the gradle-pitest-plugin author here. Analyzing this [issue](https://github.com/szpak/gradle-pitest-plugin/issues/396), I've spotted a sub optimal kotest pitest extension configuration. The tests itself don't need it, only the Pitest execution triggered by the gradle-pitest-plugin (and `pitest()` is enought - as described in the [plugin documentation](https://github.com/szpak/gradle-pitest-plugin#generic-plugin-support-also-junit-5-in-gradle-pitest-plugin-147)).

Btw, creating a draft, as I create a PR from a browser with "one file edit" and I cannot easily change also all of the documentation versions. It would be great to have it covered by you. Alternatively, I can "fix" it after the weekend.