### PR TITLE
Fix URI/URL parameter matcher NPEs and fragment/ref message typos

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/uri/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/uri/matchers.kt
@@ -87,7 +87,7 @@ infix fun URI.shouldHaveParameter(key: String) = this should haveParameter(key)
 infix fun URI.shouldNotHaveParameter(key: String) = this shouldNot haveParameter(key)
 fun haveParameter(key: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
-      value.query.split("&").any { it.split("=").first() == key },
+      value.query?.split("&")?.any { it.split("=").first() == key } == true,
       { "Uri $value should have query parameter $key" },
       {
          "Uri $value should not have query parameter $key"
@@ -101,6 +101,6 @@ fun haveFragment(fragment: String) = object : Matcher<URI> {
       value.fragment == fragment,
       { "Uri $value should have fragment $fragment" },
       {
-         "Uri $value should not fragment $fragment"
+         "Uri $value should not have fragment $fragment"
       })
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/url/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/url/matchers.kt
@@ -80,7 +80,7 @@ infix fun URL.shouldHaveParameter(key: String) = this should haveParameter(key)
 infix fun URL.shouldNotHaveParameter(key: String) = this shouldNot haveParameter(key)
 fun haveParameter(key: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
-      value.query.split("&").any { it.split("=").first() == key },
+      value.query?.split("&")?.any { it.split("=").first() == key } == true,
       { "URL $value should have query parameter $key" },
       { "URL $value should not have query parameter $key" }
    )
@@ -91,7 +91,7 @@ fun URL.shouldNotHaveParameterValue(key: String, value: String) = this shouldNot
 
 fun haveParameterValue(key: String, v: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
-      value.query.split("&").find { it.split("=").first() == key } == "$key=$v",
+      value.query?.split("&")?.find { it.split("=").first() == key } == "$key=$v",
       { "URL $value should have query parameter $key=$v" },
       { "URL $value should not have query parameter $key=$v" }
    )
@@ -103,6 +103,6 @@ fun haveRef(ref: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
       value.ref == ref,
       { "URL $value should have ref $ref" },
-      { "URL $value should not ref $ref" }
+      { "URL $value should not have ref $ref" }
    )
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/uri/UriMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/uri/UriMatchersTest.kt
@@ -57,6 +57,9 @@ class UriMatchersTest : WordSpec() {
         URI.create("https://hostname:90?a=b&c=d") should haveParameter("c")
         URI.create("https://hostname:90?a=b&c=d") shouldNot haveParameter("b")
       }
+      "fail (not NPE) when the URI has no query string" {
+        URI.create("https://hostname:90") shouldNot haveParameter("a")
+      }
     }
 
     "havePath" should {


### PR DESCRIPTION
## Summary

Two related issues across the URI and URL matchers in kotest-assertions-core:

**1. NullPointerException on URIs/URLs without a query string**

`URI.getQuery()` and `URL.getQuery()` return `null` when no query string is present. The matchers used `value.query.split("&")` directly:

```kotlin
fun haveParameter(key: String) = object : Matcher<URI> {
   override fun test(value: URI) = MatcherResult(
      value.query.split("&").any { it.split("=").first() == key },   // NPE
      ...)
}
```

So `URI("http://example.com").shouldHaveParameter("foo")` threw `NullPointerException` instead of producing a clean assertion failure. Affects:
- `uri/matchers.kt` `haveParameter`
- `url/matchers.kt` `haveParameter` and `haveParameterValue`

Fixed with the safe-call chain `value.query?.split("&")?.any { ... } == true`.

**2. Missing "have" in negated messages**

- `URI.haveFragment` negated message: `"Uri $value should not fragment $fragment"` (missing "have")
- `URL.haveRef` negated message: `"URL $value should not ref $ref"` (missing "have")

Restored to `"should not have ..."`.

## Test plan
- [x] Added regression test for the URI no-query-string case (`shouldNot haveParameter("a")`).
- [x] Existing matcher tests still pass.