### PR TITLE
Fix DescribeSpec it/fit/xit(name, lambda) missing prefix and wrong receiver

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/DescribeSpecContainerScope.kt
@@ -167,25 +167,28 @@ class DescribeSpecContainerScope(
 
    suspend fun it(name: String, test: suspend TestScope.() -> Unit) {
       registerTest(
-         name = TestNameBuilder.builder(name).build(),
+         name = TestNameBuilder.builder(name).withPrefix("It: ").build(),
          xmethod = TestXMethod.NONE,
-         config = null
-      ) { DescribeSpecContainerScope(this).test() }
+         config = null,
+         test = test,
+      )
    }
 
    suspend fun fit(name: String, test: suspend TestScope.() -> Unit) {
       registerTest(
-         name = TestNameBuilder.builder(name).build(),
+         name = TestNameBuilder.builder(name).withPrefix("It: ").build(),
          xmethod = TestXMethod.FOCUSED,
-         config = null
-      ) { DescribeSpecContainerScope(this).test() }
+         config = null,
+         test = test,
+      )
    }
 
    suspend fun xit(name: String, test: suspend TestScope.() -> Unit) {
       registerTest(
-         name = TestNameBuilder.builder(name).build(),
+         name = TestNameBuilder.builder(name).withPrefix("It: ").build(),
          xmethod = TestXMethod.DISABLED,
-         config = null
-      ) { DescribeSpecContainerScope(this).test() }
+         config = null,
+         test = test,
+      )
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/DescribeSpecItLambdaPrefixTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/DescribeSpecItLambdaPrefixTest.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.kotest.engine.spec.style
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Regression test: nested `it(name) { ... }` / `fit(name) { ... }` / `xit(name) { ... }` inside a
+ * DescribeSpec container were registered without the "It: " prefix, while the no-lambda config
+ * variants (`it("name").config(...) { }`) on the same scope did apply it. The lambda variants
+ * also wrapped the test body in a `DescribeSpecContainerScope`, leaking container DSL methods
+ * (describe/context/it) into what should be a leaf test scope.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class DescribeSpecItLambdaPrefixTest : DescribeSpec() {
+
+   init {
+      val capturedPrefixes = mutableMapOf<String, String?>()
+
+      afterAny { (tc, _) ->
+         capturedPrefixes[tc.name.name] = tc.name.prefix
+      }
+
+      afterSpec {
+         capturedPrefixes["leaf via lambda"] shouldBe "It: "
+      }
+
+      describe("outer") {
+         it("leaf via lambda") { }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

The test-lambda variants of `it` / `fit` / `xit` on `DescribeSpecContainerScope` had two issues:

```kotlin
suspend fun it(name: String, test: suspend TestScope.() -> Unit) {
   registerTest(
      name = TestNameBuilder.builder(name).build(),       // <— no prefix
      ...
   ) { DescribeSpecContainerScope(this).test() }          // <— wraps leaf in container scope
}
```

1. **Missing prefix.** The test name was built without `.withPrefix("It: ")`, while the no-lambda config-form variants on the same class (lines 138, 148, 158) do apply it. So `describe("foo") { it("bar") { } }` was registered as `"bar"`, but `describe("foo") { it("bar").config(...) { } }` was registered as `"It: bar"` — inconsistent display.

2. **Wrong receiver.** The user's lambda has `TestScope` receiver, but the wrap (`DescribeSpecContainerScope(this).test()`) re-runs it with `DescribeSpecContainerScope` as receiver, leaking the full container DSL (`describe`, `context`, `it`, etc.) into what should be a leaf test.

Fix: pass the test through directly to `registerTest` and apply the prefix.

## Test plan
- [x] Added `DescribeSpecItLambdaPrefixTest` regression test asserting that the leaf produced by `describe { it("...") { } }` has `tc.name.prefix == "It: "`.