### PR TITLE
Fix JUnit4RuleExtension running test outside rule chain when rule skips

### DIFF
--- a/kotest-runner/kotest-runner-junit4/src/jvmCommonMain/kotlin/io/kotest/runner/junit4/JUnit4RuleExtension.kt
+++ b/kotest-runner/kotest-runner-junit4/src/jvmCommonMain/kotlin/io/kotest/runner/junit4/JUnit4RuleExtension.kt
@@ -58,7 +58,10 @@ internal object JUnit4RuleExtension : TestCaseExtension {
 
       return try {
          statement.evaluate()
-         result ?: execute(testCase)
+         // If no rule actually invoked the inner statement (e.g. a ConditionalIgnoreRule that
+         // chooses to skip), `result` stays null. Treat that as the rule's authoritative
+         // decision to skip — running the test outside the rule chain would defeat its purpose.
+         result ?: TestResult.Ignored("JUnit4 @Rule chose not to execute the test")
       } catch (e: Throwable) {
          TestResult.Error(Duration.ZERO, e)
       }

--- a/kotest-runner/kotest-runner-junit4/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit4/JUnit4RuleExtensionTest.kt
+++ b/kotest-runner/kotest-runner-junit4/src/jvmTest/kotlin/com/sksamuel/kotest/runner/junit4/JUnit4RuleExtensionTest.kt
@@ -1,0 +1,90 @@
+package com.sksamuel.kotest.runner.junit4
+
+import io.kotest.core.descriptors.toDescriptor
+import io.kotest.core.names.TestNameBuilder
+import io.kotest.core.source.SourceRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestType
+import io.kotest.engine.test.TestResult
+import io.kotest.engine.test.TestResultBuilder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.runner.junit4.JUnit4RuleExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class JUnit4RuleExtensionTest : FunSpec({
+
+   test("rule that skips by not calling base.evaluate() should produce TestResult.Ignored without running the test") {
+      val spec = SkippingRuleSpec()
+      val testCase = TestCase(
+         descriptor = SkippingRuleSpec::class.toDescriptor().append("foo"),
+         name = TestNameBuilder.builder("foo").build(),
+         spec = spec,
+         test = {},
+         source = SourceRef.None,
+         type = TestType.Test,
+      )
+
+      var executed = false
+      val result = runBlocking {
+         JUnit4RuleExtension.intercept(testCase) {
+            executed = true
+            TestResultBuilder.builder().build()
+         }
+      }
+
+      executed shouldBe false
+      result.shouldBeInstanceOf<TestResult.Ignored>()
+   }
+
+   test("rule that invokes base.evaluate() should run the test and return its result") {
+      val spec = PassThroughRuleSpec()
+      val testCase = TestCase(
+         descriptor = PassThroughRuleSpec::class.toDescriptor().append("foo"),
+         name = TestNameBuilder.builder("foo").build(),
+         spec = spec,
+         test = {},
+         source = SourceRef.None,
+         type = TestType.Test,
+      )
+
+      var executed = false
+      val expected = TestResultBuilder.builder().build()
+      val result = runBlocking {
+         JUnit4RuleExtension.intercept(testCase) {
+            executed = true
+            expected
+         }
+      }
+
+      executed shouldBe true
+      result shouldBe expected
+   }
+})
+
+private class SkippingRuleSpec : FunSpec() {
+   @get:Rule
+   val rule: TestRule = TestRule { _, _ ->
+      object : Statement() {
+         override fun evaluate() {
+            // Intentionally do not call base.evaluate() — emulating a ConditionalIgnoreRule.
+         }
+      }
+   }
+}
+
+private class PassThroughRuleSpec : FunSpec() {
+   @get:Rule
+   val rule: TestRule = TestRule { base, _ ->
+      object : Statement() {
+         override fun evaluate() {
+            base.evaluate()
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Summary

`JUnit4RuleExtension.intercept` evaluated the rule-wrapped statement and then fell back to `execute(testCase)` if `result` was still null:

```kotlin
return try {
   statement.evaluate()
   result ?: execute(testCase)   // <— defeats rule's skip decision
} catch (e: Throwable) {
   TestResult.Error(Duration.ZERO, e)
}
```

A rule that chooses NOT to call `base.evaluate()` — e.g. the common `ConditionalIgnoreRule` pattern, or any custom guard rule that signals "skip" by returning normally without invoking the inner statement — left `result` null. The fallback then ran the test **outside** the rule wrapping, completely defeating the rule's authority: the test the rule decided to skip executed anyway, and any setup the rule was supposed to provide was missing.

Treat a null result as the rule's authoritative skip decision and return `TestResult.Ignored` instead.

## Test plan
- [x] Existing JUnit4 runner tests still pass.
- [ ] Manual verification: a `ConditionalIgnoreRule` that skips actually skips (instead of running the bare test).