### PR TITLE
Mark AnnotationSpec lifecycle methods as implicitly used

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/implicits/AnnotationSpecImplicitUsageProvider.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/implicits/AnnotationSpecImplicitUsageProvider.kt
@@ -1,0 +1,57 @@
+package io.kotest.plugin.intellij.implicits
+
+import com.intellij.codeInsight.daemon.ImplicitUsageProvider
+import com.intellij.psi.PsiElement
+import io.kotest.plugin.intellij.psi.isContainedInSpecificSpec
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * Allows disabling highlighting of certain elements as unused when such elements are not referenced
+ * from the code but are referenced in some other way.
+ *
+ * This [ImplicitUsageProvider] marks methods annotated with AnnotationSpec lifecycle annotations
+ * (such as [io.kotest.core.spec.style.AnnotationSpec.BeforeEach],
+ * [io.kotest.core.spec.style.AnnotationSpec.AfterEach], etc.) as used, so that IntelliJ does not
+ * highlight them as unused declarations.
+ *
+ * It also marks inner classes annotated with [io.kotest.core.spec.style.AnnotationSpec.Nested]
+ * inside an AnnotationSpec subclass as used.
+ */
+class AnnotationSpecImplicitUsageProvider : ImplicitUsageProvider {
+
+   private val annotationSpecFqn = FqName("io.kotest.core.spec.style.AnnotationSpec")
+
+   private val lifecycleAnnotationNames = setOf(
+      "Test",
+      "BeforeEach", "Before",
+      "BeforeAll", "BeforeClass",
+      "AfterEach", "After",
+      "AfterAll", "AfterClass",
+      "Ignore",
+   )
+
+   override fun isImplicitWrite(element: PsiElement): Boolean = false
+   override fun isImplicitRead(element: PsiElement): Boolean = false
+
+   override fun isImplicitUsage(element: PsiElement): Boolean {
+      return when (element) {
+         is KtNamedFunction -> isAnnotationSpecFunction(element)
+         is KtClass -> isNestedAnnotationSpecClass(element)
+         else -> false
+      }
+   }
+
+   private fun isAnnotationSpecFunction(function: KtNamedFunction): Boolean {
+      val annotationNames = function.annotationEntries.mapNotNull { it.shortName?.asString() }
+      if (annotationNames.none { it in lifecycleAnnotationNames }) return false
+      return function.isContainedInSpecificSpec(annotationSpecFqn)
+   }
+
+   private fun isNestedAnnotationSpecClass(ktClass: KtClass): Boolean {
+      val hasNested = ktClass.annotationEntries.any { it.shortName?.asString() == "Nested" }
+      if (!hasNested) return false
+      return ktClass.isContainedInSpecificSpec(annotationSpecFqn)
+   }
+}

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/implicits/AnnotationSpecImplicitUsageProvider.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/implicits/AnnotationSpecImplicitUsageProvider.kt
@@ -3,7 +3,10 @@ package io.kotest.plugin.intellij.implicits
 import com.intellij.codeInsight.daemon.ImplicitUsageProvider
 import com.intellij.psi.PsiElement
 import io.kotest.plugin.intellij.psi.isContainedInSpecificSpec
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
@@ -23,14 +26,23 @@ class AnnotationSpecImplicitUsageProvider : ImplicitUsageProvider {
 
    private val annotationSpecFqn = FqName("io.kotest.core.spec.style.AnnotationSpec")
 
-   private val lifecycleAnnotationNames = setOf(
-      "Test",
-      "BeforeEach", "Before",
-      "BeforeAll", "BeforeClass",
-      "AfterEach", "After",
-      "AfterAll", "AfterClass",
-      "Ignore",
+   private val lifecycleAnnotationFqns = setOf(
+      FqName("io.kotest.core.spec.style.AnnotationSpec.Test"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.BeforeEach"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.Before"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.BeforeAll"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.BeforeClass"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.AfterEach"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.After"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.AfterAll"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.AfterClass"),
+      FqName("io.kotest.core.spec.style.AnnotationSpec.Ignore"),
    )
+
+   private val nestedAnnotationFqn = FqName("io.kotest.core.spec.style.AnnotationSpec.Nested")
+
+   // Short names for quick pre-filtering before expensive FQN resolution
+   private val lifecycleAnnotationShortNames = lifecycleAnnotationFqns.map { it.shortName().asString() }.toSet()
 
    override fun isImplicitWrite(element: PsiElement): Boolean = false
    override fun isImplicitRead(element: PsiElement): Boolean = false
@@ -44,14 +56,30 @@ class AnnotationSpecImplicitUsageProvider : ImplicitUsageProvider {
    }
 
    private fun isAnnotationSpecFunction(function: KtNamedFunction): Boolean {
-      val annotationNames = function.annotationEntries.mapNotNull { it.shortName?.asString() }
-      if (annotationNames.none { it in lifecycleAnnotationNames }) return false
+      val candidates = function.annotationEntries.filter {
+         it.shortName?.asString() in lifecycleAnnotationShortNames
+      }
+      if (candidates.isEmpty()) return false
+      if (candidates.none { isAnnotationWithFqn(it, lifecycleAnnotationFqns) }) return false
       return function.isContainedInSpecificSpec(annotationSpecFqn)
    }
 
    private fun isNestedAnnotationSpecClass(ktClass: KtClass): Boolean {
-      val hasNested = ktClass.annotationEntries.any { it.shortName?.asString() == "Nested" }
-      if (!hasNested) return false
+      val candidates = ktClass.annotationEntries.filter { it.shortName?.asString() == "Nested" }
+      if (candidates.isEmpty()) return false
+      if (candidates.none { isAnnotationWithFqn(it, setOf(nestedAnnotationFqn)) }) return false
       return ktClass.isContainedInSpecificSpec(annotationSpecFqn)
+   }
+
+   private fun isAnnotationWithFqn(entry: KtAnnotationEntry, fqns: Set<FqName>): Boolean {
+      val typeRef = entry.typeReference ?: return false
+      return try {
+         analyze(entry) {
+            val fqn = typeRef.type.symbol?.classId?.asSingleFqName() ?: return@analyze false
+            fqn in fqns
+         }
+      } catch (_: Exception) {
+         false
+      }
    }
 }

--- a/kotest-intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/kotest-intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -85,6 +85,7 @@
       <implicitUsageProvider implementation="io.kotest.plugin.intellij.implicits.SpecImplicitUsageProvider"/>
       <implicitUsageProvider implementation="io.kotest.plugin.intellij.implicits.ConfigClassesImplicitUsageProvider"/>
       <implicitUsageProvider implementation="io.kotest.plugin.intellij.implicits.AutoScanUsageProvider"/>
+      <implicitUsageProvider implementation="io.kotest.plugin.intellij.implicits.AnnotationSpecImplicitUsageProvider"/>
 
       <testFramework id="Kotest" implementation="io.kotest.plugin.intellij.KotestTestFramework"/>
       <testFinder implementation="io.kotest.plugin.intellij.tests.KotestTestFinder"/>

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/implicits/AnnotationSpecImplicitUsageProviderTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/implicits/AnnotationSpecImplicitUsageProviderTest.kt
@@ -1,0 +1,48 @@
+package io.kotest.plugin.intellij.implicits
+
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.testFramework.LightProjectDescriptor
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import io.kotest.matchers.shouldBe
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import java.nio.file.Paths
+
+class AnnotationSpecImplicitUsageProviderTest : LightJavaCodeInsightFixtureTestCase() {
+
+   override fun getProjectDescriptor(): LightProjectDescriptor = JAVA_11
+
+   override fun getTestDataPath(): String {
+      val path = Paths.get("./src/test/resources/").toAbsolutePath()
+      return path.toString()
+   }
+
+   override fun runInDispatchThread(): Boolean = false
+
+   fun testLifecycleFunctionsAreMarkedAsUsed() {
+      val psiFiles = myFixture.configureByFiles(
+         "/annotationspeclifecycle.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      val provider = AnnotationSpecImplicitUsageProvider()
+
+      ApplicationManager.getApplication().runReadAction {
+         val functions = PsiTreeUtil.findChildrenOfType(psiFiles[0], KtNamedFunction::class.java)
+
+         val beforeEach = functions.find { it.name == "beforeEachTest" }!!
+         val afterEach = functions.find { it.name == "afterEachTest" }!!
+         val beforeAll = functions.find { it.name == "beforeAllTests" }!!
+         val afterAll = functions.find { it.name == "afterAllTests" }!!
+         val test = functions.find { it.name == "myTest" }!!
+         val ignored = functions.find { it.name == "ignoredTest" }!!
+
+         provider.isImplicitUsage(beforeEach) shouldBe true
+         provider.isImplicitUsage(afterEach) shouldBe true
+         provider.isImplicitUsage(beforeAll) shouldBe true
+         provider.isImplicitUsage(afterAll) shouldBe true
+         provider.isImplicitUsage(test) shouldBe true
+         provider.isImplicitUsage(ignored) shouldBe true
+      }
+   }
+}

--- a/kotest-intellij-plugin/src/test/resources/annotationspeclifecycle.kt
+++ b/kotest-intellij-plugin/src/test/resources/annotationspeclifecycle.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.kotest.specs
+
+import io.kotest.core.spec.style.AnnotationSpec
+
+class AnnotationSpecLifecycleExample : AnnotationSpec() {
+
+   @BeforeEach
+   fun beforeEachTest() {
+   }
+
+   @AfterEach
+   fun afterEachTest() {
+   }
+
+   @BeforeAll
+   fun beforeAllTests() {
+   }
+
+   @AfterAll
+   fun afterAllTests() {
+   }
+
+   @Test
+   fun myTest() {
+   }
+
+   @Ignore
+   fun ignoredTest() {
+   }
+}

--- a/kotest-intellij-plugin/src/test/resources/io/kotest/core/spec/style/specs.kt
+++ b/kotest-intellij-plugin/src/test/resources/io/kotest/core/spec/style/specs.kt
@@ -18,4 +18,16 @@ abstract class FeatureSpec(body: FeatureSpec.() -> Unit = {})
 
 abstract class ShouldSpec(body: ShouldSpec.() -> Unit = {})
 
-abstract class AnnotationSpec()
+abstract class AnnotationSpec() {
+   annotation class Test
+   annotation class BeforeEach
+   annotation class Before
+   annotation class BeforeAll
+   annotation class BeforeClass
+   annotation class AfterEach
+   annotation class After
+   annotation class AfterAll
+   annotation class AfterClass
+   annotation class Ignore
+   annotation class Nested
+}


### PR DESCRIPTION
## Summary
- Adds `AnnotationSpecImplicitUsageProvider` that marks methods annotated with AnnotationSpec lifecycle annotations (`@Test`, `@BeforeEach`, `@AfterEach`, `@BeforeAll`, `@AfterAll`, `@Before`, `@After`, `@BeforeClass`, `@AfterClass`, `@Ignore`) as implicitly used
- Prevents IntelliJ from highlighting these methods as unused declarations when they appear inside an `AnnotationSpec` subclass
- Also marks inner classes annotated with `@Nested` inside an `AnnotationSpec` as used

Fixes https://github.com/kotest/kotest/issues/5420

## Test plan
- [ ] `AnnotationSpecImplicitUsageProviderTest` verifies that all lifecycle-annotated methods in an `AnnotationSpec` subclass are reported as implicitly used

🤖 Generated with [Claude Code](https://claude.com/claude-code)