### PR TITLE
Fix InvocationTimeoutInterceptor missing WasmWasi guard

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/InvocationTimeoutInterceptor.kt
@@ -1,5 +1,7 @@
 package io.kotest.engine.test.interceptors
 
+import io.kotest.common.Platform
+import io.kotest.common.platform
 import io.kotest.core.Logger
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestScope
@@ -32,8 +34,10 @@ internal class InvocationTimeoutInterceptor(private val testConfigResolver: Test
          logger.log { Pair(testCase.name.name, "Switching context to add invocationTimeout $timeout") }
 
          // D8's setTimeout fires callbacks in registration order (ignoring delay values), so
-         // withTimeout would fire before any delay() in the test body. Skip timeout on D8.
-         if (isD8Runtime()) {
+         // withTimeout would fire before any delay() in the test body. WasmWasi also hangs
+         // with withTimeout for unrelated reasons. Skip the timeout on those runtimes — same
+         // exclusions as TimeoutInterceptor.
+         if (platform == Platform.WasmWasi || isD8Runtime()) {
             return test(testCase, scope.withCoroutineContext(currentCoroutineContext()))
          }
 


### PR DESCRIPTION
## Summary

`TimeoutInterceptor` already skips `withTimeout` on both WasmWasi and D8 because the JVM-style timeout primitives don't behave correctly in those runtimes:

```kotlin
if (platform != Platform.WasmWasi && !isD8Runtime()) {
   withAppropriateTimeout(timeout) { ... }
} else {
   test(...)
}
```

`InvocationTimeoutInterceptor` only excluded D8 — WasmWasi was missing. `withAppropriateTimeoutOrNull` ultimately calls `withTimeoutOrNull`, which hangs on WasmWasi for the same underlying reason that makes `withTimeout` hang there. Net effect: any test on WasmWasi with a non-default invocation timeout (e.g. `.config(invocationTimeout = 5.seconds)`) would hang rather than time out, while the same test under `TimeoutInterceptor` (the test-level timeout) correctly skipped the timeout.

```diff
-      if (isD8Runtime()) {
+      if (platform == Platform.WasmWasi || isD8Runtime()) {
          return test(testCase, scope.withCoroutineContext(currentCoroutineContext()))
       }
```

Brought InvocationTimeoutInterceptor's runtime check into line with TimeoutInterceptor's.

## Test plan
- [ ] Compiles. Behavioural change is limited to the WasmWasi target.