### PR TITLE
Fix CompletableFuture cancelled() matcher reporting "completed"

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/future/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/future/matchers.kt
@@ -42,9 +42,9 @@ fun <T> cancelled() = object : Matcher<CompletableFuture<T>> {
    override fun test(value: CompletableFuture<T>): MatcherResult =
       MatcherResult(
          value.isCancelled,
-         { "Future should be completed" },
+         { "Future should be cancelled" },
          {
-            "Future should not be completed"
+            "Future should not be cancelled"
          })
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/future/FutureMatcherTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/future/FutureMatcherTest.kt
@@ -47,6 +47,19 @@ class FutureMatcherTest : StringSpec({
       val completableFuture = CompletableFuture<Int>()
       completableFuture.shouldNotBeCancelled()
    }
+   "shouldBeCancelled error message names cancellation, not completion" {
+      val completableFuture = CompletableFuture<Int>()
+      shouldThrowMessage("Future should be cancelled") {
+         completableFuture.shouldBeCancelled()
+      }
+   }
+   "shouldNotBeCancelled error message names cancellation, not completion" {
+      val completableFuture = CompletableFuture<Int>()
+      completableFuture.cancel(true)
+      shouldThrowMessage("Future should not be cancelled") {
+         completableFuture.shouldNotBeCancelled()
+      }
+   }
    "test future is completed exceptionally" {
       val completableFuture = CompletableFuture<Int>()
       runOnSeparateThread {


### PR DESCRIPTION
## Summary

The `cancelled()` matcher's failure messages were copy-pasted from the `completed()` matcher just above:

```kotlin
fun <T> cancelled() = object : Matcher<CompletableFuture<T>> {
   override fun test(value: CompletableFuture<T>): MatcherResult =
      MatcherResult(
         value.isCancelled,
         { "Future should be completed" },          // wrong word
         { "Future should not be completed" })     // wrong word
}
```

The matcher tests `value.isCancelled` but reports about completion. Existing tests only checked the success path for `shouldBeCancelled` / `shouldNotBeCancelled`, so the wrong message slipped through.

## Test plan
- [x] Added regression tests asserting both failure messages name "cancelled".