### PR TITLE
Fix integer shrinkers proposing wrap-around values for near-MIN inputs

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/ints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/ints.kt
@@ -14,7 +14,11 @@ class IntShrinker(val range: IntRange) : Shrinker<Int> {
       1, -1 -> listOf(0).filter { it in range }
       else -> {
          val a = intArrayOf(0, 1, -1, abs(value), value / 3, value / 2, value * 2 / 3)
-         val b = (1..5).map { value - it }.reversed().filter { it > 0 }
+         // Only include value-1..value-5 when the subtraction is safe AND yields a positive
+         // number. The previous `(1..5).map { value - it }.filter { it > 0 }` underflowed for
+         // values near Int.MIN_VALUE, wrapping into the positive Int.MAX_VALUE range, and the
+         // `> 0` filter then surfaced those wrapped values as bogus shrink candidates.
+         val b = (1..5).mapNotNull { i -> if (value > i) value - i else null }.reversed()
          (a + b).distinct().filterNot { it == value }.filter { it in range }
       }
    }
@@ -88,7 +92,10 @@ class UIntShrinker(val range: UIntRange) : Shrinker<UInt> {
       1u -> listOf(0u).filter { it in range }
       else -> {
          val a = listOf(0u, 1u, value / 3u, value / 2u, value * 2u / 3u)
-         val b = (1u..5u).map { value - it }.reversed().filter { it > 0u }
+         // Only include value-1..value-5 when the subtraction is safe. UInt subtraction
+         // underflows silently for small values (e.g. 2u - 5u wraps to UInt.MAX_VALUE - 2),
+         // which then survived the `> 0u` filter and ended up as bogus shrink candidates.
+         val b = (1u..5u).mapNotNull { i -> if (value > i) value - i else null }.reversed()
          (a + b).distinct().filterNot { it == value }.filter { it in range }
       }
    }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/longs.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/longs.kt
@@ -14,7 +14,10 @@ class LongShrinker(private val range: LongRange) : Shrinker<Long> {
       1L, -1L -> listOf(0L).filter { it in range }
       else -> {
          val a = listOf(0, 1, -1, abs(value), value / 3, value / 2, value * 2 / 3)
-         val b = (1..5).map { value - it }.reversed().filter { it > 0 }
+         // Only include value-1..value-5 when the subtraction is safe. The previous
+         // `(1..5).map { value - it }.filter { it > 0 }` underflowed for values near
+         // Long.MIN_VALUE and surfaced wrapped Long.MAX_VALUE-area numbers as shrink candidates.
+         val b = (1..5).mapNotNull { i -> if (value > i) value - i else null }.reversed()
          (a + b).distinct().filterNot { it == value }.filter { it in range }
       }
    }
@@ -81,7 +84,10 @@ class ULongShrinker(val range: ULongRange) : Shrinker<ULong> {
       1uL -> listOf(0uL).filter { it in range }
       else -> {
          val a = listOf(0uL, 1uL, value / 3u, value / 2u, value * 2u / 3u)
-         val b = (1u..5u).map { value - it }.reversed().filter { it > 0u }
+         // Only include value-1..value-5 when the subtraction is safe. ULong subtraction
+         // underflows silently, wrapping into the upper ULong range, which the `> 0u` filter
+         // then surfaced as bogus shrink candidates.
+         val b = (1u..5u).mapNotNull { i -> if (value > i) value - i else null }.reversed()
          (a + b).distinct().filterNot { it == value }.filter { it in range }
       }
    }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/IntShrinkerTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/IntShrinkerTest.kt
@@ -63,6 +63,23 @@ class IntShrinkerTest : WordSpec() {
             val candidates = shrinker.shrink(90)
             candidates.shouldContain(60)
          }
+         // regression: subtracting 1..5 from a value near Int.MIN_VALUE underflowed silently
+         // and the wrapped-positive results then survived the `> 0` filter, so the shrinker
+         // proposed values ~Int.MAX_VALUE as "shrinks" of values ~Int.MIN_VALUE.
+         // regression: subtracting 1..5 from a value near Int.MIN_VALUE underflowed silently
+         // and the wrapped-positive results then survived the `> 0` filter, so the shrinker
+         // proposed values ~Int.MAX_VALUE as "shrinks" of values ~Int.MIN_VALUE.
+         "not propose subtract-underflowed candidates when shrinking values near Int.MIN_VALUE" {
+            // Specifically check the wrapped values that were the bug. abs(value) is intended
+            // to appear and is allowed (it's a legitimate "flip the sign" shrink candidate).
+            //
+            // For value = Int.MIN_VALUE+4, the buggy code computed `value - 5 = Int.MIN_VALUE-1`
+            // which wrapped to Int.MAX_VALUE, then survived the `it > 0` filter. abs(value)
+            // for the same input is Int.MAX_VALUE - 3, so we can disambiguate.
+            shrinker.shrink(Int.MIN_VALUE + 4).shouldNotContain(Int.MAX_VALUE)
+            shrinker.shrink(Int.MIN_VALUE + 3).shouldNotContain(Int.MAX_VALUE)
+            shrinker.shrink(Int.MIN_VALUE + 3).shouldNotContain(Int.MAX_VALUE - 1)
+         }
       }
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/LongShrinkerTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/LongShrinkerTest.kt
@@ -62,6 +62,17 @@ class LongShrinkerTest : WordSpec() {
             val candidates = shrinker.shrink(90)
             candidates.shouldContain(60)
          }
+         // regression: subtracting 1..5 from a value near Long.MIN_VALUE underflowed silently
+         // and the wrapped-positive results survived the `> 0` filter, so the shrinker proposed
+         // values ~Long.MAX_VALUE as "shrinks" of values ~Long.MIN_VALUE.
+         "not propose subtract-underflowed candidates when shrinking values near Long.MIN_VALUE" {
+            // abs(value) is allowed (legitimate sign-flip candidate). We check the specific
+            // wrapped values from the bug. For value = Long.MIN_VALUE + 4, the buggy code
+            // computed `value - 5 = Long.MIN_VALUE - 1` which wrapped to Long.MAX_VALUE.
+            shrinker.shrink(Long.MIN_VALUE + 4L).shouldNotContain(Long.MAX_VALUE)
+            shrinker.shrink(Long.MIN_VALUE + 3L).shouldNotContain(Long.MAX_VALUE)
+            shrinker.shrink(Long.MIN_VALUE + 3L).shouldNotContain(Long.MAX_VALUE - 1L)
+         }
       }
    }
 }


### PR DESCRIPTION
## Summary

\`IntShrinker\`, \`LongShrinker\`, \`UIntShrinker\` and \`ULongShrinker\` each build a list of \`value - 1 .. value - 5\` candidates as part of their shrink output:

\`\`\`kotlin
val b = (1..5).map { value - it }.reversed().filter { it > 0 }
\`\`\`

For values near \`MIN_VALUE\` (or near zero for the unsigned variants) the subtraction underflows silently in two's-complement and wraps into the upper end of the value range. The post-hoc \`it > 0\` filter then *surfaces* those wrapped values as shrink candidates instead of rejecting them — so the shrinker proposes e.g. \`Int.MAX_VALUE\` as a "shrink" of \`Int.MIN_VALUE + 4\`.

Concrete examples on master:

\`\`\`
IntShrinker(MIN..MAX).shrink(Int.MIN_VALUE + 4) ⊇ {Int.MAX_VALUE}        // bug
LongShrinker(MIN..MAX).shrink(Long.MIN_VALUE + 4) ⊇ {Long.MAX_VALUE}      // bug
UIntShrinker(MIN..MAX).shrink(2u) ⊇ {UInt.MAX_VALUE - 2u}                 // bug
ULongShrinker(MIN..MAX).shrink(2uL) ⊇ {ULong.MAX_VALUE - 2uL}             // bug
\`\`\`

## Fix

Replace the post-hoc filter with a precondition that gates the subtraction itself:

\`\`\`kotlin
val b = (1..5).mapNotNull { i -> if (value > i) value - i else null }.reversed()
\`\`\`

We only compute \`value - i\` when we know it cannot underflow (i.e. when \`value > i\`, the result is positive). Applied identically to all four shrinkers.

\`abs(value)\` is *not* changed — for negative inputs it deliberately surfaces a positive sign-flip candidate, which is part of the intended shrinking strategy and was never the bug.

## Test plan

Added regression tests in \`IntShrinkerTest\` and \`LongShrinkerTest\` that pin the specific wrapped values that were appearing. Both fail on master and pass after the fix.

- [x] \`./gradlew :kotest-property:jvmTest\` — green
- [x] Verified the new tests fail on master before the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)