### PR TITLE
Fix typo in `SpringExtension`

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
@@ -57,7 +57,7 @@ open class SpringExtension(
       val manager = getTestContextManager(clazz)
       val context = manager.testContext.applicationContext
 
-      println("Creating nstance of $clazz")
+      println("Creating instance of $clazz")
 
       logger.log { Pair(clazz.simpleName, "Spring extension will try to create autowired instance") }
       return context.autowireCapableBeanFactory.autowire(


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

`s/ntance/instance`