### PR TITLE
Fix Arb.subsequence only producing prefixes

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
@@ -105,8 +105,7 @@ fun <A> Arb.Companion.shuffle(list: List<A>): Arb<List<A>> = arbitrary {
  * The returned list has the same order as the input list.
  */
 fun <A> Arb.Companion.subsequence(list: List<A>): Arb<List<A>> = arbitrary {
-   val size = it.random.nextInt(0, list.size + 1)
-   list.take(size)
+   list.filter { _ -> it.random.nextBoolean() }
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CombinationsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CombinationsTest.kt
@@ -46,6 +46,13 @@ class CombinationsTest : FunSpec({
       Arb.subsequence(listOf(1, 2, 3, 4, 5)).take(1000).toSet().shouldContain(listOf(1, 2, 3, 4, 5))
    }
 
+   test("subsequence should produce non-prefix subsequences") {
+      val samples = Arb.subsequence(listOf(1, 2, 3, 4, 5)).take(2000).toSet()
+      samples.shouldContain(listOf(2, 4))
+      samples.shouldContain(listOf(1, 3, 5))
+      samples.shouldContain(listOf(5))
+   }
+
    test("slice") {
       val actual = Arb.slice(listOf(1, 2, 3, 4, 5)).take(10000).toList()
       actual.map { it.size }.distinct().shouldContainAll(0, 1, 2, 3, 4, 5)


### PR DESCRIPTION
## Summary

`Arb.subsequence(list)` used `list.take(size)`, which only produces prefixes:

```kotlin
fun <A> Arb.Companion.subsequence(list: List<A>): Arb<List<A>> = arbitrary {
   val size = it.random.nextInt(0, list.size + 1)
   list.take(size)
}
```

For `Arb.subsequence(listOf(1, 2, 3))`, only `[]`, `[1]`, `[1, 2]`, and `[1, 2, 3]` are reachable — genuine subsequences like `[2]`, `[3]`, `[2, 3]`, `[1, 3]` are never produced. The KDoc says "Generates a random subsequence of the input list... The returned list has the same order as the input list." — prefixes are a strict subset of subsequences.

The existing tests only check `shouldContain(emptyList())` and `shouldContain(listOf(1, 2, 3, 4, 5))`, both of which are also prefixes, so the bug slipped through.

Fix: keep each element independently with 50% probability.

## Test plan
- [x] Added regression tests asserting non-prefix subsequences `[2, 4]`, `[1, 3, 5]`, `[5]` appear in the output.
- [x] Existing tests still pass.