### PR TITLE
Fix JUnit4 runner not firing testIgnored events

### DIFF
--- a/kotest-runner/kotest-runner-junit4/src/jvmCommonMain/kotlin/io/kotest/runner/junit4/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit4/src/jvmCommonMain/kotlin/io/kotest/runner/junit4/JUnitTestEngineListener.kt
@@ -47,6 +47,13 @@ internal class JUnitTestEngineListener(
       notifier.fireTestStarted(desc)
    }
 
+   override suspend fun testIgnored(testCase: TestCase, reason: String?) {
+      // Ignored tests bypass testStarted/testFinished, so JUnit4 only sees them
+      // if we forward the event explicitly here.
+      val desc = Descriptions.createTestDescription(testCase)
+      notifier.fireTestIgnored(desc)
+   }
+
    override suspend fun testFinished(testCase: TestCase, result: TestResult) {
       val desc = Descriptions.createTestDescription(testCase)
       when (result) {

--- a/kotest-runner/kotest-runner-junit4/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit4/JUnitTestEngineListenerTest.kt
+++ b/kotest-runner/kotest-runner-junit4/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit4/JUnitTestEngineListenerTest.kt
@@ -84,6 +84,24 @@ class JUnitTestEngineListenerTest : FunSpec({
       listener.failures.single().message shouldBe "boom"
    }
 
+   test("ignored tests should fire testIgnored on the JUnit4 RunNotifier") {
+
+      val tc = TestCase(
+         JUnitTestEngineListenerTest::class.toDescriptor().append("ignored test"),
+         TestNameBuilder.builder("ignored test").build(),
+         JUnitTestEngineListenerTest(),
+         {},
+         SourceRef.None,
+         TestType.Test
+      )
+
+      val notifier = RunNotifier()
+      val listener = CollectingRunListener()
+      notifier.addListener(listener)
+      JUnitTestEngineListener(notifier).testIgnored(tc, "no reason")
+      listener.testsIgnored.single().methodName shouldBe "ignored test"
+   }
+
 })
 
 class CollectingRunListener : RunListener() {
@@ -91,6 +109,7 @@ class CollectingRunListener : RunListener() {
    val testsStarted = mutableListOf<Description>()
    val testsSuiteStarted = mutableListOf<Description>()
    val testsFinished = mutableListOf<Description>()
+   val testsIgnored = mutableListOf<Description>()
    val failures = mutableListOf<Failure>()
 
    override fun testStarted(description: Description) {
@@ -103,6 +122,10 @@ class CollectingRunListener : RunListener() {
 
    override fun testFinished(description: Description) {
       testsFinished.add(description)
+   }
+
+   override fun testIgnored(description: Description) {
+      testsIgnored.add(description)
    }
 
    override fun testFailure(failure: Failure) {


### PR DESCRIPTION
## Summary

The JUnit4 `JUnitTestEngineListener` overrode `testStarted`, `testFinished`, `specStarted`, `specIgnored`, and `specFinished`, but not `testIgnored`. The base `AbstractTestEngineListener.testIgnored` is a no-op.

The engine dispatches ignored tests through the `testIgnored(testCase, reason)` channel (see `TestCaseExecutionListenerToTestEngineListenerAdapter`, `FailFastInterceptor`, `TestFinishedInterceptor`, etc.). With no override, those events were dropped — `testIgnored`s never reached `RunNotifier.fireTestIgnored`. Net effect: tests ignored via `xtest`, `!` prefix, `@Ignored`, `EnabledIf` returning false, fail-fast skipping, or any tag/extension-based skip were **invisible** to JUnit4 / Android test reporting.

(The dead-looking `is TestResult.Ignored -> notifier.fireTestIgnored(desc)` branch in `testFinished` does not save this — `testFinished` is only invoked when a test was actually run; ignored tests use the separate `testIgnored` channel.)

```diff
+   override suspend fun testIgnored(testCase: TestCase, reason: String?) {
+      val desc = Descriptions.createTestDescription(testCase)
+      notifier.fireTestIgnored(desc)
+   }
```

## Test plan
- [x] Added regression test asserting `testIgnored(...)` produces a `fireTestIgnored` event.