### PR TITLE
Sample Arb.byte directly instead of rejection sampling

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bytes.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/bytes.kt
@@ -3,6 +3,7 @@ package io.kotest.property.arbitrary
 import io.kotest.property.Arb
 import io.kotest.property.Gen
 import io.kotest.property.bimap
+import kotlin.random.nextInt
 import kotlin.random.nextUInt
 
 /**
@@ -11,7 +12,9 @@ import kotlin.random.nextUInt
  */
 fun Arb.Companion.byte(min: Byte = Byte.MIN_VALUE, max: Byte = Byte.MAX_VALUE): Arb<Byte> =
    arbitrary(byteArrayOf(min, -1, 0, 1, max).filter { it in min..max }.distinct(), ByteShrinker) {
-      generateSequence { it.random.nextBytes(1).first() }.filter { it in min..max }.first()
+      // Sample directly in [min..max] rather than drawing from the full Byte range and rejecting,
+      // which used to require ~256/(max-min+1) attempts on average for narrow ranges.
+      it.random.nextInt(min.toInt()..max.toInt()).toByte()
    }
 
 val ByteShrinker = IntShrinker(Byte.MIN_VALUE..Byte.MAX_VALUE).bimap({ it.toInt() }, { it.toByte() })


### PR DESCRIPTION
## Summary

\`Arb.byte\` was implemented as:

\`\`\`kotlin
arbitrary(...) {
   generateSequence { it.random.nextBytes(1).first() }.filter { it in min..max }.first()
}
\`\`\`

This draws a uniform Byte over the full 256-value range and rejects samples that fall outside \`[min..max]\`. For narrow ranges it costs ~\`256 / (max - min + 1)\` attempts per sample on average:

- \`byte(0, 7)\` ≈ 32× slower than necessary
- \`byte(0, 0)\` ≈ 256× slower than necessary

Switch to direct sampling via \`nextInt(min..max).toByte()\`, matching how \`Arb.uByte\` already works on the unsigned side.

## Test plan

- [x] \`./gradlew :kotest-property:jvmTest\` — green (existing \`ByteTest\` and full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)