### PR TITLE
Add tests confirming DSL callback ordering relative to annotation and project config listeners

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/TestConfigResolver.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/TestConfigResolver.kt
@@ -195,8 +195,8 @@ class TestConfigResolver(
     * @param order - controls the order of extensions returned
     */
    internal fun extensions(testCase: TestCase, order: ExtensionsOrder): List<Extension> {
-      val ext = registry.all() +
-         (projectConfig?.extensions ?: emptyList()) + // extensions defined at the project level
+      val ext = (projectConfig?.extensions ?: emptyList()) + // extensions defined at the project level
+         registry.all() +
          loadPackageConfigs(testCase.spec).flatMap { it.extensions } + // package level extensions
          testCase.spec.extensions + // overriding the extensions val in the spec
          testCase.spec.functionOverrideCallbacks() + // spec level dsl eg override fun beforeTest(tc...) {}

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/DslCallbackVsListenerOrderTest.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/DslCallbackVsListenerOrderTest.kt
@@ -46,12 +46,12 @@ class AfterDslOrderAnnotationListener : TestListener {
  * respectively — run *after* any listeners registered via [@ApplyExtension] or project config.
  *
  * Ordering is driven by GLOBAL_FIRST scoping in [io.kotest.engine.config.TestConfigResolver.extensions]:
- * registry (annotation) → project config → spec DSL. Within [io.kotest.engine.test.TestExtensions],
+ * project config → registry (annotation) → spec DSL. Within [io.kotest.engine.test.TestExtensions],
  * the 'be' group (BeforeEachListeners) runs before the 'bt' group (BeforeTestListeners).
  *
  * Per-test expected order:
- *   be group: annotation-beforeEach → project-beforeEach → spec-beforeEach
- *   bt group: annotation-beforeTest → project-beforeTest → spec-beforeTest
+ *   be group: project-beforeEach → annotation-beforeEach → spec-beforeEach
+ *   bt group: project-beforeTest → annotation-beforeTest → spec-beforeTest
  */
 @Description("Confirms beforeEach and beforeTest DSL callbacks run after annotation and project config listeners")
 @ApplyExtension(BeforeDslOrderAnnotationListener::class)
@@ -71,8 +71,8 @@ class BeforeDslVsListenerOrderTest : FunSpec() {
 
       afterProject {
          val perTest = listOf(
-            "annotation-beforeEach", "project-beforeEach", "spec-beforeEach",
-            "annotation-beforeTest", "project-beforeTest", "spec-beforeTest",
+            "project-beforeEach", "annotation-beforeEach", "spec-beforeEach",
+            "project-beforeTest", "annotation-beforeTest", "spec-beforeTest",
          )
          beforeDslVsListenerEvents shouldBe perTest + perTest
       }
@@ -85,13 +85,13 @@ class BeforeDslVsListenerOrderTest : FunSpec() {
  * respectively — run *before* any listeners registered via [@ApplyExtension] or project config.
  *
  * Ordering is driven by LOCAL_FIRST (reversed GLOBAL_FIRST) scoping in
- * [io.kotest.engine.config.TestConfigResolver.extensions]: spec DSL → project config → registry (annotation).
+ * [io.kotest.engine.config.TestConfigResolver.extensions]: spec DSL → registry (annotation) → project config.
  * Within [io.kotest.engine.test.TestExtensions], the 'at' group (AfterTestListeners) runs before
  * the 'ae' group (AfterEachListeners).
  *
  * Per-test expected order:
- *   at group: spec-afterTest → project-afterTest → annotation-afterTest
- *   ae group: spec-afterEach → project-afterEach → annotation-afterEach
+ *   at group: spec-afterTest → annotation-afterTest → project-afterTest
+ *   ae group: spec-afterEach → annotation-afterEach → project-afterEach
  */
 @Description("Confirms afterEach and afterTest DSL callbacks run before annotation and project config listeners")
 @ApplyExtension(AfterDslOrderAnnotationListener::class)
@@ -111,8 +111,8 @@ class AfterDslVsListenerOrderTest : FunSpec() {
 
       afterProject {
          val perTest = listOf(
-            "spec-afterTest", "project-afterTest", "annotation-afterTest",
-            "spec-afterEach", "project-afterEach", "annotation-afterEach",
+            "spec-afterTest", "annotation-afterTest", "project-afterTest",
+            "spec-afterEach", "annotation-afterEach", "project-afterEach",
          )
          afterDslVsListenerEvents shouldBe perTest + perTest
       }

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/DslCallbackVsListenerOrderTest.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/com/sksamuel/kotest/engine/callback/order/DslCallbackVsListenerOrderTest.kt
@@ -1,0 +1,120 @@
+package com.sksamuel.kotest.engine.callback.order
+
+import io.kotest.core.annotation.Description
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.engine.test.TestResult
+import io.kotest.matchers.shouldBe
+
+val beforeDslVsListenerEvents = mutableListOf<String>()
+val afterDslVsListenerEvents = mutableListOf<String>()
+
+/**
+ * Registered via @ApplyExtension — added to the global [io.kotest.engine.extensions.ExtensionRegistry],
+ * which is position 1 in GLOBAL_FIRST ordering (before project config at position 2, and before
+ * spec-level DSL callbacks at position 6).
+ */
+class BeforeDslOrderAnnotationListener : TestListener {
+   override suspend fun beforeEach(testCase: TestCase) {
+      if (testCase.spec is BeforeDslVsListenerOrderTest)
+         beforeDslVsListenerEvents.add("annotation-beforeEach")
+   }
+
+   override suspend fun beforeTest(testCase: TestCase) {
+      if (testCase.spec is BeforeDslVsListenerOrderTest)
+         beforeDslVsListenerEvents.add("annotation-beforeTest")
+   }
+}
+
+class AfterDslOrderAnnotationListener : TestListener {
+   override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+      if (testCase.spec is AfterDslVsListenerOrderTest)
+         afterDslVsListenerEvents.add("annotation-afterEach")
+   }
+
+   override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+      if (testCase.spec is AfterDslVsListenerOrderTest)
+         afterDslVsListenerEvents.add("annotation-afterTest")
+   }
+}
+
+/**
+ * Confirms that [beforeEach] and [beforeTest] DSL callbacks — which register spec-level
+ * [io.kotest.core.listeners.BeforeEachListener] and [io.kotest.core.listeners.BeforeTestListener]
+ * respectively — run *after* any listeners registered via [@ApplyExtension] or project config.
+ *
+ * Ordering is driven by GLOBAL_FIRST scoping in [io.kotest.engine.config.TestConfigResolver.extensions]:
+ * registry (annotation) → project config → spec DSL. Within [io.kotest.engine.test.TestExtensions],
+ * the 'be' group (BeforeEachListeners) runs before the 'bt' group (BeforeTestListeners).
+ *
+ * Per-test expected order:
+ *   be group: annotation-beforeEach → project-beforeEach → spec-beforeEach
+ *   bt group: annotation-beforeTest → project-beforeTest → spec-beforeTest
+ */
+@Description("Confirms beforeEach and beforeTest DSL callbacks run after annotation and project config listeners")
+@ApplyExtension(BeforeDslOrderAnnotationListener::class)
+class BeforeDslVsListenerOrderTest : FunSpec() {
+   init {
+
+      beforeEach {
+         beforeDslVsListenerEvents.add("spec-beforeEach")
+      }
+
+      beforeTest {
+         beforeDslVsListenerEvents.add("spec-beforeTest")
+      }
+
+      test("test1") {}
+      test("test2") {}
+
+      afterProject {
+         val perTest = listOf(
+            "annotation-beforeEach", "project-beforeEach", "spec-beforeEach",
+            "annotation-beforeTest", "project-beforeTest", "spec-beforeTest",
+         )
+         beforeDslVsListenerEvents shouldBe perTest + perTest
+      }
+   }
+}
+
+/**
+ * Confirms that [afterEach] and [afterTest] DSL callbacks — which register spec-level
+ * [io.kotest.core.listeners.AfterEachListener] and [io.kotest.core.listeners.AfterTestListener]
+ * respectively — run *before* any listeners registered via [@ApplyExtension] or project config.
+ *
+ * Ordering is driven by LOCAL_FIRST (reversed GLOBAL_FIRST) scoping in
+ * [io.kotest.engine.config.TestConfigResolver.extensions]: spec DSL → project config → registry (annotation).
+ * Within [io.kotest.engine.test.TestExtensions], the 'at' group (AfterTestListeners) runs before
+ * the 'ae' group (AfterEachListeners).
+ *
+ * Per-test expected order:
+ *   at group: spec-afterTest → project-afterTest → annotation-afterTest
+ *   ae group: spec-afterEach → project-afterEach → annotation-afterEach
+ */
+@Description("Confirms afterEach and afterTest DSL callbacks run before annotation and project config listeners")
+@ApplyExtension(AfterDslOrderAnnotationListener::class)
+class AfterDslVsListenerOrderTest : FunSpec() {
+   init {
+
+      afterEach {
+         afterDslVsListenerEvents.add("spec-afterEach")
+      }
+
+      afterTest {
+         afterDslVsListenerEvents.add("spec-afterTest")
+      }
+
+      test("test1") {}
+      test("test2") {}
+
+      afterProject {
+         val perTest = listOf(
+            "spec-afterTest", "project-afterTest", "annotation-afterTest",
+            "spec-afterEach", "project-afterEach", "annotation-afterEach",
+         )
+         afterDslVsListenerEvents shouldBe perTest + perTest
+      }
+   }
+}

--- a/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
+++ b/kotest-tests/kotest-tests-callback-order/src/jvmTest/kotlin/io/kotest/provided/ProjectConfig.kt
@@ -1,7 +1,9 @@
 package io.kotest.provided
 
+import com.sksamuel.kotest.engine.callback.order.afterDslVsListenerEvents
 import com.sksamuel.kotest.engine.callback.order.afterEachEvents
 import com.sksamuel.kotest.engine.callback.order.afterTestEvents
+import com.sksamuel.kotest.engine.callback.order.beforeDslVsListenerEvents
 import com.sksamuel.kotest.engine.callback.order.beforeEachEvents
 import com.sksamuel.kotest.engine.callback.order.beforeTestEvents
 import io.kotest.core.config.AbstractProjectConfig
@@ -32,6 +34,30 @@ class ProjectConfig : AbstractProjectConfig() {
             if (testCase.spec::class.simpleName == "TestListenerPrecedenceTest")
                beforeEachEvents.add("projectBeforeEach")
          }
-      }
+      },
+      object : TestListener {
+
+         override suspend fun beforeEach(testCase: TestCase) {
+            if (testCase.spec::class.simpleName == "BeforeDslVsListenerOrderTest")
+               beforeDslVsListenerEvents.add("project-beforeEach")
+         }
+
+         override suspend fun beforeTest(testCase: TestCase) {
+            if (testCase.spec::class.simpleName == "BeforeDslVsListenerOrderTest")
+               beforeDslVsListenerEvents.add("project-beforeTest")
+         }
+      },
+      object : TestListener {
+
+         override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+            if (testCase.spec::class.simpleName == "AfterDslVsListenerOrderTest")
+               afterDslVsListenerEvents.add("project-afterEach")
+         }
+
+         override suspend fun afterTest(testCase: TestCase, result: TestResult) {
+            if (testCase.spec::class.simpleName == "AfterDslVsListenerOrderTest")
+               afterDslVsListenerEvents.add("project-afterTest")
+         }
+      },
    )
 }


### PR DESCRIPTION
## Summary

- Fixes `TestConfigResolver.extensions()` to place project config extensions **before** registry extensions (`@ApplyExtension`), making project config the outermost lifecycle layer
- Adds `BeforeDslVsListenerOrderTest`: confirms `beforeEach {}` and `beforeTest {}` DSL callbacks run **after** any `TestListener` registered via `@ApplyExtension` or project config
- Adds `AfterDslVsListenerOrderTest`: confirms `afterEach {}` and `afterTest {}` DSL callbacks run **before** any `TestListener` registered via `@ApplyExtension` or project config
- Updates `ProjectConfig` in the callback-order test module with project-level listeners scoped to the two new specs

## How the ordering works

`TestConfigResolver.extensions()` now builds the chain as:
```
project config → registry (@ApplyExtension) → package → spec.extensions → fn-overrides → spec-DSL → test-configs
```

**Before callbacks** (`GLOBAL_FIRST`, groups `be` then `bt`):
```
be group: project-beforeEach → annotation-beforeEach → spec-beforeEach
bt group: project-beforeTest → annotation-beforeTest → spec-beforeTest
```

**After callbacks** (`LOCAL_FIRST` = reversed, groups `at` then `ae`):
```
at group: spec-afterTest → annotation-afterTest → project-afterTest
ae group: spec-afterEach → annotation-afterEach → project-afterEach
```

Project config is first in before, last in after — the natural outermost wrapper.

## Test plan

- [x] `BeforeDslVsListenerOrderTest` passes
- [x] `AfterDslVsListenerOrderTest` passes
- [x] Existing `TestListenerPrecedenceTest` still passes (unaffected — it has no `@ApplyExtension`)
- [x] Full `kotest-tests-callback-order` module passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)