### PR TITLE
Update shouldContainInOrder to find best matches

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -20,6 +20,9 @@ public final class io/kotest/assertions/AssertionsConfig {
 	public final fun getMaxCollectionPrintSize ()Lio/kotest/assertions/EnvironmentConfigValue;
 	public final fun getMaxErrorsOutput ()I
 	public final fun getMaxSimilarityPrintSize ()Lio/kotest/assertions/EnvironmentConfigValue;
+	public final fun getMaxSubstringCount ()Lio/kotest/assertions/EnvironmentConfigValue;
+	public final fun getMaxSubstringSearchDurationInMs ()Lio/kotest/assertions/EnvironmentConfigValue;
+	public final fun getMaxSubstringSize ()Lio/kotest/assertions/EnvironmentConfigValue;
 	public final fun getMaxSubtringSubmatchingSize ()Lio/kotest/assertions/EnvironmentConfigValue;
 	public final fun getMaxValueSubmatchingSize ()Lio/kotest/assertions/EnvironmentConfigValue;
 	public final fun getMinSubtringSubmatchingSize ()Lio/kotest/assertions/EnvironmentConfigValue;
@@ -3468,6 +3471,42 @@ public final class io/kotest/matchers/stats/MatchersKt {
 	public static final fun shouldNotHaveVariance (Ljava/util/Collection;Ljava/math/BigDecimal;I)V
 	public static synthetic fun shouldNotHaveVariance$default (Ljava/util/Collection;DIILjava/lang/Object;)V
 	public static synthetic fun shouldNotHaveVariance$default (Ljava/util/Collection;Ljava/math/BigDecimal;IILjava/lang/Object;)V
+}
+
+public abstract interface class io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome {
+}
+
+public final class io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Ineligible : io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Ineligible;
+	public static synthetic fun copy$default (Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Ineligible;Ljava/lang/String;ILjava/lang/Object;)Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Ineligible;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Match : io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome {
+	public static final field INSTANCE Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Match;
+}
+
+public final class io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Mismatch : io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Mismatch;
+	public static synthetic fun copy$default (Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Mismatch;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$Mismatch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBestFitIndexes ()Ljava/util/List;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getIndexesOfMatches ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$TimedOut : io/kotest/matchers/string/BestFitForSubstringsInOrderOutcome {
+	public static final field INSTANCE Lio/kotest/matchers/string/BestFitForSubstringsInOrderOutcome$TimedOut;
 }
 
 public final class io/kotest/matchers/string/CaseKt {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/AssertionsConfig.kt
@@ -62,6 +62,15 @@ object AssertionsConfig {
    val enabledSubmatchesInStrings: EnvironmentConfigValue<Boolean> =
       EnvironmentConfigValue("kotest.assertions.string.submatching.enabled", true, String::toBoolean)
 
+   val maxSubstringCount: EnvironmentConfigValue<Int> =
+      EnvironmentConfigValue("kotest.assertions.string.substring.max.count", 64, String::toInt)
+
+   val maxSubstringSize: EnvironmentConfigValue<Int> =
+      EnvironmentConfigValue("kotest.assertions.string.substring.max.size", 128, String::toInt)
+
+      val maxSubstringSearchDurationInMs: EnvironmentConfigValue<Long> =
+      EnvironmentConfigValue("kotest.assertions.string.substring.max.durationInMs", 1000L, String::toLong)
+
 }
 
 class EnvironmentConfigValue<T>(

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/Utils.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/Utils.kt
@@ -1,0 +1,69 @@
+package io.kotest.matchers.string
+
+import io.kotest.assertions.print.print
+
+internal expect fun describeBestFitForSubstringsInOrder(
+   value: String,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+) : BestFitForSubstringsInOrderOutcome
+
+sealed interface BestFitForSubstringsInOrderOutcome {
+   object Match : BestFitForSubstringsInOrderOutcome
+   data class Mismatch(
+      val bestFitIndexes: List<Int>,
+      val indexesOfMatches: List<List<Int>>,
+      ) : BestFitForSubstringsInOrderOutcome {
+      val description: String = run {
+         if(bestFitIndexes.isEmpty()) {
+            "No matches found."
+         } else {
+            val bestFitDescriptionElements = (0 until indexesOfMatches.size).map { index ->
+               if(index in bestFitIndexes) {
+                  index.toString()
+               } else {
+                  "-"
+               }
+            }
+            val bestFitDescription = "The best fit is the subset with the following indexes: ${bestFitDescriptionElements.print().value.replace("\"", "")}."
+
+            val mismatchesDescription = (0 until indexesOfMatches.size).asSequence()
+               .filter { it !in bestFitIndexes }
+               .map { index ->
+                  if(indexesOfMatches[index].isEmpty()) {
+                     "Element[$index] not found"
+                  } else {
+                     "Element[$index] found at index(es): ${indexesOfMatches[index].print().value}"
+                  }
+               }.toList()
+
+            (listOf(bestFitDescription)+mismatchesDescription).joinToString( "\n" )
+         }
+      }
+   }
+   data class Ineligible(val reason: String) : BestFitForSubstringsInOrderOutcome
+   object TimedOut : BestFitForSubstringsInOrderOutcome
+}
+
+
+
+//TODO: import this function from common module when that PR is merged
+
+internal fun powerSetIndexes(size: Int): Sequence<List<Int>> = sequence {
+   require(size > 0) { "Size should be positive, was: $size"}
+   val elementsIncluded = MutableList(size) { true }
+   val allIndexes = (0 until size).toList()
+   yield(allIndexes)
+   while(elementsIncluded.any { it }) {
+      for (index in 0 until size) {
+         if (elementsIncluded[index]) {
+            elementsIncluded[index] = false
+            yield(allIndexes.filterIndexed { i, _ -> elementsIncluded[i] })
+            break
+         } else {
+            elementsIncluded[index] = true
+         }
+      }
+   }
+}
+

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.submatching.describePartialMatchesInStringForSlice
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.MatcherResultBuilder
+import io.kotest.matchers.NeverNullMatcher
 import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
@@ -187,34 +188,58 @@ internal fun interface MatchOffset {
 fun containInOrder(vararg substrings: String) = containSubstringsInOrder({ 1 }, *substrings)
 
 internal fun containSubstringsInOrder(matchOffset: MatchOffset, vararg substrings: String) = neverNullMatcher<String> { value ->
-   val matchOutcome = matchSubstrings(
-      value,
-      substrings.toList(),
-      depth = 0,
+   val detailedMatchResult: MatcherResult? = when (val outcome = describeBestFitForSubstringsInOrder(
+      value = value,
+      substrings = substrings.toList(),
       matchOffset = matchOffset,
+   )) {
+      is BestFitForSubstringsInOrderOutcome.Ineligible -> null
+      is BestFitForSubstringsInOrderOutcome.TimedOut -> null
+      else ->
+         MatcherResult(
+            passed = outcome is BestFitForSubstringsInOrderOutcome.Match,
+            failureMessageFn = {
+               "${value.print().value} should include substrings ${substrings.print().value} in order${
+                  prefixIfNotEmpty(
+                     (outcome as? BestFitForSubstringsInOrderOutcome.Mismatch)?.description ?: "",
+                     "\n"
+                  )
+               }"
+            },
+            negatedFailureMessageFn = { "${value.print().value} should not include substrings ${substrings.print().value} in order" }
+         )
+   }
+
+   detailedMatchResult ?: run {
+      val matchOutcome = matchSubstrings(
+         value,
+         substrings.toList(),
+         depth = 0,
+         matchOffset = matchOffset,
       )
 
-   val substringFoundEarlier = if (matchOutcome is ContainInOrderOutcome.Mismatch) {
-      describePartialMatchesInStringForSlice(matchOutcome.substring, value).toString()
-   } else ""
+      val substringFoundEarlier = if (matchOutcome is ContainInOrderOutcome.Mismatch) {
+         describePartialMatchesInStringForSlice(matchOutcome.substring, value).toString()
+      } else ""
 
-   val completeMismatchDescription = joinNonEmpty(
-      "\n",
-      matchOutcome.mistmatchDescription,
-      substringFoundEarlier
-   )
+      val completeMismatchDescription = joinNonEmpty(
+         "\n",
+         matchOutcome.mistmatchDescription,
+         substringFoundEarlier
+      )
 
-   MatcherResult(
-      matchOutcome.match,
-      {
-         "${value.print().value} should include substrings ${substrings.print().value} in order${
-            prefixIfNotEmpty(
-               completeMismatchDescription,
-               "\n"
-            )
-         }"
-      },
-      { "${value.print().value} should not include substrings ${substrings.print().value} in order" })
+      MatcherResult(
+         matchOutcome.match,
+         {
+            "${value.print().value} should include substrings ${substrings.print().value} in order${
+               prefixIfNotEmpty(
+                  completeMismatchDescription,
+                  "\n"
+               )
+            }"
+         },
+         { "${value.print().value} should not include substrings ${substrings.print().value} in order" })
+   }
 }
 
 internal fun prefixIfNotEmpty(value: String, prefix: String) = if (value.isEmpty()) "" else "$prefix$value"

--- a/kotest-assertions/kotest-assertions-core/src/jsMain/kotlin/io/kotest/matchers/string/JsUtils.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jsMain/kotlin/io/kotest/matchers/string/JsUtils.kt
@@ -1,7 +1,0 @@
-package io.kotest.matchers.string
-
-internal actual fun describeBestFitForSubstringsInOrder(
-   value: String,
-   substrings: List<String>,
-   matchOffset: MatchOffset,
-) : BestFitForSubstringsInOrderOutcome = BestFitForSubstringsInOrderOutcome.Ineligible("JVM only")

--- a/kotest-assertions/kotest-assertions-core/src/jsMain/kotlin/io/kotest/matchers/string/JsUtils.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jsMain/kotlin/io/kotest/matchers/string/JsUtils.kt
@@ -1,0 +1,7 @@
+package io.kotest.matchers.string
+
+internal actual fun describeBestFitForSubstringsInOrder(
+   value: String,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+) : BestFitForSubstringsInOrderOutcome = BestFitForSubstringsInOrderOutcome.Ineligible("JVM only")

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/string/JvmUtils.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/string/JvmUtils.kt
@@ -1,0 +1,112 @@
+package io.kotest.matchers.string
+
+import io.kotest.assertions.AssertionsConfig
+import io.kotest.common.withNonVirtualTimeout
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.runBlocking
+
+internal actual fun describeBestFitForSubstringsInOrder(
+   value: String,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+) : BestFitForSubstringsInOrderOutcome = when {
+   value.length > AssertionsConfig.maxValueSubmatchingSize.value ->
+      BestFitForSubstringsInOrderOutcome.Ineligible("value length (${value.length}) exceeds maximum allowed (${AssertionsConfig.maxValueSubmatchingSize.value})")
+   substrings.isEmpty() ->
+      BestFitForSubstringsInOrderOutcome.Ineligible("substring is empty")
+   substrings.any { it.isEmpty() } ->
+      BestFitForSubstringsInOrderOutcome.Ineligible("at least one substring is empty")
+   substrings.size > AssertionsConfig.maxSubstringCount.value ->
+      BestFitForSubstringsInOrderOutcome.Ineligible("substring count (${substrings.size}) exceeds maximum allowed (${AssertionsConfig.maxSubstringCount.value})")
+   substrings.any { it.length > AssertionsConfig.maxSubstringSize.value } ->
+      BestFitForSubstringsInOrderOutcome.Ineligible("at least one substring length exceeds maximum allowed (${AssertionsConfig.maxSubstringSize.value})")
+   else -> {
+      val bestFitSearchOutcome = try {
+         findBestFitForSubstringsInOrder(
+            value,
+            substrings,
+            matchOffset,
+            )
+      } catch (_: CancellationException) {
+         return BestFitForSubstringsInOrderOutcome.TimedOut
+      }
+      if (bestFitSearchOutcome.bestFitIndexes == substrings.indices.toList() )
+         BestFitForSubstringsInOrderOutcome.Match
+      else
+         BestFitForSubstringsInOrderOutcome.Mismatch(
+            bestFitSearchOutcome.bestFitIndexes,
+            bestFitSearchOutcome.indexesOfMatches,
+            )
+   }
+}
+
+internal data class BestFitSearchOutcome(
+   val bestFitIndexes: List<Int>,
+   val indexesOfMatches: List<List<Int>>,
+)
+
+internal fun findBestFitForSubstringsInOrder(
+   value: String,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+) : BestFitSearchOutcome {
+   return runBlocking {
+      withNonVirtualTimeout(AssertionsConfig.maxSubstringSearchDurationInMs.value.milliseconds) {
+         val indexesOfMatches = allIndexesOfSubstrings(
+            value,
+            substrings,
+            matchOffset,
+            )
+         val bestFitIndexes = (powerSetIndexes(substrings.size)
+            .firstOrNull { subset ->
+               subsetFitsInOrder(
+                  indexesOfMatches,
+                  subset,
+                  substrings,
+                  matchOffset,
+               )
+            }
+            ?: emptyList())
+         return@withNonVirtualTimeout BestFitSearchOutcome(bestFitIndexes, indexesOfMatches)
+      }
+   }
+}
+
+internal fun allIndexesOfSubstrings(
+   value: String,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+   ) =
+   substrings.map { substring -> allIndexesOf(
+      value,
+      substring,
+      ) }
+
+internal fun allIndexesOf(
+   value: String,
+   substring: String,
+   ): List<Int> {
+   val indexes = mutableListOf<Int>()
+   var index = value.indexOf(substring)
+   while (index >= 0 && indexes.size < 100) {
+      indexes.add(index)
+      index = value.indexOf(substring, index + 1)
+   }
+   return indexes
+}
+
+internal fun subsetFitsInOrder(
+   indexesOfMatches: List<List<Int>>,
+   subset: List<Int>,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+   ) : Boolean {
+   var nextIndex = -1
+   (0 until subset.size).forEach { i ->
+      val nextIndexes = indexesOfMatches[subset[i]]
+      val nextIndexInSubset = nextIndexes.firstOrNull { it >= nextIndex } ?: return false
+      nextIndex = nextIndexInSubset + matchOffset(substrings[subset[i]])
+   }
+   return true
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/AllIndexesOfSubstringsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/AllIndexesOfSubstringsTest.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.kotest.matchers.string
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.allIndexesOfSubstrings
+
+class AllIndexesOfSubstringsTest : StringSpec() {
+   init {
+       "works for one substring" {
+          allIndexesOfSubstrings("no pain no gain", listOf("no"), { 1 }) shouldBe listOf(listOf(0, 8))
+       }
+      "works for multiple substrings, all found" {
+         allIndexesOfSubstrings("no pain no gain", listOf("no", "ain"), { 1 }) shouldBe listOf(
+            listOf(0, 8),
+            listOf(4, 12),
+            )
+       }
+      "works for multiple substrings, some not found" {
+         allIndexesOfSubstrings("no pain no gain", listOf("no", "main"), { 1 }) shouldBe listOf(
+            listOf(0, 8),
+            listOf(),
+         )
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/AllIndexesOfTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/AllIndexesOfTest.kt
@@ -1,0 +1,22 @@
+package com.sksamuel.kotest.matchers.string
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.allIndexesOf
+
+class AllIndexesOfTest : StringSpec() {
+   init {
+       "find two occurrences, first at the start" {
+          allIndexesOf("no pain no gain", "no") shouldBe listOf(0, 8)
+       }
+      "find two occurrences, both in the middle" {
+         allIndexesOf("no pain no gain!", "ai") shouldBe listOf(4, 12)
+      }
+      "find two occurrences, second at the end" {
+         allIndexesOf("no pain no gain", "ain") shouldBe listOf(4, 12)
+      }
+      "find none" {
+         allIndexesOf("no pain no gain", "bad") shouldBe emptyList()
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/BestFitForSubstringsInOrderOutcomeTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/BestFitForSubstringsInOrderOutcomeTest.kt
@@ -1,0 +1,47 @@
+package com.sksamuel.kotest.matchers.string
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.BestFitForSubstringsInOrderOutcome
+import io.kotest.matchers.string.shouldContain
+
+class BestFitForSubstringsInOrderOutcomeTest : StringSpec() {
+   init {
+       "no matches found" {
+          BestFitForSubstringsInOrderOutcome.Mismatch(
+             bestFitIndexes = listOf(),
+             indexesOfMatches = listOf(),
+          ).description shouldBe "No matches found."
+       }
+      "found best fit, some elements not matched" {
+         val actual = BestFitForSubstringsInOrderOutcome.Mismatch(
+            bestFitIndexes = listOf(0, 2, 4),
+            indexesOfMatches = listOf(
+               listOf(0),
+               listOf(),
+               listOf(3),
+               listOf(),
+               listOf(5),
+            ),
+         ).description
+         actual shouldContain "The best fit is the subset with the following indexes: [0, -, 2, -, 4]."
+         actual shouldContain "Element[1] not found"
+         actual shouldContain "Element[3] not found"
+      }
+      "found best fit, some elements matched out of order" {
+         val actual = BestFitForSubstringsInOrderOutcome.Mismatch(
+            bestFitIndexes = listOf(0, 2, 4),
+            indexesOfMatches = listOf(
+               listOf(0),
+               listOf(),
+               listOf(3),
+               listOf(1),
+               listOf(5),
+            ),
+         ).description
+         actual shouldContain "The best fit is the subset with the following indexes: [0, -, 2, -, 4]."
+         actual shouldContain "Element[1] not found"
+         actual shouldContain "Element[3] found at index(es): [1]"
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderMatcherTest.kt
@@ -54,11 +54,13 @@ class ContainInOrderMatcherTest : FreeSpec() {
          }
 
          "should output first mismatch" {
-            shouldThrowAny {
+            val message = shouldThrowAny {
                "The quick brown fox jumps over the lazy dog".shouldContainInOrder(
                   "The", "quick", "red", "fox", "jumps", "over", "the", "lazy", "dog"
                )
-            }.message.shouldContain("""Did not match substring[2]: <"red">""")
+            }.message
+            message.shouldContain("""The best fit is the subset with the following indexes: [0, 1, -, 3, 4, 5, 6, 7, 8]""")
+            message.shouldContain("Element[2] not found")
          }
 
          "should pass for overlapping substrings when second one occurs later" {
@@ -76,10 +78,12 @@ class ContainInOrderMatcherTest : FreeSpec() {
                )
             }.message
             assertSoftly {
-               message.shouldContain("""Did not match substring[6]: <"quick brown">""")
-               message.shouldContain("Match[0]: whole slice matched actual[4..14]")
-               message.shouldContain("""Line[0] ="The quick brown fox jumps over the lazy dog"""")
-               message.shouldContain(  "Match[0]= ----+++++++++++----------------------------")
+               message.shouldContain("""The best fit is the subset with the following indexes: [0, -, -, -, -, -, 6, 7, 8]""")
+               message.shouldContain("Element[1] found at index(es): [10]")
+               message.shouldContain("Element[2] found at index(es): [16]")
+               message.shouldContain("Element[3] found at index(es): [20]")
+               message.shouldContain("Element[4] found at index(es): [26]")
+               message.shouldContain("Element[5] found at index(es): [31]")
             }
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderWithoutOverlapsMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainInOrderWithoutOverlapsMatcherTest.kt
@@ -34,11 +34,13 @@ class containInOrderWithoutOverlapsMatcherTest : FreeSpec() {
          }
 
          "should output first mismatch" {
-            shouldThrowAny {
+            val message = shouldThrowAny {
                "The quick brown fox jumps over the lazy dog".shouldContainInOrderWithoutOverlaps(
                   "The", "quick", "red", "fox", "jumps", "over", "the", "lazy", "dog"
                )
-            }.message.shouldContain("""Did not match substring[2]: <"red">""")
+            }.message
+            message.shouldContain("""The best fit is the subset with the following indexes: [0, 1, -, 3, 4, 5, 6, 7, 8]""")
+            message.shouldContain("Element[2] not found")
          }
 
          "should fail for overlapping substrings" {
@@ -53,10 +55,12 @@ class containInOrderWithoutOverlapsMatcherTest : FreeSpec() {
                )
             }.message
             assertSoftly {
-               message.shouldContain("""Did not match substring[6]: <"quick brown">""")
-               message.shouldContain("Match[0]: whole slice matched actual[4..14]")
-               message.shouldContain("""Line[0] ="The quick brown fox jumps over the lazy dog"""")
-               message.shouldContain(  "Match[0]= ----+++++++++++----------------------------")
+               message.shouldContain("""The best fit is the subset with the following indexes: [0, -, -, -, -, -, 6, 7, 8]""")
+               message.shouldContain("Element[1] found at index(es): [10]")
+               message.shouldContain("Element[2] found at index(es): [16]")
+               message.shouldContain("Element[3] found at index(es): [20]")
+               message.shouldContain("Element[4] found at index(es): [26]")
+               message.shouldContain("Element[5] found at index(es): [31]")
             }
          }
       }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/DescribeBestFitForSubstringsInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/DescribeBestFitForSubstringsInOrderTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.matchers.string
+
+import io.kotest.assertions.AssertionsConfig
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.BestFitForSubstringsInOrderOutcome
+import io.kotest.matchers.string.describeBestFitForSubstringsInOrder
+import io.kotest.matchers.types.shouldBeInstanceOf
+
+class DescribeBestFitForSubstringsInOrderTest : StringSpec()
+{
+   init {
+      "return Match when all substrings are found in order" {
+         val value = "no pain no gain"
+         val substrings = listOf("pain", "no", "gain")
+         val outcome = describeBestFitForSubstringsInOrder(value, substrings, { 1 })
+         outcome shouldBe BestFitForSubstringsInOrderOutcome.Match
+      }
+
+      "return Mismatch with best fit indexes when not all substrings are found in order" {
+         val value = "no pain no gain"
+         val substrings = listOf("no", "no", "pain")
+         val outcome = describeBestFitForSubstringsInOrder(value, substrings, { 1 })
+         assert(outcome is BestFitForSubstringsInOrderOutcome.Mismatch)
+         val mismatchOutcome = outcome as BestFitForSubstringsInOrderOutcome.Mismatch
+         mismatchOutcome.bestFitIndexes shouldBe listOf(1, 2)
+      }
+
+      "return Ineligible when value length exceeds maximum allowed" {
+         val value = "a".repeat(AssertionsConfig.maxValueSubmatchingSize.value + 1)
+         val substrings = listOf("a")
+         val outcome = describeBestFitForSubstringsInOrder(value, substrings, { 1 })
+         outcome.shouldBeInstanceOf<BestFitForSubstringsInOrderOutcome.Ineligible>()
+      }
+
+      "return Ineligible when no substrings provided" {
+         val outcome = describeBestFitForSubstringsInOrder("Call it a day", emptyList(), { 1 })
+         outcome.shouldBeInstanceOf<BestFitForSubstringsInOrderOutcome.Ineligible>()
+      }
+
+      "return Ineligible when some substrings are empty" {
+         val outcome = describeBestFitForSubstringsInOrder("Call it a day", listOf("Call", "", "day"), { 1 })
+         outcome.shouldBeInstanceOf<BestFitForSubstringsInOrderOutcome.Ineligible>()
+      }
+
+      "return Ineligible when substring count exceeds maximum allowed" {
+         val value = "abc"
+         val substrings = List(AssertionsConfig.maxSubstringCount.value + 1) { "a" }
+         val outcome = describeBestFitForSubstringsInOrder(value, substrings, { 1 })
+         outcome.shouldBeInstanceOf<BestFitForSubstringsInOrderOutcome.Ineligible>()
+      }
+
+      "return Ineligible when at least one substring length exceeds maximum allowed" {
+         val value = "abc"
+         val longSubstring = "a".repeat(AssertionsConfig.maxSubstringSize.value + 1)
+         val substrings = listOf(longSubstring)
+         val outcome = describeBestFitForSubstringsInOrder(value, substrings, { 1 })
+         outcome.shouldBeInstanceOf<BestFitForSubstringsInOrderOutcome.Ineligible>()
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/FindBestFitForSubstringsInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/FindBestFitForSubstringsInOrderTest.kt
@@ -1,0 +1,67 @@
+package com.sksamuel.kotest.matchers.string
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.string.findBestFitForSubstringsInOrder
+
+class FindBestFitForSubstringsInOrderTest : StringSpec() {
+   val shortText = "The quick brown fox jumps over the lazy dog"
+   val longText = """
+      Lorem ipsum reads: Lorem ipsum dolor sit amet,
+      consectetur adipiscing elit, sed do eiusmod tempor incididunt
+      ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+      nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat
+   """.trimIndent()
+   init {
+       "finds a few substrings in order" {
+          findBestFitForSubstringsInOrder(
+             shortText, listOf("quick", "fox", "over"), { 1 }
+          ).bestFitIndexes shouldContainExactly listOf(0, 1, 2)
+       }
+      "finds all words in short text in order" {
+         findBestFitForSubstringsInOrder(
+            shortText, shortText.split(" "), { 1 }
+         ).bestFitIndexes shouldContainExactly listOf(0, 1, 2, 3, 4, 5, 6, 7, 8,)
+      }
+      "finds best match when mismatch in the beginning" {
+         val allWords = shortText.split(" ").replaceElement(0, "wolf")
+         findBestFitForSubstringsInOrder(
+            shortText, allWords, { 1 }
+         ).bestFitIndexes shouldContainExactly listOf(1, 2, 3, 4, 5, 6, 7, 8,)
+      }
+      "finds best match when mismatch in the middle" {
+         val allWords = shortText.split(" ").replaceElement(4, "wolf")
+         findBestFitForSubstringsInOrder(
+            shortText, allWords, { 1 }
+         ).bestFitIndexes shouldContainExactly listOf(0, 1, 2, 3, 5, 6, 7, 8,)
+      }
+      "finds best match when mismatch in the end" {
+         val allWords = shortText.split(" ").replaceElement(8, "wolf")
+         findBestFitForSubstringsInOrder(
+            shortText, allWords, { 1 }
+         ).bestFitIndexes shouldContainExactly listOf(0, 1, 2, 3, 4, 5, 6, 7,)
+      }
+      "finds some words in long text in order" {
+         findBestFitForSubstringsInOrder(
+            longText, listOf("Lorem", "ipsum", "dolor", "elit", "sed", "do", "eiusmod", "tempor", "incididunt"
+            ), { 1 }
+         ).bestFitIndexes shouldContainExactly listOf(0, 1, 2, 3, 4, 5, 6, 7, 8,)
+      }
+       "finds all words in long text in order" {
+          val allWords = longText.split(" ")
+          findBestFitForSubstringsInOrder(
+             longText, allWords, { 1 }
+          ).bestFitIndexes shouldContainExactly (0 until allWords.size).toList()
+       }
+      "finds all words except one in long text in order" {
+         val indexToReplace = 7
+         val allWords = longText.split(" ").replaceElement(indexToReplace, "NOT_IN_TEXT")
+         findBestFitForSubstringsInOrder(
+            longText, allWords, { 1 }
+         ).bestFitIndexes shouldContainExactly (0 until allWords.size).toList().filter { it != indexToReplace }
+      }
+   }
+}
+
+private fun List<String>.replaceElement(index: Int, value: String) =
+   this.mapIndexed { i, s -> if (i == index) value else s }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/SubsetFitsInOrderTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/SubsetFitsInOrderTest.kt
@@ -1,0 +1,111 @@
+package com.sksamuel.kotest.matchers.string
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.subsetFitsInOrder
+
+class SubsetFitsInOrderTest : StringSpec() {
+   init {
+       "returns true in the simplest case of one match per substring" {
+            val indexesOfMatches = listOf(
+               listOf(0),
+               listOf(1),
+               listOf(2),
+            )
+            subsetFitsInOrder(
+               indexesOfMatches,
+               listOf(0, 1, 2),
+               listOf("a", "b", "c"),
+               { 1 },
+               ) shouldBe true
+       }
+      "returns true when multiple matches per substring and an increasing sequence is found" {
+         val indexesOfMatches = listOf(
+            listOf(10, 15, 20,),
+            listOf(8, 16, 24,),
+            listOf(6, 12, 18, ),
+         )
+         subsetFitsInOrder(
+            indexesOfMatches,
+            listOf(0, 1, 2),
+            listOf("a", "b", "c"),
+            { 1 },
+            ) shouldBe true
+      }
+      "returns false when multiple matches per substring and an increasing sequence cannot be found" {
+         val indexesOfMatches = listOf(
+            listOf(10, 15, 20,),
+            listOf(8, 16, 24,),
+            listOf(6, 12, 16, ),
+         )
+         subsetFitsInOrder(
+            indexesOfMatches,
+            listOf(0, 1, 2),
+            listOf("a", "b", "c"),
+            { 1 },
+            ) shouldBe false
+      }
+      "returns false when first substring has no matches" {
+         val indexesOfMatches = listOf(
+            emptyList(),
+            listOf(8, 16, 24,),
+            listOf(6, 12, 16, ),
+         )
+         subsetFitsInOrder(
+            indexesOfMatches,
+            listOf(0, 1, 2),
+            listOf("a", "b", "c"),
+            { 1 },
+            ) shouldBe false
+      }
+       "returns false when substring in the middle has no matches" {
+          val indexesOfMatches = listOf(
+             listOf(10, 15, 20,),
+             emptyList(),
+             listOf(6, 12, 16, ),
+          )
+          subsetFitsInOrder(
+             indexesOfMatches,
+             listOf(0, 1, 2),
+             listOf("a", "b", "c"),
+             { 1 },
+             ) shouldBe false
+       }
+       "returns false when last substring has no matches" {
+          val indexesOfMatches = listOf(
+             listOf(10, 15, 20,),
+             listOf(8, 16, 24,),
+             emptyList(),
+          )
+          subsetFitsInOrder(
+             indexesOfMatches,
+             listOf(0, 1, 2),
+             listOf("a", "b", "c"),
+             { 1 },
+             ) shouldBe false
+       }
+      "return true if overlaps allowed" {
+         subsetFitsInOrder(
+            listOf(
+               listOf(0),
+               listOf(1),
+            ),
+            listOf(0, 1),
+            listOf("bread", "read"),
+            { 1 },
+         ) shouldBe true
+      }
+      "return false if overlaps allowed" {
+         subsetFitsInOrder(
+            listOf(
+               listOf(0),
+               listOf(1),
+            ),
+            listOf(0, 1),
+            listOf("bread", "read"),
+            { value -> value.length },
+         ) shouldBe false
+      }
+
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/nonjvmMain/kotlin/io/kotest/matchers/string/NonJvmUtlis.kt
+++ b/kotest-assertions/kotest-assertions-core/src/nonjvmMain/kotlin/io/kotest/matchers/string/NonJvmUtlis.kt
@@ -1,0 +1,7 @@
+package io.kotest.matchers.string
+
+internal actual fun describeBestFitForSubstringsInOrder(
+   value: String,
+   substrings: List<String>,
+   matchOffset: MatchOffset,
+) : BestFitForSubstringsInOrderOutcome = BestFitForSubstringsInOrderOutcome.Ineligible("JVM only")


### PR DESCRIPTION
improve `containInOrder`: instead of bailing out at first mismatch, try finding the best match in subsets, such as:

```
        actual shouldContain "The best fit is the subset with the following indexes: [0, -, 2, -, 4]."
         actual shouldContain "Element[1] not found"
         actual shouldContain "Element[3] found at index(es): [1]"
```

this may run a bit slowish on larger texts, so we can time out and fall back on the old implementation 

I know that `powerSetIndexes` is already in a shared lib, but I'd rather switch to it in a separate small PR because it's easier 