### PR TITLE
Fix Arb.map maxSize off-by-one and minSize == maxSize crash

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
@@ -2,6 +2,7 @@ package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
 import io.kotest.property.Shrinker
+import kotlin.random.nextInt
 
 /**
  * Returns an [Arb] where each generated value is a map, with the entries of the map
@@ -33,7 +34,11 @@ fun <K, V> Arb.Companion.map(
    val edgecase = if (minSize == 0) listOf(emptyMap<K, V>()) else emptyList()
 
    return arbitrary(edgecase, MapShrinker(minSize)) { random ->
-      val targetSize = random.random.nextInt(minSize, maxSize)
+      // Inclusive on both ends to match the doc and the rest of Arb (Arb.list,
+      // Arb.string, ...). The previous `nextInt(minSize, maxSize)` call was the half-open
+      // `[minSize, maxSize)` overload, which silently capped output at maxSize - 1 and threw
+      // IllegalArgumentException for the perfectly reasonable minSize == maxSize case.
+      val targetSize = random.random.nextInt(minSize..maxSize)
       val maxMisses = targetSize * slippage
       val map = mutableMapOf<K, V>()
       var iterations = 0

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
@@ -1,6 +1,6 @@
 package com.sksamuel.kotest.property.arbitrary
 
-import io.kotest.assertions.throwables.shouldThrowWithMessage
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
@@ -10,6 +10,8 @@ import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.Codepoint
@@ -72,11 +74,10 @@ class MapsTest : FunSpec({
       test("should throw when the cardinality of the key arbitrary does not satisfy the required minimum size") {
          val arbKey = Arb.int(1..3)
          val arbMap = Arb.map(arbKey, Arb.string(1..10), minSize = 5, maxSize = 10)
-         shouldThrowWithMessage<IllegalArgumentException>(
-            "the minimum size requirement of 5 could not be satisfied after 90 consecutive samples"
-         ) {
+         val ex = shouldThrow<IllegalArgumentException> {
             arbMap.single(RandomSource.seeded(1234L))
          }
+         ex.message shouldStartWith "the minimum size requirement of 5 could not be satisfied"
       }
    }
 
@@ -102,11 +103,26 @@ class MapsTest : FunSpec({
       test("should throw when the cardinality of the key arbitrary does not satisfy the required minimum size") {
          val arbPair = Arb.pair(Arb.int(1..3), Arb.string(1..10, Codepoint.alphanumeric()))
          val arbMap = Arb.map(arbPair, minSize = 5, maxSize = 10)
-         shouldThrowWithMessage<IllegalArgumentException>(
-            "the minimum size requirement of 5 could not be satisfied after 90 consecutive samples"
-         ) {
+         val ex = shouldThrow<IllegalArgumentException> {
             arbMap.single(RandomSource.seeded(1234L))
          }
+         ex.message shouldStartWith "the minimum size requirement of 5 could not be satisfied"
+      }
+   }
+
+   // regression: Arb.map used `nextInt(minSize, maxSize)` (half-open) instead of
+   // `nextInt(minSize..maxSize)` (inclusive) so it silently capped at maxSize - 1 and threw
+   // IllegalArgumentException for minSize == maxSize.
+   context("Arb.map size bounds") {
+      test("should be able to generate maps with minSize == maxSize") {
+         val arbMap = Arb.map(Arb.int(1..1000), Arb.int(1..1000), minSize = 5, maxSize = 5)
+         arbMap.take(50, RandomSource.seeded(12345L)).toList().forAll { it.size shouldBe 5 }
+      }
+
+      test("should sometimes produce maps of exactly maxSize") {
+         val arbMap = Arb.map(Arb.int(1..1000), Arb.int(1..1000), minSize = 1, maxSize = 5)
+         val maps = arbMap.take(500, RandomSource.seeded(12345L)).toList()
+         maps.any { it.size == 5 } shouldBe true
       }
    }
 


### PR DESCRIPTION
## Summary

\`Arb.map\` was implemented with:

\`\`\`kotlin
val targetSize = random.random.nextInt(minSize, maxSize)
\`\`\`

That's the **two-Int** overload of \`Random.nextInt\`, which produces values in \`[minSize, maxSize)\` — half-open, exclusive on the upper bound. Two consequences:

- The documented "maximum size of the generated map" was never actually reached. \`Arb.map(k, v, minSize = 5, maxSize = 10)\` produced maps of size 5..9, not 5..10.
- \`Arb.map(k, v, minSize = N, maxSize = N)\` threw \`IllegalArgumentException\` on every sample because the half-open range \`[N, N)\` is empty. Useful "give me maps of exactly this size" calls were unusable.

\`Arb.list\` and \`Arb.string\` use the **IntRange** overload (\`nextInt(min..max)\`, inclusive on both ends), which is what \`Arb.map\` should match.

## Fix

Switch to \`nextInt(minSize..maxSize)\` and add the missing \`kotlin.random.nextInt\` import.

## Test plan

Added two regression tests:

- \`minSize == maxSize\` should produce maps of exactly that size (used to throw).
- Over many samples in range \`1..5\`, at least one map should have size 5 (used to be impossible).

Also relaxed two existing assertions that pinned the exact \`"after 90 consecutive samples"\` error message. The 90 came from \`targetSize × slippage\`, where \`targetSize\` is now drawn from a different \`nextInt\` overload — so for the same seed it's a different value. The assertion now just checks the message prefix.

- [x] \`./gradlew :kotest-property:jvmTest\` — green
- [x] Verified the new tests fail on master before the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)