### PR TITLE
Fix Arb.ipAddressV4 unable to produce 255 in any octet

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/network.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/network.kt
@@ -1,17 +1,21 @@
 package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
+import kotlin.random.nextInt
 
 /**
  * Returns an [Arb] where each generated value is an IP Address in V4 format represented as a String.
  * Each part is a number between 0 and 255 except for the first part which is 1-255.
  */
 fun Arb.Companion.ipAddressV4(): Arb<String> = arbitrary {
+   // The two-Int nextInt(from, until) overload is half-open, so e.g. `nextInt(0, 255)` only
+   // produces 0..254 - octet 255 (used in valid addresses like 192.168.1.255 and broadcast
+   // 255.255.255.255) was unreachable. Use the inclusive IntRange overload instead.
    listOf(
-      it.random.nextInt(1, 255),
-      it.random.nextInt(0, 255),
-      it.random.nextInt(0, 255),
-      it.random.nextInt(0, 255)
+      it.random.nextInt(1..255),
+      it.random.nextInt(0..255),
+      it.random.nextInt(0..255),
+      it.random.nextInt(0..255)
    ).joinToString(".")
 }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/IpAddressTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/IpAddressTest.kt
@@ -3,6 +3,7 @@ package com.sksamuel.kotest.property.arbitrary
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.comparables.shouldBeBetween
 import io.kotest.matchers.string.shouldMatch
 import io.kotest.property.Arb
@@ -28,6 +29,20 @@ class IpAddressTest : FunSpec() {
             result.groupValues[3].toInt().shouldBeBetween(0, 255)
             result.groupValues[4].toInt().shouldBeBetween(0, 255)
          }
+      }
+
+      // regression: nextInt(from, until) is half-open, so the previous `nextInt(0, 255)` only
+      // produced octets 0..254. Octet 255 (used in addresses like 192.168.1.255 and the broadcast
+      // 255.255.255.255) was never generated.
+      test("Arb.ipAddressV4 should be able to produce 255 in any octet") {
+         val octetsSeen = Array(4) { mutableSetOf<Int>() }
+         checkAll(20_000, Arb.ipAddressV4()) { ip ->
+            val parts = ip.split(".").map { it.toInt() }
+            parts.forEachIndexed { i, p -> octetsSeen[i].add(p) }
+         }
+         // The chance of not seeing 255 in any given octet over 20k samples (with 256-value range)
+         // is negligible if the generator can in fact produce it.
+         (0..3).forEach { i -> octetsSeen[i].shouldContain(255) }
       }
 
       test("Arb.ipAddressV6 should generate in a:b:c:d:e:f:g:h format") {


### PR DESCRIPTION
## Summary

\`Arb.ipAddressV4\` used the half-open \`Random.nextInt(from, until)\` overload:

\`\`\`kotlin
listOf(
   it.random.nextInt(1, 255),
   it.random.nextInt(0, 255),
   ...
)
\`\`\`

\`nextInt(from, until)\` produces \`[from, until)\`, so each octet is in 0..254 (or 1..254 for the first), never 255. The doc explicitly says octets are "between 0 and 255".

This means the generator never produces:

- \`*.*.*.255\` style addresses (subnet broadcast in many /24 networks)
- \`255.255.255.255\` (limited broadcast)
- \`192.168.1.255\`, \`10.0.0.255\`, etc.

Anything testing IPv4 parsing/handling against \`Arb.ipAddressV4\` was missing the upper edge of every octet.

## Fix

Use the inclusive \`Random.nextInt(IntRange)\` overload (\`nextInt(0..255)\`), matching what \`ipAddressV6\` already does (it uses the single-arg \`nextInt(0x10000)\` which is \`[0, 0x10000)\` — correctly including 0xFFFF).

## Test plan

Added a regression test that draws 20k addresses and asserts each octet position produces 255 at some point. On master 255 never appears; with the fix every octet sees it well within the sample budget.

- [x] \`./gradlew :kotest-property:jvmTest\` — green
- [x] Verified the new test fails on master before the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)