### PR TITLE
Fix WordSpec config-form should producing " when" suffix instead of " should"

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
@@ -174,7 +174,7 @@ interface WordSpecRootScope : RootScope {
 
    private fun addShould(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecShouldContainerScope.() -> Unit) {
       addContainer(
-         testName = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         testName = TestNameBuilder.builder(name).withSuffix(" should").build(),
          xmethod = xmethod,
          config = config
       ) { WordSpecShouldContainerScope(this).test() }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
@@ -155,7 +155,7 @@ class WordSpecWhenContainerScope(
 
    private suspend fun addShould(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecShouldContainerScope.() -> Unit) {
       registerContainer(
-         name = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         name = TestNameBuilder.builder(name).withSuffix(" should").build(),
          xmethod = xmethod,
          config = config
       ) { WordSpecShouldContainerScope(this).test() }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/WordSpecConfigSuffixTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/WordSpecConfigSuffixTest.kt
@@ -1,0 +1,40 @@
+package com.sksamuel.kotest.engine.spec.style
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test for WordSpec config-form `should` producing the wrong test-name
+ * suffix (" when" instead of " should").
+ *
+ * Verifies the suffix on the [TestCase.name] for the container created by
+ * `"name".config(...) should { ... }` at the root and inside a `when` container.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class WordSpecConfigSuffixTest : WordSpec() {
+
+   init {
+      val capturedSuffixes = mutableMapOf<String, String?>()
+
+      afterAny { (tc, _) ->
+         capturedSuffixes[tc.name.name] = tc.name.suffix
+      }
+
+      afterSpec {
+         capturedSuffixes["with config at root"] shouldBe " should"
+         capturedSuffixes["with config nested"] shouldBe " should"
+      }
+
+      "with config at root".config(enabled = true) should {
+         "leaf at root" { }
+      }
+
+      "outer" `when` {
+         "with config nested".config(enabled = true) should {
+            "leaf nested" { }
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

The `addShould` helper in both `WordSpecRootScope` and `WordSpecWhenContainerScope` applied `withSuffix(" when")` to the test name — a copy-paste from the parallel `addWhen` helper directly above. Tests registered via the config form `"name".config(...) should { ... }` ended up with the wrong suffix (and therefore the wrong unique-id, display name, and Gradle/IntelliJ rendering).

```kotlin
// WordSpecRootScope.kt:175-181
private fun addShould(name: String, ...) {
   addContainer(
      testName = TestNameBuilder.builder(name).withSuffix(" when").build(),  // <— wrong
      ...
}
```

The non-config `should` paths (lines 30 and 70 of the respective files) correctly use `withSuffix(" should")`.

## Test plan
- [x] Added `WordSpecConfigSuffixTest` regression test verifying `tc.name.suffix == " should"` for both root-level and nested config-form `should` containers.