### PR TITLE
Add primitive array support for contain matcher (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1282,12 +1282,28 @@ public final class io/kotest/matchers/collections/ContainKt {
 	public static synthetic fun contain$default (Ljava/lang/Object;Lio/kotest/assertions/equals/Equality;ILjava/lang/Object;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldContain (Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun shouldContain (Ljava/lang/Iterable;Ljava/lang/Object;Lio/kotest/assertions/equals/Equality;)Ljava/lang/Iterable;
+	public static final fun shouldContain ([BB)[B
+	public static final fun shouldContain ([CC)[C
+	public static final fun shouldContain ([DD)[D
+	public static final fun shouldContain ([FF)[F
+	public static final fun shouldContain ([II)[I
+	public static final fun shouldContain ([JJ)[J
 	public static final fun shouldContain ([Ljava/lang/Object;Ljava/lang/Object;)[Ljava/lang/Object;
 	public static final fun shouldContain ([Ljava/lang/Object;Ljava/lang/Object;Lio/kotest/assertions/equals/Equality;)[Ljava/lang/Object;
+	public static final fun shouldContain ([SS)[S
+	public static final fun shouldContain ([ZZ)[Z
 	public static final fun shouldNotContain (Ljava/lang/Iterable;Ljava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun shouldNotContain (Ljava/lang/Iterable;Ljava/lang/Object;Lio/kotest/assertions/equals/Equality;)Ljava/lang/Iterable;
+	public static final fun shouldNotContain ([BB)[B
+	public static final fun shouldNotContain ([CC)[C
+	public static final fun shouldNotContain ([DD)[D
+	public static final fun shouldNotContain ([FF)[F
+	public static final fun shouldNotContain ([II)[I
+	public static final fun shouldNotContain ([JJ)[J
 	public static final fun shouldNotContain ([Ljava/lang/Object;Ljava/lang/Object;)[Ljava/lang/Object;
 	public static final fun shouldNotContain ([Ljava/lang/Object;Ljava/lang/Object;Lio/kotest/assertions/equals/Equality;)[Ljava/lang/Object;
+	public static final fun shouldNotContain ([SS)[S
+	public static final fun shouldNotContain ([ZZ)[Z
 }
 
 public final class io/kotest/matchers/collections/ContainOnlyKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
@@ -8,6 +8,24 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+// Primitive array overloads
+infix fun BooleanArray.shouldContain(t: Boolean): BooleanArray = apply { asList().shouldContain(t) }
+infix fun BooleanArray.shouldNotContain(t: Boolean): BooleanArray = apply { asList().shouldNotContain(t) }
+infix fun ByteArray.shouldContain(t: Byte): ByteArray = apply { asList().shouldContain(t) }
+infix fun ByteArray.shouldNotContain(t: Byte): ByteArray = apply { asList().shouldNotContain(t) }
+infix fun ShortArray.shouldContain(t: Short): ShortArray = apply { asList().shouldContain(t) }
+infix fun ShortArray.shouldNotContain(t: Short): ShortArray = apply { asList().shouldNotContain(t) }
+infix fun CharArray.shouldContain(t: Char): CharArray = apply { asList().shouldContain(t) }
+infix fun CharArray.shouldNotContain(t: Char): CharArray = apply { asList().shouldNotContain(t) }
+infix fun IntArray.shouldContain(t: Int): IntArray = apply { asList().shouldContain(t) }
+infix fun IntArray.shouldNotContain(t: Int): IntArray = apply { asList().shouldNotContain(t) }
+infix fun LongArray.shouldContain(t: Long): LongArray = apply { asList().shouldContain(t) }
+infix fun LongArray.shouldNotContain(t: Long): LongArray = apply { asList().shouldNotContain(t) }
+infix fun FloatArray.shouldContain(t: Float): FloatArray = apply { asList().shouldContain(t) }
+infix fun FloatArray.shouldNotContain(t: Float): FloatArray = apply { asList().shouldNotContain(t) }
+infix fun DoubleArray.shouldContain(t: Double): DoubleArray = apply { asList().shouldContain(t) }
+infix fun DoubleArray.shouldNotContain(t: Double): DoubleArray = apply { asList().shouldNotContain(t) }
+
 // Infix
 infix fun <T, I : Iterable<T>> I.shouldNotContain(t: T): I = shouldNotContain(t, Equality.default())
 infix fun <T> Array<T>.shouldNotContain(t: T): Array<T> = shouldNotContain(t, Equality.default())

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainTest.kt
@@ -147,6 +147,62 @@ class ShouldContainTest : WordSpec({
          message.shouldContain("""qeqweew" should include substring "ooo"
 expected:<ooo> but was:<qeqweew>""")
       }
+
+      "support primitive BooleanArray" {
+         booleanArrayOf(true, false) shouldContain true
+         booleanArrayOf(true) shouldNotContain false
+         shouldThrow<AssertionError> { booleanArrayOf(true) shouldContain false }
+         shouldThrow<AssertionError> { booleanArrayOf(true, false) shouldNotContain true }
+      }
+
+      "support primitive ByteArray" {
+         byteArrayOf(1, 2, 3) shouldContain 2.toByte()
+         byteArrayOf(1, 2, 3) shouldNotContain 5.toByte()
+         shouldThrow<AssertionError> { byteArrayOf(1, 2, 3) shouldContain 5.toByte() }
+         shouldThrow<AssertionError> { byteArrayOf(1, 2, 3) shouldNotContain 2.toByte() }
+      }
+
+      "support primitive ShortArray" {
+         shortArrayOf(1, 2, 3) shouldContain 2.toShort()
+         shortArrayOf(1, 2, 3) shouldNotContain 5.toShort()
+         shouldThrow<AssertionError> { shortArrayOf(1, 2, 3) shouldContain 5.toShort() }
+         shouldThrow<AssertionError> { shortArrayOf(1, 2, 3) shouldNotContain 2.toShort() }
+      }
+
+      "support primitive CharArray" {
+         charArrayOf('a', 'b', 'c') shouldContain 'b'
+         charArrayOf('a', 'b', 'c') shouldNotContain 'z'
+         shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c') shouldContain 'z' }
+         shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c') shouldNotContain 'b' }
+      }
+
+      "support primitive IntArray" {
+         intArrayOf(1, 2, 3) shouldContain 2
+         intArrayOf(1, 2, 3) shouldNotContain 5
+         shouldThrow<AssertionError> { intArrayOf(1, 2, 3) shouldContain 5 }
+         shouldThrow<AssertionError> { intArrayOf(1, 2, 3) shouldNotContain 2 }
+      }
+
+      "support primitive LongArray" {
+         longArrayOf(1L, 2L, 3L) shouldContain 2L
+         longArrayOf(1L, 2L, 3L) shouldNotContain 5L
+         shouldThrow<AssertionError> { longArrayOf(1L, 2L, 3L) shouldContain 5L }
+         shouldThrow<AssertionError> { longArrayOf(1L, 2L, 3L) shouldNotContain 2L }
+      }
+
+      "support primitive FloatArray" {
+         floatArrayOf(1f, 2f, 3f) shouldContain 2f
+         floatArrayOf(1f, 2f, 3f) shouldNotContain 5f
+         shouldThrow<AssertionError> { floatArrayOf(1f, 2f, 3f) shouldContain 5f }
+         shouldThrow<AssertionError> { floatArrayOf(1f, 2f, 3f) shouldNotContain 2f }
+      }
+
+      "support primitive DoubleArray" {
+         doubleArrayOf(1.0, 2.0, 3.0) shouldContain 2.0
+         doubleArrayOf(1.0, 2.0, 3.0) shouldNotContain 5.0
+         shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0) shouldContain 5.0 }
+         shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0) shouldNotContain 2.0 }
+      }
    }
 })
 


### PR DESCRIPTION
## Summary

- Adds `shouldContain` / `shouldNotContain` infix extension functions for all 8 primitive array types: `BooleanArray`, `ByteArray`, `ShortArray`, `CharArray`, `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`
- Each overload delegates to `asList().shouldContain(t)` / `asList().shouldNotContain(t)`, reusing the existing collection matcher logic
- Adds tests in `ShouldContainTest` covering positive case, negative case (`shouldThrow<AssertionError>`), and `shouldNotContain` for all 8 primitive types

Closes #4354 (partial)

## Test plan

- [ ] `ShouldContainTest` — new `"support primitive *Array"` test blocks compile and pass for all 8 primitive types
- [ ] Existing `ShouldContainTest` tests remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)