### PR TITLE
Fix WordSpec config-form addWhen/addShould missing withDefaultAffixes

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecRootScope.kt
@@ -156,7 +156,7 @@ interface WordSpecRootScope : RootScope {
 
    private fun addWhen(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecWhenContainerScope.() -> Unit) {
       addContainer(
-         testName = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         testName = TestNameBuilder.builder(name).withSuffix(" when").withDefaultAffixes().build(),
          xmethod = xmethod,
          config = config
       ) { WordSpecWhenContainerScope(this).test() }
@@ -174,7 +174,7 @@ interface WordSpecRootScope : RootScope {
 
    private fun addShould(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecShouldContainerScope.() -> Unit) {
       addContainer(
-         testName = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         testName = TestNameBuilder.builder(name).withSuffix(" when").withDefaultAffixes().build(),
          xmethod = xmethod,
          config = config
       ) { WordSpecShouldContainerScope(this).test() }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/WordSpecWhenContainerScope.kt
@@ -137,7 +137,7 @@ class WordSpecWhenContainerScope(
 
    private suspend fun addWhen(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecWhenContainerScope.() -> Unit) =
       registerContainer(
-         name = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         name = TestNameBuilder.builder(name).withSuffix(" when").withDefaultAffixes().build(),
          xmethod = xmethod,
          config = config
       ) { WordSpecWhenContainerScope(this).test() }
@@ -155,7 +155,7 @@ class WordSpecWhenContainerScope(
 
    private suspend fun addShould(name: String, xmethod: TestXMethod, config: TestConfig?, test: suspend WordSpecShouldContainerScope.() -> Unit) {
       registerContainer(
-         name = TestNameBuilder.builder(name).withSuffix(" when").build(),
+         name = TestNameBuilder.builder(name).withSuffix(" when").withDefaultAffixes().build(),
          xmethod = xmethod,
          config = config
       ) { WordSpecShouldContainerScope(this).test() }


### PR DESCRIPTION
## Summary

The config-form code paths in both `WordSpecRootScope` and `WordSpecWhenContainerScope` (`addWhen` and `addShould`) built the container name without `.withDefaultAffixes()`:

```kotlin
testName = TestNameBuilder.builder(name).withSuffix(" when").build(),  // missing .withDefaultAffixes()
```

The parallel non-config form (lines 30/78 of root, 42/70 of when-container) does apply it:

```kotlin
testName = TestNameBuilder.builder(name).withSuffix(" should").withDefaultAffixes().build(),
```

Net effect: `"a context".config(...) When { ... }` and `"a context".config(...) should { ... }` ended up with `defaultAffixes = false` on their `TestName`, so reporters that respect default affixes rendered them differently from their non-config siblings.

Same family as the previously-fixed [BehaviorSpec missing-affixes issue (#5975)](https://github.com/kotest/kotest/pull/5975).

Note: the `addShould` lines still pass `" when"` as the suffix on master — that separate bug is fixed by [#5964](https://github.com/kotest/kotest/pull/5964) and is left alone in this PR (the affix change is orthogonal and composes cleanly).

## Test plan
- [ ] Compiles. Existing WordSpec tests still pass.