### PR TITLE
Refactor `Discovery` to improve class visibility filtering

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,8 +10,7 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
-	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;
@@ -36,41 +35,6 @@ public final class io/kotest/runner/junit/platform/discovery/DiscoveryFilter$Cla
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter : io/kotest/runner/junit/platform/discovery/DiscoveryFilter {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public final fun component1 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Lkotlin/jvm/functions/Function1;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getF ()Lkotlin/jvm/functions/Function1;
-	public fun hashCode ()I
-	public fun test (Lkotlin/reflect/KClass;)Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter : io/kotest/runner/junit/platform/discovery/DiscoveryFilter {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public final fun component1 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Lkotlin/jvm/functions/Function1;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getF ()Lkotlin/jvm/functions/Function1;
-	public fun hashCode ()I
-	public fun test (Lkotlin/reflect/KClass;)Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/kotest/runner/junit/platform/discovery/FullyQualifiedClassName {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/kotest/runner/junit/platform/discovery/FullyQualifiedClassName;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/FullyQualifiedClassName;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/FullyQualifiedClassName;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class io/kotest/runner/junit/platform/discovery/Modifier : java/lang/Enum {
 	public static final field Internal Lio/kotest/runner/junit/platform/discovery/Modifier;
 	public static final field Private Lio/kotest/runner/junit/platform/discovery/Modifier;
@@ -78,16 +42,5 @@ public final class io/kotest/runner/junit/platform/discovery/Modifier : java/lan
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/kotest/runner/junit/platform/discovery/Modifier;
 	public static fun values ()[Lio/kotest/runner/junit/platform/discovery/Modifier;
-}
-
-public final class io/kotest/runner/junit/platform/discovery/PackageName {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/kotest/runner/junit/platform/discovery/PackageName;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/PackageName;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/PackageName;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
@@ -37,44 +37,66 @@ internal object Discovery {
       val classSelectors = request.getSelectorsByType(ClassSelector::class.java) +
          convertUniqueIdsToClassSelectors(engineId, request)
 
-      val specsSelected = specsFromClassDiscoverySelectorsOnly(classSelectors)
+      val specsSelected = specsFromClassSelectors(classSelectors)
          .asSequence()
          .filter(isSpecSubclassKt)
          .filterNot(isAbstract)
          .toList()
 
-      val specsAfterInitialFiltering = specsSelected.filter(filterFn(filters(request.configurationParameters)))
+      val specsAfterInitialFiltering = specsSelected.filter(
+         filterFn(
+            listOf(
+               classVisibilityFilter(classSelectors, request.configurationParameters)
+            )
+         )
+      )
 
       logger.log { "${specsAfterInitialFiltering.size} specs will be returned" }
 
       return DiscoveryResult(specsAfterInitialFiltering.map { SpecRef.Reference(it, it.java.name) })
    }
 
-   private fun filters(configurationParameters: ConfigurationParameters): List<DiscoveryFilter> {
-      val private = if (configurationParameters.get("allow_private").isPresent) Modifier.Private else null
+   /**
+    * Returns a [DiscoveryFilter] that filters specs based on their visibility.
+    *
+    * We normally filter out private classes, with two exceptions:
+    * 1. If the configuration parameter "allow_private" is set to true, then private classes are also included.
+    * 2. If there is only a single class, then we include it regardless of visibility, as this is most likely
+    *    a test class that is being run directly from the IDE
+    */
+   private fun classVisibilityFilter(
+      classSelectors: List<ClassSelector>,
+      configurationParameters: ConfigurationParameters
+   ): DiscoveryFilter {
+
+      val private = if (classSelectors.size == 1 ||
+         configurationParameters.get("allow_private").isPresent
+      ) Modifier.Private else null
+
       val modifiers = listOfNotNull(Modifier.Public, Modifier.Internal, private)
-      return listOf(DiscoveryFilter.ClassModifierDiscoveryFilter(modifiers.toSet()))
+      return DiscoveryFilter.ClassModifierDiscoveryFilter(modifiers.toSet())
    }
 
    /**
-    * Returns the request's [Spec]s if they are completely specified by class selectors, null otherwise.
+    * JUnit provides a list of [ClassSelector]s, which we can use to discover specs.
+    * We check that the classes are subclasses of [Spec] as the list may include JUnit classes or other
+    * test framework classes.
     */
-   private fun specsFromClassDiscoverySelectorsOnly(selectors: List<ClassSelector>): List<KClass<out Spec>> {
+   private fun specsFromClassSelectors(selectors: List<ClassSelector>): List<KClass<out Spec>> {
 
       // first filter down to spec instances only, then load the full class
       val specs = selectors
          .asSequence()
-         // must load the class without initializing it, we just want to check if it's a subclass of Spec
+         // must load the class without initializing it, as we just want to check if it's a subclass of Spec
          .mapNotNull { runCatching { Class.forName(it.className, false, this::class.java.classLoader) }.getOrNull() }
          .filter(isSpecSubclass)
          // now we can properly initialize it
          .map { Class.forName(it.name).kotlin }
          .filterNot(isAbstract)
-         // we know this will be true
          .filterIsInstance<KClass<out Spec>>()
          .toList()
 
-      logger.log { "Collected specs via ${selectors.size} class discovery selectors: found ${specs.size} specs" }
+      logger.log { "Collected specs via ${selectors.size} class selectors: found ${specs.size} specs" }
       return specs
    }
 
@@ -85,14 +107,6 @@ internal object Discovery {
    private fun filterFn(filters: List<DiscoveryFilter>): (KClass<out Spec>) -> Boolean = { kclass ->
       filters.isEmpty() || filters.all { it.test(kclass) }
    }
-
-//   val classFilters = getFiltersByType(ClassNameFilter::class.java).map { filter ->
-//      DiscoveryFilter.ClassNameDiscoveryFilter { filter.toPredicate().test(it.value) }
-//   }
-//
-//   val packageFilters = getFiltersByType(PackageNameFilter::class.java).map { filter ->
-//      DiscoveryFilter.PackageNameDiscoveryFilter { filter.toPredicate().test(it.value) }
-//   }
 
    /**
     * Based on a previously discovered `TestPlan`, tools may decide to split


### PR DESCRIPTION
Related to #5639

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
