### PR TITLE
Fix PropTestConfig.maxDiscardPercentage ignoring the global setting

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/config.kt
@@ -132,7 +132,7 @@ data class PropTestConfig(
    val outputClassifications: Boolean = PropertyTesting.defaultOutputClassifications,
    val classificationReporter: LabelsReporter = StandardClassificationReporter,
    val constraints: Constraints? = null,
-   val maxDiscardPercentage: Int = 20,
+   val maxDiscardPercentage: Int = PropertyTesting.maxDiscardPercentage,
    val skipTo: Int = 0,
    val outputHexForUnprintableChars: Boolean = PropertyTesting.defaultOutputHexForUnprintableChars,
 )

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigMaxDiscardDefaultTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropTestConfigMaxDiscardDefaultTest.kt
@@ -1,0 +1,22 @@
+package com.sksamuel.kotest.property
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.PropTestConfig
+import io.kotest.property.PropertyTesting
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class PropTestConfigMaxDiscardDefaultTest : FunSpec({
+
+   test("PropTestConfig.maxDiscardPercentage default should track PropertyTesting.maxDiscardPercentage") {
+      val original = PropertyTesting.maxDiscardPercentage
+      try {
+         PropertyTesting.maxDiscardPercentage = 73
+         PropTestConfig().maxDiscardPercentage shouldBe 73
+      } finally {
+         PropertyTesting.maxDiscardPercentage = original
+      }
+   }
+})


### PR DESCRIPTION
## Summary

`PropTestConfig.maxDiscardPercentage` defaulted to a hardcoded literal `20`:

```kotlin
val maxDiscardPercentage: Int = 20,
```

`PropertyTesting.maxDiscardPercentage` (config.kt:32) is the documented global, configurable via system property `kotest.proptest.max.discard.percentage`. The intent is the same as the other fields (`seed`, `minSuccess`, `maxFailure`, `iterations`, etc.) which all default from `PropertyTesting.*`. Because of the hardcoded `20`, the global setting and the system property had **no effect** on per-test configuration — `assumptions.kt:32` reads `config.maxDiscardPercentage`, which always saw `20`.

```diff
-   val maxDiscardPercentage: Int = 20,
+   val maxDiscardPercentage: Int = PropertyTesting.maxDiscardPercentage,
```

## Test plan
- [x] Compiles. Default value remains `20` (the `PropertyTesting.maxDiscardPercentage` default), so existing tests are unaffected. Setting `PropertyTesting.maxDiscardPercentage` or the corresponding system property now correctly drives the per-test default.