### PR TITLE
Fix Arb.date never producing Dec 31 in leap years

### DIFF
--- a/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
+++ b/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
+import kotlinx.datetime.daysUntil
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
@@ -22,7 +23,10 @@ import kotlin.random.nextInt
 fun Arb.Companion.date(
    yearRange: IntRange = 1970..Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).year,
 ): Arb<LocalDate> = arbitrary {
-   LocalDate(it.random.nextInt(yearRange), 1, 1).plus(it.random.nextInt(0..364), DateTimeUnit.DAY)
+   val year = it.random.nextInt(yearRange)
+   val firstOfYear = LocalDate(year, 1, 1)
+   val daysInYear = firstOfYear.daysUntil(LocalDate(year + 1, 1, 1))
+   firstOfYear.plus(it.random.nextInt(0 until daysInYear), DateTimeUnit.DAY)
 }
 
 /**

--- a/kotest-property/kotest-property-datetime/src/commonTest/kotlin/io/kotest/property/kotlinx/datetime/DateTest.kt
+++ b/kotest-property/kotest-property-datetime/src/commonTest/kotlin/io/kotest/property/kotlinx/datetime/DateTest.kt
@@ -7,8 +7,8 @@ import io.kotest.property.forAll
 
 class DateTest : FunSpec() {
    init {
-      test("Arb.date should generate day spread") {
-         Arb.date().samples().take(1000000).map { it.value.dayOfYear }.toSet().shouldHaveSize(365)
+      test("Arb.date should generate day spread including day 366 for leap years") {
+         Arb.date(1980..1988).samples().take(1_000_000).map { it.value.dayOfYear }.toSet().shouldHaveSize(366)
       }
       test("Arb.date should respect year range") {
           forAll(Arb.date(1980..1988)) { date ->

--- a/kotest-property/kotest-property-datetime/src/commonTest/kotlin/io/kotest/property/kotlinx/datetime/DateTimeTest.kt
+++ b/kotest-property/kotest-property-datetime/src/commonTest/kotlin/io/kotest/property/kotlinx/datetime/DateTimeTest.kt
@@ -8,7 +8,9 @@ import io.kotest.property.forAll
 class DateTimeTest : FunSpec() {
    init {
       test("Arb.datetime should generate day spread") {
-         Arb.datetime().samples().take(1000000).map { it.value.dayOfYear }.toSet().shouldHaveSize(365)
+         // 366 days are reachable because the default year range (1970..currentYear)
+         // includes leap years, so day-of-year 366 (leap-year Dec 31) is sampled.
+         Arb.datetime().samples().take(1000000).map { it.value.dayOfYear }.toSet().shouldHaveSize(366)
       }
       test("Arb.datetime should generate hour spread") {
          Arb.datetime().samples().take(10000).map { it.value.hour }.toSet().shouldHaveSize(24)


### PR DESCRIPTION
## Summary

`Arb.date(yearRange)` (in kotest-property-datetime) generated values via:

```kotlin
LocalDate(it.random.nextInt(yearRange), 1, 1).plus(it.random.nextInt(0..364), DateTimeUnit.DAY)
```

A leap year has **366** days, but the code only added 0..364 days to Jan 1, so the last day of leap years (Dec 31) was unreachable. For example, `Arb.date(2020..2020)` could never produce `LocalDate(2020, 12, 31)`.

`Arb.datetime` delegates to `Arb.date` so it had the same hole.

Fix: compute `daysInYear` per draw and sample within `0 until daysInYear`.

## Test plan
- [x] Updated `DateTest` to assert all 366 day-of-year values appear when sampling over a range that includes leap years (1980..1988 covers 1980, 1984, 1988).