### PR TITLE
Extend life of deprecated Test containers and add onStart

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
+++ b/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
@@ -148,16 +148,16 @@ public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerExte
 }
 
 public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener {
-	public fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;)V
-	public synthetic fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun mount (Lkotlin/jvm/functions/Function1;)Lcom/zaxxer/hikari/HikariDataSource;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public final class io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterSpecListener {
-	public fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;)V
-	public synthetic fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/testcontainers/containers/JdbcDatabaseContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterSpec (Lio/kotest/core/spec/Spec;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun mount (Lkotlin/jvm/functions/Function1;)Ljavax/sql/DataSource;

--- a/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
+++ b/kotest-extensions/kotest-extensions-testcontainers/api/kotest-extensions-testcontainers.api
@@ -10,7 +10,8 @@ public abstract class io/kotest/extensions/testcontainers/AbstractContainerExten
 
 public final class io/kotest/extensions/testcontainers/ComposeContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener {
 	public static final field Companion Lio/kotest/extensions/testcontainers/ComposeContainerProjectExtension$Companion;
-	public fun <init> (Lorg/testcontainers/containers/ComposeContainer;)V
+	public fun <init> (Lorg/testcontainers/containers/ComposeContainer;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/testcontainers/containers/ComposeContainer;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/ComposeContainer;
@@ -22,7 +23,8 @@ public final class io/kotest/extensions/testcontainers/ComposeContainerProjectEx
 
 public final class io/kotest/extensions/testcontainers/ComposeContainerSpecExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/TestListener {
 	public static final field Companion Lio/kotest/extensions/testcontainers/ComposeContainerSpecExtension$Companion;
-	public fun <init> (Lorg/testcontainers/containers/ComposeContainer;)V
+	public fun <init> (Lorg/testcontainers/containers/ComposeContainer;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/testcontainers/containers/ComposeContainer;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterContainer (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterEach (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -405,16 +407,16 @@ public final class io/kotest/extensions/testcontainers/TestContainerHikariConfig
 }
 
 public final class io/kotest/extensions/testcontainers/TestContainerProjectExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterProjectListener {
-	public fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;)V
-	public synthetic fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterProject (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public synthetic fun mount (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public fun mount (Lkotlin/jvm/functions/Function1;)Lorg/testcontainers/containers/GenericContainer;
 }
 
 public final class io/kotest/extensions/testcontainers/TestContainerSpecExtension : io/kotest/core/extensions/MountableExtension, io/kotest/core/listeners/AfterSpecListener, io/kotest/core/listeners/TestListener {
-	public fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;)V
-	public synthetic fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lorg/testcontainers/containers/GenericContainer;Lio/kotest/extensions/testcontainers/options/ContainerExtensionConfig;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterAny (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterContainer (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun afterEach (Lio/kotest/core/test/TestCase;Lio/kotest/engine/test/TestResult;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/AbstractContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/AbstractContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -6,7 +8,7 @@ import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.spec.Spec
 import org.testcontainers.containers.GenericContainer
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 abstract class AbstractContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerProjectExtension.kt
@@ -11,15 +11,17 @@ import java.util.concurrent.locks.ReentrantLock
 
 /**
  * A Kotest [MountableExtension] for [ComposeContainer]s that will launch the container
- * upon first install, and close after the test suite has completed. This extension will only
- * launch the container once per project, and will not reset it between specs.
+ * upon first installation, and close after the test suite has completed. This extension will only
+ * initalize the container once per project and will not reset it between specs regardless of how many
+ * specs it is installed into.
  *
- * Note: This extension requires Kotest 6.0+
+ * This is thread safe, so it is safe to be used in specs that run in parallel.
  *
  * @param container the specific test container type
  */
 class ComposeContainerProjectExtension(
    private val container: ComposeContainer,
+   private val onStart: ComposeContainer.() -> Unit = {},
 ) : MountableExtension<ComposeContainer, ComposeContainer>, AfterProjectListener {
 
    companion object {
@@ -38,6 +40,7 @@ class ComposeContainerProjectExtension(
       if (t == null) {
          configure(container)
          container.start()
+         container.onStart()
          ref.set(container)
       }
       lock.unlock()

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerProjectExtension.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.locks.ReentrantLock
  */
 class ComposeContainerProjectExtension(
    private val container: ComposeContainer,
-   private val onStart: ComposeContainer.() -> Unit = {},
+   private val onStart: (ComposeContainer) -> Unit = {},
 ) : MountableExtension<ComposeContainer, ComposeContainer>, AfterProjectListener {
 
    companion object {
@@ -40,7 +40,7 @@ class ComposeContainerProjectExtension(
       if (t == null) {
          configure(container)
          container.start()
-         container.onStart()
+         onStart(container)
          ref.set(container)
       }
       lock.unlock()

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerSpecExtension.kt
@@ -17,7 +17,7 @@ import java.io.File
  */
 class ComposeContainerSpecExtension(
    private val container: ComposeContainer,
-   private val onStart: ComposeContainer.() -> Unit = {},
+   private val onStart: (ComposeContainer) -> Unit = {},
 ) : MountableExtension<ComposeContainer, ComposeContainer>, AfterSpecListener, TestListener {
 
    companion object {
@@ -30,7 +30,7 @@ class ComposeContainerSpecExtension(
    override fun mount(configure: ComposeContainer.() -> Unit): ComposeContainer {
       configure(container)
       container.start()
-      container.onStart()
+      onStart(container)
       return container
    }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerSpecExtension.kt
@@ -11,14 +11,13 @@ import java.io.File
 
 /**
  * A Kotest [MountableExtension] for [ComposeContainer]s that will launch the container
- * upon first install, and close after the spec has completed.
- *
- * Note: This extension requires Kotest 6.0+
+ * upon first installation, and close after the spec has completed.
  *
  * @param container the specific test container type
  */
 class ComposeContainerSpecExtension(
    private val container: ComposeContainer,
+   private val onStart: ComposeContainer.() -> Unit = {},
 ) : MountableExtension<ComposeContainer, ComposeContainer>, AfterSpecListener, TestListener {
 
    companion object {
@@ -31,6 +30,7 @@ class ComposeContainerSpecExtension(
    override fun mount(configure: ComposeContainer.() -> Unit): ComposeContainer {
       configure(container)
       container.start()
+      container.onStart()
       return container
    }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -53,7 +55,7 @@ import org.testcontainers.containers.GenericContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class ContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerLifecycleMode.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ContainerLifecycleMode.kt
@@ -3,7 +3,7 @@ package io.kotest.extensions.testcontainers
 /**
  * Determines the lifetime of a test container installed in a Kotest extension.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 enum class ContainerLifecycleMode {
 
    /**

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -48,7 +50,7 @@ import java.io.File
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class DockerComposeContainerExtension<T : DockerComposeContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainersExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/DockerComposeContainersExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -15,7 +17,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
 import java.util.Optional
 import org.testcontainers.containers.DockerComposeContainer
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class DockerComposeContainersExtension<T : DockerComposeContainer<*>>(
    private val container: T,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/Extensions.kt
@@ -1,34 +1,36 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.TestConfiguration
 import org.testcontainers.lifecycle.Startable
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> T.perTest(): StartablePerTestListener<T> = StartablePerTestListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> T.perSpec(): StartablePerSpecListener<T> = StartablePerSpecListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> T.perProject(): StartablePerProjectListener<T> = StartablePerProjectListener(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> T.perProject(containerName: String): StartablePerProjectListener<T> =
    StartablePerProjectListener<T>(this)
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> TestConfiguration.configurePerTest(startable: T): T {
    extension(StartablePerTestListener(startable))
    return startable
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> TestConfiguration.configurePerSpec(startable: T): T {
    extension(StartablePerSpecListener(startable))
    return startable
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 fun <T : Startable> TestConfiguration.configurePerProject(startable: T, containerName: String): T {
    extension(StartablePerProjectListener(startable))
    return startable

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import com.zaxxer.hikari.HikariConfig
@@ -50,7 +52,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class JdbcDatabaseContainerExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
@@ -29,6 +29,7 @@ import javax.sql.DataSource
 class JdbcDatabaseContainerProjectExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val config: ContainerExtensionConfig = ContainerExtensionConfig(),
+   private val onStart: (DataSource) -> Unit = { },
 ) : MountableExtension<HikariConfig, DataSource>, AfterProjectListener {
 
    private val ref = AtomicReference<HikariDataSource>(null)
@@ -46,6 +47,7 @@ class JdbcDatabaseContainerProjectExtension(
          config.password = container.password
          config.configure()
          val ds = HikariDataSource(config)
+         onStart(ds)
          ref.set(ds)
       }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension.kt
@@ -13,7 +13,7 @@ import javax.sql.DataSource
 
 /**
  * A Kotest [MountableExtension] for [JdbcDatabaseContainer]s that will launch the container
- * upon install, and close after the spec has completed.
+ * upon installation, and close after the spec has completed.
  *
  * This extension will create a pooled [HikariDataSource] attached to the database and
  * return that to the user as the materialized value.
@@ -29,6 +29,7 @@ import javax.sql.DataSource
 class JdbcDatabaseContainerSpecExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val config: ContainerExtensionConfig = ContainerExtensionConfig(),
+   private val onStart: (DataSource) -> Unit = { },
 ) : MountableExtension<HikariConfig, DataSource>, AfterSpecListener {
 
    override fun mount(configure: HikariConfig.() -> Unit): DataSource {
@@ -40,6 +41,7 @@ class JdbcDatabaseContainerSpecExtension(
       config.password = container.password
       config.configure()
       val ds = HikariDataSource(config)
+      onStart(ds)
       return ds
    }
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcTestContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcTestContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import com.zaxxer.hikari.HikariDataSource
@@ -31,7 +33,7 @@ import javax.sql.DataSource
  *
  * @since 1.1.0
  */
-@Deprecated("Use JdbcTestContainerProjectExtension or JdbcTestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use JdbcTestContainerProjectExtension or JdbcTestContainerSpecExtension instead. Will be removed in 6.3")
 class JdbcTestContainerExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/LifecycleMode.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/LifecycleMode.kt
@@ -1,6 +1,6 @@
 package io.kotest.extensions.testcontainers
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 enum class LifecycleMode {
    Spec, EveryTest, Leaf, Root
 }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ProjectContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ProjectContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -53,7 +55,7 @@ import org.testcontainers.containers.GenericContainer
  * @param afterShutdown a callback that is invoked only once, just after the container is stopped.
  * If the container is never started, this callback will not be invoked.
  */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class ProjectContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ResourceLoader.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ResourceLoader.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import java.io.BufferedReader
@@ -11,19 +13,19 @@ import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.name
 
-@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.3")
 sealed interface Resource {
    data class Classpath(val resource: String) : Resource
    data class File(val path: Path) : Resource
 }
 
-@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.3")
 fun Resource.endsWith(name: String): Boolean = when (this) {
    is Resource.Classpath -> this.resource.endsWith(name)
    is Resource.File -> this.path.name.endsWith(name)
 }
 
-@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.3")
 fun Resource.loadToReader(): BufferedReader = when (this) {
    is Resource.Classpath -> javaClass.getResourceAsStream(this.resource)?.bufferedReader()
       ?: error("$this was not found on classpath")
@@ -31,7 +33,7 @@ fun Resource.loadToReader(): BufferedReader = when (this) {
    is Resource.File -> Files.newBufferedReader(this.path)
 }
 
-@Deprecated("use Flyway or another db migration tool. Will be removed in 6.2")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.3")
 class ResourceLoader {
 
    private fun Path.getDirContentsOrItself(): List<Path> {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SettableDataSource.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SettableDataSource.kt
@@ -6,7 +6,7 @@ import java.sql.Connection
 import java.util.logging.Logger
 import javax.sql.DataSource
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class SettableDataSource(private var ds: HikariDataSource?) : DataSource {
 
    private fun getDs(): DataSource = ds ?: error("DataSource is not ready")

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedJdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedJdbcDatabaseContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import com.zaxxer.hikari.HikariConfig
@@ -16,7 +18,7 @@ import java.sql.Connection
 
 /**
  * A Kotest [MountableExtension] for [JdbcDatabaseContainer]s that are started the first time they are
- * installed in a test, and then shared throughout the same gradle module. The container is shutdown
+ * installed in a test, and then shared throughout the same Gradle module. The container is shutdown
  * after all specs have completed.
  *
  * If no spec is executed that installs a particular container, then that container is never started.
@@ -40,7 +42,7 @@ import java.sql.Connection
  *
  * @since 1.3.0
  */
-@Deprecated("use JdbcDatabaseContainerExtension")
+@Deprecated("Use JdbcDatabaseContainerExtension. Will be removed in 6.3")
 class SharedJdbcDatabaseContainerExtension(
    private val container: JdbcDatabaseContainer<*>,
    private val beforeTest: suspend (HikariDataSource) -> Unit = {},

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedTestContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedTestContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -35,7 +37,7 @@ import org.testcontainers.containers.GenericContainer
  *
  * @since 1.3.0
  */
-@Deprecated("use ContainerExtension. Will be removed in 6.2")
+@Deprecated("use ContainerExtension. Will be removed in 6.3")
 class SharedTestContainerExtension<T : GenericContainer<*>, U>(
    private val container: T,
    private val beforeTest: suspend (T) -> Unit = {},

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerProjectListener.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.listeners.ProjectListener
@@ -19,7 +21,7 @@ import org.testcontainers.lifecycle.Startable
  * @see
  * [StartablePerTestListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class StartablePerProjectListener<T : Startable>(private val startable: T) : TestListener, ProjectListener {
 
    @Deprecated("The containerName arg is no longer used")

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerSpecListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerSpecListener.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.listeners.TestListener
@@ -22,7 +24,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
  * @see
  * [StartablePerTestListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class StartablePerSpecListener<T : Startable>(private val startable: T) : TestListener {
    private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)
 

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerTestListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/StartablePerTestListener.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.listeners.TestListener
@@ -19,7 +21,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
  *
  * @see[StartablePerSpecListener]
  * */
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class StartablePerTestListener<T : Startable>(private val startable: T) : TestListener {
 
    private val testLifecycleAwareListener = TestLifecycleAwareListener(startable)

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.extensions.MountableExtension
@@ -14,7 +16,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.lifecycle.TestLifecycleAware
 import java.util.Optional
 
-@Deprecated("use ContainerExtension. Will be removed in 6.2")
+@Deprecated("use ContainerExtension. Will be removed in 6.3")
 class TestContainerExtension<T : GenericContainer<*>>(
    private val container: T,
    private val lifecycleMode: LifecycleMode = LifecycleMode.Spec,

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerHikariConfig.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerHikariConfig.kt
@@ -2,7 +2,7 @@ package io.kotest.extensions.testcontainers
 
 import com.zaxxer.hikari.HikariConfig
 
-@Deprecated("use Flyway or another db migration tool")
+@Deprecated("use Flyway or another db migration tool. Will be removed in 6.3")
 class TestContainerHikariConfig : HikariConfig() {
 
    var dbInitScripts: List<String> = emptyList()

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
@@ -11,16 +11,15 @@ import java.util.concurrent.locks.ReentrantLock
 
 /**
  * A Kotest [MountableExtension] for [GenericContainer]s that will launch the container
- * upon first install, and close after the test suite has completed. This extension will only
- * launch the container once per project, and will not reset it between specs.
- *
- * Note: This extension requires Kotest 6.0+
+ * upon first installation, and close after the test suite has completed. This extension will only
+ * launch the container once per project and will not reset it between specs.
  *
  * @param container the specific test container type
  */
 class TestContainerProjectExtension<T : GenericContainer<*>>(
    private val container: T,
    private val config: ContainerExtensionConfig = ContainerExtensionConfig(),
+   private val onStart: T.() -> Unit = {},
 ) : MountableExtension<T, T>, AfterProjectListener {
 
    private val ref = AtomicReference<T>(null)
@@ -32,6 +31,7 @@ class TestContainerProjectExtension<T : GenericContainer<*>>(
       if (t == null) {
          configure(container)
          container.start()
+         onStart(container)
          container.followOutput(config.logConsumer)
          ref.set(container)
       }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.locks.ReentrantLock
 class TestContainerProjectExtension<T : GenericContainer<*>>(
    private val container: T,
    private val config: ContainerExtensionConfig = ContainerExtensionConfig(),
-   private val onStart: T.() -> Unit = {},
+   private val onStart: (T) -> Unit = {},
 ) : MountableExtension<T, T>, AfterProjectListener {
 
    private val ref = AtomicReference<T>(null)

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerSpecExtension.kt
@@ -11,20 +11,21 @@ import org.testcontainers.containers.GenericContainer
 
 /**
  * A Kotest [MountableExtension] for [GenericContainer]s that will launch the container
- * upon first install, and close after the spec has completed.
- *
- * Note: This extension requires Kotest 6.0+
+ * upon first installation, and close after the spec has completed.
  *
  * @param container the specific test container type
+ * @param onStart a callback that is invoked after the container is started
  */
 class TestContainerSpecExtension<T : GenericContainer<*>>(
    private val container: T,
    private val config: ContainerExtensionConfig = ContainerExtensionConfig(),
+   private val onStart: T.() -> Unit = {},
 ) : MountableExtension<T, T>, AfterSpecListener, TestListener {
 
    override fun mount(configure: T.() -> Unit): T {
       configure(container)
       container.start()
+      onStart(container)
       container.followOutput(config.logConsumer)
       return container
    }

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerSpecExtension.kt
@@ -19,7 +19,7 @@ import org.testcontainers.containers.GenericContainer
 class TestContainerSpecExtension<T : GenericContainer<*>>(
    private val container: T,
    private val config: ContainerExtensionConfig = ContainerExtensionConfig(),
-   private val onStart: T.() -> Unit = {},
+   private val onStart: (T) -> Unit = {},
 ) : MountableExtension<T, T>, AfterSpecListener, TestListener {
 
    override fun mount(configure: T.() -> Unit): T {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestLifecycleAwareListener.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestLifecycleAwareListener.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.extensions.testcontainers
 
 import io.kotest.core.listeners.TestListener
@@ -9,7 +11,7 @@ import org.testcontainers.lifecycle.TestLifecycleAware
 import java.net.URLEncoder
 import java.util.Optional
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 class TestLifecycleAwareListener(startable: Startable) : TestListener {
    private val testLifecycleAware = startable as? TestLifecycleAware
 
@@ -22,7 +24,7 @@ class TestLifecycleAwareListener(startable: Startable) : TestListener {
    }
 }
 
-@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.2")
+@Deprecated("Use TestContainerProjectExtension or TestContainerSpecExtension instead. Will be removed in 6.3")
 internal fun TestCase.toTestDescription() = object : TestDescription {
 
    override fun getFilesystemFriendlyName(): String {

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka.kt
@@ -15,7 +15,8 @@ import java.util.UUID
 /**
  * Creates a [KafkaProducer] for the given [KafkaContainer] with a String serializer for both keys and values.
  */
-@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
+@Suppress("DEPRECATION")
+@Deprecated("Deprecated since 6.1. Will be removed in 6.3")
 fun KafkaContainer.createStringStringProducer(
    configure: Properties.() -> Unit = {},
 ): KafkaProducer<String, String> {
@@ -25,7 +26,7 @@ fun KafkaContainer.createStringStringProducer(
 /**
  * Creates a [KafkaProducer] for the given [KafkaContainer] with the given serializers.
  */
-@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
+@Deprecated("Deprecated since 6.1. Will be removed in 6.3")
 fun <K, V> KafkaContainer.createProducer(
    kserializer: Serializer<K>,
    vserializer: Serializer<V>,
@@ -40,7 +41,7 @@ fun <K, V> KafkaContainer.createProducer(
 /**
  * Creates a [KafkaConsumer] for the given [KafkaContainer] with a String deserializer for both keys and values.
  */
-@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
+@Deprecated("Deprecated since 6.1. Will be removed in 6.3")
 fun KafkaContainer.createStringStringConsumer(
    configure: Properties.() -> Unit = {},
 ): KafkaConsumer<String, String> {
@@ -50,7 +51,7 @@ fun KafkaContainer.createStringStringConsumer(
 /**
  * Creates a [KafkaConsumer] for the given [KafkaContainer] with the given deserializers.
  */
-@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
+@Deprecated("Deprecated since 6.1. Will be removed in 6.3")
 fun <K, V> KafkaContainer.createConsumer(
    kserializer: Deserializer<K>,
    vserializer: Deserializer<V>,
@@ -66,7 +67,7 @@ fun <K, V> KafkaContainer.createConsumer(
 /**
  * Creates a [AdminClient] for the given [KafkaContainer].
  */
-@Deprecated("Deprecated since 6.1. Will be removed in 6.2")
+@Deprecated("Deprecated since 6.1. Will be removed in 6.3")
 fun KafkaContainer.createAdminClient(configure: Properties.() -> Unit = {}): AdminClient {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/KafkaContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/KafkaContainerExtension.kt
@@ -19,7 +19,7 @@ import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.utility.DockerImageName
 import java.util.Properties
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 class KafkaContainerExtension(
    container: KafkaContainer,
    mode: ContainerLifecycleMode = ContainerLifecycleMode.Project,
@@ -31,7 +31,7 @@ class KafkaContainerExtension(
    ) : this(KafkaContainer(image), mode)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.admin(configure: Properties.() -> Unit = {}): Admin {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -39,7 +39,7 @@ fun KafkaContainer.admin(configure: Properties.() -> Unit = {}): Admin {
    return Admin.create(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.producer(configure: Properties.() -> Unit = {}): KafkaProducer<Bytes, Bytes> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -49,7 +49,7 @@ fun KafkaContainer.producer(configure: Properties.() -> Unit = {}): KafkaProduce
    return KafkaProducer<Bytes, Bytes>(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.stringStringProducer(configure: Properties.() -> Unit = {}): KafkaProducer<String, String> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -59,7 +59,7 @@ fun KafkaContainer.stringStringProducer(configure: Properties.() -> Unit = {}): 
    return KafkaProducer<String, String>(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.consumer(configure: Properties.() -> Unit = {}): KafkaConsumer<Bytes, Bytes> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers
@@ -71,7 +71,7 @@ fun KafkaContainer.consumer(configure: Properties.() -> Unit = {}): KafkaConsume
    return KafkaConsumer<Bytes, Bytes>(props)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.stringStringConsumer(configure: Properties.() -> Unit = {}): KafkaConsumer<String, String> {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers

--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/kafka.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/kafka/kafka.kt
@@ -14,14 +14,14 @@ import org.testcontainers.containers.KafkaContainer
 import java.util.Properties
 import java.util.UUID
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.createStringStringProducer(
    configure: Properties.() -> Unit = {},
 ): KafkaProducer<String, String> {
    return createProducer(StringSerializer(), StringSerializer(), configure)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun <K, V> KafkaContainer.createProducer(
    kserializer: Serializer<K>,
    vserializer: Serializer<V>,
@@ -33,14 +33,14 @@ fun <K, V> KafkaContainer.createProducer(
    return KafkaProducer(props, kserializer, vserializer)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.createStringStringConsumer(
    configure: Properties.() -> Unit = {},
 ): KafkaConsumer<String, String> {
    return createConsumer(StringDeserializer(), StringDeserializer(), configure)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun <K, V> KafkaContainer.createConsumer(
    kserializer: Deserializer<K>,
    vserializer: Deserializer<V>,
@@ -53,7 +53,7 @@ fun <K, V> KafkaContainer.createConsumer(
    return KafkaConsumer(props, kserializer, vserializer)
 }
 
-@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.2")
+@Deprecated("Use org.testcontainers.kafka.KafkaContainer or org.testcontainers.kafka.ConfluentKafkaContainer. Deprecated since 6.0. Will be removed in 6.3")
 fun KafkaContainer.createAdminClient(configure: Properties.() -> Unit = {}): AdminClient {
    val props = Properties()
    props[CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG] = bootstrapServers


### PR DESCRIPTION
Add onStart functionality to containers.

Suppress warnings to clean build

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
