### PR TITLE
Fix Arb.factor crashing on k=1 and never producing k itself

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/multiples.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/multiples.kt
@@ -27,6 +27,9 @@ class MultiplesShrinker(private val multiple: Int) : Shrinker<Int> {
    }
 }
 
-fun Arb.Companion.factor(k: Int): Arb<Int> = arbitrary {
-   generateSequence { it.random.nextInt(k) }.filter { it > 0 }.filter { k % it == 0 }.first()
+fun Arb.Companion.factor(k: Int): Arb<Int> {
+   require(k >= 1) { "k must be >= 1" }
+   return arbitrary {
+      generateSequence { it.random.nextInt(1..k) }.filter { k % it == 0 }.first()
+   }
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FactorTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FactorTest.kt
@@ -1,8 +1,10 @@
 package com.sksamuel.kotest.property.arbitrary
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.factor
@@ -12,5 +14,13 @@ import io.kotest.property.arbitrary.take
 class FactorTest : FunSpec({
    test("factors of k") {
       Arb.factor(99).take(100).forEach { 99 % it shouldBe 0 }
+   }
+
+   test("factor(k) can produce k itself") {
+      Arb.factor(99).take(2000).toSet().shouldContain(99)
+   }
+
+   test("factor(1) does not throw") {
+      shouldNotThrowAny { Arb.factor(1).take(10).toList() }
    }
 })


### PR DESCRIPTION
## Summary

`Arb.factor(k)` was implemented as:

```kotlin
fun Arb.Companion.factor(k: Int): Arb<Int> = arbitrary {
   generateSequence { it.random.nextInt(k) }.filter { it > 0 }.filter { k % it == 0 }.first()
}
```

Two bugs:

1. **`Arb.factor(1)` throws.** `nextInt(1)` always returns `0`, the `> 0` filter rejects it, the resulting sequence is empty, and `.first()` throws `NoSuchElementException`.
2. **`Arb.factor(k)` for `k >= 2` never produces `k` itself.** `nextInt(k)` samples `0..k-1`, so the divisor `k` (always a factor of `k`) is unreachable. e.g. `Arb.factor(99)` never returns `99`.

Switched to the inclusive `nextInt(1..k)` overload and added a positivity guard.

## Test plan
- [x] `factor(1)` doesn't throw.
- [x] `factor(99)` reliably produces `99` within 2000 samples.
- [x] Existing test (every value divides 99) still passes.