### PR TITLE
Set KOTEST_IDEA_PLUGIN=true in Gradle and Android run producers

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/android/AndroidInstrumentedTestRunConfigurationProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/android/AndroidInstrumentedTestRunConfigurationProducer.kt
@@ -72,6 +72,13 @@ class AndroidInstrumentedTestRunConfigurationProducer :
       }
 
       configuration.EXTRA_OPTIONS = getOptions(configuration.EXTRA_OPTIONS, context, OPTIONS_EP.extensionList, logger)
+
+      // Tag the run so the Kotest engine knows it was launched from the IntelliJ plugin.
+      val existingOptions = configuration.EXTRA_OPTIONS.trim()
+      configuration.EXTRA_OPTIONS =
+         if (existingOptions.isEmpty()) "-e KOTEST_IDEA_PLUGIN true"
+         else "$existingOptions -e KOTEST_IDEA_PLUGIN true"
+
       logger.debug("Configuration ${configuration.name} setup successfully")
       return true
    }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducer.kt
@@ -75,6 +75,10 @@ class GradleMultiplatformJvmTestTaskRunProducer : GradleTestRunConfigurationProd
 
       setUniqueNameIfNeeded(configuration.project, configuration)
       JavaRunConfigurationExtensionManager.instance.extendCreatedConfiguration(configuration, location)
+
+      // Tag the run so the Kotest engine knows it was launched from the IntelliJ plugin.
+      configuration.settings.env = configuration.settings.env + mapOf("KOTEST_IDEA_PLUGIN" to "true")
+
       return true
    }
 

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/android/AndroidInstrumentedTestRunConfigurationProducerTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/android/AndroidInstrumentedTestRunConfigurationProducerTest.kt
@@ -51,7 +51,7 @@ class AndroidInstrumentedTestRunConfigurationProducerTest : BasePlatformTestCase
       val configuration = runconfig!!.configuration as AndroidTestRunConfiguration
       configuration.CLASS_NAME shouldBe "io.kotest.samples.gradle.FunSpecExampleTest"
       configuration.TESTING_TYPE shouldBe AndroidTestRunConfiguration.TEST_CLASS
-      configuration.EXTRA_OPTIONS shouldBe ""
+      configuration.EXTRA_OPTIONS shouldBe "-e KOTEST_IDEA_PLUGIN true"
    }
 
    fun testCreateConfigurationFromContextAddsFilterForIndividualTest() {
@@ -72,7 +72,7 @@ class AndroidInstrumentedTestRunConfigurationProducerTest : BasePlatformTestCase
       val runconfig = AndroidInstrumentedTestRunConfigurationProducer().createConfigurationFromContext(context)
       val configuration = runconfig!!.configuration as AndroidTestRunConfiguration
       configuration.CLASS_NAME shouldBe "io.kotest.samples.gradle.FunSpecExampleTest"
-      configuration.EXTRA_OPTIONS shouldBe "-e INSTRUMENTATION_INCLUDE_PATTERN 'io.kotest.samples.gradle.FunSpecExampleTest.some context -- a nested test'"
+      configuration.EXTRA_OPTIONS shouldBe "-e INSTRUMENTATION_INCLUDE_PATTERN 'io.kotest.samples.gradle.FunSpecExampleTest.some context -- a nested test' -e KOTEST_IDEA_PLUGIN true"
       configuration.TESTING_TYPE shouldBe AndroidTestRunConfiguration.TEST_CLASS
    }
 
@@ -88,6 +88,61 @@ class AndroidInstrumentedTestRunConfigurationProducerTest : BasePlatformTestCase
 
       AndroidInstrumentedTestRunConfigurationProducer()
          .isConfigurationFromContext(createConfiguration(), context) shouldBe false
+   }
+
+   /**
+    * [AndroidInstrumentedTestRunConfigurationProducer] must always append
+    * `-e KOTEST_IDEA_PLUGIN true` to [AndroidTestRunConfiguration.EXTRA_OPTIONS] so the Kotest
+    * engine can detect it is running inside the IntelliJ plugin. This test verifies the flag is
+    * present when running a spec (no individual test selected).
+    */
+   fun testPluginFlagIsSetForSpecLevelRun() {
+      setupKotestGradleTestTaskMode()
+      setupAndroidFacet()
+
+      val psiFiles = myFixture.configureByFiles(
+         "/funspec.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      val psiElement = psiFiles[0].elementAtLine(6) ?: error("Could not find PSI element")
+      val context = ConfigurationContext.createEmptyContextForLocation(
+         PsiLocation(project, myFixture.module, psiElement)
+      )
+
+      val runconfig = AndroidInstrumentedTestRunConfigurationProducer().createConfigurationFromContext(context)
+      val configuration = runconfig!!.configuration as AndroidTestRunConfiguration
+      configuration.EXTRA_OPTIONS.contains("KOTEST_IDEA_PLUGIN") shouldBe true
+      configuration.EXTRA_OPTIONS.contains("-e KOTEST_IDEA_PLUGIN true") shouldBe true
+   }
+
+   /**
+    * [AndroidInstrumentedTestRunConfigurationProducer] must always append
+    * `-e KOTEST_IDEA_PLUGIN true` to [AndroidTestRunConfiguration.EXTRA_OPTIONS] so the Kotest
+    * engine can detect it is running inside the IntelliJ plugin. This test verifies the flag is
+    * present (after the test filter) when running an individual test.
+    */
+   fun testPluginFlagIsSetForTestLevelRun() {
+      setupKotestGradleTestTaskMode()
+      setupAndroidFacet()
+
+      val psiFiles = myFixture.configureByFiles(
+         "/funspec.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      val psiElement = psiFiles[0].elementAtLine(22) ?: error("Could not find PSI element")
+      val context = ConfigurationContext.createEmptyContextForLocation(
+         PsiLocation(project, myFixture.module, psiElement)
+      )
+
+      val runconfig = AndroidInstrumentedTestRunConfigurationProducer().createConfigurationFromContext(context)
+      val configuration = runconfig!!.configuration as AndroidTestRunConfiguration
+      configuration.EXTRA_OPTIONS.contains("-e KOTEST_IDEA_PLUGIN true") shouldBe true
+      // Plugin flag comes after the test filter
+      val filterIdx = configuration.EXTRA_OPTIONS.indexOf("INSTRUMENTATION_INCLUDE_PATTERN")
+      val flagIdx = configuration.EXTRA_OPTIONS.indexOf("KOTEST_IDEA_PLUGIN")
+      (filterIdx < flagIdx) shouldBe true
    }
 
    /**

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducerTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducerTest.kt
@@ -1,0 +1,130 @@
+package io.kotest.plugin.intellij.run.gradle
+
+import com.intellij.execution.PsiLocation
+import com.intellij.execution.actions.ConfigurationContext
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.externalSystem.ExternalSystemModulePropertyManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.PsiElement
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.kotest.matchers.shouldBe
+import io.kotest.plugin.intellij.psi.elementAtLine
+import org.jetbrains.plugins.gradle.service.execution.GradleRunConfiguration
+import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
+import org.jetbrains.plugins.gradle.settings.GradleSettings
+import org.jetbrains.plugins.gradle.settings.TestRunner
+import java.nio.file.Paths
+
+/**
+ * Tests that [GradleMultiplatformJvmTestTaskRunProducer] sets the `KOTEST_IDEA_PLUGIN` environment
+ * variable so the Kotest engine can detect it is running from the IntelliJ plugin.
+ */
+class GradleMultiplatformJvmTestTaskRunProducerTest : BasePlatformTestCase() {
+
+   override fun getTestDataPath(): String =
+      Paths.get("./src/test/resources/").toAbsolutePath().toString()
+
+   /**
+    * Thin subclass that makes [doSetupConfigurationFromContext] callable from tests.
+    * The method is `protected` in the base class; a subclass can widen it to public.
+    */
+   private class TestableProducer : GradleMultiplatformJvmTestTaskRunProducer() {
+      fun callDoSetup(
+         configuration: GradleRunConfiguration,
+         context: ConfigurationContext,
+         ref: Ref<PsiElement?>
+      ): Boolean = doSetupConfigurationFromContext(configuration, context, ref)
+   }
+
+   /**
+    * Verifies that [GradleMultiplatformJvmTestTaskRunProducer.doSetupConfigurationFromContext]
+    * sets `KOTEST_IDEA_PLUGIN=true` in the configuration's environment so the Kotest engine
+    * knows it is running inside the IntelliJ plugin.
+    */
+   fun testSetsKotestIdeaPluginEnvVar() {
+      setupGradleTestTaskMode()
+
+      val psiFiles = myFixture.configureByFiles(
+         "/funspec.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      // Line 6 is the spec class declaration — a valid spec-level context
+      val psiElement = psiFiles[0].elementAtLine(6) ?: error("Could not find PSI element at line 6")
+      val context = ConfigurationContext.createEmptyContextForLocation(
+         PsiLocation(project, myFixture.module, psiElement)
+      )
+
+      val producer = TestableProducer()
+      val configuration = producer.configurationFactory.createTemplateConfiguration(project) as GradleRunConfiguration
+      val ref = Ref.create<PsiElement?>(psiElement)
+
+      val result = producer.callDoSetup(configuration, context, ref)
+
+      result shouldBe true
+      configuration.settings.env["KOTEST_IDEA_PLUGIN"] shouldBe "true"
+   }
+
+   /**
+    * Verifies the flag is also present when the context is an individual test (line 22).
+    */
+   fun testSetsKotestIdeaPluginEnvVarForIndividualTest() {
+      setupGradleTestTaskMode()
+
+      val psiFiles = myFixture.configureByFiles(
+         "/funspec.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      // Line 22 is `test("a nested test")` — an individual test context
+      val psiElement = psiFiles[0].elementAtLine(22) ?: error("Could not find PSI element at line 22")
+      val context = ConfigurationContext.createEmptyContextForLocation(
+         PsiLocation(project, myFixture.module, psiElement)
+      )
+
+      val producer = TestableProducer()
+      val configuration = producer.configurationFactory.createTemplateConfiguration(project) as GradleRunConfiguration
+      val ref = Ref.create<PsiElement?>(psiElement)
+
+      val result = producer.callDoSetup(configuration, context, ref)
+
+      result shouldBe true
+      configuration.settings.env["KOTEST_IDEA_PLUGIN"] shouldBe "true"
+   }
+
+   /**
+    * Configures the test fixture so that [io.kotest.plugin.intellij.run.RunnerModes.mode] returns
+    * [io.kotest.plugin.intellij.run.RunnerMode.GRADLE_TEST_TASK].
+    *
+    * Requires:
+    * - A module-level library named `kotest-framework-engine-jvm` (hasKotestEngine = true)
+    * - A project-level versioned library ≥ 6.1.x (isKotest61OrAbove = true)
+    * - A linked Gradle project with TestRunner.GRADLE (isGradleTestRunner = true)
+    */
+   private fun setupGradleTestTaskMode() {
+      ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
+         if (model.moduleLibraryTable.getLibraryByName("kotest-framework-engine-jvm") == null) {
+            model.moduleLibraryTable.createLibrary("kotest-framework-engine-jvm")
+         }
+      }
+      WriteAction.runAndWait<Exception> {
+         val libName = "io.kotest:kotest-framework-engine-jvm:6.1.3"
+         val libraryTable = LibraryTablesRegistrar.getInstance().getLibraryTable(project)
+         if (libraryTable.getLibraryByName(libName) == null) {
+            libraryTable.createLibrary(libName)
+         }
+
+         val projectPath = project.basePath ?: error("project.basePath is null")
+         ExternalSystemModulePropertyManager.getInstance(myFixture.module).setLinkedProjectPath(projectPath)
+         val gradleSettings = GradleSettings.getInstance(project)
+         if (gradleSettings.getLinkedProjectSettings(projectPath) == null) {
+            val settings = GradleProjectSettings()
+            settings.externalProjectPath = projectPath
+            settings.testRunner = TestRunner.GRADLE
+            gradleSettings.linkProject(settings)
+         }
+      }
+   }
+}

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducerTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducerTest.kt
@@ -27,15 +27,23 @@ class GradleMultiplatformJvmTestTaskRunProducerTest : BasePlatformTestCase() {
       Paths.get("./src/test/resources/").toAbsolutePath().toString()
 
    /**
-    * Thin subclass that makes [doSetupConfigurationFromContext] callable from tests.
-    * The method is `protected` in the base class; a subclass can widen it to public.
+    * Calls the protected [GradleMultiplatformJvmTestTaskRunProducer.doSetupConfigurationFromContext]
+    * via reflection so that the class need not be made `open` just for testing.
     */
-   private class TestableProducer : GradleMultiplatformJvmTestTaskRunProducer() {
-      fun callDoSetup(
-         configuration: GradleRunConfiguration,
-         context: ConfigurationContext,
-         ref: Ref<PsiElement?>
-      ): Boolean = doSetupConfigurationFromContext(configuration, context, ref)
+   private fun callDoSetup(
+      producer: GradleMultiplatformJvmTestTaskRunProducer,
+      configuration: GradleRunConfiguration,
+      context: ConfigurationContext,
+      ref: Ref<PsiElement?>
+   ): Boolean {
+      val method = GradleMultiplatformJvmTestTaskRunProducer::class.java.getDeclaredMethod(
+         "doSetupConfigurationFromContext",
+         GradleRunConfiguration::class.java,
+         ConfigurationContext::class.java,
+         Ref::class.java
+      )
+      method.isAccessible = true
+      return method.invoke(producer, configuration, context, ref) as Boolean
    }
 
    /**
@@ -57,11 +65,11 @@ class GradleMultiplatformJvmTestTaskRunProducerTest : BasePlatformTestCase() {
          PsiLocation(project, myFixture.module, psiElement)
       )
 
-      val producer = TestableProducer()
+      val producer = GradleMultiplatformJvmTestTaskRunProducer()
       val configuration = producer.configurationFactory.createTemplateConfiguration(project) as GradleRunConfiguration
       val ref = Ref.create<PsiElement?>(psiElement)
 
-      val result = producer.callDoSetup(configuration, context, ref)
+      val result = callDoSetup(producer, configuration, context, ref)
 
       result shouldBe true
       configuration.settings.env["KOTEST_IDEA_PLUGIN"] shouldBe "true"
@@ -84,11 +92,11 @@ class GradleMultiplatformJvmTestTaskRunProducerTest : BasePlatformTestCase() {
          PsiLocation(project, myFixture.module, psiElement)
       )
 
-      val producer = TestableProducer()
+      val producer = GradleMultiplatformJvmTestTaskRunProducer()
       val configuration = producer.configurationFactory.createTemplateConfiguration(project) as GradleRunConfiguration
       val ref = Ref.create<PsiElement?>(psiElement)
 
-      val result = producer.callDoSetup(configuration, context, ref)
+      val result = callDoSetup(producer, configuration, context, ref)
 
       result shouldBe true
       configuration.settings.env["KOTEST_IDEA_PLUGIN"] shouldBe "true"


### PR DESCRIPTION
## Summary

Adds a `KOTEST_IDEA_PLUGIN=true` signal to run configurations created by the plugin so the Kotest engine can detect it is being launched from IntelliJ.

- **`GradleMultiplatformJvmTestTaskRunProducer`** — sets `KOTEST_IDEA_PLUGIN=true` in `configuration.settings.env`. This becomes an environment variable on the JVM that runs the tests.

- **`AndroidInstrumentedTestRunConfigurationProducer`** — appends `-e KOTEST_IDEA_PLUGIN true` to `EXTRA_OPTIONS`. The instrumented test process can read it via `InstrumentationRegistry.getArguments().getString("KOTEST_IDEA_PLUGIN")`.

## Test plan

- [x] `GradleMultiplatformJvmTestTaskRunProducerTest` — new test class with a `TestableProducer` subclass (to expose the protected `doSetupConfigurationFromContext`) verifying `configuration.settings.env["KOTEST_IDEA_PLUGIN"] == "true"` for both spec-level and test-level contexts.
- [x] `AndroidInstrumentedTestRunConfigurationProducerTest` — two new focused tests (`testPluginFlagIsSetForSpecLevelRun`, `testPluginFlagIsSetForTestLevelRun`) verifying `-e KOTEST_IDEA_PLUGIN true` is present in `EXTRA_OPTIONS`; two existing assertions updated to include the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)