### PR TITLE
Fix JS engine mocha race: single channel send in engineFinished

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TestEngineListener.kt
@@ -38,7 +38,7 @@ interface TestEngineListener {
    /**
     * Is invoked when the [TestEngine] has finished execution of all tests.
     *
-    * If any unexpected errors were detected during execution then they will be
+    * If any unexpected errors were detected during execution, then they will be
     * passed to this method.
     */
    suspend fun engineFinished(t: List<Throwable>)

--- a/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListener.kt
@@ -42,8 +42,8 @@ internal class JsTestFrameworkTestEngineListener(
       // we have to launch the engine inside a test and return a promise, so mocha will wait for the engine to finish
       // otherwise our engine is running in a coroutine and mocha will have exited before we start emitting tests
       // The downside is that we get an extra node in the output (todo, perhaps the IDE plugin can hide this?)
-      kotlinJsTestFramework.suite("Kotest", false) {
-         kotlinJsTestFramework.test("Executor", false) {
+      framework.suite("Kotest", false) {
+         framework.test("Executor", false) {
             promise {
                channel.receive() // will suspend this placeholder test until all tests have completed
             }

--- a/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListener.kt
@@ -45,7 +45,7 @@ internal class JsTestFrameworkTestEngineListener(
       kotlinJsTestFramework.suite("Kotest", false) {
          kotlinJsTestFramework.test("Executor", false) {
             promise {
-               channel.receive() // will suspend this placeholder test until the first real test releases us
+               channel.receive() // will suspend this placeholder test until all tests have completed
             }
          }
       }

--- a/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsHostedMain/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListener.kt
@@ -1,6 +1,7 @@
 package io.kotest.engine.js
 
 import io.kotest.common.reflection.bestName
+import io.kotest.core.Logger
 import io.kotest.core.descriptors.DescriptorId
 import io.kotest.core.descriptors.DescriptorPaths
 import io.kotest.core.spec.SpecRef
@@ -26,20 +27,25 @@ internal class JsTestFrameworkTestEngineListener(
       const val SPEC_DELIMITER = "/"
    }
 
+   private val logger = Logger<JsTestFrameworkTestEngineListener>()
+
+   // hold up mocha from exiting before our tests are registered
+   // also note that we must only have one receive/send, we can't release specs as they complete like we did in 6.1.8
+   // because they run as macrotasks vs. microtasks which break's mochas suite scanning code (it will advance to the
+   // next suite, on a delay inside a test, but the next suite isn't registered yet, so it disappears)
+   private val channel = Channel<Unit>(1)
+
    // a multimap of completed tests for a given spec
    private val proxies = mutableMapOf<DescriptorId, MutableList<TestProxy>>()
-
-   // hold up mocha from exiting until a real test is registered
-   private val channel = Channel<Unit>(1)
 
    override suspend fun engineStarted() {
       // we have to launch the engine inside a test and return a promise, so mocha will wait for the engine to finish
       // otherwise our engine is running in a coroutine and mocha will have exited before we start emitting tests
       // The downside is that we get an extra node in the output (todo, perhaps the IDE plugin can hide this?)
-      framework.suite("Kotest Engine", false) {
-         framework.test("Executor", false) {
+      kotlinJsTestFramework.suite("Kotest", false) {
+         kotlinJsTestFramework.test("Executor", false) {
             promise {
-               channel.receive() // will suspend this anchor test until the first real test is registered
+               channel.receive() // will suspend this placeholder test until the first real test releases us
             }
          }
       }
@@ -48,7 +54,8 @@ internal class JsTestFrameworkTestEngineListener(
    override suspend fun engineInitialized(context: TestEngineInitializedContext) {}
 
    override suspend fun engineFinished(t: List<Throwable>) {
-      // close out the final test
+      // now we can release the mocha anchor test, and mocha will run all the registered describes
+      logger.log { "Releasing mocha anchor test" }
       channel.send(Unit)
    }
 
@@ -62,7 +69,6 @@ internal class JsTestFrameworkTestEngineListener(
    }
 
    override suspend fun specFinished(ref: SpecRef, result: TestResult) {
-
       // if this spec had no tests, we just skip it
       val tests = proxies[ref.descriptor().id] ?: return
 
@@ -70,8 +76,9 @@ internal class JsTestFrameworkTestEngineListener(
       // All tests are output at a single level as the kotlin.test apparatus doesn't support nested tests.
       // (If we try to use nested output, then every suite goes to the top level rather than properly nesting.)
 
+      logger.log { "Emitting tests for spec ${ref.fqn}" }
       framework.suite(ref.fqn, false) {
-         tests.forEachIndexed { index, proxy ->
+         tests.forEach { proxy ->
 
             // we have to escape the actual test name (but not the FQN) to remove any periods.
             // if the test name contains the FQN, then only the substring after the FQN is displayed,
@@ -80,22 +87,15 @@ internal class JsTestFrameworkTestEngineListener(
             // remove fqn plus the spec delimiter
             val escapedName = testNameEscape(proxy.name.removePrefix(ref.fqn).removePrefix(SPEC_DELIMITER))
 
+            logger.log { "Emitting test ${ref.fqn} $escapedName" }
             framework.test(escapedName, proxy.result.isIgnored) {
                promise {
-
-                  // this promise will wait until we are released so that mocha sticks around
-                  // we only need one receive call per spec
-                  if (index == 0) channel.receive()
-
                   // just returning without an error is enough to mark as success in jasmine style frameworks
                   proxy.result.errorOrNull?.let { throw it }
                }
             }
          }
       }
-
-      // now that this spec is queued up at mocha, we can release the previous one
-      channel.send(Unit)
 
       // remove the proxies for this spec as we don't need them anymore
       proxies.remove(ref.descriptor().id)
@@ -120,7 +120,7 @@ internal class JsTestFrameworkTestEngineListener(
       proxies[testCase.descriptor.spec().id]?.find { it.name == path }?.result = result
    }
 
-   // since the kotlin.test apparatus doesn't like nested JS tests, we flatten using >> to indicate nesting
+   // since the kotlin.test apparatus doesn't like nested JS tests, we flatten
    private fun renderTestPath(testCase: TestCase): String =
       DescriptorPaths.render(testCase.descriptor, SPEC_DELIMITER, TEST_DELIMITER).value
 }

--- a/kotest-framework/kotest-framework-engine/src/jsTest/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsTest/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListenerTest.kt
@@ -72,12 +72,12 @@ class JsTestFrameworkTestEngineListenerTest : FunSpec({
 
    context("engineStarted") {
 
-      test("registers an anchor suite named 'Kotest Engine'") {
+      test("registers an anchor suite named 'Kotest'") {
          val fw = RecordingFramework()
          val listener = JsTestFrameworkTestEngineListener(fw)
          listener.engineStarted()
          fw.suites.size shouldBe 1
-         fw.suites[0].name shouldBe "Kotest Engine"
+         fw.suites[0].name shouldBe "Kotest"
          fw.suites[0].ignored shouldBe false
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jsTest/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jsTest/kotlin/io/kotest/engine/js/JsTestFrameworkTestEngineListenerTest.kt
@@ -270,4 +270,59 @@ class JsTestFrameworkTestEngineListenerTest : FunSpec({
          fw.suites[0].tests[0].ignored shouldBe true
       }
    }
+
+   context("engineFinished") {
+
+      test("spec suite is registered with the framework during specFinished, not deferred to engineFinished") {
+         // Regression guard: suites must be registered in specFinished so that all framework.suite() calls
+         // happen before channel.send(Unit) in engineFinished. If registration were deferred to
+         // engineFinished, mocha would have already advanced past the executor before suites exist.
+         val fw = RecordingFramework()
+         val listener = JsTestFrameworkTestEngineListener(fw)
+
+         val ref = specRef("com.example.MySpec")
+         listener.specStarted(ref)
+         val tc = rootTestCase("com.example.MySpec", "a test")
+         listener.testStarted(tc)
+         listener.testFinished(tc, TestResultBuilder.builder().build())
+         listener.specFinished(ref, TestResultBuilder.builder().build())
+
+         // suite must be visible before engineFinished is called
+         fw.suites.size shouldBe 1
+         fw.suites[0].name shouldBe "com.example.MySpec"
+
+         listener.engineFinished(emptyList())
+
+         // engineFinished only releases the channel — it must not register any additional suites
+         fw.suites.size shouldBe 1
+      }
+
+      test("all spec suites from multiple specs are registered before engineFinished is called") {
+         // Regression guard: with multiple specs each suite must be visible after its own specFinished,
+         // long before engineFinished sends the channel. A per-spec channel send (the pre-fix behaviour)
+         // would release mocha before the remaining specs are registered.
+         val fw = RecordingFramework()
+         val listener = JsTestFrameworkTestEngineListener(fw)
+
+         listOf("com.example.Spec1", "com.example.Spec2", "com.example.Spec3").forEach { fqn ->
+            val ref = specRef(fqn)
+            listener.specStarted(ref)
+            val tc = rootTestCase(fqn, "a test")
+            listener.testStarted(tc)
+            listener.testFinished(tc, TestResultBuilder.builder().build())
+            listener.specFinished(ref, TestResultBuilder.builder().build())
+         }
+
+         // all three spec suites are registered before engineFinished is called
+         fw.suites.size shouldBe 3
+         fw.suites[0].name shouldBe "com.example.Spec1"
+         fw.suites[1].name shouldBe "com.example.Spec2"
+         fw.suites[2].name shouldBe "com.example.Spec3"
+
+         listener.engineFinished(emptyList())
+
+         // engineFinished must not register any new suites
+         fw.suites.size shouldBe 3
+      }
+   }
 })


### PR DESCRIPTION
## Summary

- Removes the per-spec `channel.receive()/send()` pattern from `specFinished` that was present in 6.1.8
- The channel is now sent exactly once, in `engineFinished`, after all specs have registered their suites with the JS test framework
- This eliminates the mocha race condition where a delayed spec (e.g. a test with `delay(Nms)`) would be registered as a macrotask after mocha had already advanced past its slot in `root.suites`
- Adds a regression test suite (`engineFinished` context in `JsTestFrameworkTestEngineListenerTest`) that verifies suites are registered in `specFinished` and that `engineFinished` adds no new suites

## Root cause

Mocha's `runSuite` uses a closure variable `i` and reads `suite.suites[i++]` live on each `next()` call. When specs with async delays were running, the suite for a given spec was being registered via a macrotask callback, which could fire *after* mocha had already read (and found empty) that index in `root.suites`. The channel mechanism prevents mocha from advancing past the Executor test until `channel.send(Unit)` fires — but only if that send happens after all suites are registered.

## Test plan

- [x] Existing `JsTestFrameworkTestEngineListenerTest` tests pass
- [x] New `engineFinished` context tests pass: "spec suite is registered during specFinished" and "all spec suites from multiple specs are registered before engineFinished"
- [x] JS tests with `delay()` calls in specs run correctly under mocha (no missing suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)