### PR TITLE
Remove deprecated Descriptor.isEqual

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1008,7 +1008,6 @@ public abstract interface class io/kotest/core/descriptors/Descriptor {
 	public fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isChildOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isEqual (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isParentOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isRootTest ()Z
@@ -1028,7 +1027,6 @@ public final class io/kotest/core/descriptors/Descriptor$DefaultImpls {
 	public static fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isChildOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
-	public static fun isEqual (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isParentOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;Lio/kotest/core/descriptors/Descriptor;)Z
 	public static fun isRootTest (Lio/kotest/core/descriptors/Descriptor;)Z
@@ -1055,7 +1053,6 @@ public final class io/kotest/core/descriptors/Descriptor$SpecDescriptor : io/kot
 	public fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isChildOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isEqual (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isParentOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isRootTest ()Z
@@ -1085,7 +1082,6 @@ public final class io/kotest/core/descriptors/Descriptor$TestDescriptor : io/kot
 	public fun isAncestorOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isChildOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isDescendentOf (Lio/kotest/core/descriptors/Descriptor;)Z
-	public fun isEqual (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isParentOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isPrefixOf (Lio/kotest/core/descriptors/Descriptor;)Z
 	public fun isRootTest ()Z

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/descriptors/descriptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/descriptors/descriptor.kt
@@ -17,7 +17,6 @@ import kotlin.reflect.KClass
  * and the top most parent being a [SpecDescriptor].
  *
  */
-@Suppress("DEPRECATION")
 sealed interface Descriptor {
 
    val id: DescriptorId
@@ -55,31 +54,6 @@ sealed interface Descriptor {
    fun ids(): List<DescriptorId> = when (this) {
       is SpecDescriptor -> listOf(this.id)
       is TestDescriptor -> this.parent.ids() + this.id
-   }
-
-   /**
-    * On KMP the KClass reference does not include the fully qualified name, so if the spec descriptor
-    * is just the simple class name, then we will have to compare using that only.
-    */
-   @Deprecated("This method will be removed in 6.2 as Kotest 6.1 now populates the fully qualified name")
-   fun isEqual(other: Descriptor): Boolean {
-      return when (other) {
-         is SpecDescriptor if this is SpecDescriptor -> {
-            // if both descriptors have the fully qualified name, then we can compare string equals
-            if (this.id.value.contains('.') && other.id.value.contains('.')) {
-               this.id == other.id
-            } else {
-               // if the id is not FQN, then we can only compare the simple class name
-               this.id.value.substringAfterLast('.') == other.id.value.substringAfterLast('.')
-            }
-         }
-
-         is TestDescriptor if this is TestDescriptor -> {
-            this.parent.isEqual(other.parent) && this.id == other.id
-         }
-
-         else -> false
-      }
    }
 
    /**
@@ -136,7 +110,7 @@ sealed interface Descriptor {
     */
    fun isParentOf(descriptor: Descriptor): Boolean = when (descriptor) {
       is SpecDescriptor -> false // nothing can be the parent of a spec
-      is TestDescriptor -> this.isEqual(descriptor.parent)
+      is TestDescriptor -> this == descriptor.parent
    }
 
    /**
@@ -163,7 +137,7 @@ sealed interface Descriptor {
     * Returns `true` if this [descriptor] is an ancestor of, or the same as, the given [descriptor].
     */
    fun isPrefixOf(descriptor: Descriptor): Boolean =
-      this.isEqual(descriptor) || this.isAncestorOf(descriptor)
+      this == descriptor || this.isAncestorOf(descriptor)
 
    /**
     * Returns true if this [descriptor] could be a parent or a child of the given [descriptor].
@@ -179,7 +153,7 @@ sealed interface Descriptor {
     *
     */
    fun hasSharedPath(descriptor: Descriptor): Boolean {
-      return this.isEqual(descriptor) || this.isAncestorOf(descriptor) || this.isDescendentOf(descriptor)
+      return this == descriptor || this.isAncestorOf(descriptor) || this.isDescendentOf(descriptor)
    }
 
    /**

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/descriptors/DescriptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/descriptors/DescriptorTest.kt
@@ -23,6 +23,14 @@ class DescriptorTest : FunSpec({
    val e = d.append("e")
    val f = spec.append("f")
 
+   // descriptor tree rooted at jsSpec (simple name, no FQN) for "without FQNs" tests
+   val jsA = jsSpec.append("a")
+   val jsB = jsA.append("b")
+   val jsC = jsB.append("c")
+   val jsD = jsSpec.append("d")
+   val jsE = jsD.append("e")
+   val jsF = jsSpec.append("f")
+
    test("isTestCase") {
       spec.isTestCase() shouldBe false
       listOf(a, b, c, d, e, f).forAll {
@@ -109,16 +117,16 @@ class DescriptorTest : FunSpec({
 
    test("isDescendentOf without FQNs") {
 
-      a.isDescendentOf(b) shouldBe false
-      b.isDescendentOf(c) shouldBe false
-      b.isDescendentOf(a) shouldBe true
-      c.isDescendentOf(a) shouldBe true
-      c.isDescendentOf(b) shouldBe true
+      jsA.isDescendentOf(jsB) shouldBe false
+      jsB.isDescendentOf(jsC) shouldBe false
+      jsB.isDescendentOf(jsA) shouldBe true
+      jsC.isDescendentOf(jsA) shouldBe true
+      jsC.isDescendentOf(jsB) shouldBe true
 
-      e.isDescendentOf(d) shouldBe true
-      d.isDescendentOf(e) shouldBe false
+      jsE.isDescendentOf(jsD) shouldBe true
+      jsD.isDescendentOf(jsE) shouldBe false
 
-      listOf(a, b, c, d, e, f).forAll {
+      listOf(jsA, jsB, jsC, jsD, jsE, jsF).forAll {
          it.isDescendentOf(jsSpec) shouldBe true
          jsSpec.isDescendentOf(it) shouldBe false
       }
@@ -139,17 +147,17 @@ class DescriptorTest : FunSpec({
    }
 
    test("isPrefixOf without FQNs") {
-      jsSpec.isPrefixOf(a) shouldBe true
-      jsSpec.isPrefixOf(b) shouldBe true
-      jsSpec.isPrefixOf(c) shouldBe true
-      a.isPrefixOf(b) shouldBe true
-      a.isPrefixOf(c) shouldBe true
-      b.isPrefixOf(a) shouldBe false
-      c.isPrefixOf(a) shouldBe false
-      c.isPrefixOf(b) shouldBe false
+      jsSpec.isPrefixOf(jsA) shouldBe true
+      jsSpec.isPrefixOf(jsB) shouldBe true
+      jsSpec.isPrefixOf(jsC) shouldBe true
+      jsA.isPrefixOf(jsB) shouldBe true
+      jsA.isPrefixOf(jsC) shouldBe true
+      jsB.isPrefixOf(jsA) shouldBe false
+      jsC.isPrefixOf(jsA) shouldBe false
+      jsC.isPrefixOf(jsB) shouldBe false
 
-      d.isPrefixOf(e) shouldBe true
-      e.isPrefixOf(d) shouldBe false
+      jsD.isPrefixOf(jsE) shouldBe true
+      jsE.isPrefixOf(jsD) shouldBe false
    }
 
    test("hasSharedPath") {
@@ -175,22 +183,22 @@ class DescriptorTest : FunSpec({
 
    test("hasSharedPath without FQNs") {
 
-      listOf(a, b, c, d, e, f).forAll {
+      listOf(jsA, jsB, jsC, jsD, jsE, jsF).forAll {
          jsSpec.hasSharedPath(it) shouldBe true
       }
 
-      a.hasSharedPath(b) shouldBe true
-      a.hasSharedPath(c) shouldBe true
-      b.hasSharedPath(a) shouldBe true
-      b.hasSharedPath(c) shouldBe true
-      c.hasSharedPath(a) shouldBe true
-      c.hasSharedPath(b) shouldBe true
+      jsA.hasSharedPath(jsB) shouldBe true
+      jsA.hasSharedPath(jsC) shouldBe true
+      jsB.hasSharedPath(jsA) shouldBe true
+      jsB.hasSharedPath(jsC) shouldBe true
+      jsC.hasSharedPath(jsA) shouldBe true
+      jsC.hasSharedPath(jsB) shouldBe true
 
-      d.hasSharedPath(e) shouldBe true
-      e.hasSharedPath(d) shouldBe true
+      jsD.hasSharedPath(jsE) shouldBe true
+      jsE.hasSharedPath(jsD) shouldBe true
 
-      f.hasSharedPath(a) shouldBe false
-      f.hasSharedPath(b) shouldBe false
-      f.hasSharedPath(c) shouldBe false
+      jsF.hasSharedPath(jsA) shouldBe false
+      jsF.hasSharedPath(jsB) shouldBe false
+      jsF.hasSharedPath(jsC) shouldBe false
    }
 })


### PR DESCRIPTION
## Summary

- Removes `Descriptor.isEqual()` which was deprecated in 6.1 when Kotest began populating the fully qualified spec name on all platforms
- Replaces the three internal call sites in `descriptor.kt` (`isParentOf`, `isPrefixOf`, `hasSharedPath`) with plain `==`
- Updates the three "without FQNs" test cases in `DescriptorTest` to operate within a `jsSpec`-rooted descriptor tree rather than crossing between a FQN tree and a simple-name tree (which `==` correctly treats as distinct)
- Removes `isEqual` from the API dump (`kotest-framework-engine.api`)

## Test plan

- [x] `DescriptorTest` passes (`./gradlew :kotest-framework:kotest-framework-engine:jvmTest --tests "com.sksamuel.kotest.engine.descriptors.DescriptorTest"`)
- [ ] Full `apiCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)