### PR TITLE
Fix import alias clash when spec name digits concatenate with index digits

### DIFF
--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/TestEngineGenerator.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/TestEngineGenerator.kt
@@ -82,7 +82,7 @@ val specs = listOf(
     """.trim()
          ).addCode("\n")
       specs.forEachIndexed { index, spec ->
-         val sn = spec.simpleName.asString() + index
+         val sn = spec.simpleName.asString() + "_" + index
          val fqn = spec.qualifiedName?.asString() ?: spec.simpleName.asString()
          function.addCode("""SpecRef.Function ({ `${sn}`() }, `${sn}`::class, "$fqn"), """)
          function.addCode("\n")
@@ -117,7 +117,7 @@ val specs = listOf(
       specs.forEachIndexed { index, spec ->
          file.addAliasedImport(
             ClassName(spec.packageName.asString(), spec.simpleName.asString()),
-            `as` = spec.simpleName.asString() + index.toString()
+            `as` = spec.simpleName.asString() + "_" + index.toString()
          )
       }
 

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/TestEngineGeneratorTest.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/TestEngineGeneratorTest.kt
@@ -27,13 +27,13 @@ class TestEngineGeneratorTest : FunSpec({
          configs = listOf(SimpleKSClassDeclaration("com.sksamuel.MyConfig",)),
       ).toString()
 
-      file shouldContain """import com.sksamuel.a.MyTestSpec as MyTestSpec0"""
-      file shouldContain """import com.sksamuel.b.MyTestSpec as MyTestSpec1"""
-      file shouldContain """import com.sksamuel.c.OtherTestSpec as OtherTestSpec2"""
+      file shouldContain """import com.sksamuel.a.MyTestSpec as MyTestSpec_0"""
+      file shouldContain """import com.sksamuel.b.MyTestSpec as MyTestSpec_1"""
+      file shouldContain """import com.sksamuel.c.OtherTestSpec as OtherTestSpec_2"""
 
-      file shouldContain """SpecRef.Function ({ `MyTestSpec0`() }, `MyTestSpec0`::class, "com.sksamuel.a.MyTestSpec")"""
-      file shouldContain """SpecRef.Function ({ `MyTestSpec1`() }, `MyTestSpec1`::class, "com.sksamuel.b.MyTestSpec")"""
-      file shouldContain """SpecRef.Function ({ `OtherTestSpec2`() }, `OtherTestSpec2`::class, "com.sksamuel.c.OtherTestSpec")"""
+      file shouldContain """SpecRef.Function ({ `MyTestSpec_0`() }, `MyTestSpec_0`::class, "com.sksamuel.a.MyTestSpec")"""
+      file shouldContain """SpecRef.Function ({ `MyTestSpec_1`() }, `MyTestSpec_1`::class, "com.sksamuel.b.MyTestSpec")"""
+      file shouldContain """SpecRef.Function ({ `OtherTestSpec_2`() }, `OtherTestSpec_2`::class, "com.sksamuel.c.OtherTestSpec")"""
    }
 
    test("should specify config when present") {
@@ -54,6 +54,31 @@ class TestEngineGeneratorTest : FunSpec({
       ).toString()
 
       file.shouldContain("val config = com.sksamuel.MyConfig()")
+   }
+
+   // see https://github.com/kotest/kotest/issues/5621
+   // Without an underscore separator, "Spec1" at index 0 produces alias "Spec10",
+   // which clashes with "Spec" at index 10 also producing "Spec10".
+   test("import alias underscore separator prevents clash between spec name digits and index digits") {
+      val env = SymbolProcessorEnvironment(
+         options = emptyMap(),
+         kotlinVersion = KotlinVersion.CURRENT,
+         apiVersion = KotlinVersion.CURRENT,
+         compilerVersion = KotlinVersion.CURRENT,
+         codeGenerator = SimpleCodeGenerator(),
+         logger = NoOpKSPLogger,
+         platforms = listOf(DefaultJsPlatformInfo),
+      )
+      // Build a list where Spec1 lands at index 0 and Spec lands at index 10.
+      // Without underscore: both would produce the alias "Spec10".
+      val specs = mutableListOf(SimpleKSClassDeclaration("com.example.Spec1"))
+      repeat(9) { i -> specs.add(SimpleKSClassDeclaration("com.example.Filler$i")) }
+      specs.add(SimpleKSClassDeclaration("com.example.Spec"))
+
+      val file = TestEngineGenerator(env).createFileSpec(specs, emptyList()).toString()
+
+      file shouldContain """import com.example.Spec1 as Spec1_0"""
+      file shouldContain """import com.example.Spec as Spec_10"""
    }
 
    test("handle empty configs") {


### PR DESCRIPTION
## Summary

- `TestEngineGenerator` generates an import alias for each spec as `simpleName + index` (e.g. `MySpec0`, `MySpec1`)
- This produces a collision when a spec name ends in digits that, when concatenated with the index, produce the same string as another spec's alias — e.g. `Spec1` at index `0` → `Spec10`, and `Spec` at index `10` → `Spec10`
- Fixed by inserting an underscore between the name and index: `Spec1_0` and `Spec_10` are now unambiguous

## Test plan

- [ ] New regression test `"import alias underscore separator prevents clash between spec name digits and index digits"` demonstrates the exact collision scenario and passes with the fix
- [ ] Existing test `"handle test classes having the same name in different packages"` updated to expect the new `_` separator format

Closes #5621

🤖 Generated with [Claude Code](https://claude.com/claude-code)