### PR TITLE
Fix Discovery allow_private respecting only presence, not value

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/discovery/Discovery.kt
@@ -69,9 +69,10 @@ internal object Discovery {
       configurationParameters: ConfigurationParameters
    ): DiscoveryFilter {
 
-      val private = if (classSelectors.size == 1 ||
-         configurationParameters.get("allow_private").isPresent
-      ) Modifier.Private else null
+      val allowPrivateConfigured = configurationParameters.get("allow_private")
+         .map { it.toBoolean() }
+         .orElse(false)
+      val private = if (classSelectors.size == 1 || allowPrivateConfigured) Modifier.Private else null
 
       val modifiers = listOfNotNull(Modifier.Public, Modifier.Internal, private)
       return DiscoveryFilter.ClassModifierDiscoveryFilter(modifiers.toSet())


### PR DESCRIPTION
## Summary

The KDoc on `classVisibilityFilter` says:

> If the configuration parameter `allow_private` is set to **true**, then private classes are also included.

But the implementation checked `configurationParameters.get("allow_private").isPresent` — which is `true` for any value, including `"false"`:

```kotlin
val private = if (classSelectors.size == 1 ||
   configurationParameters.get("allow_private").isPresent  // ignores the value
) Modifier.Private else null
```

So setting `kotest.allow_private=false` in `junit-platform.properties` to explicitly disable private spec discovery had no effect — it still included private classes.

Read the value with `.toBoolean()` and default to `false` to match the documented contract.

## Test plan
- [ ] Compiles. Behaviour change: passing `allow_private=false` now correctly excludes private specs (matching the docstring).