### PR TITLE
build: remove -Xwhen-guards compiler flag

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -33,7 +33,6 @@ kotlin {
    compilerOptions {
 
       freeCompilerArgs.add("-Xexpect-actual-classes")
-      freeCompilerArgs.add("-Xwhen-guards")
 
       // See https://mbonnin.net/2026-02-22-kotlin-versions
       compilerVersion.set(libs.findVersion("kotlin-compile-version").get().toString())


### PR DESCRIPTION
## Summary

- Removes the `-Xwhen-guards` experimental compiler flag from `buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts`
- When guards are stable in Kotlin 2.2 and no longer require an opt-in flag

## Test plan

- [ ] Verify the project builds successfully without the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)