### PR TITLE
Fix shouldNotBeRegex calling positive shouldEqualRegex

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/regex/RegexMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/regex/RegexMatchers.kt
@@ -35,7 +35,7 @@ infix fun Regex.shouldEqualRegex(anotherRegex: Regex): Regex {
    "Use `shouldNotEqualRegex` instead. Deprecated in 6.0",
    ReplaceWith("this shouldNotEqualRegex anotherRegex")
 )
-infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldEqualRegex(anotherRegex)
+infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldNotEqualRegex(anotherRegex)
 
 /**
  * Assert that [Regex] is not equal to [anotherRegex] by comparing their pattern and options([RegexOption]).


### PR DESCRIPTION
## Summary

The deprecated `shouldNotBeRegex` alias was wired up to the positive `shouldEqualRegex`, inverting the intended assertion:

```kotlin
@Deprecated("Use \`shouldNotEqualRegex\` instead. Deprecated in 6.0", ...)
infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldEqualRegex(anotherRegex)
```

The deprecation message itself names `shouldNotEqualRegex` as the migration target, confirming the intent. Concrete failure: `Regex("a") shouldNotBeRegex Regex("b")` should pass (the regexes are different) but currently throws "Regex should have pattern b but has pattern a".

```diff
-infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldEqualRegex(anotherRegex)
+infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldNotEqualRegex(anotherRegex)
```

## Test plan
- [ ] Existing tests pass; the function is deprecated so no in-tree usages exist.