### PR TITLE
Add primitive array support for containAll matcher (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1236,14 +1236,30 @@ public final class io/kotest/matchers/collections/ContainAllKt {
 	public static final fun shouldContainAll (Ljava/lang/Iterable;[Ljava/lang/Object;)Ljava/util/Collection;
 	public static final fun shouldContainAll (Ljava/util/Collection;Ljava/util/Collection;)Ljava/util/Collection;
 	public static final fun shouldContainAll (Ljava/util/Collection;[Ljava/lang/Object;)Ljava/util/Collection;
+	public static final fun shouldContainAll ([B[B)[B
+	public static final fun shouldContainAll ([C[C)[C
+	public static final fun shouldContainAll ([D[D)[D
+	public static final fun shouldContainAll ([F[F)[F
+	public static final fun shouldContainAll ([I[I)[I
+	public static final fun shouldContainAll ([J[J)[J
 	public static final fun shouldContainAll ([Ljava/lang/Object;Ljava/util/Collection;)[Ljava/lang/Object;
 	public static final fun shouldContainAll ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun shouldContainAll ([S[S)[S
+	public static final fun shouldContainAll ([Z[Z)[Z
 	public static final fun shouldNotContainAll (Ljava/lang/Iterable;Ljava/util/Collection;)Ljava/util/Collection;
 	public static final fun shouldNotContainAll (Ljava/lang/Iterable;[Ljava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun shouldNotContainAll (Ljava/util/Collection;Ljava/util/Collection;)Ljava/util/Collection;
 	public static final fun shouldNotContainAll (Ljava/util/Collection;[Ljava/lang/Object;)Ljava/util/Collection;
+	public static final fun shouldNotContainAll ([B[B)[B
+	public static final fun shouldNotContainAll ([C[C)[C
+	public static final fun shouldNotContainAll ([D[D)[D
+	public static final fun shouldNotContainAll ([F[F)[F
+	public static final fun shouldNotContainAll ([I[I)[I
+	public static final fun shouldNotContainAll ([J[J)[J
 	public static final fun shouldNotContainAll ([Ljava/lang/Object;Ljava/util/Collection;)[Ljava/lang/Object;
 	public static final fun shouldNotContainAll ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
+	public static final fun shouldNotContainAll ([S[S)[S
+	public static final fun shouldNotContainAll ([Z[Z)[Z
 }
 
 public final class io/kotest/matchers/collections/ContainExactlyInAnyOrderKt {

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1262,6 +1262,14 @@ public final class io/kotest/matchers/collections/ContainAllKt {
 	public static final fun shouldContainAll ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
 	public static final fun shouldContainAll ([S[S)[S
 	public static final fun shouldContainAll ([Z[Z)[Z
+	public static final fun shouldContainAll_booleanArray_infix ([Z[Z)[Z
+	public static final fun shouldContainAll_byteArray_infix ([B[B)[B
+	public static final fun shouldContainAll_charArray_infix ([C[C)[C
+	public static final fun shouldContainAll_doubleArray_infix ([D[D)[D
+	public static final fun shouldContainAll_floatArray_infix ([F[F)[F
+	public static final fun shouldContainAll_intArray_infix ([I[I)[I
+	public static final fun shouldContainAll_longArray_infix ([J[J)[J
+	public static final fun shouldContainAll_shortArray_infix ([S[S)[S
 	public static final fun shouldNotContainAll (Ljava/lang/Iterable;Ljava/util/Collection;)Ljava/util/Collection;
 	public static final fun shouldNotContainAll (Ljava/lang/Iterable;[Ljava/lang/Object;)Ljava/lang/Iterable;
 	public static final fun shouldNotContainAll (Ljava/util/Collection;Ljava/util/Collection;)Ljava/util/Collection;
@@ -1276,6 +1284,14 @@ public final class io/kotest/matchers/collections/ContainAllKt {
 	public static final fun shouldNotContainAll ([Ljava/lang/Object;[Ljava/lang/Object;)[Ljava/lang/Object;
 	public static final fun shouldNotContainAll ([S[S)[S
 	public static final fun shouldNotContainAll ([Z[Z)[Z
+	public static final fun shouldNotContainAll_booleanArray_infix ([Z[Z)[Z
+	public static final fun shouldNotContainAll_byteArray_infix ([B[B)[B
+	public static final fun shouldNotContainAll_charArray_infix ([C[C)[C
+	public static final fun shouldNotContainAll_doubleArray_infix ([D[D)[D
+	public static final fun shouldNotContainAll_floatArray_infix ([F[F)[F
+	public static final fun shouldNotContainAll_intArray_infix ([I[I)[I
+	public static final fun shouldNotContainAll_longArray_infix ([J[J)[J
+	public static final fun shouldNotContainAll_shortArray_infix ([S[S)[S
 }
 
 public final class io/kotest/matchers/collections/ContainExactlyInAnyOrderKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -109,51 +109,35 @@ infix fun <T> Collection<T>.shouldNotContainAll(ts: Collection<T>): Collection<T
 
 // BooleanArray
 fun BooleanArray.shouldContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun BooleanArray.shouldContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
 fun BooleanArray.shouldNotContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun BooleanArray.shouldNotContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // ByteArray
 fun ByteArray.shouldContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun ByteArray.shouldContainAll(expected: ByteArray): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
 fun ByteArray.shouldNotContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun ByteArray.shouldNotContainAll(expected: ByteArray): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // ShortArray
 fun ShortArray.shouldContainAll(vararg expected: Short): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun ShortArray.shouldContainAll(expected: ShortArray): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
 fun ShortArray.shouldNotContainAll(vararg expected: Short): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun ShortArray.shouldNotContainAll(expected: ShortArray): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // CharArray
 fun CharArray.shouldContainAll(vararg expected: Char): CharArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun CharArray.shouldContainAll(expected: CharArray): CharArray = apply { asList().shouldContainAll(expected.asList()) }
 fun CharArray.shouldNotContainAll(vararg expected: Char): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun CharArray.shouldNotContainAll(expected: CharArray): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // IntArray
 fun IntArray.shouldContainAll(vararg expected: Int): IntArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun IntArray.shouldContainAll(expected: IntArray): IntArray = apply { asList().shouldContainAll(expected.asList()) }
 fun IntArray.shouldNotContainAll(vararg expected: Int): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun IntArray.shouldNotContainAll(expected: IntArray): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // LongArray
 fun LongArray.shouldContainAll(vararg expected: Long): LongArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun LongArray.shouldContainAll(expected: LongArray): LongArray = apply { asList().shouldContainAll(expected.asList()) }
 fun LongArray.shouldNotContainAll(vararg expected: Long): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun LongArray.shouldNotContainAll(expected: LongArray): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // FloatArray
 fun FloatArray.shouldContainAll(vararg expected: Float): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun FloatArray.shouldContainAll(expected: FloatArray): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
 fun FloatArray.shouldNotContainAll(vararg expected: Float): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun FloatArray.shouldNotContainAll(expected: FloatArray): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // DoubleArray
 fun DoubleArray.shouldContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
-infix fun DoubleArray.shouldContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
 fun DoubleArray.shouldNotContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
-infix fun DoubleArray.shouldNotContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -107,6 +107,54 @@ infix fun <T> Collection<T>.shouldNotContainAll(ts: Collection<T>): Collection<T
    return this
 }
 
+// BooleanArray
+fun BooleanArray.shouldContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun BooleanArray.shouldContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
+fun BooleanArray.shouldNotContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun BooleanArray.shouldNotContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// ByteArray
+fun ByteArray.shouldContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun ByteArray.shouldContainAll(expected: ByteArray): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
+fun ByteArray.shouldNotContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun ByteArray.shouldNotContainAll(expected: ByteArray): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// ShortArray
+fun ShortArray.shouldContainAll(vararg expected: Short): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun ShortArray.shouldContainAll(expected: ShortArray): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
+fun ShortArray.shouldNotContainAll(vararg expected: Short): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun ShortArray.shouldNotContainAll(expected: ShortArray): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// CharArray
+fun CharArray.shouldContainAll(vararg expected: Char): CharArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun CharArray.shouldContainAll(expected: CharArray): CharArray = apply { asList().shouldContainAll(expected.asList()) }
+fun CharArray.shouldNotContainAll(vararg expected: Char): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun CharArray.shouldNotContainAll(expected: CharArray): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// IntArray
+fun IntArray.shouldContainAll(vararg expected: Int): IntArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun IntArray.shouldContainAll(expected: IntArray): IntArray = apply { asList().shouldContainAll(expected.asList()) }
+fun IntArray.shouldNotContainAll(vararg expected: Int): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun IntArray.shouldNotContainAll(expected: IntArray): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// LongArray
+fun LongArray.shouldContainAll(vararg expected: Long): LongArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun LongArray.shouldContainAll(expected: LongArray): LongArray = apply { asList().shouldContainAll(expected.asList()) }
+fun LongArray.shouldNotContainAll(vararg expected: Long): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun LongArray.shouldNotContainAll(expected: LongArray): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// FloatArray
+fun FloatArray.shouldContainAll(vararg expected: Float): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun FloatArray.shouldContainAll(expected: FloatArray): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
+fun FloatArray.shouldNotContainAll(vararg expected: Float): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun FloatArray.shouldNotContainAll(expected: FloatArray): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
+// DoubleArray
+fun DoubleArray.shouldContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
+infix fun DoubleArray.shouldContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
+fun DoubleArray.shouldNotContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
+infix fun DoubleArray.shouldNotContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
 fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 
 fun <T> containAll(ts: Collection<T>): Matcher<Collection<T>> =

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import kotlin.jvm.JvmName
 
 /**
  * Verifies that the given [Iterable] contains all the specified elements in given order.
@@ -107,37 +108,71 @@ infix fun <T> Collection<T>.shouldNotContainAll(ts: Collection<T>): Collection<T
    return this
 }
 
+
 // BooleanArray
 fun BooleanArray.shouldContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_booleanArray_infix")
+infix fun BooleanArray.shouldContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
 fun BooleanArray.shouldNotContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_booleanArray_infix")
+infix fun BooleanArray.shouldNotContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // ByteArray
 fun ByteArray.shouldContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_byteArray_infix")
+infix fun ByteArray.shouldContainAll(expected: ByteArray): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
 fun ByteArray.shouldNotContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_byteArray_infix")
+infix fun ByteArray.shouldNotContainAll(expected: ByteArray): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // ShortArray
 fun ShortArray.shouldContainAll(vararg expected: Short): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_shortArray_infix")
+infix fun ShortArray.shouldContainAll(expected: ShortArray): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
 fun ShortArray.shouldNotContainAll(vararg expected: Short): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_shortArray_infix")
+infix fun ShortArray.shouldNotContainAll(expected: ShortArray): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // CharArray
 fun CharArray.shouldContainAll(vararg expected: Char): CharArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_charArray_infix")
+infix fun CharArray.shouldContainAll(expected: CharArray): CharArray = apply { asList().shouldContainAll(expected.asList()) }
 fun CharArray.shouldNotContainAll(vararg expected: Char): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_charArray_infix")
+infix fun CharArray.shouldNotContainAll(expected: CharArray): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // IntArray
 fun IntArray.shouldContainAll(vararg expected: Int): IntArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_intArray_infix")
+infix fun IntArray.shouldContainAll(expected: IntArray): IntArray = apply { asList().shouldContainAll(expected.asList()) }
 fun IntArray.shouldNotContainAll(vararg expected: Int): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_intArray_infix")
+infix fun IntArray.shouldNotContainAll(expected: IntArray): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // LongArray
 fun LongArray.shouldContainAll(vararg expected: Long): LongArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_longArray_infix")
+infix fun LongArray.shouldContainAll(expected: LongArray): LongArray = apply { asList().shouldContainAll(expected.asList()) }
 fun LongArray.shouldNotContainAll(vararg expected: Long): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_longArray_infix")
+infix fun LongArray.shouldNotContainAll(expected: LongArray): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // FloatArray
 fun FloatArray.shouldContainAll(vararg expected: Float): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_floatArray_infix")
+infix fun FloatArray.shouldContainAll(expected: FloatArray): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
 fun FloatArray.shouldNotContainAll(vararg expected: Float): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_floatArray_infix")
+infix fun FloatArray.shouldNotContainAll(expected: FloatArray): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // DoubleArray
 fun DoubleArray.shouldContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
+@JvmName("shouldContainAll_doubleArray_infix")
+infix fun DoubleArray.shouldContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
 fun DoubleArray.shouldNotContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
+@JvmName("shouldNotContainAll_doubleArray_infix")
+infix fun DoubleArray.shouldNotContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
+
 
 fun <T> containAll(vararg ts: T) = containAll(ts.asList())
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainAllTest.kt
@@ -153,6 +153,78 @@ class ShouldContainAllTest : WordSpec() {
                |    "name" expected: <"apple">, but was: <"pear">
     """.trimMargin())
          }
+
+         "test that BooleanArray supports shouldContainAll" {
+            booleanArrayOf(true, false, true).shouldContainAll(true, false)
+            booleanArrayOf(true, false, true).shouldContainAll(booleanArrayOf(true, false))
+            booleanArrayOf(true).shouldNotContainAll(false)
+            booleanArrayOf(true).shouldNotContainAll(booleanArrayOf(false))
+            shouldThrow<AssertionError> { booleanArrayOf(true).shouldContainAll(false) }
+            shouldThrow<AssertionError> { booleanArrayOf(true).shouldContainAll(booleanArrayOf(false)) }
+         }
+
+         "test that ByteArray supports shouldContainAll" {
+            byteArrayOf(1, 2, 3).shouldContainAll(1.toByte(), 2.toByte())
+            byteArrayOf(1, 2, 3).shouldContainAll(byteArrayOf(1, 2))
+            byteArrayOf(1, 2, 3).shouldNotContainAll(6.toByte())
+            byteArrayOf(1, 2, 3).shouldNotContainAll(byteArrayOf(6))
+            shouldThrow<AssertionError> { byteArrayOf(1, 2, 3).shouldContainAll(6.toByte()) }
+            shouldThrow<AssertionError> { byteArrayOf(1, 2, 3).shouldContainAll(byteArrayOf(6)) }
+         }
+
+         "test that ShortArray supports shouldContainAll" {
+            shortArrayOf(1, 2, 3).shouldContainAll(1.toShort(), 2.toShort())
+            shortArrayOf(1, 2, 3).shouldContainAll(shortArrayOf(1, 2))
+            shortArrayOf(1, 2, 3).shouldNotContainAll(6.toShort())
+            shortArrayOf(1, 2, 3).shouldNotContainAll(shortArrayOf(6))
+            shouldThrow<AssertionError> { shortArrayOf(1, 2, 3).shouldContainAll(6.toShort()) }
+            shouldThrow<AssertionError> { shortArrayOf(1, 2, 3).shouldContainAll(shortArrayOf(6)) }
+         }
+
+         "test that CharArray supports shouldContainAll" {
+            charArrayOf('a', 'b', 'c').shouldContainAll('a', 'b')
+            charArrayOf('a', 'b', 'c').shouldContainAll(charArrayOf('a', 'b'))
+            charArrayOf('a', 'b', 'c').shouldNotContainAll('z')
+            charArrayOf('a', 'b', 'c').shouldNotContainAll(charArrayOf('z'))
+            shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c').shouldContainAll('z') }
+            shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c').shouldContainAll(charArrayOf('z')) }
+         }
+
+         "test that IntArray supports shouldContainAll" {
+            intArrayOf(1, 2, 3).shouldContainAll(1, 2)
+            intArrayOf(1, 2, 3).shouldContainAll(intArrayOf(1, 2))
+            intArrayOf(1, 2, 3).shouldNotContainAll(6)
+            intArrayOf(1, 2, 3).shouldNotContainAll(intArrayOf(6))
+            shouldThrow<AssertionError> { intArrayOf(1, 2, 3).shouldContainAll(6) }
+            shouldThrow<AssertionError> { intArrayOf(1, 2, 3).shouldContainAll(intArrayOf(6)) }
+         }
+
+         "test that LongArray supports shouldContainAll" {
+            longArrayOf(1L, 2L, 3L).shouldContainAll(1L, 2L)
+            longArrayOf(1L, 2L, 3L).shouldContainAll(longArrayOf(1L, 2L))
+            longArrayOf(1L, 2L, 3L).shouldNotContainAll(6L)
+            longArrayOf(1L, 2L, 3L).shouldNotContainAll(longArrayOf(6L))
+            shouldThrow<AssertionError> { longArrayOf(1L, 2L, 3L).shouldContainAll(6L) }
+            shouldThrow<AssertionError> { longArrayOf(1L, 2L, 3L).shouldContainAll(longArrayOf(6L)) }
+         }
+
+         "test that FloatArray supports shouldContainAll" {
+            floatArrayOf(1f, 2f, 3f).shouldContainAll(1f, 2f)
+            floatArrayOf(1f, 2f, 3f).shouldContainAll(floatArrayOf(1f, 2f))
+            floatArrayOf(1f, 2f, 3f).shouldNotContainAll(6f)
+            floatArrayOf(1f, 2f, 3f).shouldNotContainAll(floatArrayOf(6f))
+            shouldThrow<AssertionError> { floatArrayOf(1f, 2f, 3f).shouldContainAll(6f) }
+            shouldThrow<AssertionError> { floatArrayOf(1f, 2f, 3f).shouldContainAll(floatArrayOf(6f)) }
+         }
+
+         "test that DoubleArray supports shouldContainAll" {
+            doubleArrayOf(1.0, 2.0, 3.0).shouldContainAll(1.0, 2.0)
+            doubleArrayOf(1.0, 2.0, 3.0).shouldContainAll(doubleArrayOf(1.0, 2.0))
+            doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainAll(6.0)
+            doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainAll(doubleArrayOf(6.0))
+            shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0).shouldContainAll(6.0) }
+            shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0).shouldContainAll(doubleArrayOf(6.0)) }
+         }
       }
    }
 }

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;


### PR DESCRIPTION
## Summary

- Adds `shouldContainAll` and `shouldNotContainAll` extension functions for all 8 Kotlin primitive array types: `BooleanArray`, `ByteArray`, `ShortArray`, `CharArray`, `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`
- Each type gets both a vararg overload (e.g. `intArrayOf(1,2,3).shouldContainAll(1, 2)`) and an infix array overload (e.g. `intArrayOf(1,2,3).shouldContainAll(intArrayOf(1, 2))`)
- Implementations delegate to the existing `Collection`-based matchers via `asList()`

Fixes #4354 

## Test plan

- [ ] Vararg version passes when all expected elements are present
- [ ] Array version passes when all expected elements are present
- [ ] `shouldNotContainAll` passes when at least one expected element is absent
- [ ] Both overloads throw `AssertionError` on failure
- Tests added for all 8 primitive array types in `ShouldContainAllTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)