### PR TITLE
Fix List<Arb>.edgecase recursing on the unshuffled tail

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/edgecases.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/edgecases.kt
@@ -16,7 +16,7 @@ tailrec fun <A> List<Arb<A>>.edgecase(rs: RandomSource): Sample<A>? {
    if (this.isEmpty()) return null
    val shuffled = this.shuffled(rs.random)
    return when (val edge = shuffled.first().edgecase(rs)) {
-      null -> this.drop(1).edgecase(rs)
+      null -> shuffled.drop(1).edgecase(rs)
       else -> edge
    }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ChoiceTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/ChoiceTest.kt
@@ -12,10 +12,12 @@ import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.choice
+import io.kotest.property.arbitrary.edgecase
 import io.kotest.property.arbitrary.int
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.negativeInt
 import io.kotest.property.arbitrary.positiveInt
+import io.kotest.property.arbitrary.removeEdgecases
 import io.kotest.property.arbitrary.take
 import io.kotest.property.forAll
 
@@ -81,6 +83,14 @@ class ChoiceTest : WordSpec({
             listOf(1, 2, 3, 4).contains(i)
          }
          values shouldBe setOf(1, 2, 3, 4)
+      }
+      "finds the only arb with edge cases when most have none" {
+         val arbWithEdge = arbitrary(listOf(42)) { 0 }
+         val arbWithoutEdge = arbitrary { 0 }.removeEdgecases()
+         val arbList = listOf(arbWithoutEdge, arbWithoutEdge, arbWithEdge, arbWithoutEdge)
+         repeat(20) { seed ->
+            arbList.edgecase(RandomSource.seeded(seed.toLong())) shouldNotBe null
+         }
       }
       "edge cases should not be in Arb.samples" {
          val valueSet = Arb


### PR DESCRIPTION
## Summary

`List<Arb<A>>.edgecase` shuffled the list, picked the first element, and on a `null` result recursed on `this.drop(1)` — i.e. dropping the first element of the **original** (unshuffled) list, not the one that was just tried.

```kotlin
val shuffled = this.shuffled(rs.random)
return when (val edge = shuffled.first().edgecase(rs)) {
   null -> this.drop(1).edgecase(rs)   // drops first of ORIGINAL
   else -> edge
}
```

Trace with `[A, B, C]` where only `A` has an edgecase:
1. shuffled = `[B, A, C]`, try `B` → null. Recurse with `[B, C]` (dropping `A` from the original).
2. shuffled = `[C, B]`, try `C` → null. Recurse with `[C]`.
3. shuffled = `[C]`, try `C` → null again. Recurse with `[]`.
4. Empty → return null.

`A`'s edgecase was never tried. This function is used by `Arb.choice` (combinations.kt:135, 153) and the `Pair<Int, Arb<A>>` overload of `Arb.choose` (combinations.kt:87), so all three combinator edgecase paths could miss known edgecases.

Fix: recurse on `shuffled.drop(1)` so we drop the actually-tried element.

## Test plan
- [x] Added a regression test in `ChoiceTest` confirming that a list containing a single edgecase-bearing arb amongst three edgecase-free arbs reliably surfaces the edgecase across 20 different seeds.