### PR TITLE
Fix Arb.multiple unable to produce the largest multiple of k <= max

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/multiples.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/multiples.kt
@@ -2,6 +2,7 @@ package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
 import io.kotest.property.Shrinker
+import kotlin.random.nextInt
 
 /**
  * Returns an [Arb] where each generated value is a multiple of k between 0 to the specified max.
@@ -13,7 +14,10 @@ import io.kotest.property.Shrinker
  *
  */
 fun Arb.Companion.multiple(k: Int, max: Int): Arb<Int> =
-   arbitrary(MultiplesShrinker(k)) { it.random.nextInt(0, max / k) * k }
+   // Use the inclusive IntRange overload: nextInt(0, max / k) was half-open and produced
+   // 0..(max/k - 1), so the largest multiple of k <= max was never generated. For example,
+   // Arb.multiple(5, 100) produced 0..95 instead of 0..100.
+   arbitrary(MultiplesShrinker(k)) { it.random.nextInt(0..(max / k)) * k }
 
 class MultiplesShrinker(private val multiple: Int) : Shrinker<Int> {
    override fun shrink(value: Int): List<Int> = when (value) {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MultipleArbitraryTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MultipleArbitraryTest.kt
@@ -4,6 +4,7 @@ import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.inspectors.forAll
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
@@ -17,6 +18,27 @@ class MultipleArbitraryTest : FunSpec() {
             .generate(RandomSource.default())
             .take(100)
             .forAll { it.value % 3 shouldBe 0 }
+      }
+
+      // regression: nextInt(0, max / k) was half-open, so the largest multiple of k that is <= max
+      // was unreachable. For Arb.multiple(5, 100), the value 100 was never produced even though
+      // 100 is a valid multiple of 5 within the range.
+      test("multiple should be able to produce the largest multiple of k <= max") {
+         val seen = Arb.multiple(5, 100)
+            .generate(RandomSource.seeded(1234L))
+            .take(2000)
+            .map { it.value }
+            .toSet()
+         seen.shouldContain(100)
+      }
+
+      test("multiple(k, k) should be able to produce k") {
+         val seen = Arb.multiple(7, 7)
+            .generate(RandomSource.seeded(1234L))
+            .take(200)
+            .map { it.value }
+            .toSet()
+         seen.shouldContain(7)
       }
    }
 }


### PR DESCRIPTION
## Summary

\`Arb.multiple(k, max)\` was implemented as:

\`\`\`kotlin
arbitrary(MultiplesShrinker(k)) { it.random.nextInt(0, max / k) * k }
\`\`\`

\`Random.nextInt(from, until)\` is half-open, so this draws \`0..(max/k - 1)\` and multiplies by \`k\`, giving \`0..(max - k)\`. The largest multiple of \`k\` that fits in \`[0..max]\` is *never* produced.

Examples on master:

- \`Arb.multiple(5, 100)\` → 0..95, never 100.
- \`Arb.multiple(7, 7)\` → only 0.
- \`Arb.multiple(10, 99)\` → 0..80, never 90.

## Fix

Use the inclusive \`IntRange\` overload: \`nextInt(0..(max / k))\` so \`max/k\` is reachable, multiplying to \`max\` (when \`max\` is a multiple of k) or to the largest multiple ≤ max otherwise.

## Test plan

Added two regression tests:

- \`Arb.multiple(5, 100)\` over 2000 samples should include \`100\`.
- \`Arb.multiple(7, 7)\` should include \`7\`.

Both fail on master, pass with the fix.

- [x] \`./gradlew :kotest-property:jvmTest\` — green
- [x] Verified the new tests fail on master before the fix is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)