### PR TITLE
Remove dead 0L branch in Long.random()

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/random.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/random.kt
@@ -21,7 +21,4 @@ data class RandomSource(val random: Random, val seed: Long) {
 /**
  * Returns a [RandomSource] seeded with the given seed.
  */
-fun Long.random(): RandomSource = when (this) {
-   0L -> RandomSource(Random(0), 0)
-   else -> RandomSource(Random(this), this)
-}
+fun Long.random(): RandomSource = RandomSource(Random(this), this)


### PR DESCRIPTION
\`Long.random()\` was:

\`\`\`kotlin
fun Long.random(): RandomSource = when (this) {
   0L -> RandomSource(Random(0), 0)
   else -> RandomSource(Random(this), this)
}
\`\`\`

The \`0L\` arm produces the same value the else arm would for \`this == 0L\`, so the \`when\` doesn't actually branch. Collapse to a single expression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)