### PR TITLE
Escape dots in test names in --tests filter to prevent Gradle FQN misparse

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/filter/TestPatternIncludeDescriptorFilter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/filter/TestPatternIncludeDescriptorFilter.kt
@@ -24,7 +24,52 @@ abstract class TestPatternIncludeDescriptorFilter : DescriptorFilter {
       if (pattern.className == null) return packageMatch(pattern, descriptor.spec())
       val spec: Descriptor = Descriptor.SpecDescriptor(DescriptorId(pattern.packageName + "." + pattern.className))
       val tests = pattern.contexts.fold(spec) { acc, op -> acc.append(op) }
-      return descriptor.normalizeLineBreaks().hasSharedPath(tests)
+      return descriptor.normalizeLineBreaks().hasSharedPathWithWildcards(tests)
+   }
+
+   /**
+    * Like [Descriptor.hasSharedPath] but treats `?` in the [pattern] descriptor's test IDs as
+    * a single-character wildcard (matching exactly one character in the actual descriptor's IDs).
+    *
+    * This is needed because `GradleTestFilterBuilder` (in the IntelliJ plugin) replaces `.` in test names with `?` to
+    * prevent Gradle from misinterpreting them as FQN separators. When the resulting pattern
+    * reaches this filter, we must honour that wildcard so that e.g. the pattern context
+    * "1?2?3 my test" still matches a test whose real name is "1.2.3 my test".
+    */
+   private fun Descriptor.hasSharedPathWithWildcards(pattern: Descriptor): Boolean {
+      return wildcardEqual(this, pattern) ||
+         wildcardIsAncestorOf(pattern, this) ||
+         wildcardIsAncestorOf(this, pattern)
+   }
+
+   /** Returns true if [actual] and [pattern] refer to the same node, with `?` wildcards in [pattern]. */
+   private fun wildcardEqual(actual: Descriptor, pattern: Descriptor): Boolean = when {
+      actual is Descriptor.SpecDescriptor && pattern is Descriptor.SpecDescriptor ->
+         actual.isEqual(pattern)
+      actual is Descriptor.TestDescriptor && pattern is Descriptor.TestDescriptor ->
+         wildcardEqual(actual.parent, pattern.parent) && actual.id.value.matchesGlob(pattern.id.value)
+      else -> false
+   }
+
+   /**
+    * Returns true if [ancestor] is a strict ancestor of [descendant],
+    * using wildcard-aware ID comparison.
+    */
+   private fun wildcardIsAncestorOf(ancestor: Descriptor, descendant: Descriptor): Boolean =
+      when (descendant) {
+         is Descriptor.SpecDescriptor -> false
+         is Descriptor.TestDescriptor ->
+            wildcardEqual(ancestor, descendant.parent) || wildcardIsAncestorOf(ancestor, descendant.parent)
+      }
+
+   /**
+    * Returns true if this string matches [pattern] where `?` in [pattern] stands for
+    * exactly one arbitrary character, and all other characters are matched literally.
+    */
+   private fun String.matchesGlob(pattern: String): Boolean {
+      if ('?' !in pattern) return this == pattern
+      val regex = pattern.split('?').joinToString(".") { Regex.escape(it) }.toRegex()
+      return this.matches(regex)
    }
 
    private fun Descriptor.normalizeLineBreaks(): Descriptor = when (this) {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/IncludeTestPatternDescriptorFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/IncludeTestPatternDescriptorFilterTest.kt
@@ -87,4 +87,45 @@ class IncludeTestPatternDescriptorFilterTest : FunSpec({
       val pattern = "com.sksamuel.kotest.engine.extensions.IncludeTestPatternDescriptorFilterTest.a test"
       IncludePatternEnvDescriptorFilter.filter(pattern, test1) shouldBe DescriptorFilterResult.Include
    }
+
+   context("question-mark wildcard in test name matches tests with periods") {
+      // GradleTestFilterBuilder replaces '.' in test names with '?' to avoid Gradle
+      // misinterpreting them as FQN separators. This filter must treat '?' as a
+      // single-character wildcard so that e.g. "1?2?3 my test" matches "1.2.3 my test".
+
+      val spec = IncludeTestPatternDescriptorFilterTest::class.toDescriptor()
+      val fqcn = "com.sksamuel.kotest.engine.extensions.IncludeTestPatternDescriptorFilterTest"
+
+      test("root test named '1.2.3 my test' is INCLUDED by pattern with question marks") {
+         val testDescriptor = spec.append("1.2.3 my test")
+         IncludePatternEnvDescriptorFilter.filter("$fqcn.1?2?3 my test", testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("root test named '1.2.3 my test' is EXCLUDED by non-matching question-mark pattern") {
+         val testDescriptor = spec.append("1.2.3 my test")
+         IncludePatternEnvDescriptorFilter.filter("$fqcn.4?5?6 my test", testDescriptor) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+
+      test("spec is INCLUDED when filtering to a test with question-mark pattern") {
+         IncludePatternEnvDescriptorFilter.filter("$fqcn.1?2?3 my test", spec) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("child of '1.2.3 my test' is INCLUDED when filtering to parent with question marks") {
+         val parent = spec.append("1.2.3 my test")
+         val child = parent.append("nested child")
+         IncludePatternEnvDescriptorFilter.filter("$fqcn.1?2?3 my test", child) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("nested test with periods in name is INCLUDED by question-mark pattern") {
+         val parent = spec.append("v1.0 context")
+         val child = parent.append("feature 2.0")
+         IncludePatternEnvDescriptorFilter.filter("$fqcn.v1?0 context -- feature 2?0", child) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("question mark does not match multiple characters") {
+         val testDescriptor = spec.append("1..2 my test")
+         // '?' matches exactly one char, so "1?2" should NOT match "1..2"
+         IncludePatternEnvDescriptorFilter.filter("$fqcn.1?2 my test", testDescriptor) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+   }
 })

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilder.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilder.kt
@@ -33,7 +33,7 @@ data class GradleTestFilterBuilder(
          }
          if (test != null) {
             append(".")
-            append(test.path().joinToString(" -- ") { it.name.removeLineBreaks().escapeSingleQuotes() })
+            append(test.path().joinToString(" -- ") { it.name.removeLineBreaks().escapeSingleQuotes().escapeDots() })
          }
          append("'")
       }
@@ -53,3 +53,14 @@ data class GradleTestFilterBuilder(
 private fun String.escapeSingleQuotes(): String = replace("'", "'\\''")
 
 private fun String.removeLineBreaks(): String = replace(Regex("\r\n|\n|\r"), " ")
+
+/**
+ * Replaces periods in test names with the single-character wildcard `?` so that Gradle
+ * does not mistake them for package/class-name separators in the `--tests` filter.
+ *
+ * Gradle's `--tests` filter splits patterns on `.` to find the class boundary. A test
+ * named e.g. `1.2.3 my test` would cause Gradle to look for a class named `MySpec.1.2.3`
+ * (which doesn't exist), so no tests are discovered. Replacing `.` with `?` (Gradle's
+ * single-character wildcard) avoids the misparse while still matching the correct test.
+ */
+private fun String.escapeDots(): String = replace(".", "?")

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilderTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilderTest.kt
@@ -172,6 +172,51 @@ class GradleTestFilterBuilderTest : BasePlatformTestCase() {
          .build(true) shouldBe "--tests 'MyTestClass.a test with crlf'"
    }
 
+   fun testPeriodInTestNameIsReplacedWithQuestionMark() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
+      val test = Test(
+         name = TestName(prefix = null, name = "1.2.3 my test", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MyTestClass.1?2?3 my test'"
+   }
+
+   fun testPeriodInNestedTestNameIsReplacedWithQuestionMark() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")
+      val root = Test(
+         name = TestName(prefix = null, name = "v1.0 context", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Container,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      val test = Test(
+         name = TestName(prefix = null, name = "feature 2.0", interpolated = false),
+         parent = root,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MyTestClass.v1?0 context -- feature 2?0'"
+   }
+
    fun testCarriageReturnInTestNameIsReplacedWithSpace() {
       val factory = KtPsiFactory(project)
       val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/GradleClassMethodRegexTestFilterTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/GradleClassMethodRegexTestFilterTest.kt
@@ -198,6 +198,49 @@ class GradleClassMethodRegexTestFilterTest : FunSpec({
       }
    }
 
+   context("question-mark wildcards in test names match tests with periods") {
+      // GradleTestFilterBuilder replaces '.' in test names with '?' to avoid Gradle
+      // misinterpreting them as FQN separators. Gradle converts '?' -> '.' (regex any-char)
+      // and wraps surrounding literals in \Q...\E, so the filter for test name "1.2.3 my test"
+      // becomes the regex pattern \Q...MySpec.1\E.\Q2\E.\Q3 my test\E.
+
+      val spec = Descriptor.SpecDescriptor(DescriptorId("io.example.MySpec"))
+      val fqn = "\\Qio.example.MySpec\\E"
+
+      test("root test named '1.2.3 my test' is INCLUDED by question-mark-escaped filter") {
+         val testDescriptor = spec.append("1.2.3 my test")
+         // Gradle converts --tests 'io.example.MySpec.1?2?3 my test' to this regex:
+         val filter = "$fqn\\Q.1\\E.\\Q2\\E.\\Q3 my test\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("root test named '1.2.3 my test' is INCLUDED by spec-level filter") {
+         val testDescriptor = spec.append("1.2.3 my test")
+         GradleClassMethodRegexTestFilter(setOf(fqn)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("root test with a different name is EXCLUDED by question-mark-escaped filter") {
+         val testDescriptor = spec.append("4.5.6 other test")
+         val filter = "$fqn\\Q.1\\E.\\Q2\\E.\\Q3 my test\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+
+      test("nested test under '1.2.3 my test' is INCLUDED when filtering to parent") {
+         val parent = spec.append("1.2.3 my test")
+         val child = parent.append("nested child")
+         val filter = "$fqn\\Q.1\\E.\\Q2\\E.\\Q3 my test\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(child) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("context named 'v1.0 context' with nested test is INCLUDED by question-mark-escaped filter") {
+         val container = spec.append("v1.0 context")
+         val child = container.append("feature 2.0")
+         // Gradle converts --tests 'io.example.MySpec.v1?0 context -- feature 2?0'
+         val filter = "$fqn\\Q.v1\\E.\\Q0 context -- feature 2\\E.\\Q0\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(child) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
    // Unable to make field final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @62163b39
    test("!is ignored when KOTEST_INCLUDE_PATTERN is set") {
       val spec = GradleClassMethodRegexTestFilterTest::class.toDescriptor()


### PR DESCRIPTION
## Summary

- Periods in test names (e.g. `test("1.2.3 my test")`) were passed literally in the Gradle `--tests` filter, causing Gradle to misinterpret them as package/class-name separators
- Gradle could not discover the test class and no tests ran
- Fix: replace `.` with `?` (Gradle's single-character wildcard) in the test name portion of the filter only — the spec FQN dots are preserved

## Details

`GradleTestFilterBuilder` previously generated:
```
--tests 'io.example.MySpec.1.2.3 my test'
```
Gradle splits on `.` to find the class boundary and would misparse this as class `io.example.MySpec.1.2.3` (non-existent), so no tests were discovered.

After the fix it generates:
```
--tests 'io.example.MySpec.1?2?3 my test'
```
Gradle correctly identifies `io.example.MySpec` as the class, and the `?` wildcards (each matching any single character) still match the literal `.` in the test name.

Fixes #5797

## Test plan

- [x] Added `testPeriodInTestNameIsReplacedWithQuestionMark` — verifies a root test with dots in its name produces `?`-escaped filter
- [x] Added `testPeriodInNestedTestNameIsReplacedWithQuestionMark` — verifies the same for nested tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)