### PR TITLE
Fix haveMaxLength negated message reporting wrong minimum length

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/lengths.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/lengths.kt
@@ -21,7 +21,7 @@ fun haveMaxLength(length: Int): Matcher<CharSequence?> = neverNullMatcher { valu
    MatcherResult(
       value.length <= length,
       { "${value.print().value} should have maximum length of $length" },
-      { "${value.print().value} should have minimum length of ${length - 1}" })
+      { "${value.print().value} should have minimum length of ${length + 1}" })
 }
 
 infix fun <A : CharSequence> A?.shouldHaveMinLength(length: Int): A {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/MaxLengthMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/MaxLengthMatcherTest.kt
@@ -21,6 +21,10 @@ class MaxLengthMatcherTest : FreeSpec() {
             shouldThrow<AssertionError> {
                "12" should haveMaxLength(1)
             }.message shouldBe "\"12\" should have maximum length of 1"
+
+            shouldThrow<AssertionError> {
+               "12" shouldNot haveMaxLength(5)
+            }.message shouldBe "\"12\" should have minimum length of 6"
          }
          "should work on char seq" {
             val empty: CharSequence = ""


### PR DESCRIPTION
## Summary

The negated failure message of `haveMaxLength(length)` used `length - 1` where it should be `length + 1`.

For example, `"abcdef" shouldNot haveMaxLength(5)` (which fails because the matcher passes — length 6 > 5 means... wait, length 6 > 5 means it **doesn't** satisfy haveMaxLength so this would actually pass `shouldNot`):

A correct example: `"abc" shouldNot haveMaxLength(5)` fails because `"abc"` has length 3 ≤ 5. The current message says `"abc" should have minimum length of 4` (= `length - 1`). The correct message is `"abc" should have minimum length of 6` (= `length + 1`), since to fail `haveMaxLength(5)` the value would need length > 5.

(Compare with the analogous `haveMinLength` which correctly uses `length - 1` in its negated message.)

## Test plan
- [x] Added regression test in `MaxLengthMatcherTest`.