### PR TITLE
Fix IntRangeShrinker overflow on Int.MAX_VALUE singleton

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/range.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/range.kt
@@ -35,9 +35,11 @@ class IntRangeShrinker : Shrinker<IntRange> {
          return emptyList()
       }
 
+      val tailDropped = value.first until value.last
+      val headDropped = if (value.first < Int.MAX_VALUE) value.first + 1..value.last else IntRange.EMPTY
       return listOf(
-         value.first until value.last,
-         value.first + 1..value.last,
+         tailDropped,
+         headDropped,
          IntRange.EMPTY,
       ).distinct()
    }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/IntRangeShrinkerTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/IntRangeShrinkerTest.kt
@@ -54,6 +54,15 @@ class IntRangeShrinkerTest : FunSpec({
       }
    }
 
+   test("IntRangeShrinker should not produce a candidate larger than the input on Int.MAX_VALUE singleton") {
+      val candidates = IntRangeShrinker().shrink(Int.MAX_VALUE..Int.MAX_VALUE)
+      candidates.forAtLeastOne { it shouldBe IntRange.EMPTY }
+      // No candidate should span the full Int range due to overflow
+      candidates.forEach { range ->
+         (range.isEmpty() || range.last.toLong() - range.first.toLong() < Int.MAX_VALUE.toLong()) shouldBe true
+      }
+   }
+
    test("IntRangeShrinker should shrink to expected value") {
       checkAll(Arb.intRange(0..10)) { range ->
          if (!range.isEmpty()) {


### PR DESCRIPTION
## Summary

For `value = Int.MAX_VALUE..Int.MAX_VALUE` (a single-element range), `value.first + 1` overflowed to `Int.MIN_VALUE`, so the second shrink candidate became `Int.MIN_VALUE..Int.MAX_VALUE` — the entire 4-billion-element Int range. The shrinker then offered this as a "shrink", which the framework would run as a smaller candidate even though it is dramatically larger than the input.

Same issue for any singleton range whose first element is `Int.MAX_VALUE`.

```diff
-      return listOf(
-         value.first until value.last,
-         value.first + 1..value.last,
-         IntRange.EMPTY,
-      ).distinct()
+      val tailDropped = value.first until value.last
+      val headDropped = if (value.first < Int.MAX_VALUE) value.first + 1..value.last else IntRange.EMPTY
+      return listOf(tailDropped, headDropped, IntRange.EMPTY).distinct()
```

## Test plan
- [x] Added regression test asserting that no shrink candidate spans the full Int range.
- [x] Existing `IntRangeShrinkerTest` still passes.