### PR TITLE
Fix FunSpec nested context missing "context " prefix

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FunSpecContainerScope.kt
@@ -23,7 +23,7 @@ class FunSpecContainerScope(
     */
    suspend fun context(name: String, test: suspend FunSpecContainerScope.() -> Unit) {
       registerContainer(
-         TestNameBuilder.builder(name).build(),
+         contextName(name),
          xmethod = TestXMethod.NONE,
          null
       ) { FunSpecContainerScope(this).test() }
@@ -34,7 +34,7 @@ class FunSpecContainerScope(
     */
    suspend fun fcontext(name: String, test: suspend FunSpecContainerScope.() -> Unit) {
       registerContainer(
-         TestNameBuilder.builder(name).build(),
+         contextName(name),
          xmethod = TestXMethod.FOCUSED,
          null
       ) { FunSpecContainerScope(this).test() }
@@ -45,7 +45,7 @@ class FunSpecContainerScope(
     */
    suspend fun xcontext(name: String, test: suspend FunSpecContainerScope.() -> Unit) {
       registerContainer(
-         TestNameBuilder.builder(name).build(),
+         contextName(name),
          xmethod = TestXMethod.DISABLED,
          null
       ) { FunSpecContainerScope(this).test() }
@@ -56,7 +56,7 @@ class FunSpecContainerScope(
     */
    fun context(name: String): ContainerWithConfigBuilder<FunSpecContainerScope> {
       return ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          context = this,
          xmethod = TestXMethod.NONE,
          contextFn = { FunSpecContainerScope(it) }
@@ -68,7 +68,7 @@ class FunSpecContainerScope(
     */
    fun fcontext(name: String): ContainerWithConfigBuilder<FunSpecContainerScope> {
       return ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          context = this,
          xmethod = TestXMethod.FOCUSED,
       ) { FunSpecContainerScope(it) }
@@ -79,11 +79,14 @@ class FunSpecContainerScope(
     */
    fun xcontext(name: String): ContainerWithConfigBuilder<FunSpecContainerScope> {
       return ContainerWithConfigBuilder(
-         name = TestNameBuilder.builder(name).build(),
+         name = contextName(name),
          context = this,
          xmethod = TestXMethod.DISABLED,
       ) { FunSpecContainerScope(it) }
    }
+
+   private fun contextName(name: String) =
+      TestNameBuilder.builder(name).withPrefix("context ").build()
 
    /**
     * Adds a test case to this context, expecting config.

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/FunSpecNestedContextPrefixTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/spec/style/FunSpecNestedContextPrefixTest.kt
@@ -1,0 +1,33 @@
+package com.sksamuel.kotest.engine.spec.style
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainAll
+
+/**
+ * Regression test: nested `context(...)` inside a FunSpec container scope was registered
+ * without the "context " prefix, while the root-level `context(...)` correctly applied it.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class FunSpecNestedContextPrefixTest : FunSpec() {
+
+   init {
+      val capturedPrefixes = mutableListOf<String?>()
+
+      afterAny { (tc, _) ->
+         capturedPrefixes.add(tc.name.prefix)
+      }
+
+      afterSpec {
+         // both the root context and the nested one should have "context " prefix
+         capturedPrefixes.shouldContainAll("context ", "context ")
+      }
+
+      context("outer") {
+         context("inner") {
+            test("leaf") { }
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

`FunSpecRootScope` applies `.withPrefix("context ")` to every `context` overload (3 test-lambda + 3 no-lambda config builders). The matching `FunSpecContainerScope.context(...)` overloads (also 3 + 3) all called `TestNameBuilder.builder(name).build()` with no prefix — so a top-level `context("outer")` was registered as `"context outer"` but a nested `context("inner")` was registered as just `"inner"`.

```kotlin
// FunSpecRootScope (correct, line 91)
testName = TestNameBuilder.builder(name).withPrefix("context ").build(),

// FunSpecContainerScope (was missing the prefix)
TestNameBuilder.builder(name).build(),
```

This is the same family of bug already fixed in [ShouldSpecContainerScope (#5979)](https://github.com/kotest/kotest/pull/5979) and [DescribeSpecContainerScope context/fcontext (#5974)](https://github.com/kotest/kotest/pull/5974). Inlined the same helper into `FunSpecContainerScope` and routed all six context overloads through it.

## Test plan
- [x] Added `FunSpecNestedContextPrefixTest` regression test asserting both the root `context(...)` and the nested `context(...)` produce the `"context "` prefix.