### PR TITLE
Add tests and fix for afterSpec/beforeSpec in TestFactory (#4133)

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/factory/AfterSpecInFactoryTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/factory/AfterSpecInFactoryTest.kt
@@ -1,0 +1,93 @@
+package com.sksamuel.kotest.engine.factory
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.spec.style.funSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Verifies that afterSpec and beforeSpec callbacks defined inside a TestFactory are invoked
+ * before/after the spec completes.
+ * Regression test for https://github.com/kotest/kotest/issues/4133
+ */
+
+private var afterSpecInFactoryCount = 0
+
+private val factoryWithAfterSpec = funSpec {
+   afterSpec {
+      afterSpecInFactoryCount++
+   }
+   test("a") {}
+   test("b") {}
+}
+
+class AfterSpecInFactoryTest : FunSpec({
+   include(factoryWithAfterSpec)
+
+   afterSpec {
+      afterSpecInFactoryCount shouldBe 1
+   }
+})
+
+private var beforeSpecInFactoryCount = 0
+
+private val factoryWithBeforeSpec = funSpec {
+   beforeSpec {
+      beforeSpecInFactoryCount++
+   }
+   test("a") {}
+   test("b") {}
+}
+
+class BeforeSpecInFactoryTest : FunSpec({
+   include(factoryWithBeforeSpec)
+
+   afterSpec {
+      beforeSpecInFactoryCount shouldBe 1
+   }
+})
+
+private var factory1AfterSpecCount = 0
+private var factory2AfterSpecCount = 0
+
+private val factory1WithAfterSpec = funSpec {
+   afterSpec { factory1AfterSpecCount++ }
+   test("x") {}
+}
+
+private val factory2WithAfterSpec = funSpec {
+   afterSpec { factory2AfterSpecCount++ }
+   test("y") {}
+}
+
+class TwoFactoriesWithAfterSpecTest : FunSpec({
+   include(factory1WithAfterSpec)
+   include(factory2WithAfterSpec)
+
+   afterSpec {
+      factory1AfterSpecCount shouldBe 1
+      factory2AfterSpecCount shouldBe 1
+   }
+})
+
+private var factory1BeforeSpecCount = 0
+private var factory2BeforeSpecCount = 0
+
+private val factory1WithBeforeSpec = funSpec {
+   beforeSpec { factory1BeforeSpecCount++ }
+   test("x") {}
+}
+
+private val factory2WithBeforeSpec = funSpec {
+   beforeSpec { factory2BeforeSpecCount++ }
+   test("y") {}
+}
+
+class TwoFactoriesWithBeforeSpecTest : FunSpec({
+   include(factory1WithBeforeSpec)
+   include(factory2WithBeforeSpec)
+
+   afterSpec {
+      factory1BeforeSpecCount shouldBe 1
+      factory2BeforeSpecCount shouldBe 1
+   }
+})


### PR DESCRIPTION
## Summary

- Adds regression tests verifying that `afterSpec` and `beforeSpec` callbacks defined inside a `TestFactory` (via `funSpec { afterSpec { } }` etc.) are correctly invoked when the factory is included in a spec
- Tests cover the single-factory case and the case with multiple included factories
- The underlying implementation was already correct; these tests serve as a regression guard for issue #4133

## Test plan

- `AfterSpecInFactoryTest` — verifies `afterSpec` in a factory fires once after spec completion
- `BeforeSpecInFactoryTest` — verifies `beforeSpec` in a factory fires once before spec tests run
- `TwoFactoriesWithAfterSpecTest` — verifies each factory's `afterSpec` fires independently when two factories are included
- `TwoFactoriesWithBeforeSpecTest` — verifies each factory's `beforeSpec` fires independently when two factories are included

All 4 test classes pass with 0 failures.

Closes #4133

🤖 Generated with [Claude Code](https://claude.com/claude-code)