### PR TITLE
Restore large-string diff output in StringEq.diff()

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/StringEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/StringEq.kt
@@ -81,7 +81,7 @@ object StringEq : Eq<String> {
             .build()
       else
          AssertionErrorBuilder.create()
-            .withValues(Expected(StringPrint.printUnquoted(expected)), Actual(StringPrint.printUnquoted(actual)))
+            .withValues(Expected(Printed(result.first)), Actual(Printed(result.second)))
             .build()
    }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/StringEqTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/StringEqTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.shouldFailWithMessage
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainInOrder
 
 class StringEqTest : FunSpec({
@@ -49,5 +50,21 @@ class StringEqTest : FunSpec({
          val unixString = "Windows\nUnix\nOldMac\n"
          mixedString shouldBe unixString
       }
+   }
+
+   // Regression test for #5944: when StringEq picks the large-string diff path it must surface
+   // the per-chunk "[Change at line N] ..." output produced by `diffLargeString`, not the original
+   // strings. Previously both branches of the `if/else` in `diff()` used the original strings, so
+   // multi-line mismatches over `largeStringDiffMinSize` lines silently lost the diff output.
+   // Gate to Linux GitHub CI: `useDiff` early-returns false when running inside IntelliJ
+   // (sets idea.active or similar), so the diff-path is only reachable on plain JVM CI runs.
+   test("StringEq.equals should surface diffLargeString chunk output for large multi-line mismatches").config(
+      enabledIf = { System.getenv("CI") == "true" && System.getProperty("idea.active") == null }
+   ) {
+      val expected = (1..60).joinToString("\n") { "expected line $it" }
+      val actual = (1..60).joinToString("\n") { if (it == 30) "MUTATED line 30" else "expected line $it" }
+
+      val result = StringEq.equals(actual, expected, EqContext()) as EqResult.Failure
+      result.error().message shouldContain "[Change at line"
    }
 })


### PR DESCRIPTION
## Summary

Both branches of the `if/else` in `StringEq.diff()` were identical and used the original `expected`/`actual`. The `result` from `diffLargeString` (which contains the helpful per-chunk diff strings, e.g. `[Change at line 5] ...`) was computed but completely unused. The `else` branch should use `result.first` / `result.second`.

This was a regression introduced in #4971 (AssertionErrorBuilder centralization). The pre-refactor behavior was:
```kotlin
return if (result == null)
   failure(Expected(expected.print()), Actual(actual.print()))
else
   failure(Expected(Printed(result.first)), Actual(Printed(result.second)))
```

Multi-line string comparisons now correctly show the diff output again.

## Test plan
- [ ] Existing `StringEqTest` continues to pass.
- [ ] Manually verify multi-line string mismatch produces "[Change at line N]" output (only triggered outside IntelliJ).