### PR TITLE
Fix ExpectSpec root expect leaf wrapping in ExpectSpecContainerScope

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/ExpectSpecRootScope.kt
@@ -81,14 +81,15 @@ interface ExpectSpecRootScope : RootScope {
 
    private fun addExpect(
       name: String,
-      test: suspend ExpectSpecContainerScope.() -> Unit,
+      test: suspend TestScope.() -> Unit,
       xmethod: TestXMethod,
    ) {
       addTest(
          testName = TestNameBuilder.builder(name).withPrefix("Expect: ").build(),
          xmethod = xmethod,
          config = null,
-      ) { ExpectSpecContainerScope(this).test() }
+         test = test,
+      )
    }
 
    private fun addExpect(


### PR DESCRIPTION
## Summary

`ExpectSpecRootScope.addExpect(name, test, xmethod)` declared the test parameter with `ExpectSpecContainerScope.() -> Unit` receiver and wrapped the body:

```kotlin
private fun addExpect(
   name: String,
   test: suspend ExpectSpecContainerScope.() -> Unit,   // wrong receiver
   xmethod: TestXMethod,
) {
   addTest(...) { ExpectSpecContainerScope(this).test() }   // wraps leaf in container scope
}
```

The matching `ExpectSpecContainerScope.registerExpect` correctly uses `TestScope.() -> Unit` and passes `test = test` straight through.

Because `(TestScope) -> Unit` is a subtype of `(ExpectSpecContainerScope) -> Unit` (function types are contravariant in the receiver), the public `expect(name, test: TestScope.() -> Unit)` on the root still compiled — but inside the user's lambda `this` ended up being an `ExpectSpecContainerScope`, leaking the full container DSL (`context`, `expect`, `fexpect`, etc.) into a leaf test.

Switched the parameter to `TestScope.() -> Unit` and pass it through unwrapped, matching the container-scope sibling.

## Test plan
- [x] Existing ExpectSpec tests still pass.