### PR TITLE
Fix Arb.orNull(0.0) able to produce nulls via boundary draw

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/null.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/null.kt
@@ -21,7 +21,11 @@ fun <A> Arb<A>.orNull(nullProbability: Double): Arb<A?> {
    require(nullProbability in 0.0..1.0) {
       "Please specify a null probability between 0.0 and 1.0. $nullProbability was provided."
    }
-   return orNull { rs: RandomSource -> rs.random.nextDouble(0.0, 1.0) <= nullProbability }
+   // `nextDouble(0.0, 1.0)` is half-open `[0.0, 1.0)`, so:
+   // - using `<` makes nullProbability == 0.0 produce zero nulls (vs `<=` where the rare
+   //   draw of exactly 0.0 from nextDouble would still trigger a null), and
+   // - nullProbability == 1.0 still produces 100% nulls because the draw is always < 1.0.
+   return orNull { rs: RandomSource -> rs.random.nextDouble(0.0, 1.0) < nullProbability }
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/OrNullTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/OrNullTest.kt
@@ -46,6 +46,21 @@ class OrNullTest : FunSpec({
       classifications["non-null"]?.shouldBeBetween(0, 0)
    }
 
+   test("Arb.orNull(nullProbability = 0.0) should never generate null values") {
+      // Pin the boundary: a probability of exactly 0.0 must mean zero nulls. The previous
+      // implementation used `nextDouble(0.0, 1.0) <= 0.0`, which would still trigger a null on
+      // the (vanishingly rare) chance that nextDouble returned exactly 0.0. The fix uses `<`,
+      // making the predicate provably false at p == 0.0 regardless of the draw.
+      val iterations = 10_000
+      val classifications =
+         forAll(iterations, Arb.int().orNull(nullProbability = 0.0)) { num ->
+            classify(num == null, "null", "non-null")
+            true
+         }.classifications()
+      classifications["null"]?.shouldBeBetween(0, 0)
+      classifications["non-null"]?.shouldBeBetween(iterations, iterations)
+   }
+
    test("null probability values can be specified") {
       retry(3, timeout = 2.seconds, delay = 0.1.seconds) {
          listOf(0.0, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0)


### PR DESCRIPTION
## Summary

\`Arb<A>.orNull(nullProbability: Double)\` was implemented with:

\`\`\`kotlin
return orNull { rs -> rs.random.nextDouble(0.0, 1.0) <= nullProbability }
\`\`\`

\`Random.nextDouble(0.0, 1.0)\` returns \`[0.0, 1.0)\`. Combined with \`<=\` this gives two boundary issues:

- \`nullProbability = 0.0\`: a draw of exactly 0.0 (rare — about \`2^-53\` per call — but permitted by the spec) makes \`0.0 <= 0.0\` true, producing a null. The doc says 0.0 means *never* null.
- \`nullProbability\` slightly larger than the desired value: the inclusive comparison overshoots probability mass by 1 ulp.

Switch to \`<\`:

- \`p == 0.0\`: predicate always false → never null.
- \`p == 1.0\`: predicate always true (draw is always \`< 1.0\`) → always null.
- \`p ∈ (0, 1)\`: probability of null is exactly \`p\`.

## Test plan

Added an \`orNull(nullProbability = 0.0)\` test that asserts zero nulls over 10k draws. The existing \`nullProbability = 1.0\` test keeps passing.

- [x] \`./gradlew :kotest-property:jvmTest\` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)