### PR TITLE
Add primitive array support for inorder (shouldContainInOrder) matcher (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1537,6 +1537,14 @@ public final class io/kotest/matchers/collections/InorderKt {
 	public static final fun shouldContainInOrder ([Ljava/lang/Object;[Ljava/lang/Object;)V
 	public static final fun shouldContainInOrder ([S[S)[S
 	public static final fun shouldContainInOrder ([Z[Z)[Z
+	public static final fun shouldContainInOrderBooleanArray_infix ([Z[Z)[Z
+	public static final fun shouldContainInOrderByteArray_infix ([B[B)[B
+	public static final fun shouldContainInOrderCharArray_infix ([C[C)[C
+	public static final fun shouldContainInOrderDoubleArray_infix ([D[D)[D
+	public static final fun shouldContainInOrderFloatArray_infix ([F[F)[F
+	public static final fun shouldContainInOrderIntArray_infix ([I[I)[I
+	public static final fun shouldContainInOrderLongArray_infix ([J[J)[J
+	public static final fun shouldContainInOrderShortArray_infix ([S[S)[S
 	public static final fun shouldNotContainInOrder (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
 	public static final fun shouldNotContainInOrder (Ljava/lang/Iterable;Ljava/util/List;)V
 	public static final fun shouldNotContainInOrder (Ljava/util/List;Ljava/util/List;)V
@@ -1550,6 +1558,14 @@ public final class io/kotest/matchers/collections/InorderKt {
 	public static final fun shouldNotContainInOrder ([Ljava/lang/Object;[Ljava/lang/Object;)V
 	public static final fun shouldNotContainInOrder ([S[S)[S
 	public static final fun shouldNotContainInOrder ([Z[Z)[Z
+	public static final fun shouldNotContainInOrderBooleanArray_infix ([Z[Z)[Z
+	public static final fun shouldNotContainInOrderByteArray_infix ([B[B)[B
+	public static final fun shouldNotContainInOrderCharArray_infix ([C[C)[C
+	public static final fun shouldNotContainInOrderDoubleArray_infix ([D[D)[D
+	public static final fun shouldNotContainInOrderFloatArray_infix ([F[F)[F
+	public static final fun shouldNotContainInOrderIntArray_infix ([I[I)[I
+	public static final fun shouldNotContainInOrderLongArray_infix ([J[J)[J
+	public static final fun shouldNotContainInOrderShortArray_infix ([S[S)[S
 }
 
 public final class io/kotest/matchers/collections/LargerKt {

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1479,13 +1479,29 @@ public final class io/kotest/matchers/collections/InorderKt {
 	public static final fun shouldContainInOrder (Ljava/lang/Iterable;[Ljava/lang/Object;)V
 	public static final fun shouldContainInOrder (Ljava/util/List;Ljava/util/List;)V
 	public static final fun shouldContainInOrder (Ljava/util/List;[Ljava/lang/Object;)V
+	public static final fun shouldContainInOrder ([B[B)[B
+	public static final fun shouldContainInOrder ([C[C)[C
+	public static final fun shouldContainInOrder ([D[D)[D
+	public static final fun shouldContainInOrder ([F[F)[F
+	public static final fun shouldContainInOrder ([I[I)[I
+	public static final fun shouldContainInOrder ([J[J)[J
 	public static final fun shouldContainInOrder ([Ljava/lang/Object;Ljava/util/List;)V
 	public static final fun shouldContainInOrder ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldContainInOrder ([S[S)[S
+	public static final fun shouldContainInOrder ([Z[Z)[Z
 	public static final fun shouldNotContainInOrder (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
 	public static final fun shouldNotContainInOrder (Ljava/lang/Iterable;Ljava/util/List;)V
 	public static final fun shouldNotContainInOrder (Ljava/util/List;Ljava/util/List;)V
+	public static final fun shouldNotContainInOrder ([B[B)[B
+	public static final fun shouldNotContainInOrder ([C[C)[C
+	public static final fun shouldNotContainInOrder ([D[D)[D
+	public static final fun shouldNotContainInOrder ([F[F)[F
+	public static final fun shouldNotContainInOrder ([I[I)[I
+	public static final fun shouldNotContainInOrder ([J[J)[J
 	public static final fun shouldNotContainInOrder ([Ljava/lang/Object;Ljava/util/List;)V
 	public static final fun shouldNotContainInOrder ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldNotContainInOrder ([S[S)[S
+	public static final fun shouldNotContainInOrder ([Z[Z)[Z
 }
 
 public final class io/kotest/matchers/collections/LargerKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -53,3 +53,51 @@ infix fun <T> Array<T>.shouldNotContainInOrder(expected: Array<T>) = asList().sh
 infix fun <T> Iterable<T>.shouldNotContainInOrder(expected: List<T>) = toList().shouldNotContainInOrder(expected)
 infix fun <T> Array<T>.shouldNotContainInOrder(expected: List<T>) = asList().shouldNotContainInOrder(expected)
 infix fun <T> List<T>.shouldNotContainInOrder(expected: List<T>) = this shouldNot containsInOrder(expected)
+
+// BooleanArray
+fun BooleanArray.shouldContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun BooleanArray.shouldContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun BooleanArray.shouldNotContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun BooleanArray.shouldNotContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// ByteArray
+fun ByteArray.shouldContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun ByteArray.shouldContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun ByteArray.shouldNotContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun ByteArray.shouldNotContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// ShortArray
+fun ShortArray.shouldContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun ShortArray.shouldContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun ShortArray.shouldNotContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun ShortArray.shouldNotContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// CharArray
+fun CharArray.shouldContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun CharArray.shouldContainInOrder(expected: CharArray): CharArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun CharArray.shouldNotContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun CharArray.shouldNotContainInOrder(expected: CharArray): CharArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// IntArray
+fun IntArray.shouldContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun IntArray.shouldContainInOrder(expected: IntArray): IntArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun IntArray.shouldNotContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun IntArray.shouldNotContainInOrder(expected: IntArray): IntArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// LongArray
+fun LongArray.shouldContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun LongArray.shouldContainInOrder(expected: LongArray): LongArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun LongArray.shouldNotContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun LongArray.shouldNotContainInOrder(expected: LongArray): LongArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// FloatArray
+fun FloatArray.shouldContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun FloatArray.shouldContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun FloatArray.shouldNotContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun FloatArray.shouldNotContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
+
+// DoubleArray
+fun DoubleArray.shouldContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldContainInOrder(ts.asList()) }
+infix fun DoubleArray.shouldContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldContainInOrder(expected.asList()) }
+fun DoubleArray.shouldNotContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+infix fun DoubleArray.shouldNotContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainInOrder(expected.asList()) }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -56,48 +56,32 @@ infix fun <T> List<T>.shouldNotContainInOrder(expected: List<T>) = this shouldNo
 
 // BooleanArray
 fun BooleanArray.shouldContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun BooleanArray.shouldContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun BooleanArray.shouldNotContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun BooleanArray.shouldNotContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // ByteArray
 fun ByteArray.shouldContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun ByteArray.shouldContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun ByteArray.shouldNotContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun ByteArray.shouldNotContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // ShortArray
 fun ShortArray.shouldContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun ShortArray.shouldContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun ShortArray.shouldNotContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun ShortArray.shouldNotContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // CharArray
 fun CharArray.shouldContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun CharArray.shouldContainInOrder(expected: CharArray): CharArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun CharArray.shouldNotContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun CharArray.shouldNotContainInOrder(expected: CharArray): CharArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // IntArray
 fun IntArray.shouldContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun IntArray.shouldContainInOrder(expected: IntArray): IntArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun IntArray.shouldNotContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun IntArray.shouldNotContainInOrder(expected: IntArray): IntArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // LongArray
 fun LongArray.shouldContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun LongArray.shouldContainInOrder(expected: LongArray): LongArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun LongArray.shouldNotContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun LongArray.shouldNotContainInOrder(expected: LongArray): LongArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // FloatArray
 fun FloatArray.shouldContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun FloatArray.shouldContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun FloatArray.shouldNotContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun FloatArray.shouldNotContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // DoubleArray
 fun DoubleArray.shouldContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldContainInOrder(ts.asList()) }
-infix fun DoubleArray.shouldContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun DoubleArray.shouldNotContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
-infix fun DoubleArray.shouldNotContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainInOrder(expected.asList()) }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import kotlin.jvm.JvmName
 
 /** Assert that a collection contains a given subsequence, possibly with values in between. */
 fun <T> containsInOrder(vararg ts: T): Matcher<Collection<T>?> = containsInOrder(ts.asList())
@@ -56,32 +57,64 @@ infix fun <T> List<T>.shouldNotContainInOrder(expected: List<T>) = this shouldNo
 
 // BooleanArray
 fun BooleanArray.shouldContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderBooleanArray_infix")
+infix fun BooleanArray.shouldContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun BooleanArray.shouldNotContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderBooleanArray_infix")
+infix fun BooleanArray.shouldNotContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // ByteArray
 fun ByteArray.shouldContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderByteArray_infix")
+infix fun ByteArray.shouldContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun ByteArray.shouldNotContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderByteArray_infix")
+infix fun ByteArray.shouldNotContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // ShortArray
 fun ShortArray.shouldContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderShortArray_infix")
+infix fun ShortArray.shouldContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun ShortArray.shouldNotContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderShortArray_infix")
+infix fun ShortArray.shouldNotContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // CharArray
 fun CharArray.shouldContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderCharArray_infix")
+infix fun CharArray.shouldContainInOrder(expected: CharArray): CharArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun CharArray.shouldNotContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderCharArray_infix")
+infix fun CharArray.shouldNotContainInOrder(expected: CharArray): CharArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // IntArray
 fun IntArray.shouldContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderIntArray_infix")
+infix fun IntArray.shouldContainInOrder(expected: IntArray): IntArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun IntArray.shouldNotContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderIntArray_infix")
+infix fun IntArray.shouldNotContainInOrder(expected: IntArray): IntArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // LongArray
 fun LongArray.shouldContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderLongArray_infix")
+infix fun LongArray.shouldContainInOrder(expected: LongArray): LongArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun LongArray.shouldNotContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderLongArray_infix")
+infix fun LongArray.shouldNotContainInOrder(expected: LongArray): LongArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // FloatArray
 fun FloatArray.shouldContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderFloatArray_infix")
+infix fun FloatArray.shouldContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun FloatArray.shouldNotContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderFloatArray_infix")
+infix fun FloatArray.shouldNotContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // DoubleArray
 fun DoubleArray.shouldContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldContainInOrder(ts.asList()) }
+@JvmName("shouldContainInOrderDoubleArray_infix")
+infix fun DoubleArray.shouldContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldContainInOrder(expected.asList()) }
 fun DoubleArray.shouldNotContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
+@JvmName("shouldNotContainInOrderDoubleArray_infix")
+infix fun DoubleArray.shouldNotContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainInOrder(expected.asList()) }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/InOrderTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containsInOrder
 import io.kotest.matchers.collections.shouldContainInOrder
+import io.kotest.matchers.collections.shouldNotContainInOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainInOrder
@@ -61,6 +62,76 @@ class InOrderTest : WordSpec() {
                "could not match element 2 at index 3",
                "but found it before at index(es) [1]"
             )
+         }
+      }
+
+      "primitive array support" should {
+         "support IntArray with vararg" {
+            intArrayOf(1, 2, 3).shouldContainInOrder(1, 3)
+            intArrayOf(1, 2, 3).shouldContainInOrder(1, 2, 3)
+            shouldThrow<AssertionError> {
+               intArrayOf(1, 2, 3).shouldContainInOrder(3, 1)
+            }
+         }
+         "support IntArray infix with IntArray" {
+            intArrayOf(1, 2, 3).shouldContainInOrder(intArrayOf(1, 3))
+            shouldThrow<AssertionError> {
+               intArrayOf(1, 2, 3).shouldContainInOrder(intArrayOf(3, 1))
+            }
+         }
+         "support IntArray shouldNotContainInOrder with vararg" {
+            intArrayOf(1, 2, 3).shouldNotContainInOrder(2, 4)
+            shouldThrow<AssertionError> {
+               intArrayOf(1, 2, 3).shouldNotContainInOrder(1, 3)
+            }
+         }
+         "support IntArray shouldNotContainInOrder infix" {
+            intArrayOf(1, 2, 3).shouldNotContainInOrder(intArrayOf(2, 4))
+            shouldThrow<AssertionError> {
+               intArrayOf(1, 2, 3).shouldNotContainInOrder(intArrayOf(1, 3))
+            }
+         }
+         "support LongArray" {
+            longArrayOf(1L, 2L, 3L).shouldContainInOrder(1L, 3L)
+            longArrayOf(1L, 2L, 3L).shouldContainInOrder(longArrayOf(1L, 3L))
+            longArrayOf(1L, 2L, 3L).shouldNotContainInOrder(2L, 4L)
+            longArrayOf(1L, 2L, 3L).shouldNotContainInOrder(longArrayOf(2L, 4L))
+         }
+         "support DoubleArray" {
+            doubleArrayOf(1.0, 2.0, 3.0).shouldContainInOrder(1.0, 3.0)
+            doubleArrayOf(1.0, 2.0, 3.0).shouldContainInOrder(doubleArrayOf(1.0, 3.0))
+            doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainInOrder(2.0, 4.0)
+            doubleArrayOf(1.0, 2.0, 3.0).shouldNotContainInOrder(doubleArrayOf(2.0, 4.0))
+         }
+         "support FloatArray" {
+            floatArrayOf(1f, 2f, 3f).shouldContainInOrder(1f, 3f)
+            floatArrayOf(1f, 2f, 3f).shouldContainInOrder(floatArrayOf(1f, 3f))
+            floatArrayOf(1f, 2f, 3f).shouldNotContainInOrder(2f, 4f)
+            floatArrayOf(1f, 2f, 3f).shouldNotContainInOrder(floatArrayOf(2f, 4f))
+         }
+         "support ByteArray" {
+            byteArrayOf(1, 2, 3).shouldContainInOrder(1, 3)
+            byteArrayOf(1, 2, 3).shouldContainInOrder(byteArrayOf(1, 3))
+            byteArrayOf(1, 2, 3).shouldNotContainInOrder(2, 4)
+            byteArrayOf(1, 2, 3).shouldNotContainInOrder(byteArrayOf(2, 4))
+         }
+         "support ShortArray" {
+            shortArrayOf(1, 2, 3).shouldContainInOrder(1, 3)
+            shortArrayOf(1, 2, 3).shouldContainInOrder(shortArrayOf(1, 3))
+            shortArrayOf(1, 2, 3).shouldNotContainInOrder(2, 4)
+            shortArrayOf(1, 2, 3).shouldNotContainInOrder(shortArrayOf(2, 4))
+         }
+         "support CharArray" {
+            charArrayOf('a', 'b', 'c').shouldContainInOrder('a', 'c')
+            charArrayOf('a', 'b', 'c').shouldContainInOrder(charArrayOf('a', 'c'))
+            charArrayOf('a', 'b', 'c').shouldNotContainInOrder('b', 'd')
+            charArrayOf('a', 'b', 'c').shouldNotContainInOrder(charArrayOf('b', 'd'))
+         }
+         "support BooleanArray" {
+            booleanArrayOf(true, false, true).shouldContainInOrder(true, true)
+            booleanArrayOf(true, false, true).shouldContainInOrder(booleanArrayOf(true, true))
+            booleanArrayOf(true, false, true).shouldNotContainInOrder(false, false)
+            booleanArrayOf(true, false, true).shouldNotContainInOrder(booleanArrayOf(false, false))
          }
       }
    }

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;


### PR DESCRIPTION
## Summary

- Adds `shouldContainInOrder` and `shouldNotContainInOrder` extension functions for all 8 Kotlin primitive array types: `BooleanArray`, `ByteArray`, `ShortArray`, `CharArray`, `IntArray`, `LongArray`, `FloatArray`, and `DoubleArray`
- Each type gets both a vararg form (e.g. `intArrayOf(1,2,3).shouldContainInOrder(1, 3)`) and an infix form accepting the same array type (e.g. `intArrayOf(1,2,3).shouldContainInOrder(intArrayOf(1, 3))`)
- All variants delegate to the existing `List`-based implementation via `asList()`

Fixes #4354 

## Test plan

- [ ] `intArrayOf(1,2,3).shouldContainInOrder(1,3)` passes (subsequence found)
- [ ] `intArrayOf(1,2,3).shouldContainInOrder(intArrayOf(1,3))` passes (infix array form)
- [ ] `intArrayOf(1,2,3).shouldNotContainInOrder(2,4)` passes (4 not present)
- [ ] `intArrayOf(1,2,3).shouldNotContainInOrder(intArrayOf(1,3))` fails as expected
- [ ] Tests for all 8 primitive array types added to `InOrderTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)