### PR TITLE
Fix List<Arb>.edgecase silently dropping un-tested arbs

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/edgecases.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/edgecases.kt
@@ -11,14 +11,20 @@ import io.kotest.property.asSample
  * Randomly chooses an [Arb] and then generates an edge case from that [Arb].
  * If the chosen arb has no edge cases, then another arb will be chosen.
  * If all [Arb]s have no edge cases, then returns null.
+ *
+ * Iterates the *shuffled* list so each arb is visited at most once. The previous
+ * implementation shuffled a fresh copy on every recursive call but dropped the
+ * head of the *unshuffled* list, which could discard arbs that were never
+ * visited - meaning a present edge case would be missed with probability up to
+ * (n-1)/n. See [ChoiceTest] for the regression test.
  */
-tailrec fun <A> List<Arb<A>>.edgecase(rs: RandomSource): Sample<A>? {
-   if (this.isEmpty()) return null
+fun <A> List<Arb<A>>.edgecase(rs: RandomSource): Sample<A>? {
    val shuffled = this.shuffled(rs.random)
-   return when (val edge = shuffled.first().edgecase(rs)) {
-      null -> this.drop(1).edgecase(rs)
-      else -> edge
+   for (arb in shuffled) {
+      val edge = arb.edgecase(rs)
+      if (edge != null) return edge
    }
+   return null
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ChoiceTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ChoiceTest.kt
@@ -12,10 +12,12 @@ import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.choice
+import io.kotest.property.arbitrary.edgecase
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.negativeInt
 import io.kotest.property.arbitrary.positiveInt
+import io.kotest.property.arbitrary.removeEdgecases
 import io.kotest.property.arbitrary.take
 import io.kotest.property.forAll
 
@@ -92,6 +94,30 @@ class ChoiceTest : WordSpec({
             .toSet()
 
          valueSet shouldBe setOf(1, 2)
+      }
+      // regression for a bug where List<Arb<A>>.edgecase shuffled the list on every recursive
+      // call but dropped the head of the *unshuffled* list, so arbs whose edges were the only
+      // ones available could be discarded before being visited.
+      "find an edge case even when most arbs have no edge cases" {
+         // Single arb with an edge case mixed with many arbs that have none. removeEdgecases
+         // is essential here because plain `arbitrary { ... }` falls back to its sample value
+         // for edgecase(), which would mask the bug.
+         val withEdge = arbitrary(listOf(42)) { 99 }
+         val withoutEdge: List<Arb<Int>> = List(20) { arbitrary { 0 }.removeEdgecases() }
+         // withEdge is placed at the front - the buggy implementation dropped the head of the
+         // unshuffled list on every recursion, so the only arb with edges was discarded almost
+         // immediately. Placing it at the end would mask the bug because it would survive all
+         // the drops and end up tested last.
+         val arbs: List<Arb<Int>> = listOf(withEdge) + withoutEdge
+
+         // Try many seeds - on the buggy implementation this returned null for the majority of
+         // seeds, since the only-arb-with-an-edge typically ended up at an index > 0 in the
+         // original list and got dropped before being inspected. With the fix every seed should
+         // surface edge case 42.
+         repeat(50) { seed ->
+            val sample = arbs.edgecase(RandomSource.seeded(seed.toLong()))
+            sample?.value shouldBe 42
+         }
       }
    }
 })


### PR DESCRIPTION
## Summary

\`List<Arb<A>>.edgecase\` (used by \`Arb.choice\`, \`Arb.merge\`, etc.) is documented as: *if the chosen arb has no edge cases, then another arb will be chosen*. Today it can fail to do that.

The implementation reshuffles the list on every recursive call, picks the head of the *shuffled* copy, but then drops the head of the **unshuffled** \`this\` to recurse. So:

- The arb that was actually tested may stay in \`this\`.
- A different arb (the one that happened to be at index 0 of \`this\`) is discarded before ever being visited.

For an input where only the first arb carries an edge case, the bug fires with probability up to (n−1)/n: the recursion drops it before ever picking it. The existing \`ChoiceTest\` cases didn't catch this because they all use \`arbitrary(listOf(...)) { ... }\`, and the default \`arbitrary { }\` builder falls back to its sample for \`edgecase()\` rather than returning null — so the buggy code path is never exercised.

## Fix

Replace the tail-recursion + drop dance with a single shuffle followed by a linear scan. Every arb is visited at most once, and the first one that yields a non-null edge case wins.

## Test plan

Added a regression test that places the only edge-bearing arb at the head of a list of \`removeEdgecases()\` arbs. On master it fails for the majority of seeds; with the fix it passes for every seed.

- [x] \`./gradlew :kotest-property:jvmTest\` — green
- [x] Verified the new test fails on master before the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)