### PR TITLE
Fix failOnIgnoredTests never triggering due to per-spec results reset

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -96,6 +96,12 @@ class JUnitTestEngineListener(
 
    private var failOnIgnoredTests = false
 
+   // Whether at least one test was ignored across the whole engine run.
+   // Tracked separately from `results` because `results` is cleared per-spec
+   // by `reset()` and would otherwise be empty by the time `engineFinished`
+   // checks it.
+   private var anyTestIgnored = false
+
    private val results = mutableMapOf<Descriptor, TestResult>()
 
    private val dummies = hashSetOf<String>()
@@ -115,7 +121,7 @@ class JUnitTestEngineListener(
 
       registerExceptionPlaceholders(t)
 
-      val result = if (failOnIgnoredTests && results.values.any { it.isIgnored }) {
+      val result = if (failOnIgnoredTests && anyTestIgnored) {
          TestExecutionResult.failed(RuntimeException("Build contained ignored test"))
       } else {
          TestExecutionResult.successful()
@@ -275,6 +281,7 @@ class JUnitTestEngineListener(
 
       logger.log { Pair(testCase.name.name, "test ignored $reason") }
       results[testCase.descriptor] = TestResult.Ignored(reason)
+      anyTestIgnored = true
 
       logger.log { Pair(testCase.name.name, "executionSkipped: $testDescriptor") }
       listener.executionSkipped(testDescriptor, reasonIfEnabled(reason))

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/JUnitTestEngineListenerTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/JUnitTestEngineListenerTest.kt
@@ -10,6 +10,8 @@ import io.kotest.core.spec.SpecRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.engine.listener.TestEngineInitializedContext
 import io.kotest.engine.test.TestResult
 import io.kotest.engine.test.names.DisplayNameFormatting
 import io.kotest.matchers.shouldBe
@@ -354,6 +356,40 @@ class JUnitTestEngineListenerTest : FunSpec({
          ),
       )
    }
+   test("failOnIgnoredTests should fail engine even if ignored test was in an earlier spec") {
+
+      val root2 = EngineDescriptorBuilder
+         .builder(UniqueId.forEngine(KotestJunitPlatformTestEngine.ENGINE_ID))
+         .withSpecs(listOf(SpecRef.Reference(MySpec::class), SpecRef.Reference(MySpec2::class)))
+         .build()
+
+      val track = EventTrackingEngineExecutionListener()
+      val listener = JUnitTestEngineListener(track, root2, DisplayNameFormatting(null))
+
+      val projectConfig = object : AbstractProjectConfig() {
+         override val failOnIgnoredTests: Boolean = true
+      }
+      listener.engineInitialized(TestEngineInitializedContext.empty.copy(projectConfig = projectConfig))
+      listener.engineStarted()
+
+      // first spec: an ignored test, then specFinished triggers reset()
+      listener.specStarted(SpecRef.Reference(MySpec::class))
+      listener.testIgnored(tc1, "no reason")
+      listener.specFinished(SpecRef.Reference(MySpec::class), TestResult.Success(0.seconds))
+
+      // second spec: no ignored tests
+      listener.specStarted(SpecRef.Reference(MySpec2::class))
+      listener.testStarted(tc3)
+      listener.testFinished(tc3, TestResult.Success(0.milliseconds))
+      listener.specFinished(SpecRef.Reference(MySpec2::class), TestResult.Success(0.seconds))
+
+      listener.engineFinished(emptyList())
+
+      // The root engine descriptor should be FAILED because at least one test was ignored.
+      val rootFinish = track.events.last() as EventTrackingEngineExecutionListener.Event.ExecutionFinished
+      rootFinish.status shouldBe TestExecutionResult.Status.FAILED
+   }
+
 })
 
 private class MySpec : FunSpec()


### PR DESCRIPTION
## Summary

The JUnit Platform `JUnitTestEngineListener` decided whether to fail the build under `failOnIgnoredTests` by checking `results.values.any { it.isIgnored }` in `engineFinished`. But `results` is cleared in `reset()` after every `specFinished`:

```kotlin
override suspend fun specFinished(...) {
   ...
   reset()      // <— clears `results`
}

private fun reset() {
   results.clear()
   ...
}

override suspend fun engineFinished(t: List<Throwable>) {
   ...
   val result = if (failOnIgnoredTests && results.values.any { it.isIgnored }) {
      TestExecutionResult.failed(RuntimeException("Build contained ignored test"))
   } else {
      TestExecutionResult.successful()
   }
   ...
}
```

By the time `engineFinished` runs, every spec has already finished and reset, so `results` only ever contains entries from the most recently completed spec — and only if it had an ignored test. In every other case `failOnIgnoredTests` is silently a no-op.

Fix: track ignored-tests state in a dedicated `anyTestIgnored: Boolean` that is not touched by `reset()`.

## Test plan
- [x] Added regression test that ignores a test in the first spec, runs a second spec cleanly, and asserts the engine root finishes with `Status.FAILED` when `failOnIgnoredTests = true`.