### PR TITLE
ci: add workflow to auto-update API dumps on PR failures

### DIFF
--- a/.github/workflows/update-api-dump.yml
+++ b/.github/workflows/update-api-dump.yml
@@ -1,0 +1,59 @@
+name: Update API Dump
+
+on:
+   workflow_run:
+      workflows: ["pr-main"]
+      types: [completed]
+
+permissions:
+   contents: write
+
+jobs:
+   update-api-dump:
+      name: Update API Dump
+      # Only run when pr-main failed, for same-repo PRs (not forks)
+      if: >-
+         github.event.workflow_run.conclusion == 'failure' &&
+         github.event.workflow_run.event == 'pull_request' &&
+         github.event.workflow_run.head_repository.full_name == github.repository
+      runs-on: ubuntu-latest
+      steps:
+         -  name: Checkout PR branch
+            uses: actions/checkout@v5
+            with:
+               ref: ${{ github.event.workflow_run.head_branch }}
+               token: ${{ secrets.GITHUB_TOKEN }}
+
+         -  name: Setup JDK
+            uses: actions/setup-java@v5
+            with:
+               distribution: "temurin"
+               java-version-file: .github/.java-version
+
+         -  name: Setup Gradle
+            uses: gradle/actions/setup-gradle@v5
+            with:
+               cache-encryption-key: ${{ secrets.GRADLE_CONFIGURATION_CACHE_ENCRYPTION_KEY }}
+               cache-read-only: true
+
+         -  name: Check if apiCheck fails
+            id: api-check
+            run: ./gradlew apiCheck --continue
+            continue-on-error: true
+
+         -  name: Run apiDump
+            if: steps.api-check.outcome == 'failure'
+            run: ./gradlew apiDump
+
+         -  name: Commit and push updated API dumps
+            if: steps.api-check.outcome == 'failure'
+            run: |
+               git config user.name "github-actions[bot]"
+               git config user.email "github-actions[bot]@users.noreply.github.com"
+               if git diff --quiet -- '**/*.api'; then
+                 echo "No .api file changes after apiDump — failure was not API-related"
+                 exit 0
+               fi
+               git add '**/*.api'
+               git commit -m "chore: update API dumps"
+               git push

--- a/.github/workflows/update-api-dump.yml
+++ b/.github/workflows/update-api-dump.yml
@@ -7,15 +7,43 @@ on:
 
 permissions:
    contents: write
+   actions: read
+
+concurrency:
+   group: "api-dump-${{ github.event.workflow_run.head_branch }}"
+   cancel-in-progress: true
 
 jobs:
-   update-api-dump:
-      name: Update API Dump
+   check-api-failure:
+      name: Check if validate-api failed
       # Only run when pr-main failed, for same-repo PRs (not forks)
       if: >-
          github.event.workflow_run.conclusion == 'failure' &&
          github.event.workflow_run.event == 'pull_request' &&
          github.event.workflow_run.head_repository.full_name == github.repository
+      runs-on: ubuntu-latest
+      outputs:
+         api-failed: ${{ steps.check.outputs.api-failed }}
+      steps:
+         -  name: Check if validate-api job failed
+            id: check
+            env:
+               GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            run: |
+               conclusion=$(gh api \
+                 repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/jobs \
+                 --jq '.jobs[] | select(.name == "Validate API") | .conclusion')
+               echo "Validate API conclusion: $conclusion"
+               if [ "$conclusion" = "failure" ]; then
+                 echo "api-failed=true" >> "$GITHUB_OUTPUT"
+               else
+                 echo "api-failed=false" >> "$GITHUB_OUTPUT"
+               fi
+
+   update-api-dump:
+      name: Update API Dump
+      needs: check-api-failure
+      if: needs.check-api-failure.outputs.api-failed == 'true'
       runs-on: ubuntu-latest
       steps:
          -  name: Checkout PR branch
@@ -36,24 +64,17 @@ jobs:
                cache-encryption-key: ${{ secrets.GRADLE_CONFIGURATION_CACHE_ENCRYPTION_KEY }}
                cache-read-only: true
 
-         -  name: Check if apiCheck fails
-            id: api-check
-            run: ./gradlew apiCheck --continue
-            continue-on-error: true
-
          -  name: Run apiDump
-            if: steps.api-check.outcome == 'failure'
             run: ./gradlew apiDump
 
          -  name: Commit and push updated API dumps
-            if: steps.api-check.outcome == 'failure'
             run: |
                git config user.name "github-actions[bot]"
                git config user.email "github-actions[bot]@users.noreply.github.com"
-               if git diff --quiet -- '**/*.api'; then
-                 echo "No .api file changes after apiDump — failure was not API-related"
-                 exit 0
+               if git diff --name-only | grep -q '\.api$'; then
+                 git diff --name-only | grep '\.api$' | xargs git add
+                 git commit -m "chore: update API dumps"
+                 git push
+               else
+                 echo "No .api file changes after apiDump"
                fi
-               git add '**/*.api'
-               git commit -m "chore: update API dumps"
-               git push


### PR DESCRIPTION
When the pr-main validate-api job fails due to outdated .api dump files, this workflow automatically runs apiDump and commits the updated files back to the PR branch, saving contributors from having to do this manually.

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
