### PR TITLE
Fix Gradle ClassMethodNameFilterUtils.reset only clearing commandLine patterns

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtils.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtils.kt
@@ -80,14 +80,18 @@ internal object ClassMethodNameFilterUtils {
 
    /**
     * Removes any include patterns on any [ClassMethodNameFilter]s added by Gradle.
+    *
+    * Both `commandLineIncludePatterns` (populated by `--tests`) and
+    * `buildScriptIncludePatterns` (populated by `tasks.test { filter { includeTestsMatching(...) } }`)
+    * are cleared, since [extractIncludePatterns] reads from both.
     */
-   fun reset(filters: List<PostDiscoveryFilter>) {
+   fun reset(filters: List<Any>) {
       resolveClassMethodNameFilters(filters).forEach {
          runCatching {
             val matcher = testMatcher(it)
             val patternHolder = resolvePatternHolder(matcher)
-            val commandLineIncludePatterns = commandLineIncludePatterns(patternHolder) as MutableList<*>
-            commandLineIncludePatterns.clear()
+            (commandLineIncludePatterns(patternHolder) as MutableList<*>).clear()
+            (buildScriptIncludePatterns(patternHolder) as MutableList<*>).clear()
          }.onFailure { e ->
             logger.log { "Failed to reset ClassMethodNameFilter via reflection: $e" }
          }

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtilsTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/io/kotest/runner/junit/platform/gradle/ClassMethodNameFilterUtilsTest.kt
@@ -3,6 +3,7 @@ package io.kotest.runner.junit.platform.gradle
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import org.gradle.api.internal.tasks.testing.filter.TestFilterSpec
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher
@@ -67,6 +68,33 @@ class ClassMethodNameFilterUtilsTest : FunSpec({
          "\\QClassA\\E",
          "\\QClassB.test name\\E"
       )
+   }
+
+   test("reset clears buildScript include patterns as well as command-line patterns") {
+
+      // first arg → buildScriptIncludePatterns; third arg → commandLineIncludePatterns
+      val spec = TestFilterSpec(
+         setOf("BuildScriptInclude"),
+         emptySet(),
+         setOf("CommandLineInclude"),
+      )
+
+      val matcher = TestSelectionMatcher(spec)
+
+      val filter =
+         resolveClassMethodNameFilterClass()
+            .declaredConstructors.first { it.parameterCount == 1 }.let {
+               it.isAccessible = true
+               it.newInstance(matcher)
+            }
+
+      ClassMethodNameFilterUtils.extractIncludePatterns(listOf(filter)).shouldBe(
+         listOf("\\QBuildScriptInclude\\E", "\\QCommandLineInclude\\E")
+      )
+
+      ClassMethodNameFilterUtils.reset(listOf(filter))
+
+      ClassMethodNameFilterUtils.extractIncludePatterns(listOf(filter)).shouldBeEmpty()
    }
 
 })


### PR DESCRIPTION
## Summary

`extractIncludePatterns` reads from BOTH `commandLineIncludePatterns` (populated by `--tests`) and `buildScriptIncludePatterns` (populated by `tasks.test { filter { includeTestsMatching(...) } }`):

```kotlin
val regexes = buildList {
   addAll(buildScriptIncludePatterns)
   addAll(commandLineIncludePatterns)
}.map { pattern(it) }
```

But `reset` only cleared `commandLineIncludePatterns`:

```kotlin
val commandLineIncludePatterns = commandLineIncludePatterns(patternHolder) as MutableList<*>
commandLineIncludePatterns.clear()
```

Net effect when a user declared a kotest-style nested-test pattern in a Gradle build script:

```kotlin
tasks.test {
   useJUnitPlatform()
   filter { includeTestsMatching("io.foo.MySpec.context A -- nested test") }
}
```

1. `extractIncludePatterns` saw the pattern (from `buildScriptIncludePatterns`), and `NestedTestsArgParser` returned a `NestedTestArg`.
2. `ClassMethodNameFilterAdapter.adapt` called `reset(...)` to neutralize Gradle's filter so kotest's own `NestedTestsArgDescriptorFilter` could include the test.
3. `reset` only cleared `commandLineIncludePatterns`, so Gradle's filter still saw the build-script pattern, didn't understand the kotest nested-test format, and silently excluded the test.

Same bug in CLI (`--tests`) form was fine because that path populates the cleared list.

Also relaxed `reset` to accept `List<Any>` to match `extractIncludePatterns`, since the underlying class-name check already keys on simple-name rather than the static type.

## Test plan
- [x] Added regression test that constructs a `TestFilterSpec` with both `buildScriptIncludePatterns` and `commandLineIncludePatterns` set, asserts both are surfaced via `extractIncludePatterns`, calls `reset`, and asserts both are cleared.