### PR TITLE
Fix Exhaustive.azstring crashing on size-0 ranges

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/strings.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/strings.kt
@@ -6,8 +6,8 @@ import io.kotest.property.RandomSource
 fun Exhaustive.Companion.azstring(range: IntRange): Exhaustive<String> {
    fun az() = ('a'..'z').map { it.toString() }
    val values = range.toList().flatMap { size ->
-      List(size) { az() }.reduce { acc, seq -> acc.flatMap { a ->
-         seq.map { b -> a + b } }
+      List(size) { az() }.fold(listOf("")) { acc, seq ->
+         acc.flatMap { a -> seq.map { b -> a + b } }
       }
    }
    return values.exhaustive()

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/AzStringTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/AzStringTest.kt
@@ -28,4 +28,12 @@ class AzStringTest : ShouldSpec ({
    should("handle ranges") {
       Exhaustive.Companion.azstring(1..2).values shouldBe oneLetterPermutations + twoLetterPermutations
    }
+
+   should("include the empty string for range 0..0") {
+      Exhaustive.Companion.azstring(0..0).values shouldBe listOf("")
+   }
+
+   should("include the empty string when range starts at 0") {
+      Exhaustive.Companion.azstring(0..1).values shouldBe listOf("") + oneLetterPermutations
+   }
 })


### PR DESCRIPTION
## Summary

`Exhaustive.azstring(range)` crashes with `UnsupportedOperationException: Empty collection can't be reduced` whenever `range` includes `0` (e.g. `Exhaustive.azstring(0..2)`). The cause is `List(0) { az() }.reduce { ... }` — `reduce` doesn't handle an empty list.

Replaced `reduce` with `fold(listOf(""))`. For `size == 0` the fold returns `[""]` (the empty string, which is the natural inhabitant of "all strings of length 0"). For `size > 0` the behaviour is identical to the previous `reduce`.

## Test plan
- [x] Added regression tests for `azstring(0..0)` and `azstring(0..1)`.