### PR TITLE
Fix DurationShrinker discarding all shrinks if any candidate is Duration.ZERO

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/durations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/durations.kt
@@ -60,9 +60,8 @@ class DurationShrinker(
 
       return (unsafeShrinks + componentShrinks)
          .map { it.coerceIn(range) }
-         .takeIf { shrinks -> shrinks.all { it != Duration.ZERO } }
-         ?.distinct()
-         ?: emptyList()
+         .filter { it != Duration.ZERO && it != value }
+         .distinct()
    }
 
    /** Tries to shrink, but might through an [IllegalArgumentException] if the resulting duration is invalid */

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DurationArbTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DurationArbTest.kt
@@ -11,13 +11,16 @@ import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
+import io.kotest.property.arbitrary.DurationShrinker
 import io.kotest.property.arbitrary.duration
 import io.kotest.property.arbitrary.edgecases
 import io.kotest.property.arbitrary.take
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
@@ -161,6 +164,13 @@ class DurationArbTest : WordSpec({
       "generate N valid Durations (no exceptions)" {
          Arb.duration().generate(RandomSource.default()).take(10_000).toList()
             .size shouldBe 10_000
+      }
+   }
+
+   "DurationShrinker" should {
+      "produce non-empty shrinks for a typical non-zero Duration" {
+         val shrinker = DurationShrinker(-Duration.INFINITE..Duration.INFINITE)
+         shrinker.shrink(1.minutes).shouldNotBeEmpty()
       }
    }
 


### PR DESCRIPTION
## Summary

`DurationShrinker.shrink` had this peculiar logic:

```kotlin
return (unsafeShrinks + componentShrinks)
   .map { it.coerceIn(range) }
   .takeIf { shrinks -> shrinks.all { it != Duration.ZERO } }
   ?.distinct()
   ?: emptyList()
```

`takeIf { all != ZERO }` returns `null` if **any** candidate equals `Duration.ZERO`, dropping the **entire** shrink list. The component shrinker decomposes a Duration into `[days, hours, minutes, seconds, nanoseconds]` — most of which are zero for any normal input. For example, shrinking `1.minutes`:

- `unsafeShrinks` = `[6.seconds, 600.milliseconds]`
- `componentShrinks` = `[0.days, 0.hours, 1.minutes, 0.seconds, 0.nanoseconds]` (note: `0.days == Duration.ZERO`)
- combined contains zeros → `takeIf` returns `null` → empty list

So the shrinker effectively returned no shrinks for most inputs, and kotest reported the original failing duration as the smallest counterexample.

Fix: replace `takeIf` with `filter { it != Duration.ZERO && it != value }`, which preserves the apparent intent of skipping the trivial zero / identity shrinks without nuking the valid candidates.

## Test plan
- [x] Added `DurationShrinker` regression test asserting non-empty shrinks for `1.minutes`.
- [x] Existing `DurationArbTest` still passes.