### PR TITLE
Fix BehaviorSpec given/context test-lambda missing withDefaultAffixes

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecContextContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecContextContainerScope.kt
@@ -35,7 +35,7 @@ class BehaviorSpecContextContainerScope(
       test: suspend BehaviorSpecGivenContainerScope.() -> Unit,
    ) {
       registerContainer(
-         name = TestNameBuilder.builder(name).withPrefix("Given: ").build(),
+         name = TestNameBuilder.builder(name).withPrefix("Given: ").withDefaultAffixes().build(),
          xmethod = xmethod,
          config = null
       ) {
@@ -78,7 +78,7 @@ class BehaviorSpecContextContainerScope(
       test: suspend BehaviorSpecContextContainerScope.() -> Unit,
    ) {
       registerContainer(
-         name = TestNameBuilder.builder(name).withPrefix("Context: ").build(),
+         name = TestNameBuilder.builder(name).withPrefix("Context: ").withDefaultAffixes().build(),
          xmethod = xmethod,
          config = null
       ) {


### PR DESCRIPTION
## Summary

In `BehaviorSpecContextContainerScope`, the test-lambda variants of `given(...)` and `context(...)` registered the container with `withPrefix("Given: ")` / `withPrefix("Context: ")` but did not call `.withDefaultAffixes()`:

```kotlin
internal suspend fun given(name, xmethod, test) {
   registerContainer(
      name = TestNameBuilder.builder(name).withPrefix("Given: ").build(),  // <— no withDefaultAffixes
      ...
}

internal suspend fun context(name, xmethod, test) {
   registerContainer(
      name = TestNameBuilder.builder(name).withPrefix("Context: ").build(),  // <— no withDefaultAffixes
      ...
}
```

The matching no-lambda config-builders (`addGiven`, `addContext`) and every Given/Context/When/Then/And in the sibling scopes do call `.withDefaultAffixes()`. Because `IncludeTestScopeAffixes.STYLE_DEFAULT` reads the `defaultAffixes` flag, nested tests registered through these two paths displayed without their `Given: ` / `Context: ` prefix while every other BehaviorSpec test displayed it.

Repro: `Context("outer") { given("inner") { Then("t") {} } }` — `"outer"` has affixes; `"inner"` does not, so the prefix is dropped from display.

## Test plan
- [ ] Existing BehaviorSpec tests still pass.