### PR TITLE
Add primitive array support for containExactly matcher (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1266,15 +1266,47 @@ public final class io/kotest/matchers/collections/ContainExactlyKt {
 	public static final fun shouldContainExactly (Ljava/lang/Iterable;[Ljava/lang/Object;)V
 	public static final fun shouldContainExactly (Ljava/util/Collection;Ljava/util/Collection;)V
 	public static final fun shouldContainExactly (Ljava/util/Collection;[Ljava/lang/Object;)V
+	public static final fun shouldContainExactly ([B[B)[B
+	public static final fun shouldContainExactly ([C[C)[C
+	public static final fun shouldContainExactly ([D[D)[D
+	public static final fun shouldContainExactly ([F[F)[F
+	public static final fun shouldContainExactly ([I[I)[I
+	public static final fun shouldContainExactly ([J[J)[J
 	public static final fun shouldContainExactly ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldContainExactly ([S[S)[S
+	public static final fun shouldContainExactly ([Z[Z)[Z
 	public static final fun shouldContainExactly_array ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldContainExactly_booleanArray ([Z[Z)[Z
+	public static final fun shouldContainExactly_byteArray ([B[B)[B
+	public static final fun shouldContainExactly_charArray ([C[C)[C
+	public static final fun shouldContainExactly_doubleArray ([D[D)[D
+	public static final fun shouldContainExactly_floatArray ([F[F)[F
+	public static final fun shouldContainExactly_intArray ([I[I)[I
 	public static final fun shouldContainExactly_iterable (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
+	public static final fun shouldContainExactly_longArray ([J[J)[J
+	public static final fun shouldContainExactly_shortArray ([S[S)[S
 	public static final fun shouldNotContainExactly (Ljava/lang/Iterable;[Ljava/lang/Object;)V
 	public static final fun shouldNotContainExactly (Ljava/util/Collection;Ljava/util/Collection;)V
 	public static final fun shouldNotContainExactly (Ljava/util/Collection;[Ljava/lang/Object;)V
+	public static final fun shouldNotContainExactly ([B[B)[B
+	public static final fun shouldNotContainExactly ([C[C)[C
+	public static final fun shouldNotContainExactly ([D[D)[D
+	public static final fun shouldNotContainExactly ([F[F)[F
+	public static final fun shouldNotContainExactly ([I[I)[I
+	public static final fun shouldNotContainExactly ([J[J)[J
 	public static final fun shouldNotContainExactly ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldNotContainExactly ([S[S)[S
+	public static final fun shouldNotContainExactly ([Z[Z)[Z
 	public static final fun shouldNotContainExactly_array ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldNotContainExactly_booleanArray ([Z[Z)[Z
+	public static final fun shouldNotContainExactly_byteArray ([B[B)[B
+	public static final fun shouldNotContainExactly_charArray ([C[C)[C
+	public static final fun shouldNotContainExactly_doubleArray ([D[D)[D
+	public static final fun shouldNotContainExactly_floatArray ([F[F)[F
+	public static final fun shouldNotContainExactly_intArray ([I[I)[I
 	public static final fun shouldNotContainExactly_iterable (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
+	public static final fun shouldNotContainExactly_longArray ([J[J)[J
+	public static final fun shouldNotContainExactly_shortArray ([S[S)[S
 }
 
 public final class io/kotest/matchers/collections/ContainKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -188,43 +188,67 @@ fun <T> Collection<T>?.shouldNotContainExactly(vararg expected: T) = this should
 
 // region Primitive array overloads
 
+@JvmName("shouldContainExactly_booleanArray")
 infix fun BooleanArray?.shouldContainExactly(expected: BooleanArray): BooleanArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun BooleanArray?.shouldContainExactly(vararg expected: Boolean): BooleanArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_booleanArray")
 infix fun BooleanArray?.shouldNotContainExactly(expected: BooleanArray): BooleanArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun BooleanArray?.shouldNotContainExactly(vararg expected: Boolean): BooleanArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_byteArray")
 infix fun ByteArray?.shouldContainExactly(expected: ByteArray): ByteArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun ByteArray?.shouldContainExactly(vararg expected: Byte): ByteArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_byteArray")
 infix fun ByteArray?.shouldNotContainExactly(expected: ByteArray): ByteArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun ByteArray?.shouldNotContainExactly(vararg expected: Byte): ByteArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_shortArray")
 infix fun ShortArray?.shouldContainExactly(expected: ShortArray): ShortArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun ShortArray?.shouldContainExactly(vararg expected: Short): ShortArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_shortArray")
 infix fun ShortArray?.shouldNotContainExactly(expected: ShortArray): ShortArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun ShortArray?.shouldNotContainExactly(vararg expected: Short): ShortArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_charArray")
 infix fun CharArray?.shouldContainExactly(expected: CharArray): CharArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun CharArray?.shouldContainExactly(vararg expected: Char): CharArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_charArray")
 infix fun CharArray?.shouldNotContainExactly(expected: CharArray): CharArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun CharArray?.shouldNotContainExactly(vararg expected: Char): CharArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_intArray")
 infix fun IntArray?.shouldContainExactly(expected: IntArray): IntArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun IntArray?.shouldContainExactly(vararg expected: Int): IntArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_intArray")
 infix fun IntArray?.shouldNotContainExactly(expected: IntArray): IntArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun IntArray?.shouldNotContainExactly(vararg expected: Int): IntArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_longArray")
 infix fun LongArray?.shouldContainExactly(expected: LongArray): LongArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun LongArray?.shouldContainExactly(vararg expected: Long): LongArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_longArray")
 infix fun LongArray?.shouldNotContainExactly(expected: LongArray): LongArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun LongArray?.shouldNotContainExactly(vararg expected: Long): LongArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_floatArray")
 infix fun FloatArray?.shouldContainExactly(expected: FloatArray): FloatArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun FloatArray?.shouldContainExactly(vararg expected: Float): FloatArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_floatArray")
 infix fun FloatArray?.shouldNotContainExactly(expected: FloatArray): FloatArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun FloatArray?.shouldNotContainExactly(vararg expected: Float): FloatArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
+@JvmName("shouldContainExactly_doubleArray")
 infix fun DoubleArray?.shouldContainExactly(expected: DoubleArray): DoubleArray? = apply { this?.asList() should containExactly(expected.asList()) }
 fun DoubleArray?.shouldContainExactly(vararg expected: Double): DoubleArray? = apply { this?.asList() should containExactly(expected.asList()) }
+
+@JvmName("shouldNotContainExactly_doubleArray")
 infix fun DoubleArray?.shouldNotContainExactly(expected: DoubleArray): DoubleArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 fun DoubleArray?.shouldNotContainExactly(vararg expected: Double): DoubleArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -186,6 +186,50 @@ fun <T> Array<T>?.shouldNotContainExactly(vararg expected: T) = this?.asList() s
 infix fun <T, C : Collection<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
 fun <T> Collection<T>?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
 
+// region Primitive array overloads
+
+infix fun BooleanArray?.shouldContainExactly(expected: BooleanArray): BooleanArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun BooleanArray?.shouldContainExactly(vararg expected: Boolean): BooleanArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun BooleanArray?.shouldNotContainExactly(expected: BooleanArray): BooleanArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun BooleanArray?.shouldNotContainExactly(vararg expected: Boolean): BooleanArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun ByteArray?.shouldContainExactly(expected: ByteArray): ByteArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun ByteArray?.shouldContainExactly(vararg expected: Byte): ByteArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun ByteArray?.shouldNotContainExactly(expected: ByteArray): ByteArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun ByteArray?.shouldNotContainExactly(vararg expected: Byte): ByteArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun ShortArray?.shouldContainExactly(expected: ShortArray): ShortArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun ShortArray?.shouldContainExactly(vararg expected: Short): ShortArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun ShortArray?.shouldNotContainExactly(expected: ShortArray): ShortArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun ShortArray?.shouldNotContainExactly(vararg expected: Short): ShortArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun CharArray?.shouldContainExactly(expected: CharArray): CharArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun CharArray?.shouldContainExactly(vararg expected: Char): CharArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun CharArray?.shouldNotContainExactly(expected: CharArray): CharArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun CharArray?.shouldNotContainExactly(vararg expected: Char): CharArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun IntArray?.shouldContainExactly(expected: IntArray): IntArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun IntArray?.shouldContainExactly(vararg expected: Int): IntArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun IntArray?.shouldNotContainExactly(expected: IntArray): IntArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun IntArray?.shouldNotContainExactly(vararg expected: Int): IntArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun LongArray?.shouldContainExactly(expected: LongArray): LongArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun LongArray?.shouldContainExactly(vararg expected: Long): LongArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun LongArray?.shouldNotContainExactly(expected: LongArray): LongArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun LongArray?.shouldNotContainExactly(vararg expected: Long): LongArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun FloatArray?.shouldContainExactly(expected: FloatArray): FloatArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun FloatArray?.shouldContainExactly(vararg expected: Float): FloatArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun FloatArray?.shouldNotContainExactly(expected: FloatArray): FloatArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun FloatArray?.shouldNotContainExactly(vararg expected: Float): FloatArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+infix fun DoubleArray?.shouldContainExactly(expected: DoubleArray): DoubleArray? = apply { this?.asList() should containExactly(expected.asList()) }
+fun DoubleArray?.shouldContainExactly(vararg expected: Double): DoubleArray? = apply { this?.asList() should containExactly(expected.asList()) }
+infix fun DoubleArray?.shouldNotContainExactly(expected: DoubleArray): DoubleArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+fun DoubleArray?.shouldNotContainExactly(vararg expected: Double): DoubleArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+
+// endregion
+
 fun StringBuilder.appendMissingAndExtra(missing: Collection<Any?>, extra: Collection<Any?>) {
    if (missing.isNotEmpty()) {
       append("Some elements were missing: ${missing.take(AssertionsConfig.maxCollectionPrintSize.value).print().value}")

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ShouldContainExactlyTest.kt
@@ -355,6 +355,110 @@ class ShouldContainExactlyTest : WordSpec() {
                caseInsensitiveStringEquality
             )
          }
+
+         "test primitive BooleanArray" {
+            booleanArrayOf(true, false, true).shouldContainExactly(booleanArrayOf(true, false, true))
+            booleanArrayOf(true, false, true).shouldContainExactly(true, false, true)
+            booleanArrayOf(true, false).shouldNotContainExactly(booleanArrayOf(false, true))
+            booleanArrayOf(true, false).shouldNotContainExactly(false, true)
+            shouldThrow<AssertionError> {
+               booleanArrayOf(true, false, true).shouldContainExactly(false, true, true)
+            }
+            shouldThrow<AssertionError> {
+               booleanArrayOf(true, false).shouldNotContainExactly(true, false)
+            }
+         }
+
+         "test primitive ByteArray" {
+            byteArrayOf(1, 2, 3).shouldContainExactly(byteArrayOf(1, 2, 3))
+            byteArrayOf(1, 2, 3).shouldContainExactly(1.toByte(), 2.toByte(), 3.toByte())
+            byteArrayOf(1, 2, 3).shouldNotContainExactly(byteArrayOf(3, 2, 1))
+            byteArrayOf(1, 2, 3).shouldNotContainExactly(3.toByte(), 2.toByte(), 1.toByte())
+            shouldThrow<AssertionError> {
+               byteArrayOf(1, 2, 3).shouldContainExactly(3.toByte(), 2.toByte(), 1.toByte())
+            }
+            shouldThrow<AssertionError> {
+               byteArrayOf(1, 2, 3).shouldNotContainExactly(1.toByte(), 2.toByte(), 3.toByte())
+            }
+         }
+
+         "test primitive ShortArray" {
+            shortArrayOf(1, 2, 3).shouldContainExactly(shortArrayOf(1, 2, 3))
+            shortArrayOf(1, 2, 3).shouldContainExactly(1.toShort(), 2.toShort(), 3.toShort())
+            shortArrayOf(1, 2, 3).shouldNotContainExactly(shortArrayOf(3, 2, 1))
+            shortArrayOf(1, 2, 3).shouldNotContainExactly(3.toShort(), 2.toShort(), 1.toShort())
+            shouldThrow<AssertionError> {
+               shortArrayOf(1, 2, 3).shouldContainExactly(3.toShort(), 2.toShort(), 1.toShort())
+            }
+            shouldThrow<AssertionError> {
+               shortArrayOf(1, 2, 3).shouldNotContainExactly(1.toShort(), 2.toShort(), 3.toShort())
+            }
+         }
+
+         "test primitive CharArray" {
+            charArrayOf('a', 'b', 'c').shouldContainExactly(charArrayOf('a', 'b', 'c'))
+            charArrayOf('a', 'b', 'c').shouldContainExactly('a', 'b', 'c')
+            charArrayOf('a', 'b', 'c').shouldNotContainExactly(charArrayOf('c', 'b', 'a'))
+            charArrayOf('a', 'b', 'c').shouldNotContainExactly('c', 'b', 'a')
+            shouldThrow<AssertionError> {
+               charArrayOf('a', 'b', 'c').shouldContainExactly('c', 'b', 'a')
+            }
+            shouldThrow<AssertionError> {
+               charArrayOf('a', 'b', 'c').shouldNotContainExactly('a', 'b', 'c')
+            }
+         }
+
+         "test primitive IntArray" {
+            intArrayOf(1, 2, 3).shouldContainExactly(intArrayOf(1, 2, 3))
+            intArrayOf(1, 2, 3).shouldContainExactly(1, 2, 3)
+            intArrayOf(1, 2, 3).shouldNotContainExactly(intArrayOf(3, 2, 1))
+            intArrayOf(1, 2, 3).shouldNotContainExactly(3, 2, 1)
+            shouldThrow<AssertionError> {
+               intArrayOf(1, 2, 3).shouldContainExactly(3, 2, 1)
+            }
+            shouldThrow<AssertionError> {
+               intArrayOf(1, 2, 3).shouldNotContainExactly(1, 2, 3)
+            }
+         }
+
+         "test primitive LongArray" {
+            longArrayOf(1, 2, 3).shouldContainExactly(longArrayOf(1, 2, 3))
+            longArrayOf(1, 2, 3).shouldContainExactly(1L, 2L, 3L)
+            longArrayOf(1, 2, 3).shouldNotContainExactly(longArrayOf(3, 2, 1))
+            longArrayOf(1, 2, 3).shouldNotContainExactly(3L, 2L, 1L)
+            shouldThrow<AssertionError> {
+               longArrayOf(1, 2, 3).shouldContainExactly(3L, 2L, 1L)
+            }
+            shouldThrow<AssertionError> {
+               longArrayOf(1, 2, 3).shouldNotContainExactly(1L, 2L, 3L)
+            }
+         }
+
+         "test primitive FloatArray" {
+            floatArrayOf(1f, 2f, 3f).shouldContainExactly(floatArrayOf(1f, 2f, 3f))
+            floatArrayOf(1f, 2f, 3f).shouldContainExactly(1f, 2f, 3f)
+            floatArrayOf(1f, 2f, 3f).shouldNotContainExactly(floatArrayOf(3f, 2f, 1f))
+            floatArrayOf(1f, 2f, 3f).shouldNotContainExactly(3f, 2f, 1f)
+            shouldThrow<AssertionError> {
+               floatArrayOf(1f, 2f, 3f).shouldContainExactly(3f, 2f, 1f)
+            }
+            shouldThrow<AssertionError> {
+               floatArrayOf(1f, 2f, 3f).shouldNotContainExactly(1f, 2f, 3f)
+            }
+         }
+
+         "test primitive DoubleArray" {
+            doubleArrayOf(1.0, 2.0, 3.0).shouldContainExactly(doubleArrayOf(1.0, 2.0, 3.0))
+            doubleArrayOf(1.0, 2.0, 3.0).shouldContainExactly(1.0, 2.0, 3.0)
+            doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainExactly(doubleArrayOf(3.0, 2.0, 1.0))
+            doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainExactly(3.0, 2.0, 1.0)
+            shouldThrow<AssertionError> {
+               doubleArrayOf(1.0, 2.0, 3.0).shouldContainExactly(3.0, 2.0, 1.0)
+            }
+            shouldThrow<AssertionError> {
+               doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainExactly(1.0, 2.0, 3.0)
+            }
+         }
       }
 
       "containExactlyInAnyOrder" should {

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;


### PR DESCRIPTION
## Summary

- Adds `shouldContainExactly` and `shouldNotContainExactly` extension functions for all 8 primitive array types: `BooleanArray`, `ByteArray`, `ShortArray`, `CharArray`, `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`
- Each type gets both an infix array-to-array form and a vararg form, delegating to the existing `List`-based `containExactly` matcher via `asList()`
- Adds tests in `ShouldContainExactlyTest` for each primitive type covering: correct order passes, wrong order fails, `shouldNotContainExactly` passes when order differs

Fixes #4354 

## Test plan

- [ ] `intArrayOf(1,2,3).shouldContainExactly(intArrayOf(1,2,3))` passes
- [ ] `intArrayOf(1,2,3).shouldContainExactly(1, 2, 3)` passes
- [ ] `intArrayOf(3,2,1).shouldContainExactly(1,2,3)` throws `AssertionError`
- [ ] `intArrayOf(1,2,3).shouldNotContainExactly(3, 2, 1)` passes
- [ ] Same pattern verified for all 8 primitive array types
- [ ] Run `./gradlew :kotest-assertions:kotest-assertions-core:jvmTest --tests "com.sksamuel.kotest.matchers.collections.ShouldContainExactlyTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)