### PR TITLE
Fix withClue clue context not included in assertion errors on non-JVM platforms

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonTest/kotlin/com/sksamuel/kotest/assertions/ClueCommonTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonTest/kotlin/com/sksamuel/kotest/assertions/ClueCommonTest.kt
@@ -1,0 +1,41 @@
+package com.sksamuel.kotest.assertions
+
+import io.kotest.assertions.AssertionErrorBuilder
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+
+class ClueCommonTest : FunSpec({
+
+   test("withClue should include clue in message when fail is called with no expected/actual values") {
+      val error = shouldThrow<AssertionError> {
+         withClue("a clue") {
+            AssertionErrorBuilder.fail("error message")
+         }
+      }
+      error.message shouldBe "a clue\nerror message"
+   }
+
+   test("withClue should include clue in message when assertion fails with expected and actual values") {
+      val error = shouldThrow<AssertionError> {
+         withClue("a clue") {
+            "actual" shouldBe "expected"
+         }
+      }
+      error.message!! shouldStartWith "a clue\n"
+   }
+
+   test("nested withClue should include all clues in message when fail is called") {
+      val error = shouldThrow<AssertionError> {
+         withClue("outer clue") {
+            withClue("inner clue") {
+               AssertionErrorBuilder.fail("error message")
+            }
+         }
+      }
+      error.message shouldBe "outer clue\ninner clue\nerror message"
+   }
+
+})

--- a/kotest-assertions/kotest-assertions-shared/src/nonjvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.nonjvm.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/nonjvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.nonjvm.kt
@@ -20,7 +20,7 @@ actual fun createAssertionError(
    }
 
    return if (expected == null && actual == null) {
-      AssertionError(message, cause)
+      AssertionError(messageString, cause)
    } else {
       KotestAssertionFailedError(
          message = messageString,


### PR DESCRIPTION
## Summary

- Fixes a bug in `AssertionErrorBuilder.nonjvm.kt` where `withClue` and `assertSoftly` clue context was silently dropped for simple assertion errors (those with no expected/actual values) on non-JVM platforms (JS, iOS, etc.)
- Root cause: the `expected == null && actual == null` branch used the raw `message` parameter instead of the pre-built `messageString` which includes `clueContextAsString()`
- Added common tests in `ClueCommonTest` that verify clue context is included on all platforms

Fixes #3526

## Test plan

- [ ] New `ClueCommonTest` tests verify `withClue` works correctly on all platforms (JVM, JS, Native)
- [ ] Existing JVM `ClueTest` continues to pass
- [ ] Manually verify on JS/iOS by running `./gradlew jsTest` or `./gradlew iosSimulatorArm64Test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)