### PR TITLE
allow passing a block asserting on T when calling shouldBeFailure

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/result/failures.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/result/failures.kt
@@ -58,7 +58,7 @@ infix fun Result<*>.shouldBeFailure(block: ((Throwable) -> Unit)): Throwable {
 }
 
 /**
- * Asserts that this result is a failure of type [T]
+ * Asserts that this result is a failure of type [T], and optionally pass a [block] to assert on the typed exception [T]
  * ~~~
  * failure(MyException).shouldBeFailure<MyException>()      // Assertion passes
  * failure(MyException).shouldBeFailure<MyOtherException>() // Assertion fails
@@ -66,9 +66,9 @@ infix fun Result<*>.shouldBeFailure(block: ((Throwable) -> Unit)): Throwable {
  * ~~~
  */
 @JvmName("shouldBeFailureT")
-inline fun <reified T : Throwable> Result<*>.shouldBeFailure(): T {
+inline fun <reified T : Throwable> Result<*>.shouldBeFailure(block: ((T) -> Unit) = {}): T {
    this should FailureTypeMatcher(T::class)
-   return exceptionOrNull() as T
+   return (exceptionOrNull() as T).also(block)
 }
 
 internal val AnyError = object : Throwable() {}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/result/FailureMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/result/FailureMatchersTest.kt
@@ -117,11 +117,26 @@ class FailureMatchersTest : FunSpec({
          shouldThrowAny { failure<String>(DummyException2).shouldBeFailure<DummyException3>() }
          shouldThrowAny { success("abc").shouldBeFailure<DummyException2>() }
       }
+
+      test("Should be failure with reified type and test block") {
+         failure<String>(DummyException2).shouldBeFailure<DummyException2> {
+            it.innerValue shouldBe "innerValue"
+            it.toString() shouldBe "DummyException2"
+         }
+         shouldThrowAny { failure<String>(DummyException2).shouldBeFailure<DummyException3>{
+            it.toString() shouldBe "DummyException3"
+         } }
+         shouldThrowAny { success("abc").shouldBeFailure<DummyException2>{
+            it.innerValue shouldBe "innerValue"
+            it.toString() shouldBe "DummyException2"
+         } }
+      }
    }
 })
 
 private object DummyException2 : Exception() {
    override fun toString() = "DummyException2"
+   val innerValue: String = "innerValue"
 }
 
 private object DummyException3 : Exception() {


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
- allow passing a block asserting on T when calling shouldBeFailure

For https://github.com/kotest/kotest/issues/5923