### PR TITLE
Fix testIgnored creating duplicate descriptor when test already started

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -275,12 +275,31 @@ class JUnitTestEngineListener(
 
    override suspend fun testIgnored(testCase: TestCase, reason: String?) {
 
-      // an ignored test should never be started or finished;
-      // however, an ingored test may be inside a test not yet marked as started,
-      // so we must ensure we start any parents
+      // A test can reach `testIgnored` along two routes:
+      //  - it was never started: a TestEnabledExtension returned disabled, fail-fast
+      //    short-circuited it, etc. — this is the original case.
+      //  - it WAS started, then its body threw `TestAbortedException` /
+      //    `IterationSkippedException`, which `HandleSkippedExceptionsTestInterceptor`
+      //    converts to `TestResult.Ignored` and `TestFinishedInterceptor` then
+      //    routes through `testIgnored` instead of `testFinished`.
+      // In the second case, `testStarted` already created the descriptor, fired
+      // `dynamicTestRegistered` + `executionStarted`, and tracked it in `startedTests`.
+      // Re-creating the descriptor here would produce a duplicate UniqueId child
+      // and leave the original descriptor without an `executionFinished` event.
+      // Detect that case and finalize as aborted instead.
+      if (testCase.descriptor in startedTests) {
+         val descriptor = descriptors[testCase.descriptor]
+            ?: error("startedTests contains ${testCase.descriptor} but descriptors does not")
+         logger.log { Pair(testCase.name.name, "test ignored after start; finalizing as aborted: $reason") }
+         results[testCase.descriptor] = TestResult.Ignored(reason)
+         listener.executionFinished(descriptor, TestExecutionResult.aborted(null))
+         return
+      }
+
+      // an ignored test that was never started — register a fresh descriptor and skip it.
+      // Start any parents that haven't already been marked as started.
       startParents(testCase)
 
-      // like all tests, an ignored test should be registered first
       // ignored test should be a TEST type, because an ignored test will never have child tests.
       val testDescriptor = createTestDescriptorWithMethodSource(root, testCase, TestDescriptor.Type.TEST, formatter)
       attachToParent(testCase, testDescriptor)

--- a/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/JUnitTestEngineListenerTest.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit5/JUnitTestEngineListenerTest.kt
@@ -163,6 +163,67 @@ class JUnitTestEngineListenerTest : FunSpec({
       )
    }
 
+   test("a leaf root test that was started and then ignored should be finalized as ABORTED without a duplicate descriptor") {
+      // Mirrors what HandleSkippedExceptionsTestInterceptor does for `TestAbortedException`:
+      // testStarted has already fired, then testIgnored arrives instead of testFinished.
+      val leaf = TestCase(
+         MySpec::class.toDescriptor().append("foo"),
+         TestNameBuilder.builder("foo").build(),
+         MySpec(),
+         {},
+         SourceRef.None,
+         TestType.Test,
+      )
+      val track = EventTrackingEngineExecutionListener()
+      val listener = JUnitTestEngineListener(track, root, DisplayNameFormatting(null))
+      listener.specStarted(SpecRef.Reference(MySpec::class))
+      listener.testStarted(leaf)
+      listener.testIgnored(leaf, "TestAbortedException")
+      listener.specFinished(SpecRef.Reference(MySpec::class), TestResult.Success(0.seconds))
+      track.events shouldBe listOf(
+         EventTrackingEngineExecutionListener.Event.ExecutionStarted("MySpec"),
+         EventTrackingEngineExecutionListener.Event.TestCaseRegistered(
+            "foo",
+            "com.sksamuel.kotest.runner.junit5.MySpec",
+            "foo"
+         ),
+         EventTrackingEngineExecutionListener.Event.ExecutionStarted("foo"),
+         EventTrackingEngineExecutionListener.Event.ExecutionFinished("foo", TestExecutionResult.Status.ABORTED),
+         EventTrackingEngineExecutionListener.Event.ExecutionFinished(
+            "MySpec",
+            TestExecutionResult.Status.SUCCESSFUL
+         ),
+      )
+   }
+
+   test("a nested test that was started and then ignored should be finalized as ABORTED without a duplicate descriptor") {
+      val track = EventTrackingEngineExecutionListener()
+      val listener = JUnitTestEngineListener(track, root, DisplayNameFormatting(null))
+      listener.specStarted(SpecRef.Reference(MySpec::class))
+      listener.testStarted(tc1)
+      listener.testStarted(tc2)
+      listener.testIgnored(tc2, "TestAbortedException")
+      listener.testFinished(tc1, TestResult.Success(7.milliseconds))
+      listener.specFinished(SpecRef.Reference(MySpec::class), TestResult.Success(0.seconds))
+      track.events shouldBe listOf(
+         EventTrackingEngineExecutionListener.Event.ExecutionStarted("MySpec"),
+         EventTrackingEngineExecutionListener.Event.TestRegistered("foo", TestDescriptor.Type.CONTAINER),
+         EventTrackingEngineExecutionListener.Event.ExecutionStarted("foo"),
+         EventTrackingEngineExecutionListener.Event.TestCaseRegistered(
+            "bar",
+            "com.sksamuel.kotest.runner.junit5.MySpec",
+            "foo/bar"
+         ),
+         EventTrackingEngineExecutionListener.Event.ExecutionStarted("bar"),
+         EventTrackingEngineExecutionListener.Event.ExecutionFinished("bar", TestExecutionResult.Status.ABORTED),
+         EventTrackingEngineExecutionListener.Event.ExecutionFinished("foo", TestExecutionResult.Status.SUCCESSFUL),
+         EventTrackingEngineExecutionListener.Event.ExecutionFinished(
+            "MySpec",
+            TestExecutionResult.Status.SUCCESSFUL
+         ),
+      )
+   }
+
    test("a successful nested test should be marked as SUCCESSFUL with type TEST") {
       val track = EventTrackingEngineExecutionListener()
       val listener = JUnitTestEngineListener(track, root, DisplayNameFormatting(null))


### PR DESCRIPTION
## Summary

A leaf test can reach `testIgnored` along two paths:

1. **Never started** — a `TestEnabledExtension` returned disabled, fail-fast short-circuited, etc. The original code path handled this correctly.
2. **Started, then aborted mid-flight.** A test body that throws `TestAbortedException` (or `IterationSkippedException`) is converted by `HandleSkippedExceptionsTestInterceptor` into `TestResult.Ignored`, and `TestFinishedInterceptor` then routes it through `testIgnored` rather than `testFinished`. By that point `testStarted` has already created the descriptor, fired `dynamicTestRegistered` + `executionStarted`, and tracked it in `startedTests`.

The old `testIgnored` unconditionally created a fresh descriptor with the same `UniqueId`, attached it to the parent (duplicate child), fired `dynamicTestRegistered` again, then `executionSkipped` — leaving the originally started descriptor with **no** `executionFinished` event.

Net effect: JUnit Platform listeners receive a `dynamicTestRegistered` collision for the same `UniqueId` and an orphan `executionStarted` that never finishes. Gradle/IntelliJ render this inconsistently.

Fix: detect the already-started case and finalize the existing descriptor with `TestExecutionResult.aborted(null)` instead of registering a duplicate. The never-started branch is unchanged.

## Test plan
- [x] Existing `JUnitTestEngineListenerTest` cases still pass (the never-started ignored path is exercised there).
- [ ] Manual verification: a test that throws `TestAbortedException` produces a single `aborted` row instead of an orphan + duplicate `skipped`.