### PR TITLE
Support @Suppress for duplicated test name and focus-in-nested-test warnings

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/AnnotationHolderUtil.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/AnnotationHolderUtil.kt
@@ -1,9 +1,13 @@
 package io.kotest.plugin.intellij
 
+import com.intellij.codeInspection.ProblemGroup
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
 
-fun AnnotationHolder.createWarnAnnotation(element: PsiElement, msg: String) {
-   newAnnotation(HighlightSeverity.WEAK_WARNING, msg).range(element).create()
+fun AnnotationHolder.createWarnAnnotation(element: PsiElement, msg: String, suppressId: String) {
+   newAnnotation(HighlightSeverity.WEAK_WARNING, msg)
+      .range(element)
+      .problemGroup(ProblemGroup { suppressId })
+      .create()
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/AnnotationHolderUtil.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/AnnotationHolderUtil.kt
@@ -1,6 +1,5 @@
 package io.kotest.plugin.intellij
 
-import com.intellij.codeInspection.ProblemGroup
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.psi.PsiElement
@@ -8,6 +7,6 @@ import com.intellij.psi.PsiElement
 fun AnnotationHolder.createWarnAnnotation(element: PsiElement, msg: String, suppressId: String) {
    newAnnotation(HighlightSeverity.WEAK_WARNING, msg)
       .range(element)
-      .problemGroup(ProblemGroup { suppressId })
+      .problemGroup { suppressId }
       .create()
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/annotators/DuplicatedTestNameAnnotator.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/annotators/DuplicatedTestNameAnnotator.kt
@@ -37,7 +37,7 @@ class DuplicatedTestNameAnnotator : Annotator {
       val duplicated = tests.count { it.test.descriptorPath() == test.descriptorPath() } > 1
 
       if (duplicated) {
-         holder.createWarnAnnotation(test.psi, "Duplicated test name")
+         holder.createWarnAnnotation(test.psi, "Duplicated test name", "DuplicatedTestName")
       }
    }
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/annotators/FocusInNestedTestAnnotator.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/annotators/FocusInNestedTestAnnotator.kt
@@ -24,7 +24,7 @@ class FocusInNestedTestAnnotator : Annotator {
             val test = style.test(element)
             if (test != null) {
                if (test.name.focus && test.isNested) {
-                  holder.createWarnAnnotation(test.psi, "Focus only works on top level tests")
+                  holder.createWarnAnnotation(test.psi, "Focus only works on top level tests", "FocusInNestedTest")
                }
             }
          }


### PR DESCRIPTION
## Summary

- Adds a `ProblemGroup` with a stable ID to the `DuplicatedTestNameAnnotator` and `FocusInNestedTestAnnotator` warnings
- IntelliJ's `KotlinInspectionSuppressor` (registered by the Kotlin plugin) recognizes these IDs and honors `@Suppress` annotations

After this change, users can suppress warnings at test, function, class, or file level:

```kotlin
@Suppress("DuplicatedTestName")
test("my duplicate test name") { ... }
```

```kotlin
@Suppress("FocusInNestedTest")
test("f: focus in nested") { ... }
```

Fixes https://github.com/kotest/kotest/issues/5348

## Test plan
- [ ] Manually verify that `@Suppress("DuplicatedTestName")` suppresses the "Duplicated test name" warning in the IDE
- [ ] Manually verify that `@Suppress("FocusInNestedTest")` suppresses the "Focus only works on top level tests" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)