### PR TITLE
Fix Codepoint.lowSurrogate using ushr instead of and (corrupts supplementary codepoints)

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/codepoints.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/codepoints.kt
@@ -115,7 +115,14 @@ val Codepoint.highSurrogate: Char
    get() = (value ushr 10).toChar() + (Char.MIN_HIGH_SURROGATE - (MIN_SUPPLEMENTARY_CODE_POINT ushr 10)).code
 
 val Codepoint.lowSurrogate: Char
-   get() = (value ushr 0x3ff).toChar() + Char.MIN_LOW_SURROGATE.code
+   // Standard UTF-16 encoding: the low 10 bits of (value - 0x10000) become the offset from
+   // MIN_LOW_SURROGATE. For values >= 0x10000 (the only ones that go through surrogate
+   // encoding), `value and 0x3ff` is equivalent to `(value - 0x10000) and 0x3ff` since
+   // 0x10000 has no overlap with the low 10 bits. The previous implementation used
+   // `ushr 0x3ff` (shift right by 1023, which Kotlin reduces to mod 32 = 31), so it was
+   // returning just the sign bit and producing 0xDC00 for almost every supplementary
+   // codepoint - corrupting surrogate-pair output for e.g. egyptianHieroglyphs().
+   get() = (value and 0x3ff).toChar() + Char.MIN_LOW_SURROGATE.code
 
 fun Codepoint.asString(): String {
    return if (isBmpCodePoint) {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CodepointSurrogateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CodepointSurrogateTest.kt
@@ -1,0 +1,51 @@
+package com.sksamuel.kotest.property.arbitrary
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.Codepoint
+import io.kotest.property.arbitrary.asString
+
+/**
+ * Regression for a typo in `Codepoint.lowSurrogate`: it computed `value ushr 0x3ff` (shift
+ * right by 1023, which Kotlin reduces to `mod 32 = 31` for Int) instead of `value and 0x3ff`.
+ * That returned the sign bit instead of the low 10 bits, so the low surrogate of every
+ * supplementary codepoint collapsed to `0xDC00`, corrupting any surrogate-pair output
+ * (egyptianHieroglyphs(), emoji, etc.).
+ *
+ * The contract: `Codepoint(cp).asString()` round-trips through Java's UTF-16 encoding so
+ * that the resulting string's first codepoint equals `cp`.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class CodepointSurrogateTest : FunSpec({
+
+   test("supplementary codepoints round-trip through asString()") {
+      // U+10000 - first supplementary codepoint
+      Codepoint(0x10000).asString().codePointAt(0) shouldBe 0x10000
+
+      // U+10001 - the low surrogate must encode the +1 in its low 10 bits
+      Codepoint(0x10001).asString().codePointAt(0) shouldBe 0x10001
+
+      // Egyptian hieroglyph in the middle of the range
+      Codepoint(0x13042).asString().codePointAt(0) shouldBe 0x13042
+
+      // U+1F600 (😀) - emoji territory
+      Codepoint(0x1F600).asString().codePointAt(0) shouldBe 0x1F600
+
+      // U+10FFFF - last valid Unicode codepoint
+      Codepoint(0x10FFFF).asString().codePointAt(0) shouldBe 0x10FFFF
+   }
+
+   test("supplementary codepoints encode to exactly two chars") {
+      Codepoint(0x10000).asString().length shouldBe 2
+      Codepoint(0x10001).asString().length shouldBe 2
+      Codepoint(0x1F600).asString().length shouldBe 2
+   }
+
+   test("BMP codepoints still encode as a single char") {
+      Codepoint('a'.code).asString() shouldBe "a"
+      Codepoint('Z'.code).asString() shouldBe "Z"
+      Codepoint(0x4E2D).asString().codePointAt(0) shouldBe 0x4E2D
+   }
+})


### PR DESCRIPTION
## Summary

\`Codepoint.lowSurrogate\` was:

\`\`\`kotlin
val Codepoint.lowSurrogate: Char
   get() = (value ushr 0x3ff).toChar() + Char.MIN_LOW_SURROGATE.code
\`\`\`

Kotlin's \`ushr\` on \`Int\` shifts by \`shift mod 32\`, so \`ushr 0x3ff\` is \`ushr 31\` — that is, just the sign bit. For every supplementary codepoint (≥ U+10000) the result was \`0\`, and the low surrogate collapsed to \`MIN_LOW_SURROGATE\` (\`0xDC00\`) regardless of the codepoint's actual low 10 bits.

The standard UTF-16 low-surrogate formula is \`((cp - 0x10000) and 0x3FF) + 0xDC00\`. Since \`0x10000\` doesn't overlap with the low 10 bits, that simplifies to \`(cp and 0x3FF) + 0xDC00\` for cp ≥ \`0x10000\`. The original code clearly intended \`and\`, not \`ushr\`.

## Impact

Anything using a codepoint generator in the supplementary planes:

- \`Codepoint.egyptianHieroglyphs()\` (range \`0x13000..0x1342E\`) produced surrogate-pair strings whose low surrogate was always \`0xDC00\`, so two distinct hieroglyphs that differed only in their low 10 bits encoded to identical strings.
- User-supplied codepoints in emoji ranges (e.g. \`0x1F600\`) had the same problem.

\`Codepoint(0x13042).asString().codePointAt(0)\` returned \`0x13000\` on master.

## Test plan

Added \`CodepointSurrogateTest\` round-tripping supplementary codepoints through \`asString() -> codePointAt(0)\`. Fails on master, passes after the fix.

- [x] \`./gradlew :kotest-property:jvmTest\` — green
- [x] Verified the new test fails on master before the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)