### PR TITLE
Fix TagExpression OR-of-exclusions over-permissive logic

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/TagExpression.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/TagExpression.kt
@@ -20,11 +20,11 @@ data class TagExpression(val expression: String) {
        */
       operator fun invoke(included: Set<Tag>, excluded: Set<Tag>): TagExpression = when {
          included.isEmpty() && excluded.isEmpty() -> Empty
-         included.isEmpty() -> TagExpression(excluded.joinToString(" | ") { "!" + it.name })
+         included.isEmpty() -> TagExpression(excluded.joinToString(" & ") { "!" + it.name })
          excluded.isEmpty() -> TagExpression(included.joinToString(" | ") { it.name })
          else -> TagExpression(
             included.joinToString(" | ", "(", ")") { it.name } + " & " +
-               excluded.joinToString(" | ", "(", ")") { "!" + it.name }
+               excluded.joinToString(" & ", "(", ")") { "!" + it.name }
          )
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagsTest.kt
@@ -53,6 +53,22 @@ class TagsTest : StringSpec() {
          tags.parse().isActive(NamedTag("goo")) shouldBe true
          tags.parse().isActive(Roo) shouldBe true
       }
+      "test with multiple exclude tags excludes any test having any of them" {
+         val tags = TagExpression(emptySet(), setOf(Moo, Roo))
+         tags.parse().isActive(Foo) shouldBe true
+         tags.parse().isActive(Moo) shouldBe false // moo excluded
+         tags.parse().isActive(Roo) shouldBe false // roo excluded
+         tags.parse().isActive(setOf(Foo, Moo)) shouldBe false // moo excluded
+         tags.parse().isActive(setOf(Foo, Roo)) shouldBe false // roo excluded
+         tags.parse().isActive(setOf(Moo, Roo)) shouldBe false // both excluded
+      }
+      "test with include and multiple exclude tags" {
+         val tags = TagExpression(setOf(Foo), setOf(Moo, Roo))
+         tags.parse().isActive(Foo) shouldBe true
+         tags.parse().isActive(setOf(Foo, Moo)) shouldBe false // moo excluded
+         tags.parse().isActive(setOf(Foo, Roo)) shouldBe false // roo excluded
+         tags.parse().isActive(setOf(Foo, Moo, Roo)) shouldBe false // both excluded
+      }
       "test with simple expression" {
          val tags = TagExpression("Foo")
          tags.parse().isActive(Foo) shouldBe true


### PR DESCRIPTION
## Summary

`TagExpression(included, excluded)` joined excluded tags with `" | "` instead of `" & "`:

```kotlin
included.isEmpty() -> TagExpression(excluded.joinToString(" | ") { "!" + it.name })
...
included.joinToString(" | ", "(", ")") { it.name } + " & " +
   excluded.joinToString(" | ", "(", ")") { "!" + it.name }
```

For `excluded = {X, Y}` the resulting expression was `(A) & (!X | !Y)`, which is true for any test that lacks **either** `X` **or** `Y`. A test tagged `{A, X}` satisfies `!Y`, so the expression evaluates true and the test runs **despite being tagged with the excluded `X`**.

Excluding a set should disable any test that has any one of them, i.e. AND the negations: `(A) & (!X & !Y)` (or equivalently `(A) & !(X | Y)`). Same flaw existed in the `included.isEmpty()` branch.

The existing `TagsTest` only exercised single-element excluded sets, so the bug slipped through.

## Test plan
- [x] Added two regression tests covering `TagExpression(emptySet(), {Moo, Roo})` and `TagExpression({Foo}, {Moo, Roo})` — both demonstrate that a test tagged with one of the excluded tags is correctly disabled.
- [x] Existing TagsTest cases still pass.