### PR TITLE
Add tests verifying beforeEach/afterEach ordering relative to BeforeTestListener/AfterTestListener

### DIFF
--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/BeforeEachAfterEachVsTestListenerOrderTest.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/BeforeEachAfterEachVsTestListenerOrderTest.kt
@@ -1,0 +1,83 @@
+package com.sksamuel.kotest.engine.callback.order
+
+import io.kotest.core.annotation.Description
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.BeforeTestListener
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.engine.test.TestResult
+import io.kotest.matchers.shouldBe
+
+val beforeEachVsListenerEvents = mutableListOf<String>()
+val afterEachVsListenerEvents = mutableListOf<String>()
+
+class BeforeEachAnnotationBeforeTestListener : BeforeTestListener {
+   override suspend fun beforeTest(testCase: TestCase) {
+      beforeEachVsListenerEvents.add("annotation-listener")
+   }
+}
+
+class AfterEachAnnotationAfterTestListener : AfterTestListener {
+   override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+      afterEachVsListenerEvents.add("annotation-listener")
+   }
+}
+
+/**
+ * Confirms that [beforeEach] DSL callbacks (which register a [io.kotest.core.listeners.BeforeEachListener])
+ * run *before* any [BeforeTestListener]s registered via [@ApplyExtension] or project config.
+ *
+ * Execution order is driven by [io.kotest.engine.test.TestExtensions.beforeTestBeforeEachBeforeContainer]:
+ * all BeforeEachListeners (group 'be') are invoked first, then all BeforeTestListeners (group 'bt').
+ * Within 'bt', GLOBAL_FIRST ordering applies: registry extensions (@ApplyExtension) precede project config.
+ */
+@Description("Confirms beforeEach runs before BeforeTestListeners from @ApplyExtension and project config")
+@ApplyExtension(BeforeEachAnnotationBeforeTestListener::class)
+class BeforeEachVsBeforeTestListenerOrderTest : FunSpec() {
+   init {
+
+      beforeEach {
+         beforeEachVsListenerEvents.add("beforeEach")
+      }
+
+      test("test1") {}
+      test("test2") {}
+
+      afterProject {
+         beforeEachVsListenerEvents shouldBe listOf(
+            "beforeEach", "annotation-listener", "project-listener",
+            "beforeEach", "annotation-listener", "project-listener",
+         )
+      }
+   }
+}
+
+/**
+ * Confirms that [afterEach] DSL callbacks (which register a [io.kotest.core.listeners.AfterEachListener])
+ * run *after* any [AfterTestListener]s registered via [@ApplyExtension] or project config.
+ *
+ * Execution order is driven by [io.kotest.engine.test.TestExtensions.afterTestAfterEachAfterContainer]:
+ * all AfterTestListeners (group 'at') are invoked first, then all AfterEachListeners (group 'ae').
+ * Within 'at', LOCAL_FIRST ordering applies: project config precedes registry extensions (@ApplyExtension).
+ */
+@Description("Confirms afterEach runs after AfterTestListeners from @ApplyExtension and project config")
+@ApplyExtension(AfterEachAnnotationAfterTestListener::class)
+class AfterEachVsAfterTestListenerOrderTest : FunSpec() {
+   init {
+
+      afterEach {
+         afterEachVsListenerEvents.add("afterEach")
+      }
+
+      test("test1") {}
+      test("test2") {}
+
+      afterProject {
+         afterEachVsListenerEvents shouldBe listOf(
+            "project-listener", "annotation-listener", "afterEach",
+            "project-listener", "annotation-listener", "afterEach",
+         )
+      }
+   }
+}

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,10 +1,14 @@
 package io.kotest.provided
 
 import com.sksamuel.kotest.engine.callback.order.afterEachEvents
+import com.sksamuel.kotest.engine.callback.order.afterEachVsListenerEvents
 import com.sksamuel.kotest.engine.callback.order.afterTestEvents
 import com.sksamuel.kotest.engine.callback.order.beforeEachEvents
+import com.sksamuel.kotest.engine.callback.order.beforeEachVsListenerEvents
 import com.sksamuel.kotest.engine.callback.order.beforeTestEvents
 import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.listeners.AfterTestListener
+import io.kotest.core.listeners.BeforeTestListener
 import io.kotest.core.listeners.TestListener
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
@@ -32,6 +36,24 @@ class ProjectConfig : AbstractProjectConfig() {
             if (testCase.spec::class.simpleName == "TestListenerPrecedenceTest")
                beforeEachEvents.add("projectBeforeEach")
          }
-      }
+      },
+      // Pure BeforeTestListener for BeforeEachVsBeforeTestListenerOrderTest.
+      // Must NOT implement BeforeEachListener so it only appears in the 'bt' group,
+      // confirming that beforeEach (group 'be') runs before it.
+      object : BeforeTestListener {
+         override suspend fun beforeTest(testCase: TestCase) {
+            if (testCase.spec::class.simpleName == "BeforeEachVsBeforeTestListenerOrderTest")
+               beforeEachVsListenerEvents.add("project-listener")
+         }
+      },
+      // Pure AfterTestListener for AfterEachVsAfterTestListenerOrderTest.
+      // Must NOT implement AfterEachListener so it only appears in the 'at' group,
+      // confirming that afterEach (group 'ae') runs after it.
+      object : AfterTestListener {
+         override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+            if (testCase.spec::class.simpleName == "AfterEachVsAfterTestListenerOrderTest")
+               afterEachVsListenerEvents.add("project-listener")
+         }
+      },
    )
 }


### PR DESCRIPTION
## Summary

- Adds `BeforeEachVsBeforeTestListenerOrderTest`: confirms that `beforeEach {}` DSL callbacks (which register a `BeforeEachListener`) run **before** any `BeforeTestListener`s registered via `@ApplyExtension` or project config
- Adds `AfterEachVsAfterTestListenerOrderTest`: confirms that `afterEach {}` DSL callbacks (which register an `AfterEachListener`) run **after** any `AfterTestListener`s registered via `@ApplyExtension` or project config
- Updates `ProjectConfig` in the callback-order test module to supply pure `BeforeTestListener` and `AfterTestListener` fixtures for the two new specs

## Why the ordering is what it is

`TestExtensions.beforeTestBeforeEachBeforeContainer` iterates groups in order: `bc` → `be` → `bt`. Since `beforeEach {}` creates a `BeforeEachListener` (group `be`), it fires **before** group `bt` regardless of where the `BeforeTestListener` was registered.

Symmetrically, `afterTestAfterEachAfterContainer` iterates: `at` → `ac` → `ae`. Since `afterEach {}` creates an `AfterEachListener` (group `ae`), it fires **after** group `at`.

Within-group ordering follows GLOBAL_FIRST for before (registry → project → spec) and LOCAL_FIRST for after (reversed: spec → project → registry), which is why the `@ApplyExtension` annotation listener appears before the project-config listener in `beforeEach` tests but after it in `afterEach` tests.

## Test plan

- [x] `BeforeEachVsBeforeTestListenerOrderTest` passes (both tests produce `["beforeEach", "annotation-listener", "project-listener"]`)
- [x] `AfterEachVsAfterTestListenerOrderTest` passes (both tests produce `["project-listener", "annotation-listener", "afterEach"]`)
- [x] Existing `TestListenerPrecedenceTest` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)