### PR TITLE
Fix FreeSpec config leaf test registered as container

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FreeSpecContainerScope.kt
@@ -114,7 +114,7 @@ class FreeSpecContainerScope(val testScope: TestScope) : AbstractContainerScope(
     * ```
     */
    suspend infix operator fun FreeSpecContextConfigBuilder.invoke(test: suspend FreeSpecTerminalScope.() -> Unit) {
-      registerContainer(
+      registerTest(
          name = TestNameBuilder.builder(name).build(),
          xmethod = TestXMethod.NONE,
          config = config

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/types/FreeSpecTestTypeTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/types/FreeSpecTestTypeTest.kt
@@ -19,5 +19,10 @@ class FreeSpecTestTypeTest : FreeSpec() {
       "test" {
          this.testCase.type shouldBe TestType.Test
       }
+      "container with config leaf" - {
+         "leaf with config".config(enabled = true) {
+            this.testCase.type shouldBe TestType.Test
+         }
+      }
    }
 }


### PR DESCRIPTION
## Summary

In `FreeSpecContainerScope`, the `FreeSpecContextConfigBuilder.invoke` operator overload (used for the leaf form `"this test".config(...) { ... }`) called `registerContainer` instead of `registerTest`:

```kotlin
/**
 * Adds the contained config and test to this scope as a leaf test.
 *
 * E.g.
 * ```
 * "this test".config(...) { }
 * ```
 */
suspend infix operator fun FreeSpecContextConfigBuilder.invoke(test: ...) {
   registerContainer(   // <— should be registerTest
      ...
}
```

The KDoc explicitly says "leaf test", and the matching plain (no-config) `String.invoke` overload above it correctly calls `registerTest`.

Concrete impact: a nested config-form leaf test like
```kotlin
"outer" - {
   "leaf".config(invocations = 3) { ... }
}
```
was registered with `TestType.Container`, which:
- causes `InvocationCountCheckInterceptor` to fail with "Cannot execute multiple invocations in container tests"
- causes `InvocationTimeoutInterceptor` to skip its invocation timeout
- fires `BeforeContainer`/`AfterContainer` callbacks (and skips `BeforeEach`/`AfterEach`)

## Test plan
- [x] Extended `FreeSpecTestTypeTest` to assert that a `.config(...)` leaf is reported as `TestType.Test`.