### PR TITLE
Fix ProhibitedAnalysisException when re-running failed tests

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocator.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocator.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.ClassUtil
 import io.kotest.plugin.intellij.TestElement
-import io.kotest.plugin.intellij.psi.specStyle
+import io.kotest.plugin.intellij.psi.specStyleOnEdt
 import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
@@ -47,7 +47,7 @@ internal class EmbeddedLocationTestLocator(private val location: EmbeddedLocatio
       if (contexts.isEmpty()) return listOf(createPsiClassNavigable(psiClass))
 
       val ktClass = psiClass.navigationElement as? KtClassOrObject ?: return emptyList()
-      val style = ktClass.specStyle() ?: return emptyList()
+      val style = ktClass.specStyleOnEdt() ?: return emptyList()
 
       val tests = style.tests(ktClass, false)
       val test = findTest(tests, contexts) ?: return emptyList()


### PR DESCRIPTION
## Summary

- `EmbeddedLocationTestLocator.getLocation()` is invoked on the EDT when the user clicks "Rerun Failed Tests" in the Gradle test runner
- It was calling `ktClass.specStyle()`, which calls `getAllSuperClasses()`, which uses the Kotlin Analysis API — analysis is not permitted on the EDT
- `specStyleOnEdt()` already existed for exactly this purpose: it wraps the analysis in `allowAnalysisOnEdt { allowAnalysisFromWriteAction { ... } }`
- One-line fix: swap `specStyle()` for `specStyleOnEdt()` at the call site

Fixes #5765

## Test plan

- [ ] Open a project with Kotest tests, run them via the Gradle runner, then click the "Rerun Failed Tests" button — verify no `ProhibitedAnalysisException` is thrown and navigation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)