### PR TITLE
Add JSON Schema prefixItems (tuple validation) and enum support

### DIFF
--- a/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
+++ b/kotest-assertions/kotest-assertions-json/api/kotest-assertions-json.api
@@ -461,14 +461,15 @@ public final class io/kotest/assertions/json/paths/MatchersKt {
 }
 
 public final class io/kotest/assertions/json/schema/BuilderKt {
-	public static final fun array (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IIZLio/kotest/assertions/json/ContainsSpec;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
-	public static synthetic fun array$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IIZLio/kotest/assertions/json/ContainsSpec;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
+	public static final fun array (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IIZLio/kotest/assertions/json/ContainsSpec;Ljava/util/List;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
+	public static synthetic fun array$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IIZLio/kotest/assertions/json/ContainsSpec;Ljava/util/List;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
 	public static final fun boolean (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
 	public static synthetic fun boolean$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonBoolean;
 	public static final fun containsSpec (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IILkotlin/jvm/functions/Function1;)Lio/kotest/assertions/json/ContainsSpec;
 	public static synthetic fun containsSpec$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;IILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/assertions/json/ContainsSpec;
 	public static final fun decimal (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonDecimal;
 	public static synthetic fun decimal$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonDecimal;
+	public static final fun enum (Lio/kotest/assertions/json/schema/JsonSchema$Builder;[Ljava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonEnum;
 	public static final fun integer (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;)Lio/kotest/assertions/json/schema/JsonSchema$JsonInteger;
 	public static synthetic fun integer$default (Lio/kotest/assertions/json/schema/JsonSchema$Builder;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonInteger;
 	public static final fun jsonSchema (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/json/schema/JsonSchema;
@@ -499,21 +500,23 @@ public final class io/kotest/assertions/json/schema/JsonSchema$Builder {
 
 public final class io/kotest/assertions/json/schema/JsonSchema$JsonArray : io/kotest/assertions/json/schema/JsonSchemaElement {
 	public fun <init> ()V
-	public fun <init> (IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;)V
-	public synthetic fun <init> (IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;Ljava/util/List;)V
+	public synthetic fun <init> (IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()I
 	public final fun component3 ()Lio/kotest/matchers/Matcher;
 	public final fun component4 ()Lio/kotest/assertions/json/ContainsSpec;
 	public final fun component5 ()Lio/kotest/assertions/json/schema/JsonSchemaElement;
-	public final fun copy (IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
-	public static synthetic fun copy$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;Ljava/util/List;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;IILio/kotest/matchers/Matcher;Lio/kotest/assertions/json/ContainsSpec;Lio/kotest/assertions/json/schema/JsonSchemaElement;Ljava/util/List;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonArray;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContains ()Lio/kotest/assertions/json/ContainsSpec;
 	public final fun getElementType ()Lio/kotest/assertions/json/schema/JsonSchemaElement;
 	public final fun getMatcher ()Lio/kotest/matchers/Matcher;
 	public final fun getMaxItems ()I
 	public final fun getMinItems ()I
+	public final fun getPrefixItems ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun typeName ()Ljava/lang/String;
@@ -558,6 +561,18 @@ public final class io/kotest/assertions/json/schema/JsonSchema$JsonDecimal : io/
 	public static synthetic fun copy$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonDecimal;Lio/kotest/matchers/Matcher;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonDecimal;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getMatcher ()Lio/kotest/matchers/Matcher;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun typeName ()Ljava/lang/String;
+}
+
+public final class io/kotest/assertions/json/schema/JsonSchema$JsonEnum : io/kotest/assertions/json/schema/JsonSchemaElement {
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/kotest/assertions/json/schema/JsonSchema$JsonEnum;
+	public static synthetic fun copy$default (Lio/kotest/assertions/json/schema/JsonSchema$JsonEnum;Ljava/util/List;ILjava/lang/Object;)Lio/kotest/assertions/json/schema/JsonSchema$JsonEnum;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValues ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 	public fun typeName ()Ljava/lang/String;

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/builder.kt
@@ -59,8 +59,19 @@ data class JsonSchema(
      val matcher: Matcher<Sequence<JsonNode>>? = null,
      val contains: ContainsSpec? = null,
      val elementType: JsonSchemaElement? = null,
+     val prefixItems: List<JsonSchemaElement> = emptyList(),
    ) : JsonSchemaElement {
       override fun typeName() = "array"
+   }
+
+   /**
+    * Represents an enum schema element that constrains a value to a fixed set of allowed values.
+    * Allowed values can be strings, numbers, booleans, or null.
+    *
+    * https://json-schema.org/understanding-json-schema/reference/enum.html
+    */
+   data class JsonEnum(val values: List<Any?>) : JsonSchemaElement {
+      override fun typeName() = "enum"
    }
 
    class JsonObjectBuilder {
@@ -265,9 +276,14 @@ fun JsonSchema.Builder.obj(dsl: JsonSchema.JsonObjectBuilder.() -> Unit = {}) =
  * The length of the array can be specified using the [minItems] and [maxItems] keywords. Schema can ensure
  * that each of item in an array is unique specified by [uniqueItems] keyword.
  *
+ * Use [prefixItems] to define tuple validation, where each position in the array is validated against
+ * a specific schema. If [typeBuilder] is also specified, it acts as the schema for any items beyond
+ * the prefix.
+ *
  * @param minItems - minimum array length, default value is 0
  * @param maxItems - maximum array length, default value is [Int.MAX_VALUE]
  * @param uniqueItems - item uniqueness, default value is false
+ * @param prefixItems - schemas for specific array positions (tuple validation)
  */
 @ExperimentalKotest
 fun JsonSchema.Builder.array(
@@ -275,11 +291,26 @@ fun JsonSchema.Builder.array(
    maxItems: Int = Int.MAX_VALUE,
    uniqueItems: Boolean = false,
    contains: ContainsSpec? = null,
+   prefixItems: List<JsonSchemaElement> = emptyList(),
    typeBuilder: (() -> JsonSchemaElement?)? = null
 ): JsonSchema.JsonArray {
    val matcher: Matcher<Sequence<JsonNode>>? = if (uniqueItems) beUnique() else null
-   return JsonSchema.JsonArray(minItems, maxItems, matcher, contains, typeBuilder?.invoke())
+   return JsonSchema.JsonArray(minItems, maxItems, matcher, contains, typeBuilder?.invoke(), prefixItems)
 }
+
+/**
+ * Creates a [JsonSchema.JsonEnum] node that constrains a value to one of the given [values].
+ * Allowed values can be strings, numbers (Long or Double), booleans, or null.
+ *
+ * Example:
+ * ```kotlin
+ * val streetTypeSchema = jsonSchema { enum("Avenue", "Street", "Boulevard") }
+ * ```
+ *
+ * https://json-schema.org/understanding-json-schema/reference/enum.html
+ */
+@ExperimentalKotest
+fun JsonSchema.Builder.enum(vararg values: Any?) = JsonSchema.JsonEnum(values.toList())
 
 @ExperimentalKotest
 fun jsonSchema(

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
@@ -102,10 +102,20 @@ private fun validate(
 
    }
 
-   fun JsonSchemaElement.violation(tree: JsonNode.ArrayNode): List<SchemaViolation> =
-      tree.elements.flatMapIndexed { i, node ->
-         validate("$currentPath[$i]", node, this)
+   if (expected is JsonSchema.JsonEnum) {
+      val matches = expected.values.any { enumValue ->
+         when {
+            enumValue == null -> tree is JsonNode.NullNode
+            enumValue is String -> tree is JsonNode.StringNode && tree.value == enumValue
+            enumValue is Boolean -> tree is JsonNode.BooleanNode && tree.value == enumValue
+            enumValue is Long -> tree is JsonNode.NumberNode && tree.content.toLongOrNull() == enumValue
+            enumValue is Double -> tree is JsonNode.NumberNode && tree.content.toDoubleOrNull() == enumValue
+            else -> false
+         }
       }
+      return if (matches) emptyList()
+      else violation("Expected one of ${expected.values.joinToString(", ", "[", "]")} but was ${tree.type()}")
+   }
 
    return when (tree) {
       is JsonNode.ArrayNode -> {
@@ -116,8 +126,17 @@ private fun validate(
             )
             val matcherViolation = violation(expected.matcher, tree.elements.asSequence())
             val containsViolation = expected.contains?.violation(tree) ?: emptyList()
-            val elementTypeViolation = expected.elementType?.violation(tree) ?: emptyList()
-            matcherViolation + sizeViolation + containsViolation + elementTypeViolation
+            val prefixItemsViolation = expected.prefixItems.flatMapIndexed { i, schema ->
+               if (i < tree.elements.size) validate("$currentPath[$i]", tree.elements[i], schema)
+               else emptyList()
+            }
+            val elementTypeViolation = expected.elementType?.let { schema ->
+               val startIndex = expected.prefixItems.size
+               tree.elements.drop(startIndex).flatMapIndexed { i, node ->
+                  validate("$currentPath[${startIndex + i}]", node, schema)
+               }
+            } ?: emptyList()
+            matcherViolation + sizeViolation + containsViolation + prefixItemsViolation + elementTypeViolation
          } else violation("Expected ${expected.typeName()}, but was array")
       }
 

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
@@ -29,7 +29,12 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.encoding.decodeStructure
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.intellij.lang.annotations.Language
@@ -50,6 +55,7 @@ fun parseSchema(@Language("json") jsonSchema: String): JsonSchema =
 @ExperimentalKotest
 internal object SchemaDeserializer : JsonContentPolymorphicSerializer<JsonSchemaElement>(JsonSchemaElement::class) {
    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<JsonSchemaElement> {
+      if (element.jsonObject.containsKey("enum")) return JsonSchemaEnumSerializer
       return when (val type = element.jsonObject["type"]?.jsonPrimitive?.content) {
          "array" -> JsonSchemaArraySerializer
          "object" -> JsonSchema.JsonObject.serializer()
@@ -68,24 +74,6 @@ private infix fun <T> Matcher<T>?.and(other: Matcher<T>) =
 
 @ExperimentalKotest
 internal object JsonSchemaArraySerializer : KSerializer<JsonSchema.JsonArray> {
-   override fun deserialize(decoder: Decoder): JsonSchema.JsonArray =
-      decoder.decodeStructure(descriptor) {
-         var matcher: Matcher<Sequence<JsonNode>>? = null
-         val minItems = runCatching { decodeIntElement(descriptor, 1) }.getOrDefault(1)
-         val maxItems = runCatching { decodeIntElement(descriptor, 2) }.getOrDefault(Int.MAX_VALUE)
-         val elementType =
-            runCatching { decodeSerializableElement(descriptor, 4, SchemaDeserializer) }.getOrNull()
-         val containsSpec =
-            runCatching { decodeSerializableElement(descriptor, 5, ContainsSpecSerializer) }.getOrNull()
-         while (true) {
-            when (val index = decodeElementIndex(descriptor)) {
-               3 -> matcher = if (decodeBooleanElement(descriptor, index)) matcher.and(beUnique()) else matcher
-               CompositeDecoder.DECODE_DONE -> break
-            }
-         }
-         JsonSchema.JsonArray(minItems, maxItems, matcher, containsSpec, elementType)
-      }
-
    override val descriptor = buildClassSerialDescriptor("JsonSchema.JsonArray") {
       element<String>("type")
       element<Int>("minItems", isOptional = true)
@@ -93,9 +81,57 @@ internal object JsonSchemaArraySerializer : KSerializer<JsonSchema.JsonArray> {
       element<Boolean>("uniqueItems", isOptional = true)
       element<String>("elementType", isOptional = true)
       element<String>("contains", isOptional = true)
+      element<JsonElement>("prefixItems", isOptional = true)
+   }
+
+   override fun deserialize(decoder: Decoder): JsonSchema.JsonArray {
+      require(decoder is JsonDecoder) { "JsonSchemaArraySerializer only supports JSON decoding" }
+      val obj = decoder.decodeJsonElement().jsonObject
+
+      val minItems = obj["minItems"]?.jsonPrimitive?.content?.toIntOrNull() ?: 0
+      val maxItems = obj["maxItems"]?.jsonPrimitive?.content?.toIntOrNull() ?: Int.MAX_VALUE
+      val uniqueItems = obj["uniqueItems"]?.jsonPrimitive?.booleanOrNull ?: false
+      val matcher: Matcher<Sequence<JsonNode>>? = if (uniqueItems) beUnique() else null
+      val elementType = obj["elementType"]?.let { decoder.json.decodeFromJsonElement(SchemaDeserializer, it) }
+      val containsSpec = obj["contains"]?.let { decoder.json.decodeFromJsonElement(ContainsSpecSerializer, it) }
+      val prefixItems = obj["prefixItems"]?.jsonArray?.map {
+         decoder.json.decodeFromJsonElement(SchemaDeserializer, it)
+      } ?: emptyList()
+
+      return JsonSchema.JsonArray(minItems, maxItems, matcher, containsSpec, elementType, prefixItems)
    }
 
    override fun serialize(encoder: Encoder, value: JsonSchema.JsonArray) {
+      TODO("Serialization of JsonSchema not supported atm")
+   }
+}
+
+@ExperimentalKotest
+internal object JsonSchemaEnumSerializer : KSerializer<JsonSchema.JsonEnum> {
+   override val descriptor = buildClassSerialDescriptor("JsonSchema.JsonEnum") {
+      element<JsonElement>("enum")
+   }
+
+   override fun deserialize(decoder: Decoder): JsonSchema.JsonEnum {
+      require(decoder is JsonDecoder) { "JsonSchemaEnumSerializer only supports JSON decoding" }
+      val obj = decoder.decodeJsonElement().jsonObject
+      val enumArray = obj["enum"]?.jsonArray ?: error("Expected 'enum' field in schema")
+
+      val values = enumArray.map { element ->
+         when {
+            element is JsonNull -> null
+            element is JsonPrimitive && element.isString -> element.content
+            element is JsonPrimitive && element.booleanOrNull != null -> element.booleanOrNull!!
+            element is JsonPrimitive && element.longOrNull != null -> element.longOrNull!!
+            element is JsonPrimitive && element.doubleOrNull != null -> element.doubleOrNull!!
+            else -> error("Unsupported enum value: $element")
+         }
+      }
+
+      return JsonSchema.JsonEnum(values)
+   }
+
+   override fun serialize(encoder: Encoder, value: JsonSchema.JsonEnum) {
       TODO("Serialization of JsonSchema not supported atm")
    }
 }

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/parse.kt
@@ -33,10 +33,12 @@ import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 import org.intellij.lang.annotations.Language
 
 private val schemaJsonConfig = Json {
@@ -45,7 +47,7 @@ private val schemaJsonConfig = Json {
 }
 
 /**
- * Parses a subset of JSON Schema into [JsonSchemaElement] which can be used to verify a json document with
+ * Parses a subset of JSON Schema into [JsonSchemaElement] which can be used to verify a JSON document with
  * [shouldMatchSchema]
  */
 @ExperimentalKotest
@@ -118,12 +120,12 @@ internal object JsonSchemaEnumSerializer : KSerializer<JsonSchema.JsonEnum> {
       val enumArray = obj["enum"]?.jsonArray ?: error("Expected 'enum' field in schema")
 
       val values = enumArray.map { element ->
-         when {
-            element is JsonNull -> null
-            element is JsonPrimitive && element.isString -> element.content
-            element is JsonPrimitive && element.booleanOrNull != null -> element.booleanOrNull!!
-            element is JsonPrimitive && element.longOrNull != null -> element.longOrNull!!
-            element is JsonPrimitive && element.doubleOrNull != null -> element.doubleOrNull!!
+         when (element) {
+           is JsonNull -> null
+            is JsonPrimitive if element.isString -> element.content
+            is JsonPrimitive if element.booleanOrNull != null -> element.booleanOrNull!!
+            is JsonPrimitive if element.longOrNull != null -> element.longOrNull!!
+            is JsonPrimitive if element.doubleOrNull != null -> element.doubleOrNull!!
             else -> error("Unsupported enum value: $element")
          }
       }

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ArraySchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/ArraySchemaTest.kt
@@ -213,5 +213,77 @@ class ArraySchemaTest : FunSpec(
          }
          "[1, \"bob\"]" shouldMatchSchema array
       }
+
+      test("prefixItems validates each position against specific schema") {
+         val tupleSchema = jsonSchema {
+            array(prefixItems = listOf(number(), string()))
+         }
+         "[1, \"hello\"]" shouldMatchSchema tupleSchema
+      }
+
+      test("prefixItems fails when item at position has wrong type") {
+         val tupleSchema = jsonSchema {
+            array(prefixItems = listOf(number(), string()))
+         }
+         shouldFail { "[\"wrong\", \"hello\"]" shouldMatchSchema tupleSchema }.message shouldBe """
+            $[0] => Expected number, but was string
+         """.trimIndent()
+      }
+
+      test("prefixItems only validates up to number of prefix schemas") {
+         val tupleSchema = jsonSchema {
+            array(prefixItems = listOf(number()))
+         }
+         // extra items beyond prefix are unconstrained when no elementType
+         "[1, \"anything\", true]" shouldMatchSchema tupleSchema
+      }
+
+      test("prefixItems with elementType validates additional items against elementType") {
+         val tupleSchema = jsonSchema {
+            array(prefixItems = listOf(number()), typeBuilder = { string() })
+         }
+         "[1, \"hello\", \"world\"]" shouldMatchSchema tupleSchema
+         shouldFail { "[1, 2, 3]" shouldMatchSchema tupleSchema }.message shouldBe """
+            $[1] => Expected string, but was number
+            $[2] => Expected string, but was number
+         """.trimIndent()
+      }
+
+      test("prefixItems shorter than array does not fail when no elementType") {
+         val tupleSchema = jsonSchema {
+            array(prefixItems = listOf(number(), string()))
+         }
+         // array has 4 elements but only 2 prefix schemas - extra 2 are unconstrained
+         "[1, \"hello\", true, null]" shouldMatchSchema tupleSchema
+      }
+
+      test("prefixItems fails all position violations") {
+         val tupleSchema = jsonSchema {
+            array(prefixItems = listOf(number(), string(), boolean()))
+         }
+         shouldFail { "[\"x\", 1, \"y\"]" shouldMatchSchema tupleSchema }.message shouldBe """
+            $[0] => Expected number, but was string
+            $[1] => Expected string, but was number
+            $[2] => Expected boolean, but was string
+         """.trimIndent()
+      }
+
+      test("Should parse schema with prefixItems") {
+         val schema = parseSchema(
+            """
+            {
+               "type": "array",
+               "prefixItems": [
+                  {"type": "number"},
+                  {"type": "string"}
+               ]
+            }
+            """.trimIndent()
+         )
+         "[1, \"hello\"]" shouldMatchSchema schema
+         shouldFail { "[\"wrong\", \"hello\"]" shouldMatchSchema schema }.message shouldBe """
+            $[0] => Expected number, but was string
+         """.trimIndent()
+      }
    }
 )

--- a/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/EnumSchemaTest.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonTest/kotlin/io.kotest.assertions.json/schema/EnumSchemaTest.kt
@@ -1,0 +1,112 @@
+package io.kotest.assertions.json.schema
+
+import io.kotest.assertions.shouldFail
+import io.kotest.common.ExperimentalKotest
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(ExperimentalKotest::class)
+class EnumSchemaTest : FunSpec({
+
+   test("string enum matches allowed values") {
+      val schema = jsonSchema { enum("Avenue", "Street", "Boulevard") }
+      """"Avenue"""" shouldMatchSchema schema
+      """"Street"""" shouldMatchSchema schema
+      """"Boulevard"""" shouldMatchSchema schema
+   }
+
+   test("string enum rejects values not in the list") {
+      val schema = jsonSchema { enum("Avenue", "Street", "Boulevard") }
+      shouldFail { """"Road"""" shouldMatchSchema schema }.message shouldBe """
+         $ => Expected one of [Avenue, Street, Boulevard] but was string
+      """.trimIndent()
+   }
+
+   test("integer enum matches allowed values") {
+      val schema = jsonSchema { enum(1L, 2L, 3L) }
+      "1" shouldMatchSchema schema
+      "2" shouldMatchSchema schema
+      "3" shouldMatchSchema schema
+   }
+
+   test("integer enum rejects unlisted values") {
+      val schema = jsonSchema { enum(1L, 2L, 3L) }
+      shouldFail { "4" shouldMatchSchema schema }.message shouldBe """
+         $ => Expected one of [1, 2, 3] but was number
+      """.trimIndent()
+   }
+
+   test("boolean enum matches allowed values") {
+      val schema = jsonSchema { enum(true) }
+      "true" shouldMatchSchema schema
+      shouldFail { "false" shouldMatchSchema schema }.message shouldBe """
+         $ => Expected one of [true] but was boolean
+      """.trimIndent()
+   }
+
+   test("enum with null allows null") {
+      val schema = jsonSchema { enum("hello", null) }
+      """"hello"""" shouldMatchSchema schema
+      "null" shouldMatchSchema schema
+   }
+
+   test("enum type mismatch") {
+      val schema = jsonSchema { enum("1", "2") }
+      // numeric 1 does not match string "1"
+      shouldFail { "1" shouldMatchSchema schema }.message shouldBe """
+         $ => Expected one of [1, 2] but was number
+      """.trimIndent()
+   }
+
+   test("enum as prefixItem validates tuple position") {
+      val schema = jsonSchema {
+         array(
+            prefixItems = listOf(number(), string(), enum("Avenue", "Street", "Boulevard"))
+         )
+      }
+      "[1600, \"Pennsylvania Avenue NW\", \"Avenue\"]" shouldMatchSchema schema
+      shouldFail {
+         "[1600, \"Pennsylvania Avenue NW\", \"Road\"]" shouldMatchSchema schema
+      }.message shouldBe """
+         $[2] => Expected one of [Avenue, Street, Boulevard] but was string
+      """.trimIndent()
+   }
+
+   test("Should parse enum schema from JSON") {
+      val schema = parseSchema("""{"enum": ["red", "green", "blue"]}""")
+      """"red"""" shouldMatchSchema schema
+      """"green"""" shouldMatchSchema schema
+      shouldFail { """"yellow"""" shouldMatchSchema schema }.message shouldBe """
+         $ => Expected one of [red, green, blue] but was string
+      """.trimIndent()
+   }
+
+   test("Should parse enum schema with mixed types from JSON") {
+      val schema = parseSchema("""{"enum": ["red", 42, true, null]}""")
+      """"red"""" shouldMatchSchema schema
+      "42" shouldMatchSchema schema
+      "true" shouldMatchSchema schema
+      "null" shouldMatchSchema schema
+      shouldFail { """"blue"""" shouldMatchSchema schema }.message shouldBe """
+         $ => Expected one of [red, 42, true, null] but was string
+      """.trimIndent()
+   }
+
+   test("Should parse prefixItems with enum inside from JSON") {
+      val schema = parseSchema(
+         """
+         {
+            "type": "array",
+            "prefixItems": [
+               {"type": "number"},
+               {"enum": ["Avenue", "Street"]}
+            ]
+         }
+         """.trimIndent()
+      )
+      "[1600, \"Avenue\"]" shouldMatchSchema schema
+      shouldFail { "[1600, \"Road\"]" shouldMatchSchema schema }.message shouldBe """
+         $[1] => Expected one of [Avenue, Street] but was string
+      """.trimIndent()
+   }
+})


### PR DESCRIPTION
## Summary

- Adds `prefixItems` field to `JsonSchema.JsonArray` for tuple validation — each array position is validated against its own specific schema. When combined with `typeBuilder`, elements beyond the prefix are validated against the additional items schema.
- Adds `JsonSchema.JsonEnum` and an `enum()` DSL builder function for constraining values to a fixed set of allowed strings, numbers, booleans, or null.
- Updates the schema validator and JSON Schema parser (`parseSchema`) to support both new features.

Addresses #2980

### Usage

**Tuple validation with `prefixItems`:**
```kotlin
val addressSchema = jsonSchema {
    array(prefixItems = listOf(number(), string(), enum("Avenue", "Street", "Boulevard")))
}

// Validates each position: [number, string, enum]
"[1600, \"Pennsylvania Avenue NW\", \"Avenue\"]" shouldMatchSchema addressSchema
```

**Enum validation:**
```kotlin
val streetTypeSchema = jsonSchema { enum("Avenue", "Street", "Boulevard") }
"\"Avenue\"" shouldMatchSchema streetTypeSchema
```

**Parsing from JSON Schema documents:**
```kotlin
val schema = parseSchema("""
    {
        "type": "array",
        "prefixItems": [
            {"type": "number"},
            {"enum": ["Avenue", "Street"]}
        ]
    }
""")
```

## Test plan

- [ ] `ArraySchemaTest` — added tests for `prefixItems` validation, combining with `elementType`, and parser support
- [ ] `EnumSchemaTest` — new test class covering string/number/boolean/null enum values, type mismatch, nested usage in `prefixItems`, and parser support

🤖 Generated with [Claude Code](https://claude.com/claude-code)