### PR TITLE
Fix ShouldSpec nested context missing "context " prefix

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ShouldSpecContainerScope.kt
@@ -42,7 +42,7 @@ class ShouldSpecContainerScope(
 
    private suspend fun context(name: String, xmethod: TestXMethod, test: suspend ShouldSpecContainerScope.() -> Unit) {
       registerContainer(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          xmethod = xmethod,
          config = null,
       ) { ShouldSpecContainerScope(this).test() }
@@ -50,7 +50,7 @@ class ShouldSpecContainerScope(
 
    fun context(name: String): ContainerWithConfigBuilder<ShouldSpecContainerScope> {
       return ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          context = this,
          xmethod = TestXMethod.NONE
       ) {
@@ -60,7 +60,7 @@ class ShouldSpecContainerScope(
 
    fun fcontext(name: String): ContainerWithConfigBuilder<ShouldSpecContainerScope> {
       return ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          context = this,
          xmethod = TestXMethod.FOCUSED,
       ) { ShouldSpecContainerScope(it) }
@@ -68,11 +68,14 @@ class ShouldSpecContainerScope(
 
    fun xcontext(name: String): ContainerWithConfigBuilder<ShouldSpecContainerScope> {
       return ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          context = this,
          xmethod = TestXMethod.DISABLED,
       ) { ShouldSpecContainerScope(it) }
    }
+
+   private fun contextName(name: String) =
+      TestNameBuilder.builder(name).withPrefix("context ").withDefaultAffixes().build()
 
    suspend fun should(name: String): TestWithConfigBuilder {
       val testName = shouldName(name)

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/ShouldSpecNestedContextPrefixTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/ShouldSpecNestedContextPrefixTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.kotest.engine.spec.style
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContainAll
+
+/**
+ * Regression test: nested `context(...)` inside a ShouldSpec container scope was registered
+ * without the "context " prefix, while root-level `context(...)` (and the test-lambda /
+ * config-form variants in [ShouldSpecRootScope]) all applied it.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class ShouldSpecNestedContextPrefixTest : ShouldSpec() {
+
+   init {
+      val capturedPrefixes = mutableListOf<String?>()
+
+      afterAny { (tc, _) ->
+         capturedPrefixes.add(tc.name.prefix)
+      }
+
+      afterSpec {
+         // both the outer (root) and inner (container) context should have "context " prefix
+         capturedPrefixes.shouldContainAll("context ", "context ", "should ")
+      }
+
+      context("outer") {
+         context("inner") {
+            should("test") { }
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

`ShouldSpecRootScope` exposes a private `contextName` helper that applies `.withPrefix("context ").withDefaultAffixes()` to every context overload (test-lambda + 3 no-lambda forms). The matching `ShouldSpecContainerScope.context(...)` overloads all called `TestNameBuilder.builder(name).build()` with no prefix and no affixes — so a top-level `context("outer")` was registered as `"context outer"` but a nested `context("inner")` was registered as just `"inner"`.

```kotlin
// ShouldSpecRootScope (correct)
private fun contextName(name: String) =
   TestNameBuilder.builder(name).withPrefix("context ").withDefaultAffixes().build()

// ShouldSpecContainerScope (was missing the prefix)
private suspend fun context(name, xmethod, test) {
   registerContainer(name = TestNameBuilder.builder(name).build(), ...)  // no prefix
}
```

This is inconsistent with both `ShouldSpecRootScope` and the analogous `describe`/`describe nested` paths in DescribeSpec, which apply the prefix at both levels.

Inlined the same helper into `ShouldSpecContainerScope` and routed all four context overloads through it.

## Test plan
- [x] Added `ShouldSpecNestedContextPrefixTest` regression test asserting both outer and inner context get the `"context "` prefix.