### PR TITLE
Fix DescribeSpec root it/fit/xit(name) always producing DISABLED

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecRootScope.kt
@@ -92,7 +92,7 @@ interface DescribeSpecRootScope : RootScope {
    ) = RootTestWithConfigBuilder(
       this,
       TestNameBuilder.builder(name).withPrefix("It: ").withDefaultAffixes().build(),
-      xmethod = TestXMethod.DISABLED
+      xmethod = xmethod
    )
 
    private fun context(

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/DescribeSpecRootItDisabledTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/DescribeSpecRootItDisabledTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.kotest.engine.spec.style
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Regression test: at the DescribeSpec root, `it("name").config(...) { ... }`,
+ * `fit("name").config(...) { ... }`, and `xit("name").config(...) { ... }` were
+ * always registered as DISABLED, because the addIt helper hardcoded
+ * `xmethod = TestXMethod.DISABLED` instead of using its `xmethod` parameter.
+ *
+ * `it("name").config(...)` should run normally; `xit("name").config(...)` remains
+ * disabled.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class DescribeSpecRootItDisabledTest : DescribeSpec() {
+
+   companion object {
+      val itRanCount = AtomicInteger(0)
+   }
+
+   init {
+      afterSpec {
+         itRanCount.get() shouldBe 1
+      }
+
+      it("root it with config").config(enabled = true) {
+         itRanCount.incrementAndGet()
+      }
+
+      xit("root xit with config").config(enabled = true) {
+         error("xit must remain disabled")
+      }
+   }
+}


### PR DESCRIPTION
## Summary

`DescribeSpecRootScope.addIt` hardcoded `xmethod = TestXMethod.DISABLED` instead of forwarding the incoming `xmethod` parameter:

```kotlin
private fun addIt(
   name: String,
   xmethod: TestXMethod
) = RootTestWithConfigBuilder(
   this,
   TestNameBuilder.builder(name).withPrefix("It: ").withDefaultAffixes().build(),
   xmethod = TestXMethod.DISABLED   // shadows the parameter
)
```

As a result, root-level config-form tests `it("foo").config(...) { ... }` and `fit("foo").config(...) { ... }` were silently DISABLED and never ran. `xit` happened to work by accident (it was already DISABLED). Inside a `describe` / `context` the path is different (uses `DescribeSpecContainerScope`) and unaffected.

## Test plan
- [x] Added `DescribeSpecRootItDisabledTest` regression test that asserts a root-level `it(...).config(enabled = true) { ... }` actually runs (and `xit` remains disabled).