### PR TITLE
Add primitive array support for beIn (shouldBeIn) matcher (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1166,11 +1166,27 @@ public final class io/kotest/matchers/char/CharMatchersKt {
 
 public final class io/kotest/matchers/collections/BeinKt {
 	public static final fun beIn (Ljava/util/Collection;)Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeIn (B[B)B
+	public static final fun shouldBeIn (C[C)C
+	public static final fun shouldBeIn (D[D)D
+	public static final fun shouldBeIn (F[F)F
+	public static final fun shouldBeIn (I[I)I
+	public static final fun shouldBeIn (J[J)J
 	public static final fun shouldBeIn (Ljava/lang/Object;Ljava/util/Collection;)Ljava/lang/Object;
 	public static final fun shouldBeIn (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun shouldBeIn (S[S)S
+	public static final fun shouldBeIn (Z[Z)Z
 	public static final fun shouldBeInArray (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun shouldNotBeIn (B[B)B
+	public static final fun shouldNotBeIn (C[C)C
+	public static final fun shouldNotBeIn (D[D)D
+	public static final fun shouldNotBeIn (F[F)F
+	public static final fun shouldNotBeIn (I[I)I
+	public static final fun shouldNotBeIn (J[J)J
 	public static final fun shouldNotBeIn (Ljava/lang/Object;Ljava/util/Collection;)Ljava/lang/Object;
 	public static final fun shouldNotBeIn (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun shouldNotBeIn (S[S)S
+	public static final fun shouldNotBeIn (Z[Z)Z
 	public static final fun shouldNotBeInArray (Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bein.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bein.kt
@@ -113,6 +113,86 @@ infix fun <T> T.shouldNotBeIn(array: Array<T>): T {
    return this
 }
 
+infix fun Int.shouldBeIn(array: IntArray): Int {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Int.shouldNotBeIn(array: IntArray): Int {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Long.shouldBeIn(array: LongArray): Long {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Long.shouldNotBeIn(array: LongArray): Long {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Float.shouldBeIn(array: FloatArray): Float {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Float.shouldNotBeIn(array: FloatArray): Float {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Double.shouldBeIn(array: DoubleArray): Double {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Double.shouldNotBeIn(array: DoubleArray): Double {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Byte.shouldBeIn(array: ByteArray): Byte {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Byte.shouldNotBeIn(array: ByteArray): Byte {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Short.shouldBeIn(array: ShortArray): Short {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Short.shouldNotBeIn(array: ShortArray): Short {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Char.shouldBeIn(array: CharArray): Char {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Char.shouldNotBeIn(array: CharArray): Char {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
+infix fun Boolean.shouldBeIn(array: BooleanArray): Boolean {
+   this should beIn(array.asList())
+   return this
+}
+
+infix fun Boolean.shouldNotBeIn(array: BooleanArray): Boolean {
+   this shouldNot beIn(array.asList())
+   return this
+}
+
 /**
  *  Matcher that verifies that this element is in [collection] by comparing value
  *

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -1117,6 +1117,112 @@ expected:<2> but was:<3>""")
             }
          }
       }
+
+      "Be in primitive arrays" should {
+         "Pass for Int in IntArray" {
+            1.shouldBeIn(intArrayOf(1, 2, 3))
+         }
+         "Fail for Int not in IntArray" {
+            shouldThrow<AssertionError> { 4.shouldBeIn(intArrayOf(1, 2, 3)) }
+         }
+         "Pass for Int not in IntArray (negative)" {
+            4.shouldNotBeIn(intArrayOf(1, 2, 3))
+         }
+         "Fail for Int in IntArray (negative)" {
+            shouldThrow<AssertionError> { 1.shouldNotBeIn(intArrayOf(1, 2, 3)) }
+         }
+
+         "Pass for Long in LongArray" {
+            1L.shouldBeIn(longArrayOf(1L, 2L, 3L))
+         }
+         "Fail for Long not in LongArray" {
+            shouldThrow<AssertionError> { 4L.shouldBeIn(longArrayOf(1L, 2L, 3L)) }
+         }
+         "Pass for Long not in LongArray (negative)" {
+            4L.shouldNotBeIn(longArrayOf(1L, 2L, 3L))
+         }
+         "Fail for Long in LongArray (negative)" {
+            shouldThrow<AssertionError> { 1L.shouldNotBeIn(longArrayOf(1L, 2L, 3L)) }
+         }
+
+         "Pass for Float in FloatArray" {
+            1.0f.shouldBeIn(floatArrayOf(1.0f, 2.0f, 3.0f))
+         }
+         "Fail for Float not in FloatArray" {
+            shouldThrow<AssertionError> { 4.0f.shouldBeIn(floatArrayOf(1.0f, 2.0f, 3.0f)) }
+         }
+         "Pass for Float not in FloatArray (negative)" {
+            4.0f.shouldNotBeIn(floatArrayOf(1.0f, 2.0f, 3.0f))
+         }
+         "Fail for Float in FloatArray (negative)" {
+            shouldThrow<AssertionError> { 1.0f.shouldNotBeIn(floatArrayOf(1.0f, 2.0f, 3.0f)) }
+         }
+
+         "Pass for Double in DoubleArray" {
+            1.0.shouldBeIn(doubleArrayOf(1.0, 2.0, 3.0))
+         }
+         "Fail for Double not in DoubleArray" {
+            shouldThrow<AssertionError> { 4.0.shouldBeIn(doubleArrayOf(1.0, 2.0, 3.0)) }
+         }
+         "Pass for Double not in DoubleArray (negative)" {
+            4.0.shouldNotBeIn(doubleArrayOf(1.0, 2.0, 3.0))
+         }
+         "Fail for Double in DoubleArray (negative)" {
+            shouldThrow<AssertionError> { 1.0.shouldNotBeIn(doubleArrayOf(1.0, 2.0, 3.0)) }
+         }
+
+         "Pass for Byte in ByteArray" {
+            1.toByte().shouldBeIn(byteArrayOf(1, 2, 3))
+         }
+         "Fail for Byte not in ByteArray" {
+            shouldThrow<AssertionError> { 4.toByte().shouldBeIn(byteArrayOf(1, 2, 3)) }
+         }
+         "Pass for Byte not in ByteArray (negative)" {
+            4.toByte().shouldNotBeIn(byteArrayOf(1, 2, 3))
+         }
+         "Fail for Byte in ByteArray (negative)" {
+            shouldThrow<AssertionError> { 1.toByte().shouldNotBeIn(byteArrayOf(1, 2, 3)) }
+         }
+
+         "Pass for Short in ShortArray" {
+            1.toShort().shouldBeIn(shortArrayOf(1, 2, 3))
+         }
+         "Fail for Short not in ShortArray" {
+            shouldThrow<AssertionError> { 4.toShort().shouldBeIn(shortArrayOf(1, 2, 3)) }
+         }
+         "Pass for Short not in ShortArray (negative)" {
+            4.toShort().shouldNotBeIn(shortArrayOf(1, 2, 3))
+         }
+         "Fail for Short in ShortArray (negative)" {
+            shouldThrow<AssertionError> { 1.toShort().shouldNotBeIn(shortArrayOf(1, 2, 3)) }
+         }
+
+         "Pass for Char in CharArray" {
+            'a'.shouldBeIn(charArrayOf('a', 'b', 'c'))
+         }
+         "Fail for Char not in CharArray" {
+            shouldThrow<AssertionError> { 'd'.shouldBeIn(charArrayOf('a', 'b', 'c')) }
+         }
+         "Pass for Char not in CharArray (negative)" {
+            'd'.shouldNotBeIn(charArrayOf('a', 'b', 'c'))
+         }
+         "Fail for Char in CharArray (negative)" {
+            shouldThrow<AssertionError> { 'a'.shouldNotBeIn(charArrayOf('a', 'b', 'c')) }
+         }
+
+         "Pass for Boolean in BooleanArray" {
+            true.shouldBeIn(booleanArrayOf(true, false))
+         }
+         "Fail for Boolean not in BooleanArray" {
+            shouldThrow<AssertionError> { true.shouldBeIn(booleanArrayOf(false)) }
+         }
+         "Pass for Boolean not in BooleanArray (negative)" {
+            true.shouldNotBeIn(booleanArrayOf(false))
+         }
+         "Fail for Boolean in BooleanArray (negative)" {
+            shouldThrow<AssertionError> { true.shouldNotBeIn(booleanArrayOf(true, false)) }
+         }
+      }
    }
 }
 

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;


### PR DESCRIPTION
## Summary

- Adds `shouldBeIn` / `shouldNotBeIn` extension functions for all 8 primitive array types: `IntArray`, `LongArray`, `FloatArray`, `DoubleArray`, `ByteArray`, `ShortArray`, `CharArray`, `BooleanArray`
- Each overload delegates to the existing `beIn(collection)` matcher via `array.asList()`, keeping the implementation minimal and consistent
- Adds tests for every primitive type in `CollectionMatchersTest` covering: pass when present, fail when absent, pass when absent (negative), fail when present (negative)

Fixes #4354 

## Test plan

- [ ] `1.shouldBeIn(intArrayOf(1,2,3))` passes
- [ ] `4.shouldBeIn(intArrayOf(1,2,3))` throws `AssertionError`
- [ ] `4.shouldNotBeIn(intArrayOf(1,2,3))` passes
- [ ] `1.shouldNotBeIn(intArrayOf(1,2,3))` throws `AssertionError`
- [ ] Same four cases verified for `Long`, `Float`, `Double`, `Byte`, `Short`, `Char`, `Boolean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)