### PR TITLE
Support multiple --test args joined by semicolon in KOTEST_INCLUDE_PATTERN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ node_modules/
 .DS_Store
 .intellijPlatform
 yarn.lock
+
+.gemini/
+gha-creds-*.json

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/filter/IncludePatternEnvDescriptorFilter.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/filter/IncludePatternEnvDescriptorFilter.kt
@@ -13,6 +13,12 @@ internal object IncludePatternEnvDescriptorFilter : TestPatternIncludeDescriptor
    override fun filter(descriptor: Descriptor): DescriptorFilterResult {
       val env = env(INCLUDE_PATTERN_ENV)
       // if there is no include pattern, then we include everything by default
-      return if (env.isNullOrBlank()) DescriptorFilterResult.Include else filter(env, descriptor)
+      if (env.isNullOrBlank()) return DescriptorFilterResult.Include
+
+      // the Kotest Gradle plugin will merge multiple --test args to a single env var, so we must split here
+      // Gradle behavior: Cumulative Filtering: Each --tests option acts as an inclusive filter. For example, running gradle test --tests "com.packageA.*" --tests "com.packageB.*" will execute all tests in both packages
+      val args = env.split(";")
+      val any = args.any { filter(it, descriptor) == DescriptorFilterResult.Include }
+      return if (any) DescriptorFilterResult.Include else DescriptorFilterResult.Exclude(null)
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/IncludePatternEnvDescriptorFilterEnvTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/IncludePatternEnvDescriptorFilterEnvTest.kt
@@ -1,0 +1,89 @@
+package com.sksamuel.kotest.engine.extensions
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.Isolate
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.descriptors.toDescriptor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.extensions.filter.INCLUDE_PATTERN_ENV
+import io.kotest.engine.extensions.filter.DescriptorFilterResult
+import io.kotest.engine.extensions.filter.IncludePatternEnvDescriptorFilter
+import io.kotest.matchers.shouldBe
+
+private fun withEnv(key: String, value: String, block: () -> Unit) {
+   val systemEnv = System.getenv()
+   @Suppress("UNCHECKED_CAST")
+   val map = systemEnv.javaClass.getDeclaredField("m")
+      .also { it.isAccessible = true }
+      .get(systemEnv) as MutableMap<String, String>
+   val prev = map[key]
+   map[key] = value
+   try {
+      block()
+   } finally {
+      if (prev == null) map.remove(key) else map[key] = prev
+   }
+}
+
+@Isolate
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class IncludePatternEnvDescriptorFilterEnvTest : FunSpec({
+
+   val spec = IncludePatternEnvDescriptorFilterEnvTest::class.toDescriptor()
+   val fqcn = "com.sksamuel.kotest.engine.extensions.IncludePatternEnvDescriptorFilterEnvTest"
+
+   test("no env var set includes everything") {
+      IncludePatternEnvDescriptorFilter.filter(spec) shouldBe DescriptorFilterResult.Include
+   }
+
+   test("single pattern matching spec is included") {
+      withEnv(INCLUDE_PATTERN_ENV, "$fqcn") {
+         IncludePatternEnvDescriptorFilter.filter(spec) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
+   test("single pattern not matching spec is excluded") {
+      withEnv(INCLUDE_PATTERN_ENV, "com.other.SomeSpec") {
+         IncludePatternEnvDescriptorFilter.filter(spec) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+   }
+
+   test("multiple patterns joined by semicolon - first pattern matches") {
+      withEnv(INCLUDE_PATTERN_ENV, "$fqcn;com.other.SomeSpec") {
+         IncludePatternEnvDescriptorFilter.filter(spec) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
+   test("multiple patterns joined by semicolon - second pattern matches") {
+      withEnv(INCLUDE_PATTERN_ENV, "com.other.SomeSpec;$fqcn") {
+         IncludePatternEnvDescriptorFilter.filter(spec) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
+   test("multiple patterns joined by semicolon - neither matches") {
+      withEnv(INCLUDE_PATTERN_ENV, "com.other.SomeSpec;com.other.AnotherSpec") {
+         IncludePatternEnvDescriptorFilter.filter(spec) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+   }
+
+   test("multiple patterns joined by semicolon - test descriptor matched by first pattern") {
+      val test = spec.append("my test")
+      withEnv(INCLUDE_PATTERN_ENV, "$fqcn.my test;com.other.AnotherSpec") {
+         IncludePatternEnvDescriptorFilter.filter(test) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
+   test("multiple patterns joined by semicolon - test descriptor matched by second pattern") {
+      val test = spec.append("my test")
+      withEnv(INCLUDE_PATTERN_ENV, "com.other.AnotherSpec;$fqcn.my test") {
+         IncludePatternEnvDescriptorFilter.filter(test) shouldBe DescriptorFilterResult.Include
+      }
+   }
+
+   test("multiple patterns joined by semicolon - test descriptor not matched by any") {
+      val test = spec.append("my test")
+      withEnv(INCLUDE_PATTERN_ENV, "com.other.AnotherSpec;$fqcn.other test") {
+         IncludePatternEnvDescriptorFilter.filter(test) shouldBe DescriptorFilterResult.Exclude(null)
+      }
+   }
+})


### PR DESCRIPTION
`IncludePatternEnvDescriptorFilter` now splits the `KOTEST_INCLUDE_PATTERN` env var on ;
- This supports the Kotest Gradle plugin merging multiple `--test` arguments into a single env var (e.g. `gradle test --tests "com.packageA.*" --tests "com.packageB.*"`)
- Matches Gradle's own cumulative filtering semantics where each `--tests` option is an inclusive filter