### PR TITLE
Fix typo "shunk" -> "shrunk" in shrink output

### DIFF
--- a/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/shrinking.kt
+++ b/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/shrinking.kt
@@ -71,7 +71,7 @@ internal suspend fun <A> doShrinking(
 // todo print out each step if enabled
 private fun <A> printResult(sb: StringBuilder, result: ShrinkResult<A>, count: Int) {
    if (count == 0 || result.initial == result.shrink) {
-      sb.append("Arg was not shunk\n")
+      sb.append("Arg was not shrunk\n")
    } else {
       sb.append("Shrink result (after $count shrinks) => ${result.shrink.print().value}\n\n")
 //      when (val location = stacktraces.throwableLocation(result.cause, 4)) {

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/shrink.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/shrink.kt
@@ -111,7 +111,7 @@ private fun ShrinkingMode.isShrinking(count: Int): Boolean = when (this) {
 
 private fun <A> result(sb: StringBuilder, result: StepResult<A>?, count: Int) {
    if (count == 0 || result == null) {
-      sb.append("Arg was not shunk\n")
+      sb.append("Arg was not shrunk\n")
    } else {
       sb.append("Shrink result (after $count shrinks) => ${result.failed.print().value}\n\n")
       when (val location = stacktraces.throwableLocation(result.cause, 4)) {


### PR DESCRIPTION
Two copies of the no-shrink-happened message had the same typo:

- \`shrink.kt:114\`
- \`kotest-property-permutations/.../shrinking.kt:74\`

Both print to stdout when \`PropertyTesting.shouldPrintShrinkSteps\` is on, so users running with that flag would see the misspelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)