### PR TITLE
Add JVM_SUITE_NAME env var for Allure suite grouping (#4573)

### DIFF
--- a/kotest-extensions/kotest-extensions-allure/api/kotest-extensions-allure.api
+++ b/kotest-extensions/kotest-extensions-allure/api/kotest-extensions-allure.api
@@ -1,7 +1,7 @@
 public final class io/kotest/extensions/allure/AllureTestReporter : io/kotest/core/listeners/AfterTestListener, io/kotest/core/listeners/BeforeTestListener, io/kotest/core/listeners/InstantiationErrorListener {
 	public fun <init> ()V
-	public fun <init> (Z)V
-	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLio/kotest/extensions/allure/AllureWriter;)V
+	public synthetic fun <init> (ZLio/kotest/extensions/allure/AllureWriter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterTest (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun beforeAny (Lio/kotest/core/test/TestCase;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9,18 +9,8 @@ public final class io/kotest/extensions/allure/AllureTestReporter : io/kotest/co
 	public fun instantiationError (Lkotlin/reflect/KClass;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public final class io/kotest/extensions/allure/AllureWriter {
-	public static final field Companion Lio/kotest/extensions/allure/AllureWriter$Companion;
-	public static final field FRAMEWORK_LABEL Ljava/lang/String;
-	public static final field LANGUAGE_LABEL Ljava/lang/String;
-	public fun <init> ()V
-	public final fun allureResultSpecInitFailure (Lkotlin/reflect/KClass;Ljava/lang/Throwable;)V
-	public final fun finishTestCase (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;)V
-	public final fun id (Lio/kotest/core/test/TestCase;)Ljava/lang/String;
-	public final fun startTestCase (Lio/kotest/core/test/TestCase;)V
-}
-
 public final class io/kotest/extensions/allure/AllureWriter$Companion {
+	public final fun invoke ()Lio/kotest/extensions/allure/AllureWriter;
 }
 
 public final class io/kotest/extensions/allure/EpicKt {

--- a/kotest-extensions/kotest-extensions-allure/api/kotest-extensions-allure.api
+++ b/kotest-extensions/kotest-extensions-allure/api/kotest-extensions-allure.api
@@ -9,6 +9,17 @@ public final class io/kotest/extensions/allure/AllureTestReporter : io/kotest/co
 	public fun instantiationError (Lkotlin/reflect/KClass;Ljava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class io/kotest/extensions/allure/AllureWriter {
+	public static final field Companion Lio/kotest/extensions/allure/AllureWriter$Companion;
+	public static final field FRAMEWORK_LABEL Ljava/lang/String;
+	public static final field LANGUAGE_LABEL Ljava/lang/String;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun allureResultSpecInitFailure (Lkotlin/reflect/KClass;Ljava/lang/Throwable;)V
+	public final fun finishTestCase (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;)V
+	public final fun id (Lio/kotest/core/test/TestCase;)Ljava/lang/String;
+	public final fun startTestCase (Lio/kotest/core/test/TestCase;)V
+}
+
 public final class io/kotest/extensions/allure/AllureWriter$Companion {
 	public final fun invoke ()Lio/kotest/extensions/allure/AllureWriter;
 }

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureTestReporter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureTestReporter.kt
@@ -9,10 +9,9 @@ import io.kotest.core.test.TestType
 import kotlin.reflect.KClass
 
 class AllureTestReporter(
-   private val includeContainers: Boolean = false
+   private val includeContainers: Boolean = false,
+   internal val writer: AllureWriter = AllureWriter(),
 ) : BeforeTestListener, AfterTestListener, InstantiationErrorListener {
-
-   internal val writer = AllureWriter()
 
    override suspend fun beforeTest(testCase: TestCase) {
       if (includeContainers || testCase.type == TestType.Test) {

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureTestReporter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureTestReporter.kt
@@ -4,8 +4,8 @@ import io.kotest.core.listeners.AfterTestListener
 import io.kotest.core.listeners.BeforeTestListener
 import io.kotest.core.listeners.InstantiationErrorListener
 import io.kotest.core.test.TestCase
-import io.kotest.engine.test.TestResult
 import io.kotest.core.test.TestType
+import io.kotest.engine.test.TestResult
 import kotlin.reflect.KClass
 
 class AllureTestReporter(

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -16,17 +16,21 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
-class AllureWriter(
-   /**
-    * Returns the name of the currently executing Gradle [JvmTestSuite], or null when not
-    * running inside a suite (e.g. the standard `test` task without the jvm-test-suite plugin,
-    * or a non-Gradle execution). Defaults to reading the `JVM_SUITE_NAME` environment variable
-    * that is set automatically by the Kotest Gradle plugin.
-    */
-   private val jvmSuiteNameProvider: () -> String? = { System.getenv("JVM_SUITE_NAME") },
-) {
+class AllureWriter(private val jvmSuiteName: String?) {
 
    companion object {
+
+      operator fun invoke(): AllureWriter {
+         /**
+          * Returns the name of the currently executing Gradle [JvmTestSuite], or null when not
+          * running inside a suite (e.g., the standard `test` task without the jvm-test-suite plugin,
+          * or a non-Gradle execution). Defaults to reading the `JVM_SUITE_NAME` environment variable
+          * that is set automatically by the Kotest Gradle plugin.
+          */
+         val suiteName = System.getenv("JVM_SUITE_NAME")
+         return AllureWriter(suiteName)
+      }
+
       const val LANGUAGE_LABEL = "kotlin"
       const val FRAMEWORK_LABEL = "kotest"
    }
@@ -51,7 +55,6 @@ class AllureWriter(
       // When running inside a Gradle JvmTestSuite, the suite name is propagated as an
       // environment variable by the Kotest Gradle plugin. We use it as the top-level
       // Allure suite so that results are grouped by suite first, then by spec class.
-      val jvmSuiteName = jvmSuiteNameProvider()
       val suiteLabels = if (jvmSuiteName != null) {
          listOf(
             ResultsUtils.createSuiteLabel(jvmSuiteName),
@@ -64,10 +67,11 @@ class AllureWriter(
       val labels = listOfNotNull(
          testCase.epic(),
          testCase.feature(),
-         ResultsUtils.createFrameworkLabel(FRAMEWORK_LABEL),
-         ResultsUtils.createHostLabel(),
-         ResultsUtils.createLanguageLabel(LANGUAGE_LABEL),
          ResultsUtils.createTestClassLabel(testCase.spec::class.java.simpleName),
+         ResultsUtils.createThreadLabel(),
+         ResultsUtils.createHostLabel(),
+         ResultsUtils.createFrameworkLabel(FRAMEWORK_LABEL),
+         ResultsUtils.createLanguageLabel(LANGUAGE_LABEL),
          testCase.owner(),
          ResultsUtils.createPackageLabel(testCase.spec::class.java.`package`.name),
          testCase.maxSeverity()?.let { ResultsUtils.createSeverityLabel(it) },
@@ -138,7 +142,6 @@ class AllureWriter(
 
    fun allureResultSpecInitFailure(kclass: KClass<*>, t: Throwable) {
       val uuid = UUID.randomUUID()
-      val jvmSuiteName = jvmSuiteNameProvider()
       val suiteLabels = if (jvmSuiteName != null) {
          listOf(
             ResultsUtils.createSuiteLabel(jvmSuiteName),
@@ -148,6 +151,7 @@ class AllureWriter(
          listOf(ResultsUtils.createSuiteLabel(kclass.qualifiedName))
       }
       val labels = listOfNotNull(
+         ResultsUtils.createTestClassLabel(kclass.java.simpleName),
          ResultsUtils.createThreadLabel(),
          ResultsUtils.createHostLabel(),
          ResultsUtils.createLanguageLabel(LANGUAGE_LABEL),

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -16,7 +16,15 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
-class AllureWriter {
+class AllureWriter(
+   /**
+    * Returns the name of the currently executing Gradle [JvmTestSuite], or null when not
+    * running inside a suite (e.g. the standard `test` task without the jvm-test-suite plugin,
+    * or a non-Gradle execution). Defaults to reading the `JVM_SUITE_NAME` environment variable
+    * that is set automatically by the Kotest Gradle plugin.
+    */
+   private val jvmSuiteNameProvider: () -> String? = { System.getenv("JVM_SUITE_NAME") },
+) {
 
    companion object {
       const val LANGUAGE_LABEL = "kotlin"
@@ -40,6 +48,19 @@ class AllureWriter {
    fun id(testCase: TestCase) = uuids[testCase.descriptor.path()]
 
    fun startTestCase(testCase: TestCase) {
+      // When running inside a Gradle JvmTestSuite, the suite name is propagated as an
+      // environment variable by the Kotest Gradle plugin. We use it as the top-level
+      // Allure suite so that results are grouped by suite first, then by spec class.
+      val jvmSuiteName = jvmSuiteNameProvider()
+      val suiteLabels = if (jvmSuiteName != null) {
+         listOf(
+            ResultsUtils.createSuiteLabel(jvmSuiteName),
+            ResultsUtils.createSubSuiteLabel(testCase.descriptor.spec().id.value),
+         )
+      } else {
+         listOf(ResultsUtils.createSuiteLabel(testCase.descriptor.spec().id.value))
+      }
+
       val labels = listOfNotNull(
          testCase.epic(),
          testCase.feature(),
@@ -49,11 +70,10 @@ class AllureWriter {
          ResultsUtils.createTestClassLabel(testCase.spec::class.java.simpleName),
          testCase.owner(),
          ResultsUtils.createPackageLabel(testCase.spec::class.java.`package`.name),
-         ResultsUtils.createSuiteLabel(testCase.descriptor.spec().id.value),
          testCase.maxSeverity()?.let { ResultsUtils.createSeverityLabel(it) },
          testCase.story(),
          ResultsUtils.createThreadLabel(),
-      )
+      ) + suiteLabels
 
       val links = links(testCase)
       val uuid = UUID.randomUUID().toString()
@@ -118,8 +138,16 @@ class AllureWriter {
 
    fun allureResultSpecInitFailure(kclass: KClass<*>, t: Throwable) {
       val uuid = UUID.randomUUID()
+      val jvmSuiteName = jvmSuiteNameProvider()
+      val suiteLabels = if (jvmSuiteName != null) {
+         listOf(
+            ResultsUtils.createSuiteLabel(jvmSuiteName),
+            ResultsUtils.createSubSuiteLabel(kclass.qualifiedName),
+         )
+      } else {
+         listOf(ResultsUtils.createSuiteLabel(kclass.qualifiedName))
+      }
       val labels = listOfNotNull(
-         ResultsUtils.createSuiteLabel(kclass.qualifiedName),
          ResultsUtils.createThreadLabel(),
          ResultsUtils.createHostLabel(),
          ResultsUtils.createLanguageLabel(LANGUAGE_LABEL),
@@ -130,7 +158,7 @@ class AllureWriter {
          kclass.epic(),
          kclass.feature(),
          kclass.story()
-      )
+      ) + suiteLabels
 
       val links = links(kclass)
 

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -25,10 +25,10 @@ class AllureWriter(private val jvmSuiteName: String?) {
          /**
           * Returns the name of the currently executing Gradle [JvmTestSuite], or null when not
           * running inside a suite (e.g., the standard `test` task without the jvm-test-suite plugin,
-          * or a non-Gradle execution). Defaults to reading the `JVM_SUITE_NAME` environment variable
+          * or a non-Gradle execution). Defaults to reading the `JVM_TEST_SUITE` environment variable
           * that is set automatically by the Kotest Gradle plugin.
           */
-         val suiteName = System.getenv("JVM_SUITE_NAME")
+         val suiteName = System.getenv("JVM_TEST_SUITE")
          return AllureWriter(suiteName)
       }
 

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -17,7 +17,6 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
-@KotestInternal
 class AllureWriter(private val jvmSuiteName: String?) {
 
    companion object {

--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -1,5 +1,6 @@
 package io.kotest.extensions.allure
 
+import io.kotest.common.KotestInternal
 import io.kotest.core.descriptors.Descriptor
 import io.kotest.core.descriptors.DescriptorPath
 import io.kotest.core.test.TestCase
@@ -16,6 +17,7 @@ import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
+@KotestInternal
 class AllureWriter(private val jvmSuiteName: String?) {
 
    companion object {

--- a/kotest-extensions/kotest-extensions-allure/src/jvmTest/kotlin/io/kotest/extensions/allure/AllureSuiteLabelTest.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmTest/kotlin/io/kotest/extensions/allure/AllureSuiteLabelTest.kt
@@ -1,0 +1,58 @@
+package io.kotest.extensions.allure
+
+import io.kotest.core.extensions.Extension
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.inspectors.forOne
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.qameta.allure.util.ResultsUtils
+
+/**
+ * Verifies Allure suite label behaviour driven by [JVM_SUITE_NAME].
+ *
+ * When [JVM_SUITE_NAME] is absent the suite label falls back to the spec's fully-qualified
+ * class name (existing behaviour).  When it is present the suite label becomes the suite name
+ * and the spec FQN is placed in the sub-suite slot, giving a two-level hierarchy in the Allure
+ * report.
+ */
+class AllureSuiteLabelTest : FunSpec() {
+
+   // Use a custom AllureWriter that returns null – simulates no JVM_SUITE_NAME env var.
+   private val writerNoSuite = AllureWriter(jvmSuiteNameProvider = { null })
+   private val reporterNoSuite = AllureTestReporter(writer = writerNoSuite)
+
+   // Use a custom AllureWriter that returns a fixed suite name.
+   private val writerWithSuite = AllureWriter(jvmSuiteNameProvider = { "integrationTest" })
+   private val reporterWithSuite = AllureTestReporter(writer = writerWithSuite)
+
+   override val extensions: List<Extension> = listOf(reporterNoSuite, reporterWithSuite)
+
+   init {
+
+      test("suite label equals spec FQN when JVM_SUITE_NAME is not set") {
+         val id = writerNoSuite.id(this.testCase).toString()
+         writerNoSuite.allure.updateTestCase(id) { result ->
+            result.labels.forOne {
+               it.name shouldBe ResultsUtils.SUITE_LABEL_NAME
+               it.value shouldBe AllureSuiteLabelTest::class.java.canonicalName
+            }
+            // no sub-suite label should be present
+            result.labels.none { it.name == ResultsUtils.SUB_SUITE_LABEL_NAME } shouldBe true
+         }
+      }
+
+      test("suite label equals JVM_SUITE_NAME and sub-suite label equals spec FQN when JVM_SUITE_NAME is set") {
+         val id = writerWithSuite.id(this.testCase).toString()
+         writerWithSuite.allure.updateTestCase(id) { result ->
+            result.labels.forOne {
+               it.name shouldBe ResultsUtils.SUITE_LABEL_NAME
+               it.value shouldBe "integrationTest"
+            }
+            result.labels.forOne {
+               it.name shouldBe ResultsUtils.SUB_SUITE_LABEL_NAME
+               it.value shouldBe AllureSuiteLabelTest::class.java.canonicalName
+            }
+         }
+      }
+   }
+}

--- a/kotest-extensions/kotest-extensions-allure/src/jvmTest/kotlin/io/kotest/extensions/allure/AllureSuiteLabelTest.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmTest/kotlin/io/kotest/extensions/allure/AllureSuiteLabelTest.kt
@@ -3,26 +3,25 @@ package io.kotest.extensions.allure
 import io.kotest.core.extensions.Extension
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forOne
-import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.qameta.allure.util.ResultsUtils
 
 /**
- * Verifies Allure suite label behaviour driven by [JVM_SUITE_NAME].
+ * Verifies Allure suite label behavior driven by [JVM_SUITE_NAME].
  *
- * When [JVM_SUITE_NAME] is absent the suite label falls back to the spec's fully-qualified
- * class name (existing behaviour).  When it is present the suite label becomes the suite name
+ * When [JVM_SUITE_NAME] is absent the suite label falls back to the spec's fully qualified
+ * class name (existing behavior).  When it is present, the suite label becomes the suite name
  * and the spec FQN is placed in the sub-suite slot, giving a two-level hierarchy in the Allure
  * report.
  */
 class AllureSuiteLabelTest : FunSpec() {
 
    // Use a custom AllureWriter that returns null – simulates no JVM_SUITE_NAME env var.
-   private val writerNoSuite = AllureWriter(jvmSuiteNameProvider = { null })
+   private val writerNoSuite = AllureWriter(null)
    private val reporterNoSuite = AllureTestReporter(writer = writerNoSuite)
 
    // Use a custom AllureWriter that returns a fixed suite name.
-   private val writerWithSuite = AllureWriter(jvmSuiteNameProvider = { "integrationTest" })
+   private val writerWithSuite = AllureWriter("integrationTest")
    private val reporterWithSuite = AllureTestReporter(writer = writerWithSuite)
 
    override val extensions: List<Extension> = listOf(reporterNoSuite, reporterWithSuite)

--- a/kotest-extensions/kotest-extensions-allure/src/jvmTest/kotlin/io/kotest/extensions/allure/AllureSuiteLabelTest.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmTest/kotlin/io/kotest/extensions/allure/AllureSuiteLabelTest.kt
@@ -7,16 +7,16 @@ import io.kotest.matchers.shouldBe
 import io.qameta.allure.util.ResultsUtils
 
 /**
- * Verifies Allure suite label behavior driven by [JVM_SUITE_NAME].
+ * Verifies Allure suite label behavior driven by [JVM_TEST_SUITE].
  *
- * When [JVM_SUITE_NAME] is absent the suite label falls back to the spec's fully qualified
+ * When [JVM_TEST_SUITE] is absent the suite label falls back to the spec's fully qualified
  * class name (existing behavior).  When it is present, the suite label becomes the suite name
  * and the spec FQN is placed in the sub-suite slot, giving a two-level hierarchy in the Allure
  * report.
  */
 class AllureSuiteLabelTest : FunSpec() {
 
-   // Use a custom AllureWriter that returns null – simulates no JVM_SUITE_NAME env var.
+   // Use a custom AllureWriter that returns null – simulates no JVM_TEST_SUITE env var.
    private val writerNoSuite = AllureWriter(null)
    private val reporterNoSuite = AllureTestReporter(writer = writerNoSuite)
 
@@ -28,7 +28,7 @@ class AllureSuiteLabelTest : FunSpec() {
 
    init {
 
-      test("suite label equals spec FQN when JVM_SUITE_NAME is not set") {
+      test("suite label equals spec FQN when JVM_TEST_SUITE is not set") {
          val id = writerNoSuite.id(this.testCase).toString()
          writerNoSuite.allure.updateTestCase(id) { result ->
             result.labels.forOne {
@@ -40,7 +40,7 @@ class AllureSuiteLabelTest : FunSpec() {
          }
       }
 
-      test("suite label equals JVM_SUITE_NAME and sub-suite label equals spec FQN when JVM_SUITE_NAME is set") {
+      test("suite label equals JVM_TEST_SUITE and sub-suite label equals spec FQN when JVM_TEST_SUITE is set") {
          val id = writerWithSuite.id(this.testCase).toString()
          writerWithSuite.allure.updateTestCase(id) { result ->
             result.labels.forOne {

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -71,7 +71,7 @@ abstract class KotestPlugin : Plugin<Project> {
       internal const val IDEA_ACTIVE_ENV = "IDEA_ACTIVE"
       internal const val IDEA_ACTIVE_SYSPROP = "idea.active"
       internal const val FAIL_ON_NO_DISCOVERED_TESTS = "failOnNoDiscoveredTests"
-      internal const val JVM_SUITE_NAME = "JVM_SUITE_NAME"
+      internal const val JVM_TEST_SUITE = "JVM_TEST_SUITE"
 
       const val POWER_ASSERT_PLUGIN_ID = "org.jetbrains.kotlin.plugin.power-assert"
    }
@@ -206,8 +206,8 @@ abstract class KotestPlugin : Plugin<Project> {
    }
 
    /**
-    * Detects Gradle's JvmTestSuite plugin and, for each suite, sets the [JVM_SUITE_NAME]
-    * environment variable on the suite's test task so the Kotest runtime (and reporters
+    * Detects Gradle's JvmTestSuite plugin and, for each suite, sets the [JVM_TEST_SUITE]
+    * environment variable on the suite's test task during execution so the Kotest runtime (and reporters
     * such as the Allure extension) can identify which suite is currently executing.
     */
    private fun handleJvmTestSuites(project: Project) {
@@ -221,7 +221,10 @@ abstract class KotestPlugin : Plugin<Project> {
             // is only available in gradle-core-api and not in the public gradleApi() dependency.
             val suiteName = name
             project.tasks.withType(Test::class.java).matching { it.name == suiteName }.configureEach {
-               environment(JVM_SUITE_NAME, suiteName)
+               val testTask = this
+               doFirst {
+                  setEnvVar(testTask, JVM_TEST_SUITE, testTask.name)
+               }
             }
          }
       }

--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -14,11 +14,13 @@ import org.gradle.api.file.Directory
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.plugins.jvm.JvmTestSuite
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
+import org.gradle.testing.base.TestingExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.register
@@ -69,6 +71,7 @@ abstract class KotestPlugin : Plugin<Project> {
       internal const val IDEA_ACTIVE_ENV = "IDEA_ACTIVE"
       internal const val IDEA_ACTIVE_SYSPROP = "idea.active"
       internal const val FAIL_ON_NO_DISCOVERED_TESTS = "failOnNoDiscoveredTests"
+      internal const val JVM_SUITE_NAME = "JVM_SUITE_NAME"
 
       const val POWER_ASSERT_PLUGIN_ID = "org.jetbrains.kotlin.plugin.power-assert"
    }
@@ -88,6 +91,9 @@ abstract class KotestPlugin : Plugin<Project> {
 
       // configures standalone Kotlin JVM projects
       handleKotlinJvm(project, extension)
+
+      // propagates the Gradle JvmTestSuite name to the test process as an environment variable
+      handleJvmTestSuites(project)
 
       configureAlwaysRerun(project, extension.alwaysRerunTests)
 
@@ -194,6 +200,28 @@ abstract class KotestPlugin : Plugin<Project> {
                   is DefaultTestFilter -> filter.commandLineIncludePatterns.clear()
                }
                task.filter.isFailOnNoMatchingTests = false
+            }
+         }
+      }
+   }
+
+   /**
+    * Detects Gradle's JvmTestSuite plugin and, for each suite, sets the [JVM_SUITE_NAME]
+    * environment variable on the suite's test task so the Kotest runtime (and reporters
+    * such as the Allure extension) can identify which suite is currently executing.
+    */
+   private fun handleJvmTestSuites(project: Project) {
+      project.plugins.withId("jvm-test-suite") {
+         val testing = project.extensions.getByType(TestingExtension::class.java)
+         testing.suites.withType(JvmTestSuite::class.java).configureEach {
+            // By Gradle convention, each JvmTestSuite creates a Test task with the same name as
+            // the suite (e.g. suite "integrationTest" → task "integrationTest"). We use this
+            // naming convention to look up the task rather than going through suite.targets, whose
+            // return type (ExtensiblePolymorphicDomainObjectContainer<? extends JvmTestSuiteTarget>)
+            // is only available in gradle-core-api and not in the public gradleApi() dependency.
+            val suiteName = name
+            project.tasks.withType(Test::class.java).matching { it.name == suiteName }.configureEach {
+               environment(JVM_SUITE_NAME, suiteName)
             }
          }
       }

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,8 +10,7 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
-	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;
@@ -36,41 +35,6 @@ public final class io/kotest/runner/junit/platform/discovery/DiscoveryFilter$Cla
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter : io/kotest/runner/junit/platform/discovery/DiscoveryFilter {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public final fun component1 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Lkotlin/jvm/functions/Function1;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$ClassNameDiscoveryFilter;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getF ()Lkotlin/jvm/functions/Function1;
-	public fun hashCode ()I
-	public fun test (Lkotlin/reflect/KClass;)Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter : io/kotest/runner/junit/platform/discovery/DiscoveryFilter {
-	public fun <init> (Lkotlin/jvm/functions/Function1;)V
-	public final fun component1 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Lkotlin/jvm/functions/Function1;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/DiscoveryFilter$PackageNameDiscoveryFilter;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getF ()Lkotlin/jvm/functions/Function1;
-	public fun hashCode ()I
-	public fun test (Lkotlin/reflect/KClass;)Z
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/kotest/runner/junit/platform/discovery/FullyQualifiedClassName {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/kotest/runner/junit/platform/discovery/FullyQualifiedClassName;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/FullyQualifiedClassName;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/FullyQualifiedClassName;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class io/kotest/runner/junit/platform/discovery/Modifier : java/lang/Enum {
 	public static final field Internal Lio/kotest/runner/junit/platform/discovery/Modifier;
 	public static final field Private Lio/kotest/runner/junit/platform/discovery/Modifier;
@@ -78,16 +42,5 @@ public final class io/kotest/runner/junit/platform/discovery/Modifier : java/lan
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lio/kotest/runner/junit/platform/discovery/Modifier;
 	public static fun values ()[Lio/kotest/runner/junit/platform/discovery/Modifier;
-}
-
-public final class io/kotest/runner/junit/platform/discovery/PackageName {
-	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/kotest/runner/junit/platform/discovery/PackageName;
-	public static synthetic fun copy$default (Lio/kotest/runner/junit/platform/discovery/PackageName;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/runner/junit/platform/discovery/PackageName;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 

--- a/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
+++ b/kotest-runner/kotest-runner-junit-platform/api/kotest-runner-junit-platform.api
@@ -10,7 +10,8 @@ public final class io/kotest/runner/junit/platform/KotestJunitPlatformTestEngine
 	public static final field ENGINE_NAME Ljava/lang/String;
 	public static final field GROUP_ID Ljava/lang/String;
 	public fun <init> ()V
-	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
+	public fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lio/kotest/runner/junit/platform/KotestEngineDescriptor;
+	public synthetic fun discover (Lorg/junit/platform/engine/EngineDiscoveryRequest;Lorg/junit/platform/engine/UniqueId;)Lorg/junit/platform/engine/TestDescriptor;
 	public fun execute (Lorg/junit/platform/engine/ExecutionRequest;)V
 	public fun getGroupId ()Ljava/util/Optional;
 	public fun getId ()Ljava/lang/String;


### PR DESCRIPTION
## Summary

- The Kotest Gradle plugin now detects the `jvm-test-suite` plugin and sets a `JVM_SUITE_NAME` environment variable on each `JvmTestSuite`'s `Test` task (matched by the Gradle convention that the task name equals the suite name).
- The Allure extension reads `JVM_SUITE_NAME` at runtime; when present, it uses it as the top-level Allure **suite** label and moves the spec's fully-qualified class name to the **sub-suite** slot, producing a two-level grouping in the Allure report.
- When `JVM_SUITE_NAME` is absent (standard `test` task / non-Gradle runs), behaviour is unchanged — the spec FQN is used as the suite label.

## Changes

| File | Change |
|------|--------|
| `KotestPlugin.kt` | `handleJvmTestSuites()` — registers `JVM_SUITE_NAME` on each suite's test task |
| `AllureWriter.kt` | Injectable `jvmSuiteNameProvider` param; conditional suite/sub-suite label logic |
| `AllureTestReporter.kt` | Exposes `writer` as an `internal val` for testing |
| `AllureSuiteLabelTest.kt` | New: two tests verifying the suite-label behaviour with and without `JVM_SUITE_NAME` |

## Test plan

- [x] `AllureSuiteLabelTest` — verifies suite label equals spec FQN when `JVM_SUITE_NAME` is absent
- [x] `AllureSuiteLabelTest` — verifies suite label equals `JVM_SUITE_NAME` and sub-suite equals spec FQN when set
- [x] Manual: apply `jvm-test-suite` plugin and `integrationTest` suite in a sample project; confirm Allure report shows `integrationTest > com.example.MySpec > test name` hierarchy

Closes #4573

🤖 Generated with [Claude Code](https://claude.com/claude-code)