### PR TITLE
Enable -Xreturn-value-checker=full and -XXLanguage:+UnnamedLocalVariables

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -33,6 +33,8 @@ kotlin {
    compilerOptions {
 
       freeCompilerArgs.add("-Xexpect-actual-classes")
+      freeCompilerArgs.add("-Xreturn-value-checker=full")
+      freeCompilerArgs.add("-XXLanguage:+UnnamedLocalVariables")
 
       // See https://mbonnin.net/2026-02-22-kotlin-versions
       compilerVersion.set(libs.findVersion("kotlin-compile-version").get().toString())


### PR DESCRIPTION
## Summary

Adds two compiler flags to the shared \`kotlin-conventions\` plugin so they apply to every multiplatform module:

- \`-Xreturn-value-checker=full\` — surfaces unused return values as warnings (e.g. ignored \`Result.getOrThrow\`, \`shouldBe\` coerced to Unit, ignored \`flatMap\`), helping flag silent bugs.
- \`-XXLanguage:+UnnamedLocalVariables\` — enables \`val _ = ...\` for intentionally discarded results.

\`allWarningsAsErrors\` remains \`false\`, so the new diagnostics are informational rather than failing the build. A handful of legitimate \"unused return value\" warnings surface across the codebase (Result.getOrThrow, shouldBe-as-callback, etc.) — they can be triaged in follow-up PRs.

## Test plan
- [x] \`:kotest-framework:kotest-framework-engine:compileKotlinJvm\` succeeds with the new flags
- [x] \`:kotest-property:compileKotlinJvm\` succeeds
- [x] \`:kotest-assertions:kotest-assertions-core:compileKotlinJvm\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)