### PR TITLE
Enabling update-api-dump for PRs from forks

### DIFF
--- a/.github/workflows/update-api-dump.yml
+++ b/.github/workflows/update-api-dump.yml
@@ -19,8 +19,7 @@ jobs:
       # Only run when pr-main failed, for same-repo PRs (not forks)
       if: >-
          github.event.workflow_run.conclusion == 'failure' &&
-         github.event.workflow_run.event == 'pull_request' &&
-         github.event.workflow_run.head_repository.full_name == github.repository
+         github.event.workflow_run.event == 'pull_request'
       runs-on: ubuntu-latest
       outputs:
          api-failed: ${{ steps.check.outputs.api-failed }}


### PR DESCRIPTION
Forks are not being updated due to this condition.

It is working for PRs from the same repo, as seen [here](https://github.com/kotest/kotest/pull/5758)
[This failure](https://github.com/kotest/kotest/actions/runs/23308769923) on the [PR from a fork](https://github.com/kotest/kotest/pull/5760) should have triggered a run as well, but it was skipped due to this condition.
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
