### PR TITLE
Fix AnnotationSpec @Test(expected=...) requiring exact class match

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/spec/style/AnnotationSpec.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/spec/style/AnnotationSpec.kt
@@ -127,7 +127,8 @@ abstract class AnnotationSpec : Spec() {
             t.unwrapIfReflectionCall()
          } ?: failNoExceptionThrown(expected)
 
-         if (thrown::class != expected) failWrongExceptionThrown(expected, thrown)
+         // Match JUnit 4 semantics: @Test(expected = X) accepts any X subclass, not only X exactly.
+         if (!expected.java.isInstance(thrown)) failWrongExceptionThrown(expected, thrown)
       }
    }
 


### PR DESCRIPTION
## Summary

`AnnotationSpec.createTestFnExceptingException` compared the thrown exception's runtime class to the expected class with strict equality:

```kotlin
if (thrown::class != expected) failWrongExceptionThrown(expected, thrown)
```

JUnit 4's `@Test(expected = X)` accepts any subclass of `X` — that's what users migrating from JUnit expect. AnnotationSpec is a JUnit-compatibility shim (the docstring on `@Test` even uses `// This is useful when moving from JUnit, in which you use expected to verify for an exception` to motivate it), so it should match.

Concrete divergence:

```kotlin
class CustomException : IllegalStateException()

@Test(expected = IllegalStateException::class)
fun foo() {
   throw CustomException()  // passes in JUnit 4; was reported as wrong-exception failure in Kotest
}
```

Switched the check to `expected.java.isInstance(thrown)`, which accepts the expected type itself and any of its subclasses.

```diff
-         if (thrown::class != expected) failWrongExceptionThrown(expected, thrown)
+         // Match JUnit 4 semantics: @Test(expected = X) accepts any X subclass, not only X exactly.
+         if (!expected.java.isInstance(thrown)) failWrongExceptionThrown(expected, thrown)
```

## Test plan
- [ ] Compiles. Existing exact-match cases still pass (an exact-class throw is also an `isInstance` match).
- [ ] Behaviour change is purely permissive: tests previously incorrectly failing now pass; no test that previously passed now fails.

(Note: I considered adding a regression test that uses `IllegalStateException` + a `CustomException : IllegalStateException` subclass, but the existing `AnnotationSpecTest` is already broken on master — it expects `tests.size == 2` and observes 0 — so I left the test addition for a separate fix once the spec discovery for the private-inner-class test specs is repaired.)