### PR TITLE
Remove dead code: unreachable AssertionError catch + duplicate ProjectContextElement

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/instance/projectContextInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/interceptor/instance/projectContextInterceptor.kt
@@ -5,12 +5,10 @@ import io.kotest.core.project.ProjectContextElement
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
-import io.kotest.engine.TestEngineContext
 import io.kotest.engine.spec.interceptor.NextSpecInterceptor
 import io.kotest.engine.spec.interceptor.SpecInterceptor
 import io.kotest.engine.test.TestResult
 import kotlinx.coroutines.withContext
-import kotlin.coroutines.AbstractCoroutineContextElement
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -33,8 +31,3 @@ internal class ProjectContextInterceptor(
 internal val CoroutineContext.projectContext: ProjectContext
    get() = get(ProjectContextElement)?.projectContext
       ?: error("engineContext is not injected into this CoroutineContext")
-
-internal data class ProjectContextElement(val context: TestEngineContext) :
-   AbstractCoroutineContextElement(ProjectContextElement) {
-   companion object Key : CoroutineContext.Key<ProjectContextElement>
-}

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/ExceptionCapturingInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/ExceptionCapturingInterceptor.kt
@@ -26,9 +26,6 @@ internal class ExceptionCapturingInterceptor(private val timeMark: TimeMark) : T
       } catch (t: Throwable) {
          logger.log { Pair(testCase.name.name, "Throwable $t") }
          TestResultBuilder.builder().withDuration(timeMark.elapsedNow()).withError(t).build()
-      } catch (e: AssertionError) {
-         logger.log { Pair(testCase.name.name, "AssertionError $e") }
-         TestResultBuilder.builder().withDuration(timeMark.elapsedNow()).withError(e).build()
       }
    }
 }


### PR DESCRIPTION
## Summary

Two unreferenced declarations:

**1. Unreachable `catch (AssertionError)` in `ExceptionCapturingInterceptor`.**
`AssertionError` is a `Throwable`, so the `catch (Throwable)` immediately above swallows it first; the second catch can never run.

```diff
       return try {
          test(testCase, scope)
       } catch (t: Throwable) {
          logger.log { Pair(testCase.name.name, "Throwable $t") }
          TestResultBuilder.builder().withDuration(timeMark.elapsedNow()).withError(t).build()
-      } catch (e: AssertionError) {
-         logger.log { Pair(testCase.name.name, "AssertionError $e") }
-         TestResultBuilder.builder().withDuration(timeMark.elapsedNow()).withError(e).build()
       }
```

**2. Duplicate internal `ProjectContextElement` in `projectContextInterceptor.kt`.**
The file already imports the public `io.kotest.core.project.ProjectContextElement` and uses it at both call sites: `withContext(ProjectContextElement(context))` (constructor takes `ProjectContext`, matching the imported one) and `get(ProjectContextElement)?.projectContext` (the local class's only field is `context: TestEngineContext`, not `projectContext: ProjectContext`, so this could only resolve to the imported class). The local declaration had no callers.

Removing it also lets us drop the now-unused `io.kotest.engine.TestEngineContext` and `kotlin.coroutines.AbstractCoroutineContextElement` imports.

## Test plan
- [x] `./gradlew :kotest-framework:kotest-framework-engine:check` passes.