### PR TITLE
Add primitive array support for startWith/endWith matchers (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1764,33 +1764,65 @@ public final class io/kotest/matchers/collections/StartwithKt {
 	public static final fun shouldEndWith (Ljava/util/List;Ljava/lang/Object;)V
 	public static final fun shouldEndWith (Ljava/util/List;Ljava/util/Collection;)V
 	public static final fun shouldEndWith (Ljava/util/List;[Ljava/lang/Object;)V
+	public static final fun shouldEndWith ([B[B)[B
+	public static final fun shouldEndWith ([C[C)[C
+	public static final fun shouldEndWith ([D[D)[D
+	public static final fun shouldEndWith ([F[F)[F
+	public static final fun shouldEndWith ([I[I)[I
+	public static final fun shouldEndWith ([J[J)[J
 	public static final fun shouldEndWith ([Ljava/lang/Object;Ljava/lang/Object;)V
 	public static final fun shouldEndWith ([Ljava/lang/Object;Ljava/util/Collection;)V
 	public static final fun shouldEndWith ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldEndWith ([S[S)[S
+	public static final fun shouldEndWith ([Z[Z)[Z
 	public static final fun shouldNotEndWith (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
 	public static final fun shouldNotEndWith (Ljava/lang/Iterable;Ljava/lang/Object;)V
 	public static final fun shouldNotEndWith (Ljava/lang/Iterable;[Ljava/lang/Object;)V
 	public static final fun shouldNotEndWith (Ljava/util/List;Ljava/lang/Object;)V
 	public static final fun shouldNotEndWith (Ljava/util/List;Ljava/util/Collection;)V
+	public static final fun shouldNotEndWith ([B[B)[B
+	public static final fun shouldNotEndWith ([C[C)[C
+	public static final fun shouldNotEndWith ([D[D)[D
+	public static final fun shouldNotEndWith ([F[F)[F
+	public static final fun shouldNotEndWith ([I[I)[I
+	public static final fun shouldNotEndWith ([J[J)[J
 	public static final fun shouldNotEndWith ([Ljava/lang/Object;Ljava/lang/Object;)V
 	public static final fun shouldNotEndWith ([Ljava/lang/Object;Ljava/util/Collection;)V
 	public static final fun shouldNotEndWith ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldNotEndWith ([S[S)[S
+	public static final fun shouldNotEndWith ([Z[Z)[Z
 	public static final fun shouldNotStartWith (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
 	public static final fun shouldNotStartWith (Ljava/lang/Iterable;Ljava/lang/Object;)V
 	public static final fun shouldNotStartWith (Ljava/lang/Iterable;[Ljava/lang/Object;)V
 	public static final fun shouldNotStartWith (Ljava/util/List;Ljava/lang/Object;)V
 	public static final fun shouldNotStartWith (Ljava/util/List;Ljava/util/Collection;)V
+	public static final fun shouldNotStartWith ([B[B)[B
+	public static final fun shouldNotStartWith ([C[C)[C
+	public static final fun shouldNotStartWith ([D[D)[D
+	public static final fun shouldNotStartWith ([F[F)[F
+	public static final fun shouldNotStartWith ([I[I)[I
+	public static final fun shouldNotStartWith ([J[J)[J
 	public static final fun shouldNotStartWith ([Ljava/lang/Object;Ljava/lang/Object;)V
 	public static final fun shouldNotStartWith ([Ljava/lang/Object;Ljava/util/Collection;)V
 	public static final fun shouldNotStartWith ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldNotStartWith ([S[S)[S
+	public static final fun shouldNotStartWith ([Z[Z)[Z
 	public static final fun shouldStartWith (Ljava/lang/Iterable;Ljava/lang/Iterable;)V
 	public static final fun shouldStartWith (Ljava/lang/Iterable;Ljava/lang/Object;)V
 	public static final fun shouldStartWith (Ljava/lang/Iterable;[Ljava/lang/Object;)V
 	public static final fun shouldStartWith (Ljava/util/List;Ljava/lang/Object;)V
 	public static final fun shouldStartWith (Ljava/util/List;Ljava/util/Collection;)V
+	public static final fun shouldStartWith ([B[B)[B
+	public static final fun shouldStartWith ([C[C)[C
+	public static final fun shouldStartWith ([D[D)[D
+	public static final fun shouldStartWith ([F[F)[F
+	public static final fun shouldStartWith ([I[I)[I
+	public static final fun shouldStartWith ([J[J)[J
 	public static final fun shouldStartWith ([Ljava/lang/Object;Ljava/lang/Object;)V
 	public static final fun shouldStartWith ([Ljava/lang/Object;Ljava/util/Collection;)V
 	public static final fun shouldStartWith ([Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun shouldStartWith ([S[S)[S
+	public static final fun shouldStartWith ([Z[Z)[Z
 	public static final fun startWith (Ljava/util/Collection;)Lio/kotest/matchers/Matcher;
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -180,3 +180,45 @@ fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
    }
 }
 
+// Primitive array overloads for shouldStartWith / shouldNotStartWith
+
+infix fun BooleanArray.shouldStartWith(slice: BooleanArray): BooleanArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun BooleanArray.shouldNotStartWith(slice: BooleanArray): BooleanArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun BooleanArray.shouldEndWith(slice: BooleanArray): BooleanArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun BooleanArray.shouldNotEndWith(slice: BooleanArray): BooleanArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun ByteArray.shouldStartWith(slice: ByteArray): ByteArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun ByteArray.shouldNotStartWith(slice: ByteArray): ByteArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun ByteArray.shouldEndWith(slice: ByteArray): ByteArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun ByteArray.shouldNotEndWith(slice: ByteArray): ByteArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun ShortArray.shouldStartWith(slice: ShortArray): ShortArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun ShortArray.shouldNotStartWith(slice: ShortArray): ShortArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun ShortArray.shouldEndWith(slice: ShortArray): ShortArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun ShortArray.shouldNotEndWith(slice: ShortArray): ShortArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun CharArray.shouldStartWith(slice: CharArray): CharArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun CharArray.shouldNotStartWith(slice: CharArray): CharArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun CharArray.shouldEndWith(slice: CharArray): CharArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun CharArray.shouldNotEndWith(slice: CharArray): CharArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun IntArray.shouldStartWith(slice: IntArray): IntArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun IntArray.shouldNotStartWith(slice: IntArray): IntArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun IntArray.shouldEndWith(slice: IntArray): IntArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun IntArray.shouldNotEndWith(slice: IntArray): IntArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun LongArray.shouldStartWith(slice: LongArray): LongArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun LongArray.shouldNotStartWith(slice: LongArray): LongArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun LongArray.shouldEndWith(slice: LongArray): LongArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun LongArray.shouldNotEndWith(slice: LongArray): LongArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun FloatArray.shouldStartWith(slice: FloatArray): FloatArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun FloatArray.shouldNotStartWith(slice: FloatArray): FloatArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun FloatArray.shouldEndWith(slice: FloatArray): FloatArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun FloatArray.shouldNotEndWith(slice: FloatArray): FloatArray = apply { asList().shouldNotEndWith(slice.asList()) }
+
+infix fun DoubleArray.shouldStartWith(slice: DoubleArray): DoubleArray = apply { asList().shouldStartWith(slice.asList()) }
+infix fun DoubleArray.shouldNotStartWith(slice: DoubleArray): DoubleArray = apply { asList().shouldNotStartWith(slice.asList()) }
+infix fun DoubleArray.shouldEndWith(slice: DoubleArray): DoubleArray = apply { asList().shouldEndWith(slice.asList()) }
+infix fun DoubleArray.shouldNotEndWith(slice: DoubleArray): DoubleArray = apply { asList().shouldNotEndWith(slice.asList()) }
+

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/StartWithEndWithTest.kt
@@ -182,5 +182,72 @@ class StartWithEndWithTest : WordSpec() {
          }
 
       }
+
+      "primitive array startWith/endWith" should {
+         "BooleanArray shouldStartWith and shouldEndWith" {
+            booleanArrayOf(true, false, true, false).shouldStartWith(booleanArrayOf(true, false))
+            booleanArrayOf(true, false, true, false).shouldEndWith(booleanArrayOf(true, false))
+            booleanArrayOf(true, false, true, false).shouldNotStartWith(booleanArrayOf(false, true))
+            booleanArrayOf(true, false, true, false).shouldNotEndWith(booleanArrayOf(true, true))
+            shouldThrow<AssertionError> { booleanArrayOf(true, false).shouldStartWith(booleanArrayOf(false, true)) }
+            shouldThrow<AssertionError> { booleanArrayOf(true, false).shouldEndWith(booleanArrayOf(false, false)) }
+         }
+         "ByteArray shouldStartWith and shouldEndWith" {
+            byteArrayOf(1, 2, 3, 4).shouldStartWith(byteArrayOf(1, 2))
+            byteArrayOf(1, 2, 3, 4).shouldEndWith(byteArrayOf(3, 4))
+            byteArrayOf(1, 2, 3, 4).shouldNotStartWith(byteArrayOf(2, 3))
+            byteArrayOf(1, 2, 3, 4).shouldNotEndWith(byteArrayOf(1, 2))
+            shouldThrow<AssertionError> { byteArrayOf(1, 2, 3, 4).shouldStartWith(byteArrayOf(2, 3)) }
+            shouldThrow<AssertionError> { byteArrayOf(1, 2, 3, 4).shouldEndWith(byteArrayOf(1, 2)) }
+         }
+         "ShortArray shouldStartWith and shouldEndWith" {
+            shortArrayOf(1, 2, 3, 4).shouldStartWith(shortArrayOf(1, 2))
+            shortArrayOf(1, 2, 3, 4).shouldEndWith(shortArrayOf(3, 4))
+            shortArrayOf(1, 2, 3, 4).shouldNotStartWith(shortArrayOf(2, 3))
+            shortArrayOf(1, 2, 3, 4).shouldNotEndWith(shortArrayOf(1, 2))
+            shouldThrow<AssertionError> { shortArrayOf(1, 2, 3, 4).shouldStartWith(shortArrayOf(2, 3)) }
+            shouldThrow<AssertionError> { shortArrayOf(1, 2, 3, 4).shouldEndWith(shortArrayOf(1, 2)) }
+         }
+         "CharArray shouldStartWith and shouldEndWith" {
+            charArrayOf('a', 'b', 'c', 'd').shouldStartWith(charArrayOf('a', 'b'))
+            charArrayOf('a', 'b', 'c', 'd').shouldEndWith(charArrayOf('c', 'd'))
+            charArrayOf('a', 'b', 'c', 'd').shouldNotStartWith(charArrayOf('b', 'c'))
+            charArrayOf('a', 'b', 'c', 'd').shouldNotEndWith(charArrayOf('a', 'b'))
+            shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c', 'd').shouldStartWith(charArrayOf('b', 'c')) }
+            shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c', 'd').shouldEndWith(charArrayOf('a', 'b')) }
+         }
+         "IntArray shouldStartWith and shouldEndWith" {
+            intArrayOf(1, 2, 3, 4).shouldStartWith(intArrayOf(1, 2))
+            intArrayOf(1, 2, 3, 4).shouldEndWith(intArrayOf(3, 4))
+            intArrayOf(1, 2, 3, 4).shouldNotStartWith(intArrayOf(2, 3))
+            intArrayOf(1, 2, 3, 4).shouldNotEndWith(intArrayOf(1, 2))
+            shouldThrow<AssertionError> { intArrayOf(1, 2, 3, 4).shouldStartWith(intArrayOf(2, 3)) }
+            shouldThrow<AssertionError> { intArrayOf(1, 2, 3, 4).shouldEndWith(intArrayOf(1, 2)) }
+         }
+         "LongArray shouldStartWith and shouldEndWith" {
+            longArrayOf(1, 2, 3, 4).shouldStartWith(longArrayOf(1, 2))
+            longArrayOf(1, 2, 3, 4).shouldEndWith(longArrayOf(3, 4))
+            longArrayOf(1, 2, 3, 4).shouldNotStartWith(longArrayOf(2, 3))
+            longArrayOf(1, 2, 3, 4).shouldNotEndWith(longArrayOf(1, 2))
+            shouldThrow<AssertionError> { longArrayOf(1, 2, 3, 4).shouldStartWith(longArrayOf(2, 3)) }
+            shouldThrow<AssertionError> { longArrayOf(1, 2, 3, 4).shouldEndWith(longArrayOf(1, 2)) }
+         }
+         "FloatArray shouldStartWith and shouldEndWith" {
+            floatArrayOf(1f, 2f, 3f, 4f).shouldStartWith(floatArrayOf(1f, 2f))
+            floatArrayOf(1f, 2f, 3f, 4f).shouldEndWith(floatArrayOf(3f, 4f))
+            floatArrayOf(1f, 2f, 3f, 4f).shouldNotStartWith(floatArrayOf(2f, 3f))
+            floatArrayOf(1f, 2f, 3f, 4f).shouldNotEndWith(floatArrayOf(1f, 2f))
+            shouldThrow<AssertionError> { floatArrayOf(1f, 2f, 3f, 4f).shouldStartWith(floatArrayOf(2f, 3f)) }
+            shouldThrow<AssertionError> { floatArrayOf(1f, 2f, 3f, 4f).shouldEndWith(floatArrayOf(1f, 2f)) }
+         }
+         "DoubleArray shouldStartWith and shouldEndWith" {
+            doubleArrayOf(1.0, 2.0, 3.0, 4.0).shouldStartWith(doubleArrayOf(1.0, 2.0))
+            doubleArrayOf(1.0, 2.0, 3.0, 4.0).shouldEndWith(doubleArrayOf(3.0, 4.0))
+            doubleArrayOf(1.0, 2.0, 3.0, 4.0).shouldNotStartWith(doubleArrayOf(2.0, 3.0))
+            doubleArrayOf(1.0, 2.0, 3.0, 4.0).shouldNotEndWith(doubleArrayOf(1.0, 2.0))
+            shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0, 4.0).shouldStartWith(doubleArrayOf(2.0, 3.0)) }
+            shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0, 4.0).shouldEndWith(doubleArrayOf(1.0, 2.0)) }
+         }
+      }
    }
 }

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;


### PR DESCRIPTION
## Summary

- Adds `shouldStartWith`, `shouldNotStartWith`, `shouldEndWith`, and `shouldNotEndWith` infix extension functions for all 8 primitive array types: `BooleanArray`, `ByteArray`, `ShortArray`, `CharArray`, `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`
- Each overload delegates to the existing `List`-based implementation via `.asList()`, keeping the implementation minimal and consistent
- Modified file: `kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt`

Fixes #4354 

## Test plan

- [ ] Tests added in `StartWithEndWithTest.kt` for each of the 8 primitive array types
- [ ] Each type tests: passing `shouldStartWith`, passing `shouldEndWith`, passing `shouldNotStartWith`, passing `shouldNotEndWith`, failing `shouldStartWith` throws `AssertionError`, failing `shouldEndWith` throws `AssertionError`
- [ ] Run `./gradlew :kotest-assertions:kotest-assertions-core:jvmTest --tests "com.sksamuel.kotest.matchers.collections.StartWithEndWithTest"` to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)