### PR TITLE
Update IntelliJ plugin IC-261 target to 2026.1.1 release

### DIFF
--- a/kotest-intellij-plugin/build.gradle.kts
+++ b/kotest-intellij-plugin/build.gradle.kts
@@ -67,9 +67,9 @@ val descriptors = listOf(
    PluginDescriptor(
       since = "261.*", // this version is 2026.1.x
       until = "262.*",
-      sdkVersion = "261-EAP-SNAPSHOT",
+      sdkVersion = "2026.1.1",
       sourceFolder = "IC-261",
-      useInstaller = false,
+      useInstaller = true,
       jdkTarget = JavaVersion.VERSION_21,
       androidVersion = "261.20869.38",
       webpPlugin = "intellij.webp:261.21525.28",


### PR DESCRIPTION
## Summary

JetBrains released IntelliJ IDEA 2026.1.1, so move the IC-261 plugin descriptor in `kotest-intellij-plugin/build.gradle.kts` off the EAP snapshot:

```diff
    PluginDescriptor(
       since = "261.*", // this version is 2026.1.x
       until = "262.*",
-      sdkVersion = "261-EAP-SNAPSHOT",
+      sdkVersion = "2026.1.1",
       sourceFolder = "IC-261",
-      useInstaller = false,
+      useInstaller = true,
       jdkTarget = JavaVersion.VERSION_21,
       androidVersion = "261.20869.38",
       webpPlugin = "intellij.webp:261.21525.28",
       ...
    ),
```

`useInstaller = true` is the same flip we used when 253 went stable; only EAPs need the snapshot resolver.

Other 261 settings are unchanged:
- The 261-series Android (`261.20869.38`) and webp (`261.21525.28`) plugin coordinates are still applicable.
- The CI workflows already override Kotlin to 2.3.10 for `PRODUCT_NAME=IC-261`, which remains correct: 2026.1.1 still bundles Kotlin 2.3.x and writes class metadata 2.4.0 that the project's default Kotlin cannot read.

## Test plan
- [ ] PR-intellij-plugin matrix CI passes for `IC-261` against the released SDK.
- [ ] master-intellij-plugin and release-intellij-plugin matrices likewise.