### PR TITLE
Replace periods in test names with wildcards in GradleTestFilterBuilder

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilder.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilder.kt
@@ -58,7 +58,7 @@ data class GradleTestFilterBuilder(
    private fun StringBuilder.appendTestPath() {
       when {
          // Regular test - use full path
-         test != null && !test.isDataTest -> test.path().joinToString(" -- ") { it.name.removeLineBreaks().escapeSingleQuotes() }
+         test != null && !test.isDataTest -> test.path().joinToString(" -- ") { it.name.removeLineBreaks().replacePeriodsWithWildcards().escapeSingleQuotes() }
          // Data test inside a regular context - use ancestor path to scope the run
          dataTestAncestorPath != null -> dataTestAncestorPath
          // Root-level data test or no test - no path needed
@@ -81,5 +81,7 @@ data class GradleTestFilterBuilder(
  * when wrapped in outer single quotes produces `'it'\''s a test'`.
  */
 private fun String.escapeSingleQuotes(): String = replace("'", "'\\''")
+
+private fun String.replacePeriodsWithWildcards(): String = replace(".", "*")
 
 private fun String.removeLineBreaks(): String = replace(Regex("\r\n|\n|\r"), " ")

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilderTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleTestFilterBuilderTest.kt
@@ -190,6 +190,69 @@ class GradleTestFilterBuilderTest : BasePlatformTestCase() {
          .build(true) shouldBe "--tests 'MyTestClass.a test with cr'"
    }
 
+   fun testPeriodInTestNameIsReplacedWithWildcard() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MySpec { fun hello() {} }")
+      val test = Test(
+         name = TestName(prefix = null, name = "test with 1.2.3", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MySpec.test with 1*2*3'"
+   }
+
+   fun testMultiplePeriodsInTestNameAreAllReplacedWithWildcards() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MySpec { fun hello() {} }")
+      val test = Test(
+         name = TestName(prefix = null, name = "assert a.b equals c.d.e", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MySpec.assert a*b equals c*d*e'"
+   }
+
+   fun testPeriodInNestedTestNameIsReplacedWithWildcard() {
+      val factory = KtPsiFactory(project)
+      val spec: KtClass = factory.createClass("class MySpec { fun hello() {} }")
+      val root = Test(
+         name = TestName(prefix = null, name = "context with v1.0", interpolated = false),
+         parent = null,
+         specClassName = spec,
+         testType = TestType.Container,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      val test = Test(
+         name = TestName(prefix = null, name = "name with periods 1.2.3 and more", interpolated = false),
+         parent = root,
+         specClassName = spec,
+         testType = TestType.Test,
+         xdisabled = false,
+         psi = spec,
+         isDataTest = false
+      )
+      GradleTestFilterBuilder.builder()
+         .withSpec(spec)
+         .withTest(test)
+         .build(true) shouldBe "--tests 'MySpec.context with v1*0 -- name with periods 1*2*3 and more'"
+   }
+
    fun testNewlineInNestedTestNameIsReplacedWithSpace() {
       val factory = KtPsiFactory(project)
       val spec: KtClass = factory.createClass("class MyTestClass { fun hello() {} }")

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/GradleClassMethodRegexTestFilterTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/GradleClassMethodRegexTestFilterTest.kt
@@ -198,6 +198,60 @@ class GradleClassMethodRegexTestFilterTest : FunSpec({
       }
    }
 
+   context("wildcards in the middle of test names") {
+      // When test names contain periods (e.g. "test with 1.2.3"), GradleTestFilterBuilder replaces
+      // them with wildcards, producing a filter like "MySpec.test with 1*2*3".
+      // Gradle converts that to the regex: \QMySpec.test with 1\E.*\Q2\E.*\Q3\E
+      // These tests verify that the filter correctly includes/excludes the right descriptors.
+
+      val spec = Descriptor.SpecDescriptor(DescriptorId("io.pkg.MySpec"))
+
+      test("test with period in name is INCLUDED when filter has wildcard in middle") {
+         // "test with 1.2.3" → filter "MySpec.test with 1*2*3" → \QMySpec.test with 1\E.*\Q2\E.*\Q3\E
+         val testDescriptor = spec.append("test with 1.2.3")
+         val filter = "\\QMySpec.test with 1\\E.*\\Q2\\E.*\\Q3\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("test with multiple periods is INCLUDED when filter has multiple wildcards in middle") {
+         // "assert a.b equals c.d.e" → filter "MySpec.assert a*b equals c*d*e"
+         // → \QMySpec.assert a\E.*\Qb equals c\E.*\Qd\E.*\Qe\E
+         val testDescriptor = spec.append("assert a.b equals c.d.e")
+         val filter = "\\QMySpec.assert a\\E.*\\Qb equals c\\E.*\\Qd\\E.*\\Qe\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("unrelated test is EXCLUDED when filter has wildcards matching a different test name") {
+         val testDescriptor = spec.append("unrelated test")
+         val filter = "\\QMySpec.test with 1\\E.*\\Q2\\E.*\\Q3\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+
+      test("FQN filter with wildcards in middle of test name is INCLUDED") {
+         // --tests 'io.pkg.MySpec.test with 1*2*3' → \Qio.pkg.MySpec.test with 1\E.*\Q2\E.*\Q3\E
+         val testDescriptor = spec.append("test with 1.2.3")
+         val filter = "\\Qio.pkg.MySpec.test with 1\\E.*\\Q2\\E.*\\Q3\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("wildcard-prefix filter with wildcards in middle of test name is INCLUDED") {
+         // --tests '*MySpec.test with 1*2*3' → .*.*\QMySpec.test with 1\E.*\Q2\E.*\Q3\E
+         val testDescriptor = spec.append("test with 1.2.3")
+         val filter = ".*.*\\QMySpec.test with 1\\E.*\\Q2\\E.*\\Q3\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+
+      test("nested test with periods in both context and test name is INCLUDED") {
+         // context "context v1.0", test "name with periods 1.2.3 and more"
+         // filter: "MySpec.context v1*0 -- name with periods 1*2*3 and more"
+         // → \QMySpec.context v1\E.*\Q0 -- name with periods 1\E.*\Q2\E.*\Q3 and more\E
+         val container = spec.append("context v1.0")
+         val testDescriptor = container.append("name with periods 1.2.3 and more")
+         val filter = "\\QMySpec.context v1\\E.*\\Q0 -- name with periods 1\\E.*\\Q2\\E.*\\Q3 and more\\E"
+         GradleClassMethodRegexTestFilter(setOf(filter)).filter(testDescriptor) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
    // Unable to make field final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @62163b39
    test("!is ignored when KOTEST_INCLUDE_PATTERN is set") {
       val spec = GradleClassMethodRegexTestFilterTest::class.toDescriptor()

--- a/kotest-tests/kotest-tests-gradle-test-filter/kotest-tests-gradle-test-filter-class-wildcard-prefix/build.gradle.kts
+++ b/kotest-tests/kotest-tests-gradle-test-filter/kotest-tests-gradle-test-filter-class-wildcard-prefix/build.gradle.kts
@@ -18,6 +18,6 @@ kotlin {
 tasks.withType<Test>().configureEach {
    filter {
       // https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html
-//      includeTestsMatching("*Foo")
+      includeTestsMatching("*Foo")
    }
 }

--- a/kotest-tests/kotest-tests-gradle-test-filter/kotest-tests-gradle-test-filter-class-wildcard-prefix/build.gradle.kts
+++ b/kotest-tests/kotest-tests-gradle-test-filter/kotest-tests-gradle-test-filter-class-wildcard-prefix/build.gradle.kts
@@ -18,6 +18,6 @@ kotlin {
 tasks.withType<Test>().configureEach {
    filter {
       // https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html
-      includeTestsMatching("*Foo")
+//      includeTestsMatching("*Foo")
    }
 }

--- a/kotest-tests/kotest-tests-gradle-test-filter/kotest-tests-gradle-test-filter-class-wildcard-prefix/src/jvmTest/kotlin/com/sksamuel/kotest/filter/specs.kt
+++ b/kotest-tests/kotest-tests-gradle-test-filter/kotest-tests-gradle-test-filter-class-wildcard-prefix/src/jvmTest/kotlin/com/sksamuel/kotest/filter/specs.kt
@@ -18,6 +18,7 @@ class Foo : FunSpec() {
 // should be ignored completely as the filter is '*Foo'
 class Bar : FunSpec() {
    init {
+      test("name with periods 1.2.3 and more") {}
       test("whack!") {
          error("whack!")
       }


### PR DESCRIPTION
Periods in test names are replaced with '*' wildcards so that Gradle's --tests filter does not interpret them as class/method separators. Adds unit tests covering single, multiple, and nested period cases.

Fixes #5797

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
