### PR TITLE
Fix Arb.map using half-open nextInt for targetSize

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/maps.kt
@@ -2,6 +2,7 @@ package io.kotest.property.arbitrary
 
 import io.kotest.property.Arb
 import io.kotest.property.Shrinker
+import kotlin.random.nextInt
 
 /**
  * Returns an [Arb] where each generated value is a map, with the entries of the map
@@ -33,7 +34,7 @@ fun <K, V> Arb.Companion.map(
    val edgecase = if (minSize == 0) listOf(emptyMap<K, V>()) else emptyList()
 
    return arbitrary(edgecase, MapShrinker(minSize)) { random ->
-      val targetSize = random.random.nextInt(minSize, maxSize)
+      val targetSize = random.random.nextInt(minSize..maxSize)
       val maxMisses = targetSize * slippage
       val map = mutableMapOf<K, V>()
       var iterations = 0

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/MapsTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.ints.shouldBeInRange
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.Codepoint
@@ -73,7 +74,7 @@ class MapsTest : FunSpec({
          val arbKey = Arb.int(1..3)
          val arbMap = Arb.map(arbKey, Arb.string(1..10), minSize = 5, maxSize = 10)
          shouldThrowWithMessage<IllegalArgumentException>(
-            "the minimum size requirement of 5 could not be satisfied after 90 consecutive samples"
+            "the minimum size requirement of 5 could not be satisfied after 60 consecutive samples"
          ) {
             arbMap.single(RandomSource.seeded(1234L))
          }
@@ -103,10 +104,24 @@ class MapsTest : FunSpec({
          val arbPair = Arb.pair(Arb.int(1..3), Arb.string(1..10, Codepoint.alphanumeric()))
          val arbMap = Arb.map(arbPair, minSize = 5, maxSize = 10)
          shouldThrowWithMessage<IllegalArgumentException>(
-            "the minimum size requirement of 5 could not be satisfied after 90 consecutive samples"
+            "the minimum size requirement of 5 could not be satisfied after 60 consecutive samples"
          ) {
             arbMap.single(RandomSource.seeded(1234L))
          }
+      }
+   }
+
+   context("Arb.map size bounds") {
+      test("should be able to produce maxSize entries") {
+         val arbMap = Arb.map(Arb.int(1..10000), Arb.int(), minSize = 5, maxSize = 10)
+         val sizes = arbMap.take(2000, RandomSource.seeded(12345L)).map { it.size }.toSet()
+         sizes shouldContainExactly (5..10).toSet()
+      }
+
+      test("should support fixed-size maps where minSize == maxSize") {
+         val arbMap = Arb.map(Arb.int(1..10000), Arb.int(), minSize = 3, maxSize = 3)
+         val maps = arbMap.take(5, RandomSource.seeded(12345L)).toList()
+         maps.forAll { it.size shouldBe 3 }
       }
    }
 


### PR DESCRIPTION
## Summary

`Arb.map(arb, minSize, maxSize)` used `random.nextInt(minSize, maxSize)`, which is **exclusive** of `maxSize`. Two consequences:

1. `Arb.map(arb, minSize = 5, maxSize = 10)` could only ever produce sizes 5..9 — `maxSize = 10` was unreachable.
2. `Arb.map(arb, minSize = 5, maxSize = 5)` (fixed-size map) crashed with `IllegalArgumentException: Random range is empty: [5, 5)`.

The sibling `Arb.set` (sets.kt:47) already uses the closed `nextInt(range: IntRange)` overload — same fix applied here. This is the same class of bug as #5939 (Arb.multiple).

```diff
+import kotlin.random.nextInt
...
-      val targetSize = random.random.nextInt(minSize, maxSize)
+      val targetSize = random.random.nextInt(minSize..maxSize)
```

## Test plan
- [x] Added regression tests:
  - `Arb.map(..., minSize = 5, maxSize = 10)` produces all sizes 5..10 over 2000 samples.
  - `Arb.map(..., minSize = 3, maxSize = 3)` no longer throws.
- [x] Updated the existing seed-pinned test message to reflect the new deterministic targetSize for that seed.