### PR TITLE
Fix escapeString in Diff producing literal control chars instead of escape sequences

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/Diff.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/Diff.kt
@@ -138,9 +138,9 @@ private fun escapeString(s: String): String {
     .replace("\\", "\\\\")
     .replace("\"", "\\\"")
     .replace("\'", "\\\'")
-    .replace("\t", "\\\t")
-    .replace("\b", "\\\b")
-    .replace("\n", "\\\n")
-    .replace("\r", "\\\r")
+    .replace("\t", "\\t")
+    .replace("\b", "\\b")
+    .replace("\n", "\\n")
+    .replace("\r", "\\r")
     .replace("\$", "\\\$")
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/DiffTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/DiffTest.kt
@@ -65,6 +65,21 @@ class DiffTest : WordSpec() {
         """.trimMargin()
       }
 
+      "escape control characters in strings" {
+        Diff.create("a\tb", "a\nb").toString() shouldBe """
+          |expected:
+          |  "a\nb"
+          |but was:
+          |  "a\tb"
+        """.trimMargin()
+        Diff.create("x\rb", "x\bb").toString() shouldBe """
+          |expected:
+          |  "x\bb"
+          |but was:
+          |  "x\rb"
+        """.trimMargin()
+      }
+
       "test diff with nested maps" {
         val nestedMaps1 = mapOf(
             "nested" to mapOf(


### PR DESCRIPTION
## Summary

`escapeString` in `Diff.kt` was meant to convert control characters in strings into their two-character escape representation (e.g. tab → `\t`). Instead the replacements were `"\\\t"` etc., which in Kotlin string literals is a backslash followed by the actual tab character. Result: the raw control character was kept, just with a backslash prepended in front of it — the diff output stayed unreadable.

```diff
-    .replace("\t", "\\\t")
-    .replace("\b", "\\\b")
-    .replace("\n", "\\\n")
-    .replace("\r", "\\\r")
+    .replace("\t", "\\t")
+    .replace("\b", "\\b")
+    .replace("\n", "\\n")
+    .replace("\r", "\\r")
```

## Test plan
- [x] Added regression tests in `DiffTest` covering tab, newline, carriage return, and backspace.