### PR TITLE
Fix Exhaustive.merge truncating to the shorter exhaustive's length

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/Exhaustive.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/Exhaustive.kt
@@ -40,7 +40,13 @@ fun <A> List<A>.exhaustive(): Exhaustive<A> {
  * @return the merged arg.
  */
 fun <A, B : A, C : A> Exhaustive<B>.merge(other: Exhaustive<C>): Exhaustive<A> = object : Exhaustive<A>() {
-   override val values: List<A> = this@merge.values.zip(other.values).flatMap { listOf(it.first, it.second) }
+   override val values: List<A> = run {
+      val a: List<A> = this@merge.values
+      val b: List<A> = other.values
+      (0 until maxOf(a.size, b.size)).flatMap { i ->
+         listOfNotNull(a.getOrNull(i), b.getOrNull(i))
+      }
+   }
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/MergeTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/exhaustive/MergeTest.kt
@@ -24,6 +24,13 @@ class MergeTest : FunSpec({
       listOf(1, 2, 3).exhaustive().merge(listOf(4, 5, 6).exhaustive()).values shouldBe listOf(1, 4, 2, 5, 3, 6)
    }
 
+   test("merge keeps surplus elements from the longer exhaustive") {
+      listOf(1, 2, 3, 4, 5).exhaustive().merge(listOf(10, 20).exhaustive()).values shouldBe
+         listOf(1, 10, 2, 20, 3, 4, 5)
+      listOf(10, 20).exhaustive().merge(listOf(1, 2, 3, 4, 5).exhaustive()).values shouldBe
+         listOf(10, 1, 20, 2, 3, 4, 5)
+   }
+
    test("merge two exhaustive gens where neither is a subtype of the other") {
       val firstGen = listOf(Common.Foo(1), Common.Foo(2), Common.Foo(3)).exhaustive()
       val secondGen = listOf(Common.Bar(4), Common.Bar(5), Common.Bar(6)).exhaustive()


### PR DESCRIPTION
## Summary

`Exhaustive<B>.merge(other: Exhaustive<C>)` was implemented with `zip`, which truncates to the shorter list:

```kotlin
override val values: List<A> = this@merge.values.zip(other.values).flatMap { listOf(it.first, it.second) }
```

So `Exhaustive.of(1, 2, 3, 4, 5).merge(Exhaustive.of(10, 20))` produced `[1, 10, 2, 20]` — the values 3, 4, 5 were silently dropped. The KDoc explicitly says "merge the values from this Exhaustive and the values of the supplied Exhaustive together, taking one from each in turn" — there's no truncation contract.

Switched to an interleave that keeps the surplus from whichever side is longer.

## Test plan
- [x] Added regression test asserting that `[1,2,3,4,5].merge([10,20])` keeps surplus elements (and the symmetric case).
- [x] Existing merge tests still pass (equal-length cases unchanged).