### PR TITLE
closing #5782 : add ClasspathRootSelector support to shouldRunTests g…

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine.kt
@@ -18,6 +18,7 @@ import org.junit.platform.engine.ExecutionRequest
 import org.junit.platform.engine.TestEngine
 import org.junit.platform.engine.UniqueId
 import org.junit.platform.engine.discovery.ClassSelector
+import org.junit.platform.engine.discovery.ClasspathRootSelector
 import org.junit.platform.engine.discovery.MethodSelector
 import org.junit.platform.engine.discovery.UniqueIdSelector
 import java.util.Optional
@@ -146,7 +147,7 @@ class KotestJunitPlatformTestEngine : TestEngine {
 
    /**
     * Returns true if there are selectors compatible with Kotest.
-    * Kotest supports [ClassSelector]s and [UniqueIdSelector]s.
+    * Kotest supports [ClasspathRootSelector]s, [ClassSelector]s, and [UniqueIdSelector]s.
     *
     * A [MethodSelector] is passed by intellij to run just a single method inside a test file.
     * Kotest will never use method selectors, so if we have one, then we know it is something
@@ -155,7 +156,8 @@ class KotestJunitPlatformTestEngine : TestEngine {
    private fun shouldRunTests(request: EngineDiscoveryRequest): Boolean {
       if (request.getSelectorsByType(MethodSelector::class.java).isNotEmpty()) return false
       return request.getSelectorsByType(ClassSelector::class.java).isNotEmpty() ||
-         request.getSelectorsByType(UniqueIdSelector::class.java).isNotEmpty()
+         request.getSelectorsByType(UniqueIdSelector::class.java).isNotEmpty() ||
+         request.getSelectorsByType(ClasspathRootSelector::class.java).isNotEmpty()
    }
 
    /**

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
@@ -68,7 +68,7 @@ internal object Discovery {
             ReflectionSupport.findAllClassesInClasspathRoot(selector.classpathRoot, isSpecSubclass) { true }
          }
          .asSequence()
-         .map(Class::kotlin)
+         .map(Class<*>::kotlin)
          .filterNot(isAbstract)
          .filterIsInstance<KClass<out Spec>>()
          .toList()

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
@@ -4,10 +4,12 @@ import io.kotest.core.log
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecRef
 import io.kotest.runner.junit.platform.Segment
+import org.junit.platform.commons.support.ReflectionSupport
 import org.junit.platform.engine.ConfigurationParameters
 import org.junit.platform.engine.EngineDiscoveryRequest
 import org.junit.platform.engine.UniqueId
 import org.junit.platform.engine.discovery.ClassSelector
+import org.junit.platform.engine.discovery.ClasspathRootSelector
 import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.engine.discovery.UniqueIdSelector
 import kotlin.reflect.KClass
@@ -33,11 +35,12 @@ internal object Discovery {
 
       log { "[Discovery] Starting spec discovery" }
 
-      // kotest only supports class selectors and unique id selectors (which we convert to class selectors)
+      // kotest only supports classpath root, class and unique id selectors (which we convert to class selectors)
+      val classpathRootSelectors = request.getSelectorsByType(ClasspathRootSelector::class.java)
       val classSelectors = request.getSelectorsByType(ClassSelector::class.java) +
          convertUniqueIdsToClassSelectors(engineId, request)
 
-      val specsSelected = specsFromClassDiscoverySelectorsOnly(classSelectors)
+      val specsSelected = (specsFromClasspathRootDiscoverySelectorsOnly(classpathRootSelectors) + specsFromClassDiscoverySelectorsOnly(classSelectors))
          .asSequence()
          .filter(isSpecSubclassKt)
          .filterNot(isAbstract)
@@ -54,6 +57,27 @@ internal object Discovery {
       val private = if (configurationParameters.get("allow_private").isPresent) Modifier.Private else null
       val modifiers = listOfNotNull(Modifier.Public, Modifier.Internal, private)
       return listOf(DiscoveryFilter.ClassModifierDiscoveryFilter(modifiers.toSet()))
+   }
+
+   /**
+    * Returns the request's [Spec]s if they are completely specified by classpath root selectors, null otherwise.
+    */
+   private fun specsFromClasspathRootDiscoverySelectorsOnly(selectors: List<ClasspathRootSelector>): List<KClass<out Spec>> {
+      val specs = selectors
+         .flatMap { selector ->
+            ReflectionSupport.findAllClassesInClasspathRoot(selector.classpathRoot, isSpecSubclass) { true }
+         }
+         .asSequence()
+         .map(Class::kotlin)
+         .filterNot(isAbstract)
+         .filterIsInstance<KClass<out Spec>>()
+         .toList()
+
+      log {
+         "[Discovery] Collected specs via ${selectors.size} class discovery selectors: found ${specs.size} specs"
+      }
+
+      return specs
    }
 
    /**

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
@@ -29,20 +29,19 @@ internal object Discovery {
    private val logger = Logger<Discovery>()
 
    // filter functions
-   private val isSpecSubclassKt: (KClass<*>) -> Boolean = { Spec::class.java.isAssignableFrom(it.java) }
    private val isSpecSubclass: (Class<*>) -> Boolean = { Spec::class.java.isAssignableFrom(it) }
    private val isAbstract: (KClass<*>) -> Boolean = { it.isAbstract }
 
    fun discover(engineId: UniqueId, request: EngineDiscoveryRequest): DiscoveryResult {
 
-      log { "[Discovery] Starting spec discovery" }
+      logger.log { "[Discovery] Starting spec discovery" }
 
       // kotest only supports classpath root, class and unique id selectors (which we convert to class selectors)
       val classpathRootSelectors = request.getSelectorsByType(ClasspathRootSelector::class.java)
       val classSelectors = request.getSelectorsByType(ClassSelector::class.java) +
          convertUniqueIdsToClassSelectors(engineId, request)
 
-      val specsSelected = (specsFromClasspathRootSelectors(classpathRootSelectors) + specsFromClassDiscoverySelectorsOnly(classSelectors))
+      val specsSelected = (specsFromClasspathRootSelectors(classpathRootSelectors) + specsFromClassSelectors(classSelectors))
 
       val specsAfterInitialFiltering = specsSelected.filter(
          filterFn(

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DiscoveryTestWithSelectors.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/DiscoveryTestWithSelectors.kt
@@ -4,9 +4,11 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine
 import io.kotest.runner.junit.platform.Segment
+import io.kotest.runner.junit.platform.discovery.Discovery
 import org.junit.platform.engine.UniqueId
 import org.junit.platform.engine.discovery.DiscoverySelectors
 import org.junit.platform.engine.support.descriptor.ClassSource
@@ -112,6 +114,35 @@ class DiscoveryTestWithSelectors : FunSpec({
          com.sksamuel.kotest.runner.junit5.mypackage.DummySpec1::class.java,
          com.sksamuel.kotest.runner.junit5.mypackage.DummySpec2::class.java,
       )
+   }
+
+   test("classpath root selector should discover spec classes in that root") {
+      val classpathRoot = java.nio.file.Paths.get(
+         com.sksamuel.kotest.runner.junit5.mypackage.DummySpec1::class.java
+            .protectionDomain.codeSource.location.toURI()
+      )
+      val engineId = UniqueId.forEngine(KotestJunitPlatformTestEngine.ENGINE_ID)
+      val req = LauncherDiscoveryRequestBuilder.request()
+         .selectors(DiscoverySelectors.selectClasspathRoots(setOf(classpathRoot)))
+         .build()
+      val result = Discovery.discover(engineId, req)
+      result.specs.map { it.fqn } shouldContain com.sksamuel.kotest.runner.junit5.mypackage.DummySpec1::class.java.canonicalName
+      result.specs.map { it.fqn } shouldContain com.sksamuel.kotest.runner.junit5.mypackage.DummySpec2::class.java.canonicalName
+   }
+
+   test("engine should not skip discovery for classpath root selectors") {
+      val classpathRoot = java.nio.file.Paths.get(
+         com.sksamuel.kotest.runner.junit5.mypackage.DummySpec1::class.java
+            .protectionDomain.codeSource.location.toURI()
+      )
+      val engineId = UniqueId.forEngine(KotestJunitPlatformTestEngine.ENGINE_ID)
+      val req = LauncherDiscoveryRequestBuilder.request()
+         .selectors(DiscoverySelectors.selectClasspathRoots(setOf(classpathRoot)))
+         .build()
+      val engine = KotestJunitPlatformTestEngine()
+      val descriptor = engine.discover(req, engineId)
+      descriptor.specs.map { it.fqn } shouldContain com.sksamuel.kotest.runner.junit5.mypackage.DummySpec1::class.java.canonicalName
+      descriptor.specs.map { it.fqn } shouldContain com.sksamuel.kotest.runner.junit5.mypackage.DummySpec2::class.java.canonicalName
    }
 
    xtest("package selector should include packages and subpackages") {


### PR DESCRIPTION
This PR adds support for `ClasspathRootSelector` test discovery method to make kotest engine compatible with SBT build tool.

More details about rationale [here](https://github.com/kotest/kotest/issues/5782)

Closes #5782
