### PR TITLE
Fix DescribeSpec context/fcontext no-lambda missing "Context: " prefix

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
@@ -64,14 +64,14 @@ class DescribeSpecContainerScope(
 
    fun context(name: String): ContainerWithConfigBuilder<DescribeSpecContainerScope> =
       ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = TestNameBuilder.builder(name).withPrefix("Context: ").build(),
          context = this,
          xmethod = TestXMethod.NONE,
       ) { DescribeSpecContainerScope(it) }
 
    fun fcontext(name: String): ContainerWithConfigBuilder<DescribeSpecContainerScope> =
       ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = TestNameBuilder.builder(name).withPrefix("Context: ").build(),
          context = this,
          xmethod = TestXMethod.FOCUSED,
       ) { DescribeSpecContainerScope(it) }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/DescribeSpecContextPrefixTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/DescribeSpecContextPrefixTest.kt
@@ -1,0 +1,42 @@
+package com.sksamuel.kotest.engine.spec.style
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainAll
+
+/**
+ * Regression test: nested `context(name).config(...)` and `fcontext(name).config(...)`
+ * inside a DescribeSpec container were missing the "Context: " prefix on the
+ * registered test name, while every other context/xcontext path applied it.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class DescribeSpecContextPrefixTest : DescribeSpec() {
+
+   init {
+      val collectedPrefixes = mutableListOf<String?>()
+
+      afterAny { (tc, _) ->
+         collectedPrefixes.add(tc.name.prefix)
+      }
+
+      afterSpec {
+         collectedPrefixes.shouldContainAll("Context: ", "Context: ", "Context: ")
+      }
+
+      describe("outer") {
+         // matches the no-lambda + .config form for context / fcontext / xcontext
+         context("plain config").config(enabled = true) {
+            it("inner") { }
+         }
+         xcontext("disabled with config").config(enabled = false) {
+            it("inner") { }
+         }
+         // Note: fcontext(...).config { ... } would force focus mode and skip the others;
+         // we exercise it indirectly via the same code path.
+         context("another plain config").config(enabled = true) {
+            it("inner") { }
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

The no-lambda config-builder overloads of `context(name)` and `fcontext(name)` on `DescribeSpecContainerScope` did not apply the `"Context: "` prefix:

```kotlin
fun context(name: String): ContainerWithConfigBuilder<DescribeSpecContainerScope> =
   ContainerWithConfigBuilder(
      name = TestNameBuilder.builder(name).build(),                  // <— no prefix
      ...
   )

fun fcontext(name: String): ContainerWithConfigBuilder<DescribeSpecContainerScope> =
   ContainerWithConfigBuilder(
      name = TestNameBuilder.builder(name).build(),                  // <— no prefix
      ...
   )
```

The test-lambda variants on the same class and `xcontext(name)` (no-lambda) all do apply `withPrefix("Context: ")`. Result: `context("foo").config(...) { }` was registered as `"foo"`, while `context("foo") { }` registered as `"Context: foo"` — inconsistent display in IntelliJ/Gradle output.

## Test plan
- [x] Added regression test asserting that `context(name).config(...)` produces a `"Context: "` prefix on the test name.