### PR TITLE
re-add support for gradle test filters after gradle 9.4.0

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtils.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtils.kt
@@ -21,6 +21,16 @@ import java.util.regex.Pattern
  * to this reflection hackery to get the raw strings out, so we can parse and apply the patterns ourselves,
  * thus allowing kotest to properly support the --tests options for nested tests.
  *
+ * Note: There are two Gradle version-dependent changes we handle:
+ *
+ * 1. In Gradle 9.4+, `ClassMethodNameFilter` is no longer passed directly as a `PostDiscoveryFilter`.
+ *    Instead, it is wrapped inside a `DelegatingByTypeFilter` which dispatches to different filters
+ *    based on `TestSource` type. We detect this wrapper and extract `ClassMethodNameFilter` from it.
+ *
+ * 2. In Gradle 9.4+, `TestSelectionMatcher` was refactored. The `commandLineIncludePatterns` and
+ *    `buildScriptIncludePatterns` fields moved from `TestSelectionMatcher` into a new delegate class
+ *    `ClassTestSelectionMatcher`, accessed via the `classTestSelectionMatcher` field.
+ *
  */
 internal object ClassMethodNameFilterUtils {
 
@@ -29,9 +39,12 @@ internal object ClassMethodNameFilterUtils {
    /**
     * Returns the include patterns enclosed in any [ClassMethodNameFilter]s added by Gradle
     * from the --tests command line arg.
+    *
+    * In Gradle < 9.4, [ClassMethodNameFilter] appears directly in the post-discovery filters list.
+    * In Gradle >= 9.4, it is wrapped inside a [DelegatingByTypeFilter], so we unwrap it first.
     */
    fun extractIncludePatterns(filters: List<Any>): List<String> {
-      val classMethodFilters = filters.filter { it.javaClass.simpleName == "ClassMethodNameFilter" }
+      val classMethodFilters = resolveClassMethodNameFilters(filters)
       return classMethodFilters.flatMap { extract(it) }
    }
 
@@ -40,10 +53,17 @@ internal object ClassMethodNameFilterUtils {
       val matcher = testMatcher(filter)
       logger.log { Pair(null, "TestMatcher [$matcher]") }
 
-      val buildScriptIncludePatterns = buildScriptIncludePatterns(matcher)
+      // Resolve the object that holds the include pattern lists.
+      // In Gradle < 9.4 this is the TestSelectionMatcher itself.
+      // In Gradle >= 9.4 the fields moved to ClassTestSelectionMatcher,
+      // accessed via TestSelectionMatcher.classTestSelectionMatcher.
+      val patternHolder = resolvePatternHolder(matcher)
+      logger.log { Pair(null, "PatternHolder [${patternHolder::class.java.name}]") }
+
+      val buildScriptIncludePatterns = buildScriptIncludePatterns(patternHolder)
       logger.log { Pair(null, "buildScriptIncludePatterns [$buildScriptIncludePatterns]") }
 
-      val commandLineIncludePatterns = commandLineIncludePatterns(matcher)
+      val commandLineIncludePatterns = commandLineIncludePatterns(patternHolder)
       logger.log { Pair(null, "commandLineIncludePatterns [$commandLineIncludePatterns]") }
 
       val regexes = buildList {
@@ -53,23 +73,90 @@ internal object ClassMethodNameFilterUtils {
 
       logger.log { Pair(null, "ClassMethodNameFilter regexes [$regexes]") }
       regexes
-   }.getOrElse { emptyList() }
+   }.getOrElse { e ->
+      logger.log { Pair(null, "Failed to extract include patterns from ClassMethodNameFilter via reflection: $e") }
+      emptyList()
+   }
 
    /**
     * Removes any include patterns on any [ClassMethodNameFilter]s added by Gradle.
     */
    fun reset(filters: List<PostDiscoveryFilter>) {
-      filters.filter { it.javaClass.simpleName == "ClassMethodNameFilter" }.forEach {
-         val matcher = testMatcher(it)
-         val commandLineIncludePatterns = commandLineIncludePatterns(matcher) as MutableList<*>
-         commandLineIncludePatterns.clear()
+      resolveClassMethodNameFilters(filters).forEach {
+         runCatching {
+            val matcher = testMatcher(it)
+            val patternHolder = resolvePatternHolder(matcher)
+            val commandLineIncludePatterns = commandLineIncludePatterns(patternHolder) as MutableList<*>
+            commandLineIncludePatterns.clear()
+         }.onFailure { e ->
+            logger.log { Pair(null, "Failed to reset ClassMethodNameFilter via reflection: $e") }
+         }
       }
+   }
+
+   /**
+    * Finds all `ClassMethodNameFilter` instances from the post-discovery filters list.
+    *
+    * In Gradle < 9.4, `ClassMethodNameFilter` appears directly in the list.
+    * In Gradle >= 9.4, `ClassMethodNameFilter` is wrapped inside a `DelegatingByTypeFilter`
+    * which has a `delegates` map of `TestSource` type → `PostDiscoveryFilter`. We extract
+    * the `ClassMethodNameFilter` instances from those delegate maps.
+    */
+   private fun resolveClassMethodNameFilters(filters: List<Any>): List<Any> {
+      val result = mutableListOf<Any>()
+
+      for (filter in filters) {
+         when (filter.javaClass.simpleName) {
+            "ClassMethodNameFilter" -> result.add(filter)
+            "DelegatingByTypeFilter" -> {
+               // Gradle >= 9.4: unwrap ClassMethodNameFilter from the DelegatingByTypeFilter's delegates map
+               runCatching {
+                  val delegatesField = filter::class.java.getDeclaredField("delegates")
+                  delegatesField.isAccessible = true
+                  val delegates = delegatesField.get(filter) as? Map<*, *> ?: emptyMap<Any, Any>()
+                  for ((_, delegate) in delegates) {
+                     if (delegate != null && delegate.javaClass.simpleName == "ClassMethodNameFilter") {
+                        result.add(delegate)
+                     }
+                  }
+               }.onFailure { e ->
+                  logger.log { Pair(null, "Failed to unwrap DelegatingByTypeFilter via reflection: $e") }
+               }
+            }
+         }
+      }
+
+      // Deduplicate: in Gradle 9.4, the same ClassMethodNameFilter instance is registered
+      // as a delegate for both ClassSource and MethodSource types
+      return result.distinct()
    }
 
    private fun testMatcher(obj: Any): Any {
       val field = obj::class.java.getDeclaredField("matcher")
       field.isAccessible = true
       return field.get(obj)
+   }
+
+   /**
+    * Resolves the object that holds `commandLineIncludePatterns` and `buildScriptIncludePatterns`.
+    *
+    * In Gradle < 9.4, these fields live directly on [TestSelectionMatcher].
+    * In Gradle >= 9.4, [TestSelectionMatcher] was refactored and the fields moved to a
+    * delegate class [ClassTestSelectionMatcher], accessed via the `classTestSelectionMatcher` field.
+    *
+    * We try the old layout first (direct field access) and fall back to the new delegate layout.
+    */
+   private fun resolvePatternHolder(matcher: Any): Any {
+      // Try the old layout: commandLineIncludePatterns directly on the matcher (Gradle < 9.4)
+      return runCatching {
+         matcher::class.java.getDeclaredField("commandLineIncludePatterns")
+         matcher // field exists directly — use the matcher itself
+      }.getOrElse {
+         // New layout (Gradle >= 9.4): delegate through classTestSelectionMatcher
+         val field = matcher::class.java.getDeclaredField("classTestSelectionMatcher")
+         field.isAccessible = true
+         field.get(matcher)
+      }
    }
 
    private fun commandLineIncludePatterns(obj: Any): List<Any> {

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtilsTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtilsTest.kt
@@ -6,7 +6,26 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import org.gradle.api.internal.tasks.testing.filter.TestFilterSpec
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher
-import org.junit.platform.launcher.PostDiscoveryFilter
+/**
+ * The ClassMethodNameFilter class has moved across Gradle versions:
+ * - Gradle 8.x: org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$ClassMethodNameFilter
+ * - Gradle 9.3: org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$ClassMethodNameFilter
+ * - Gradle 9.4+: org.gradle.api.internal.tasks.testing.junitplatform.filters.ClassMethodNameFilter
+ *
+ * We try all known locations to find the one available on the test classpath.
+ */
+private val classMethodNameFilterFqns = listOf(
+   "org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor\$ClassMethodNameFilter",
+   "org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor\$ClassMethodNameFilter",
+   "org.gradle.api.internal.tasks.testing.junitplatform.filters.ClassMethodNameFilter",
+)
+
+private fun resolveClassMethodNameFilterClass(): Class<*> {
+   for (fqn in classMethodNameFilterFqns) {
+      runCatching { return Class.forName(fqn) }.getOrNull()
+   }
+   error("Could not find ClassMethodNameFilter on the classpath. Tried: $classMethodNameFilterFqns")
+}
 
 @EnabledIf(LinuxOnlyGithubCondition::class)
 class ClassMethodNameFilterUtilsTest : FunSpec({
@@ -39,7 +58,7 @@ class ClassMethodNameFilterUtilsTest : FunSpec({
       val matcher = TestSelectionMatcher(spec)
 
       val filter =
-         Class.forName($$"org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestClassProcessor$ClassMethodNameFilter")
+         resolveClassMethodNameFilterClass()
             .declaredConstructors.first { it.parameterCount == 1 }.let {
                it.isAccessible = true
                it.newInstance(matcher)


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
For https://github.com/kotest/kotest/issues/5784

- re-add support for gradle test filters after gradle 9.4.0

Tested this with:
- gradle 8.14.0 - kotest plugin applied
- gradle 8.14.0 - no kotest plugin applied
- gradle 9.3.1 - kotest plugin applied
- gradle 9.3.1 - no kotest plugin applied
- gradle 9.4.0 - kotest plugin applied
- gradle 9.4.0 - no kotest plugin applied
- gradle 9.4.1 - kotest plugin applied
- gradle 9.4.1 - no kotest plugin applied


