### PR TITLE
Rename FeatureSpec xfscenario to fscenario

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -2467,13 +2467,13 @@ public final class io/kotest/core/spec/style/scopes/FeatureSpecContainerScope : 
 	public final fun feature (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ffeature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun ffeature (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun fscenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fscenario (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getTestScope ()Lio/kotest/core/test/TestScope;
 	public final fun scenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun scenario (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xfeature (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xfeature (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun xfscenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xscenario (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun xscenario (Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
@@ -85,7 +85,7 @@ class FeatureSpecContainerScope(
       )
    }
 
-   suspend fun xfscenario(name: String): TestWithConfigBuilder {
+   suspend fun fscenario(name: String): TestWithConfigBuilder {
       val testName = TestNameBuilder.builder(name).withPrefix("Scenario: ").build()
       TestDslState.startTest(testName)
       return TestWithConfigBuilder(


### PR DESCRIPTION
## Summary

`FeatureSpecContainerScope.xfscenario(name)` is the no-lambda config-builder for a *focused* scenario. The name is wrong on two counts:

- Every other Kotest spec style uses `f<name>` for focused, `x<name>` for disabled (`fcontext`/`xcontext`, `fshould`/`xshould`, `ffeature`/`xfeature`, etc.).
- The matching test-lambda variant on the same scope is already named `fscenario(name, test)` — so users writing `fscenario("foo").config(...)` hit a compile error, while the misnamed `xfscenario("foo").config(...)` produces a focused test (despite the `x` prefix everywhere else meaning disabled).

Renamed to `fscenario`. The disabled `xscenario(name)` no-lambda variant is unaffected.

## Test plan
- [x] `apiDump` regenerates the binary-compat API.
- [ ] Existing tests still pass.