### PR TITLE
Add missing f* overloads to BehaviorSpecRootScope

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1831,8 +1831,14 @@ public abstract class io/kotest/core/spec/style/BehaviorSpec : io/kotest/core/sp
 	public final fun context (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fContext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public final fun given (Lio/kotest/core/spec/style/scopes/ContainerScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
@@ -1863,8 +1869,14 @@ public final class io/kotest/core/spec/style/BehaviorSpecTestFactoryConfiguratio
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public fun context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fContext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
@@ -2245,8 +2257,14 @@ public abstract interface class io/kotest/core/spec/style/scopes/BehaviorSpecRoo
 	public fun addGiven (Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public fun context (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun context (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fContext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fGiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fGiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public fun fcontext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fcontext (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun fgiven (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public fun fgiven (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun given (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public fun given (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public fun xContext (Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
@@ -2270,8 +2288,14 @@ public final class io/kotest/core/spec/style/scopes/BehaviorSpecRootScope$Defaul
 	public static fun addGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lio/kotest/core/spec/style/TestXMethod;Lkotlin/jvm/functions/Function2;)V
 	public static fun context (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun context (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun fContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public static fun fContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun fGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public static fun fGiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static fun fcontext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public static fun fcontext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun fgiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
+	public static fun fgiven (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun given (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;
 	public static fun given (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static fun xContext (Lio/kotest/core/spec/style/scopes/BehaviorSpecRootScope;Ljava/lang/String;)Lio/kotest/core/spec/style/scopes/RootContainerWithConfigBuilder;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/BehaviorSpecRootScope.kt
@@ -50,6 +50,25 @@ interface BehaviorSpecRootScope : RootScope {
       test = test
    )
 
+   /**
+    * Adds a top level focused [BehaviorSpecGivenContainerScope] to this spec.
+    */
+   fun fgiven(name: String, test: suspend BehaviorSpecGivenContainerScope.() -> Unit) = addGiven(
+      name = name,
+      xmethod = TestXMethod.FOCUSED,
+      test = test
+   )
+
+   /**
+    * Adds a top level focused [BehaviorSpecGivenContainerScope] to this spec.
+    */
+   @Suppress("FunctionName")
+   fun fGiven(name: String, test: suspend BehaviorSpecGivenContainerScope.() -> Unit) = addGiven(
+      name = name,
+      xmethod = TestXMethod.FOCUSED,
+      test = test
+   )
+
    fun addGiven(name: String, xmethod: TestXMethod, test: suspend BehaviorSpecGivenContainerScope.() -> Unit) {
       addContainer(
          testName = TestNameBuilder.builder(name).withPrefix("Given: ").withDefaultAffixes().build(),
@@ -128,6 +147,19 @@ interface BehaviorSpecRootScope : RootScope {
    fun xContext(name: String, test: suspend BehaviorSpecContextContainerScope.() -> Unit) =
       addContext(name = name, xmethod = TestXMethod.DISABLED, test = test)
 
+   /**
+    * Adds a top level focused [BehaviorSpecContextContainerScope] to this spec.
+    */
+   fun fcontext(name: String, test: suspend BehaviorSpecContextContainerScope.() -> Unit) =
+      addContext(name = name, xmethod = TestXMethod.FOCUSED, test = test)
+
+   /**
+    * Adds a top level focused [BehaviorSpecContextContainerScope] to this spec.
+    */
+   @Suppress("FunctionName")
+   fun fContext(name: String, test: suspend BehaviorSpecContextContainerScope.() -> Unit) =
+      addContext(name = name, xmethod = TestXMethod.FOCUSED, test = test)
+
    fun addContext(name: String, xmethod: TestXMethod, test: suspend BehaviorSpecContextContainerScope.() -> Unit) {
       addContainer(
          testName = TestNameBuilder.builder(name).withPrefix("Context: ").withDefaultAffixes().build(),
@@ -160,6 +192,19 @@ interface BehaviorSpecRootScope : RootScope {
     */
    fun xContext(name: String) =
       addContext(name = name, xmethod = TestXMethod.DISABLED)
+
+   /**
+    * Adds a top level focused [BehaviorSpecContextContainerScope] to this spec.
+    */
+   fun fcontext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.FOCUSED)
+
+   /**
+    * Adds a top level focused [BehaviorSpecContextContainerScope] to this spec.
+    */
+   @Suppress("FunctionName")
+   fun fContext(name: String) =
+      addContext(name = name, xmethod = TestXMethod.FOCUSED)
 
    fun addContext(name: String, xmethod: TestXMethod): RootContainerWithConfigBuilder<BehaviorSpecContextContainerScope> {
       return RootContainerWithConfigBuilder(


### PR DESCRIPTION
## Summary

`BehaviorSpecRootScope` had `fgiven` / `fGiven` only as no-lambda config builders and was missing `fcontext` / `fContext` entirely — both as test-lambda overloads and as no-lambda config builders. The matching `x*` variants existed in both forms, and the container-scope siblings exposed all of these, so users writing `fgiven("foo") { ... }` or any `fcontext` form at the spec root hit an "unresolved reference" compile error despite the equivalent calls working everywhere else (FunSpec, ShouldSpec, DescribeSpec, ExpectSpec…).

Added six overloads to align the root scope with its container scopes and with every other spec style:

| Form | Variants added |
|---|---|
| `fgiven(name, test)` / `fGiven(name, test)` | test-lambda |
| `fcontext(name, test)` / `fContext(name, test)` | test-lambda |
| `fcontext(name)` / `fContext(name)` | no-lambda config builder |

## Test plan
- [x] `./gradlew :kotest-framework:kotest-framework-engine:apiDump` regenerates the binary-compat API; the diff is +24 entries (six overloads × 2 dispatch shapes × 2 call sites).
- [ ] Existing BehaviorSpec tests still pass.