### PR TITLE
AI: add Kotest debugging path and reference guide

### DIFF
--- a/skills/alfonsos-ai-dump/SKILL.md
+++ b/skills/alfonsos-ai-dump/SKILL.md
@@ -40,14 +40,15 @@ structured summary.
 
 ### Classify the Task
 
-| User Intent | Path |
-|-------------|------|
-| Start from scratch — new Kotest project | **Path A** — Setup & First Tests |
-| Migrate from JUnit/TestNG/Spek | **Path B** — Migration |
-| Add assertions to existing tests (any framework) | **Path C** — Assertions Only |
-| Add property-based testing | **Path D** — Property Testing |
+| User Intent                                                 | Path                                |
+|-------------------------------------------------------------|-------------------------------------|
+| Start from scratch — new Kotest project                     | **Path A** — Setup & First Tests    |
+| Migrate from JUnit/TestNG/Spek                              | **Path B** — Migration              |
+| Add assertions to existing tests (any framework)            | **Path C** — Assertions Only        |
+| Add property-based testing                                  | **Path D** — Property Testing       |
 | Configure advanced features (concurrency, extensions, tags) | **Path E** — Advanced Configuration |
-| Writing tests for Kotlin Multiplatform | **Path F** — KMP Testing |
+| Writing tests for Kotlin Multiplatform                      | **Path F** — KMP Testing            |
+| Debugging Kotest Issues                                     | **Path G** - Kotest Troubleshooting |
 
 ## Path A: Setup & First Tests
 
@@ -565,6 +566,20 @@ See [references/SETUP-REFERENCE.md](references/SETUP-REFERENCE.md) for platform-
 - On Native: Data-driven tests require at least one non-data test in the spec
 - Android instrumented tests use JUnit4 runner: `kotest-runner-junit4`
 
+## Path G: Kotest Debugging
+
+See [references/KOTEST-DEBUGGING.md](references/KOTEST-DEBUGGING.md) for the full guide.
+
+### Quick Checklist
+
+1. **Enable debug logging** — set `KOTEST_DEBUG=true` to get verbose engine output
+2. **Collect versions** — Kotest, Kotlin, Gradle, JVM, and target platform
+3. **Capture full output** — `KOTEST_DEBUG=true ./gradlew test 2>&1 | tee kotest-debug.log`
+4. **Check test reports** — `build/reports/tests/test/index.html`
+5. **Isolate the failure** — `./gradlew test --tests "com.example.MyFailingTest"`
+6. **Verify ProjectConfig** — grep debug output for `projectconfig` if config changes have no effect
+7. **Reproduce minimally** — stripped-down spec with no external dependencies
+
 ## Verification
 
 After setup or migration, verify with the [checklist](assets/checklist.md). Key checks:
@@ -603,4 +618,5 @@ See [references/KNOWN-ISSUES.md](references/KNOWN-ISSUES.md) for details. Key go
 - [Property Testing Reference](references/PROPERTY-TESTING-REFERENCE.md) — generators, config, shrinking
 - [Migration Guide](references/MIGRATION-GUIDE.md) — JUnit 4/5, TestNG, Spek migration mappings
 - [Known Issues](references/KNOWN-ISSUES.md) — common problems and workarounds
+- [Kotest Debugging](references/KOTEST-DEBUGGING.md) — how to gather diagnostic info and reproduce issues
 

--- a/skills/alfonsos-ai-dump/references/KOTEST-DEBUGGING.md
+++ b/skills/alfonsos-ai-dump/references/KOTEST-DEBUGGING.md
@@ -1,0 +1,155 @@
+# Kotest Debugging Guide
+
+When a user reports a Kotest issue, gather the following information before diagnosing.
+
+## Step 1: Enable Debug Logging
+
+Set the `KOTEST_DEBUG` environment variable to `true` to enable verbose internal logging from the
+Kotest engine. This prints lifecycle events, spec discovery, extension callbacks, and configuration
+resolution to stderr.
+
+**Gradle (one-off):**
+```bash
+KOTEST_DEBUG=true ./gradlew test
+```
+
+**Gradle (persistent in build file):**
+```kotlin
+tasks.withType<Test>().configureEach {
+    environment("KOTEST_DEBUG", "true")
+}
+```
+
+**IntelliJ Run Configuration:**
+Add `KOTEST_DEBUG=true` to the environment variables field of the run configuration.
+
+The debug output will include lines such as:
+```
+[kotest] loading spec io.example.MySpec
+[kotest] executing test: my test name
+[kotest] extension callback: BeforeSpecListener
+```
+
+## Step 2: Collect Version Information
+
+Ask the user to provide:
+
+- **Kotest version** — check `build.gradle.kts` or `libs.versions.toml`
+- **Kotlin version** — check `kotlin()` plugin version in build file
+- **Gradle version** — from `gradle/wrapper/gradle-wrapper.properties`
+- **JVM version** — `java -version` or `./gradlew --version`
+- **Platform** — JVM / JS / WasmJS / Native / Android
+- **Test runner** — `kotest-runner-junit5`, `kotest-runner-junit4`, or engine-only (KMP)
+
+## Step 3: Collect the Full Error Output
+
+Request the full output from one of:
+
+```bash
+./gradlew test --info 2>&1 | tee kotest-debug.log
+KOTEST_DEBUG=true ./gradlew test 2>&1 | tee kotest-debug.log
+```
+
+Using `--info` surfaces task-level detail that `--debug` buries in Gradle noise. The log should
+include the test report summary and any stack traces.
+
+## Step 4: Check the Test Report
+
+HTML and XML test reports are written to `build/reports/tests/test/` by default.
+
+```bash
+open build/reports/tests/test/index.html   # macOS
+xdg-open build/reports/tests/test/index.html  # Linux
+```
+
+The XML reports under `build/test-results/` are useful for CI failures where HTML is unavailable.
+
+## Step 5: Isolate the Failure
+
+Ask the user to try running the failing test in isolation:
+
+```bash
+./gradlew test --tests "com.example.MyFailingTest"
+./gradlew test --tests "com.example.MyFailingTest.my test name"
+```
+
+If the test passes in isolation but fails as part of the full suite, the issue is likely
+ordering-dependent state (see `IsolationMode`) or a shared extension side-effect.
+
+## Step 6: Check ProjectConfig Resolution
+
+Kotest scans the classpath for a class at `io.kotest.provided.ProjectConfig`. If configuration
+changes appear to have no effect, verify discovery with:
+
+```bash
+KOTEST_DEBUG=true ./gradlew test 2>&1 | grep -i "projectconfig\|config"
+```
+
+The package `io.kotest.provided` is the default scan location. If a custom location is used, it
+must be set via:
+
+```bash
+./gradlew test -Dkotest.framework.config.fqn=com.example.MyProjectConfig
+```
+
+## Step 7: Reproduce with a Minimal Example
+
+If the issue is still unclear, ask the user to create a minimal reproduction:
+
+1. Create a new Gradle project with only the relevant Kotest dependencies
+2. Copy the failing spec with the minimum code needed to trigger the bug
+3. Confirm the failure reproduces before sharing
+
+A reproduction that uses `StringSpec` or `FunSpec` with no external dependencies is ideal.
+
+## Common Debug Scenarios
+
+### Tests not discovered
+
+```bash
+KOTEST_DEBUG=true ./gradlew test 2>&1 | grep -i "spec\|discover\|scan"
+```
+
+Check:
+- `useJUnitPlatform()` is present in the `test` task configuration (JVM)
+- For KMP: KSP plugin and Kotest Gradle plugin are both applied
+- The spec class is not abstract and extends a Kotest spec style
+
+### Extension or lifecycle callback not firing
+
+```bash
+KOTEST_DEBUG=true ./gradlew test 2>&1 | grep -i "extension\|listener\|before\|after"
+```
+
+Check:
+- Extension is registered via `extension(...)` inside the spec, or globally in `ProjectConfig`
+- `@AutoScan` was removed in Kotest 6.0 — explicit registration is required
+
+### Timeout or coroutine hang
+
+Add a short timeout to isolate the hanging test:
+
+```kotlin
+test("my test").config(timeout = 5.seconds) {
+    // ...
+}
+```
+
+Use `blockingTest = true` if the test body calls blocking (non-suspending) code.
+
+### Property test failure — reproducing a specific seed
+
+When a property test fails, Kotest prints the failing seed:
+
+```
+Attempting to shrink arg...
+Caused by: Property test failed for inputs listed below after 42 attempts
+Repeat this test by using seed 8168214184
+
+```
+
+Reproduce deterministically with:
+
+```kotlin
+checkAll(PropTestConfig(seed = 8168214184)) { ... }
+```

--- a/skills/alfonsos-ai-dump/references/KOTEST-DEBUGGING.md
+++ b/skills/alfonsos-ai-dump/references/KOTEST-DEBUGGING.md
@@ -92,13 +92,14 @@ must be set via:
 ./gradlew test -Dkotest.framework.config.fqn=com.example.MyProjectConfig
 ```
 
-## Step 7: Reproduce with a Minimal Example
+## Step 7: Reproduce with a Minimal Example and report
 
 If the issue is still unclear, ask the user to create a minimal reproduction:
 
 1. Create a new Gradle project with only the relevant Kotest dependencies
 2. Copy the failing spec with the minimum code needed to trigger the bug
-3. Confirm the failure reproduces before sharing
+3. Confirm the failure reproduces
+4. ask the user to share it with the kotest team with a brief summary of the issue and steps to reproduce via https://github.com/kotest/kotest/issues/new/choose
 
 A reproduction that uses `StringSpec` or `FunSpec` with no external dependencies is ideal.
 


### PR DESCRIPTION
Adds Path G with a quick checklist and a detailed KOTEST-DEBUGGING.md covering KOTEST_DEBUG=true, version collection, test isolation, ProjectConfig resolution, and common debug scenarios (discovery, lifecycle, timeouts, property seeds).