### PR TITLE
Fix KSP processor including abstract / sealed spec classes

### DIFF
--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
@@ -35,7 +35,7 @@ class KotestFileVisitor : KSVisitorVoid() {
 
    override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
       super.visitClassDeclaration(classDeclaration, data)
-      if (isPublic(classDeclaration) && isSpec(classDeclaration)) {
+      if (isPublic(classDeclaration) && !isAbstract(classDeclaration) && isSpec(classDeclaration)) {
          specs.add(classDeclaration)
       } else if (isConfig(classDeclaration)) {
          configs.add(classDeclaration)
@@ -44,6 +44,15 @@ class KotestFileVisitor : KSVisitorVoid() {
 
    internal fun isPublic(declaration: KSClassDeclaration): Boolean =
       !declaration.modifiers.contains(Modifier.PRIVATE)
+
+   /**
+    * Returns true for classes that cannot be instantiated directly (abstract or sealed).
+    * The generated entry point invokes the spec's no-arg constructor (e.g. `MySpec()`),
+    * so abstract / sealed spec subclasses must be excluded — including them produces
+    * generated code that fails to compile.
+    */
+   internal fun isAbstract(declaration: KSClassDeclaration): Boolean =
+      declaration.modifiers.contains(Modifier.ABSTRACT) || declaration.modifiers.contains(Modifier.SEALED)
 
    internal fun isSpec(declaration: KSClassDeclaration): Boolean =
       declaration.getAllSuperTypes().map { it.declaration }

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/KotestFileVisitorTest.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/KotestFileVisitorTest.kt
@@ -79,4 +79,51 @@ class KotestFileVisitorTest : FunSpec({
          )
       ) shouldBe false
    }
+
+   test("isAbstract returns true for abstract spec classes") {
+      KotestFileVisitor().isAbstract(
+         SimpleKSClassDeclaration(
+            className = "com.sksamuel.AbstractSpec",
+            modifiers = setOf(Modifier.ABSTRACT),
+         )
+      ) shouldBe true
+   }
+
+   test("isAbstract returns true for sealed spec classes") {
+      KotestFileVisitor().isAbstract(
+         SimpleKSClassDeclaration(
+            className = "com.sksamuel.SealedSpec",
+            modifiers = setOf(Modifier.SEALED),
+         )
+      ) shouldBe true
+   }
+
+   test("isAbstract returns false for plain classes") {
+      KotestFileVisitor().isAbstract(
+         SimpleKSClassDeclaration(
+            className = "com.sksamuel.MySpec",
+         )
+      ) shouldBe false
+   }
+
+   test("abstract spec subclasses are excluded from visitor.specs") {
+      val visitor = KotestFileVisitor()
+      visitor.visitClassDeclaration(
+         SimpleKSClassDeclaration(
+            className = "com.sksamuel.AbstractSpec",
+            supers = listOf(
+               SimpleKSTypeReference(
+                  SimpleKSType(
+                     declaration = SimpleKSClassDeclaration(
+                        className = FunSpec::class.qualifiedName!!,
+                     )
+                  )
+               )
+            ),
+            modifiers = setOf(Modifier.ABSTRACT),
+         ),
+         Unit
+      )
+      visitor.specs shouldBe emptyList()
+   }
 })


### PR DESCRIPTION
## Summary

`KotestFileVisitor.visitClassDeclaration` accepted any `KSClassDeclaration` whose super-chain contained a known spec type, regardless of whether that class itself was concrete. Abstract or sealed spec subclasses — commonly used as shared bases for KMP test setup — ended up in `visitor.specs`, and `TestEngineGenerator` then emitted the equivalent of:

```kotlin
SpecRef.Function ({ AbstractSpec_0() }, AbstractSpec_0::class, "...")
```

into the generated `kotest.kt`. Calling the no-arg constructor of an abstract / sealed class is a compile error, so user projects that defined an abstract spec base failed to build under the symbol processor.

The JVM `Discovery` path already excludes abstract specs via `.filterNot(isAbstract)`. Brought the KSP path in line with the same contract:

```diff
-      if (isPublic(classDeclaration) && isSpec(classDeclaration)) {
+      if (isPublic(classDeclaration) && !isAbstract(classDeclaration) && isSpec(classDeclaration)) {
          specs.add(classDeclaration)
       } else if (isConfig(classDeclaration)) {
          configs.add(classDeclaration)
       }

+   internal fun isAbstract(declaration: KSClassDeclaration): Boolean =
+      declaration.modifiers.contains(Modifier.ABSTRACT) || declaration.modifiers.contains(Modifier.SEALED)
```

`isConfig` detection (for `AbstractProjectConfig` subclasses) is intentionally unaffected.

## Test plan
- [x] Added `KotestFileVisitorTest` cases asserting `isAbstract` returns `true` for `Modifier.ABSTRACT` and `Modifier.SEALED`, and `false` for plain classes.
- [x] Added an end-to-end visitor test verifying that an abstract spec subclass is excluded from `visitor.specs`.