### PR TITLE
Add primitive array support for sorted (shouldBeSorted) matcher (#4354)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -1730,7 +1730,15 @@ public final class io/kotest/matchers/collections/SortedKt {
 	public static final fun beSortedWith (Lkotlin/jvm/functions/Function2;)Lio/kotest/matchers/Matcher;
 	public static final fun shouldBeSorted (Ljava/lang/Iterable;)Ljava/lang/Iterable;
 	public static final fun shouldBeSorted (Ljava/util/List;)Ljava/util/List;
+	public static final fun shouldBeSorted ([B)[B
+	public static final fun shouldBeSorted ([C)[C
+	public static final fun shouldBeSorted ([D)[D
+	public static final fun shouldBeSorted ([F)[F
+	public static final fun shouldBeSorted ([I)[I
+	public static final fun shouldBeSorted ([J)[J
 	public static final fun shouldBeSorted ([Ljava/lang/Comparable;)[Ljava/lang/Comparable;
+	public static final fun shouldBeSorted ([S)[S
+	public static final fun shouldBeSorted ([Z)[Z
 	public static final fun shouldBeSortedBy (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
 	public static final fun shouldBeSortedBy (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static final fun shouldBeSortedBy ([Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)[Ljava/lang/Object;
@@ -1742,7 +1750,15 @@ public final class io/kotest/matchers/collections/SortedKt {
 	public static final fun shouldBeSortedWith ([Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)[Ljava/lang/Object;
 	public static final fun shouldNotBeSorted (Ljava/lang/Iterable;)Ljava/lang/Iterable;
 	public static final fun shouldNotBeSorted (Ljava/util/List;)Ljava/util/List;
+	public static final fun shouldNotBeSorted ([B)[B
+	public static final fun shouldNotBeSorted ([C)[C
+	public static final fun shouldNotBeSorted ([D)[D
+	public static final fun shouldNotBeSorted ([F)[F
+	public static final fun shouldNotBeSorted ([I)[I
+	public static final fun shouldNotBeSorted ([J)[J
 	public static final fun shouldNotBeSorted ([Ljava/lang/Comparable;)[Ljava/lang/Comparable;
+	public static final fun shouldNotBeSorted ([S)[S
+	public static final fun shouldNotBeSorted ([Z)[Z
 	public static final fun shouldNotBeSortedBy (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Iterable;
 	public static final fun shouldNotBeSortedBy (Ljava/util/List;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public static final fun shouldNotBeSortedBy ([Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)[Ljava/lang/Object;

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sorted.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sorted.kt
@@ -139,6 +139,32 @@ infix fun <T, I : Iterable<T>> I.shouldNotBeSortedWith(cmp: (T, T) -> Int): I {
    return this
 }
 
+// Primitive Arrays ==================================================================================
+
+fun BooleanArray.shouldBeSorted(): BooleanArray = apply { asList().shouldBeSorted() }
+fun BooleanArray.shouldNotBeSorted(): BooleanArray = apply { asList().shouldNotBeSorted() }
+
+fun ByteArray.shouldBeSorted(): ByteArray = apply { asList().shouldBeSorted() }
+fun ByteArray.shouldNotBeSorted(): ByteArray = apply { asList().shouldNotBeSorted() }
+
+fun ShortArray.shouldBeSorted(): ShortArray = apply { asList().shouldBeSorted() }
+fun ShortArray.shouldNotBeSorted(): ShortArray = apply { asList().shouldNotBeSorted() }
+
+fun CharArray.shouldBeSorted(): CharArray = apply { asList().shouldBeSorted() }
+fun CharArray.shouldNotBeSorted(): CharArray = apply { asList().shouldNotBeSorted() }
+
+fun IntArray.shouldBeSorted(): IntArray = apply { asList().shouldBeSorted() }
+fun IntArray.shouldNotBeSorted(): IntArray = apply { asList().shouldNotBeSorted() }
+
+fun LongArray.shouldBeSorted(): LongArray = apply { asList().shouldBeSorted() }
+fun LongArray.shouldNotBeSorted(): LongArray = apply { asList().shouldNotBeSorted() }
+
+fun FloatArray.shouldBeSorted(): FloatArray = apply { asList().shouldBeSorted() }
+fun FloatArray.shouldNotBeSorted(): FloatArray = apply { asList().shouldNotBeSorted() }
+
+fun DoubleArray.shouldBeSorted(): DoubleArray = apply { asList().shouldBeSorted() }
+fun DoubleArray.shouldNotBeSorted(): DoubleArray = apply { asList().shouldNotBeSorted() }
+
 fun <T> beSortedWith(comparator: Comparator<in T>): Matcher<List<T>> = sortedWith(comparator)
 
 fun <T> beSortedWith(cmp: (T, T) -> Int): Matcher<List<T>> = sortedWith(cmp)

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SortedTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/SortedTest.kt
@@ -131,5 +131,107 @@ class SortedTest : WordSpec() {
             }.shouldHaveMessage("List [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, ...and 980 more (set 'kotest.assertions.collection.print.size' to see more / less items)] should not be sorted")
          }
       }
+
+      "primitive arrays" should {
+
+         "IntArray shouldBeSorted" {
+            intArrayOf().shouldBeSorted()
+            intArrayOf(1).shouldBeSorted()
+            intArrayOf(1, 2, 3).shouldBeSorted()
+            shouldThrow<AssertionError> { intArrayOf(3, 2, 1).shouldBeSorted() }
+         }
+
+         "IntArray shouldNotBeSorted" {
+            intArrayOf(3, 2, 1).shouldNotBeSorted()
+            shouldThrow<AssertionError> { intArrayOf(1, 2, 3).shouldNotBeSorted() }
+         }
+
+         "LongArray shouldBeSorted" {
+            longArrayOf().shouldBeSorted()
+            longArrayOf(1L).shouldBeSorted()
+            longArrayOf(1L, 2L, 3L).shouldBeSorted()
+            shouldThrow<AssertionError> { longArrayOf(3L, 2L, 1L).shouldBeSorted() }
+         }
+
+         "LongArray shouldNotBeSorted" {
+            longArrayOf(3L, 2L, 1L).shouldNotBeSorted()
+            shouldThrow<AssertionError> { longArrayOf(1L, 2L, 3L).shouldNotBeSorted() }
+         }
+
+         "DoubleArray shouldBeSorted" {
+            doubleArrayOf().shouldBeSorted()
+            doubleArrayOf(1.0).shouldBeSorted()
+            doubleArrayOf(1.0, 2.0, 3.0).shouldBeSorted()
+            shouldThrow<AssertionError> { doubleArrayOf(3.0, 2.0, 1.0).shouldBeSorted() }
+         }
+
+         "DoubleArray shouldNotBeSorted" {
+            doubleArrayOf(3.0, 2.0, 1.0).shouldNotBeSorted()
+            shouldThrow<AssertionError> { doubleArrayOf(1.0, 2.0, 3.0).shouldNotBeSorted() }
+         }
+
+         "FloatArray shouldBeSorted" {
+            floatArrayOf().shouldBeSorted()
+            floatArrayOf(1.0f).shouldBeSorted()
+            floatArrayOf(1.0f, 2.0f, 3.0f).shouldBeSorted()
+            shouldThrow<AssertionError> { floatArrayOf(3.0f, 2.0f, 1.0f).shouldBeSorted() }
+         }
+
+         "FloatArray shouldNotBeSorted" {
+            floatArrayOf(3.0f, 2.0f, 1.0f).shouldNotBeSorted()
+            shouldThrow<AssertionError> { floatArrayOf(1.0f, 2.0f, 3.0f).shouldNotBeSorted() }
+         }
+
+         "ByteArray shouldBeSorted" {
+            byteArrayOf().shouldBeSorted()
+            byteArrayOf(1).shouldBeSorted()
+            byteArrayOf(1, 2, 3).shouldBeSorted()
+            shouldThrow<AssertionError> { byteArrayOf(3, 2, 1).shouldBeSorted() }
+         }
+
+         "ByteArray shouldNotBeSorted" {
+            byteArrayOf(3, 2, 1).shouldNotBeSorted()
+            shouldThrow<AssertionError> { byteArrayOf(1, 2, 3).shouldNotBeSorted() }
+         }
+
+         "ShortArray shouldBeSorted" {
+            shortArrayOf().shouldBeSorted()
+            shortArrayOf(1).shouldBeSorted()
+            shortArrayOf(1, 2, 3).shouldBeSorted()
+            shouldThrow<AssertionError> { shortArrayOf(3, 2, 1).shouldBeSorted() }
+         }
+
+         "ShortArray shouldNotBeSorted" {
+            shortArrayOf(3, 2, 1).shouldNotBeSorted()
+            shouldThrow<AssertionError> { shortArrayOf(1, 2, 3).shouldNotBeSorted() }
+         }
+
+         "CharArray shouldBeSorted" {
+            charArrayOf().shouldBeSorted()
+            charArrayOf('a').shouldBeSorted()
+            charArrayOf('a', 'b', 'c').shouldBeSorted()
+            shouldThrow<AssertionError> { charArrayOf('c', 'b', 'a').shouldBeSorted() }
+         }
+
+         "CharArray shouldNotBeSorted" {
+            charArrayOf('c', 'b', 'a').shouldNotBeSorted()
+            shouldThrow<AssertionError> { charArrayOf('a', 'b', 'c').shouldNotBeSorted() }
+         }
+
+         "BooleanArray shouldBeSorted (false < true)" {
+            booleanArrayOf().shouldBeSorted()
+            booleanArrayOf(false).shouldBeSorted()
+            booleanArrayOf(true).shouldBeSorted()
+            booleanArrayOf(false, true).shouldBeSorted()
+            booleanArrayOf(false, false).shouldBeSorted()
+            booleanArrayOf(true, true).shouldBeSorted()
+            shouldThrow<AssertionError> { booleanArrayOf(true, false).shouldBeSorted() }
+         }
+
+         "BooleanArray shouldNotBeSorted" {
+            booleanArrayOf(true, false).shouldNotBeSorted()
+            shouldThrow<AssertionError> { booleanArrayOf(false, true).shouldNotBeSorted() }
+         }
+      }
    }
 }


### PR DESCRIPTION
## Summary

- Adds `shouldBeSorted()` and `shouldNotBeSorted()` extension functions for all 8 primitive array types: `BooleanArray`, `ByteArray`, `ShortArray`, `CharArray`, `IntArray`, `LongArray`, `FloatArray`, and `DoubleArray`
- Each extension delegates to `asList().shouldBeSorted()` / `asList().shouldNotBeSorted()`, reusing the existing `List<T>` matcher infrastructure
- Returns the original array for fluent chaining

Fixes #4354 

## Test plan

- [ ] `intArrayOf(1,2,3).shouldBeSorted()` passes
- [ ] `intArrayOf(3,2,1).shouldNotBeSorted()` passes
- [ ] `intArrayOf(3,2,1).shouldBeSorted()` throws `AssertionError`
- [ ] `intArrayOf(1,2,3).shouldNotBeSorted()` throws `AssertionError`
- [ ] Empty arrays always pass `shouldBeSorted()`
- [ ] Single-element arrays always pass `shouldBeSorted()`
- [ ] `floatArrayOf(1.0f, 2.0f, 3.0f).shouldBeSorted()` passes
- [ ] `booleanArrayOf(false, true).shouldBeSorted()` passes (false < true)
- [ ] `charArrayOf('a', 'b', 'c').shouldBeSorted()` passes
- [ ] All 8 primitive types covered by equivalent tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)