### PR TITLE
Add finalizeSpec DSL function to TestConfiguration and Spec

### DIFF
--- a/documentation/src/pages/index.js
+++ b/documentation/src/pages/index.js
@@ -21,6 +21,19 @@ const features = [
       ),
    },
    {
+      title: 'Multiplatform Support',
+      imageUrl: 'img/index_graphic_kmp.png',
+      description: (
+         <>
+            Kotest is fully multiplatform with support for JVM, JS, Native (Linux, Windows, iOS, macOS, tvOS, watchOS), Wasm, and Android unit and instrumented tests.
+            <br/><br/>
+            Multiplatform support leverages the existing Kotlin Gradle tasks for seamless integration into the Kotlin ecosystem.
+            <br/><br/>
+            <a href="/docs/framework/framework.html">Read more</a>
+         </>
+      ),
+   },
+   {
       title: 'Powerful Assertions',
       imageUrl: 'img/index_graphic_assertions.png',
       description: (
@@ -46,19 +59,6 @@ const features = [
             exhaustive checks, repeatable random seeds, coverage metrics, and more.
             <br/><br/>
             <a href="/docs/proptesframeworkt/property-based-testing.html">Read more</a>
-         </>
-      ),
-   },
-   {
-      title: 'Multiplatform Support',
-      imageUrl: 'img/index_graphic_kmp.png',
-      description: (
-         <>
-            Kotest is fully multiplatform with support for JVM, JS, Native (Linux, Windows, iOS, macOS, tvOS, watchOS), Wasm, and Android unit and instrumented tests.
-            <br/><br/>
-            Multiplatform support leverages the existing Kotlin Gradle tasks for seamless integration into the Kotlin ecosystem.
-            <br/><br/>
-            <a href="/docs/framework/framework.html">Read more</a>
          </>
       ),
    },

--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1672,6 +1672,7 @@ public abstract class io/kotest/core/spec/Spec : io/kotest/core/TestConfiguratio
 	public final fun beforeTest (Lkotlin/jvm/functions/Function2;)V
 	public fun coroutineDispatcherFactory ()Lio/kotest/engine/coroutines/CoroutineDispatcherFactory;
 	public fun duplicateTestNameMode ()Lio/kotest/core/names/DuplicateTestNameMode;
+	public final fun finalizeSpec (Lkotlin/jvm/functions/Function3;)V
 	public final fun getAssertionMode ()Lio/kotest/core/test/AssertionMode;
 	public final fun getBlockingTest ()Ljava/lang/Boolean;
 	public final fun getCoroutineDebugProbes ()Ljava/lang/Boolean;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -10,6 +10,7 @@ import io.kotest.core.listeners.AfterEachListener
 import io.kotest.core.listeners.AfterInvocationListener
 import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.FinalizeSpecListener
 import io.kotest.core.listeners.BeforeContainerListener
 import io.kotest.core.listeners.BeforeEachListener
 import io.kotest.core.listeners.BeforeInvocationListener
@@ -21,6 +22,7 @@ import io.kotest.core.spec.AfterEach
 import io.kotest.core.spec.AfterInvocation
 import io.kotest.core.spec.AfterSpec
 import io.kotest.core.spec.AfterTest
+import io.kotest.core.spec.FinalizeSpec
 import io.kotest.core.spec.AroundTestFn
 import io.kotest.core.spec.AutoCloseable
 import io.kotest.core.spec.BeforeAny
@@ -37,6 +39,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
 import io.kotest.core.test.TestType
 import kotlin.js.JsName
+import kotlin.reflect.KClass
 
 /**
  * An abstract base implementation for shared configuration between [Spec] and [TestFactoryConfiguration].
@@ -274,6 +277,19 @@ abstract class TestConfiguration : Extendable() {
       extension(object : AfterSpecListener {
          override suspend fun afterSpec(spec: Spec) {
             f(spec)
+         }
+      })
+   }
+
+   /**
+    * Registers a callback to be executed once per spec class after all tests in the spec have completed.
+    * Unlike [afterSpec], this callback is invoked only once regardless of the number of spec instances created,
+    * and receives the full map of test results.
+    */
+   open fun finalizeSpec(f: FinalizeSpec) {
+      extension(object : FinalizeSpecListener {
+         override suspend fun finalizeSpec(kclass: KClass<out Spec>, results: Map<TestCase, TestResult>) {
+            f(kclass, results)
          }
       })
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -281,19 +281,6 @@ abstract class TestConfiguration : Extendable() {
       })
    }
 
-   /**
-    * Registers a callback to be executed once per spec class after all tests in the spec have completed.
-    * Unlike [afterSpec], this callback is invoked only once regardless of the number of spec instances created,
-    * and receives the full map of test results.
-    */
-   open fun finalizeSpec(f: FinalizeSpec) {
-      extension(object : FinalizeSpecListener {
-         override suspend fun finalizeSpec(kclass: KClass<out Spec>, results: Map<TestCase, TestResult>) {
-            f(kclass, results)
-         }
-      })
-   }
-
    fun aroundTest(aroundTestFn: AroundTestFn) {
       this@TestConfiguration.extension(object : TestCaseExtension {
          override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -9,6 +9,7 @@ import io.kotest.core.extensions.Extension
 import io.kotest.core.factory.FactoryId
 import io.kotest.core.listeners.AfterProjectListener
 import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.FinalizeSpecListener
 import io.kotest.core.listeners.AfterTestListener
 import io.kotest.core.listeners.BeforeTestListener
 import io.kotest.core.names.DuplicateTestNameMode
@@ -28,6 +29,7 @@ import io.kotest.engine.coroutines.CoroutineDispatcherFactory
 import io.kotest.engine.test.TestResult
 import kotlinx.coroutines.CoroutineScope
 import kotlin.js.JsName
+import kotlin.reflect.KClass
 import kotlin.time.Duration
 
 /**
@@ -361,6 +363,15 @@ abstract class Spec : TestConfiguration() {
          override suspend fun afterSpec(spec: Spec) {
             if (spec::class == this@Spec::class)
                f(spec)
+         }
+      })
+   }
+
+   final override fun finalizeSpec(f: FinalizeSpec) {
+      extension(object : FinalizeSpecListener {
+         override suspend fun finalizeSpec(kclass: KClass<out Spec>, results: Map<TestCase, TestResult>) {
+            if (kclass == this@Spec::class)
+               f(kclass, results)
          }
       })
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/Spec.kt
@@ -9,9 +9,9 @@ import io.kotest.core.extensions.Extension
 import io.kotest.core.factory.FactoryId
 import io.kotest.core.listeners.AfterProjectListener
 import io.kotest.core.listeners.AfterSpecListener
-import io.kotest.core.listeners.FinalizeSpecListener
 import io.kotest.core.listeners.AfterTestListener
 import io.kotest.core.listeners.BeforeTestListener
+import io.kotest.core.listeners.FinalizeSpecListener
 import io.kotest.core.names.DuplicateTestNameMode
 import io.kotest.core.names.TestName
 import io.kotest.core.source.SourceRef
@@ -355,7 +355,8 @@ abstract class Spec : TestConfiguration() {
 
 
    /**
-    * Registers a callback to be executed after all tests in this spec.
+    * Registers a callback to be executed after all tests in this spec instance have completed.
+    *
     * The spec instance is provided as a parameter.
     */
    final override fun afterSpec(f: AfterSpec) {
@@ -367,7 +368,13 @@ abstract class Spec : TestConfiguration() {
       })
    }
 
-   final override fun finalizeSpec(f: FinalizeSpec) {
+   /**
+    * Registers a callback to be executed once all tests defined in a spec class have completed.
+    *
+    * Unlike [afterSpec], this callback is invoked only once all spec instances have completed,
+    * and receives the full map of test results.
+    */
+   fun finalizeSpec(f: FinalizeSpec) {
       extension(object : FinalizeSpecListener {
          override suspend fun finalizeSpec(kclass: KClass<out Spec>, results: Map<TestCase, TestResult>) {
             if (kclass == this@Spec::class)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/callbackAliases.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/callbackAliases.kt
@@ -3,6 +3,7 @@ package io.kotest.core.spec
 import io.kotest.core.Tuple2
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import kotlin.reflect.KClass
 
 typealias BeforeTest = suspend (TestCase) -> Unit
 typealias AfterTest = suspend (Tuple2<TestCase, TestResult>) -> Unit
@@ -15,6 +16,7 @@ typealias BeforeInvocation = suspend (TestCase, Int) -> Unit
 typealias AfterAny = suspend (Tuple2<TestCase, TestResult>) -> Unit
 typealias BeforeSpec = suspend (Spec) -> Unit
 typealias AfterSpec = suspend (Spec) -> Unit
+typealias FinalizeSpec = suspend (KClass<out Spec>, Map<TestCase, TestResult>) -> Unit
 typealias AfterInvocation = suspend (TestCase, Int) -> Unit
 typealias AfterProject = suspend () -> Unit
 typealias TestCaseExtensionFn = suspend (Tuple2<TestCase, suspend (TestCase) -> TestResult>) -> TestResult


### PR DESCRIPTION
## Summary

- Adds `FinalizeSpec` option to the spec DSL.

Unlike `afterSpec`, `finalizeSpec` is invoked after spec class (not per instance) and receives the full map of test results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)