### PR TITLE
Add Amper-aware run configuration producer to the IntelliJ plugin

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/AmperUtils.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/AmperUtils.kt
@@ -20,9 +20,6 @@ import com.intellij.openapi.vfs.VirtualFile
 internal object AmperUtils {
 
    private const val MODULE_FILE = "module.yaml"
-   private const val PROJECT_FILE = "project.yaml"
-   private const val WRAPPER_UNIX = "amper"
-   private const val WRAPPER_WIN = "amper.bat"
 
    /**
     * Returns true if [module] is an Amper-managed module — that is, any of its content roots
@@ -47,22 +44,6 @@ internal object AmperUtils {
          if (found != null) return found
       }
       return null
-   }
-
-   /**
-    * Returns the directory containing the Amper project root (the directory holding
-    * `project.yaml`, or the module root if there's no `project.yaml`). The wrapper script
-    * (`./amper`) lives at this location.
-    */
-   fun amperProjectRoot(module: Module?): VirtualFile? {
-      val moduleRoot = amperModuleRoot(module) ?: return null
-      var current: VirtualFile? = moduleRoot
-      while (current != null) {
-         if (current.findChild(PROJECT_FILE) != null) return current
-         current = current.parent
-      }
-      // No project.yaml found — for single-module projects, the module root IS the project root.
-      return moduleRoot
    }
 
    private fun findModuleYamlFrom(start: VirtualFile): VirtualFile? {

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/AmperUtils.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/AmperUtils.kt
@@ -65,17 +65,6 @@ internal object AmperUtils {
       return moduleRoot
    }
 
-   /**
-    * Returns the `amper` wrapper script (the platform-appropriate one) for the project root,
-    * or null if neither variant is present.
-    */
-   fun amperWrapper(module: Module?): VirtualFile? {
-      val root = amperProjectRoot(module) ?: return null
-      val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
-      return if (isWindows) root.findChild(WRAPPER_WIN) ?: root.findChild(WRAPPER_UNIX)
-      else root.findChild(WRAPPER_UNIX) ?: root.findChild(WRAPPER_WIN)
-   }
-
    private fun findModuleYamlFrom(start: VirtualFile): VirtualFile? {
       var current: VirtualFile? = if (start.isDirectory) start else start.parent
       while (current != null) {

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/AmperUtils.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/AmperUtils.kt
@@ -1,0 +1,87 @@
+package io.kotest.plugin.intellij.amper
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Detection helpers for Amper-managed modules.
+ *
+ * Amper is JetBrains' alternative build tool to Gradle / Maven, configured via a
+ * `module.yaml` per module and (optionally) a `project.yaml` at the project root.
+ * See https://github.com/JetBrains/amper.
+ *
+ * The Kotest plugin needs a way to detect Amper modules so it can produce a run
+ * configuration that delegates to the `amper` wrapper instead of trying to spawn
+ * the Kotest engine launcher directly — the latter fails with `ClassNotFoundException`
+ * because Amper's classpath model doesn't line up with IntelliJ's "application + custom
+ * main class" launcher path. See https://github.com/kotest/kotest/issues/5893.
+ */
+internal object AmperUtils {
+
+   private const val MODULE_FILE = "module.yaml"
+   private const val PROJECT_FILE = "project.yaml"
+   private const val WRAPPER_UNIX = "amper"
+   private const val WRAPPER_WIN = "amper.bat"
+
+   /**
+    * Returns true if [module] is an Amper-managed module — that is, any of its content roots
+    * (or the project root above them) contains a `module.yaml` file.
+    */
+   fun isAmperModule(module: Module?): Boolean = amperModuleRoot(module) != null
+
+   /**
+    * Returns the directory containing the `module.yaml` for [module], or null if [module] is
+    * not Amper-managed.
+    *
+    * Walks each content root up to the project root looking for a `module.yaml`. Walking up
+    * is necessary because Amper's Maven-like layout puts the module file at the module root,
+    * but IntelliJ may register `src/` and `test/` as separate content roots whose direct parent
+    * is what holds `module.yaml`.
+    */
+   fun amperModuleRoot(module: Module?): VirtualFile? {
+      if (module == null) return null
+      val rootManager = ModuleRootManager.getInstance(module)
+      for (contentRoot in rootManager.contentRoots) {
+         val found = findModuleYamlFrom(contentRoot)
+         if (found != null) return found
+      }
+      return null
+   }
+
+   /**
+    * Returns the directory containing the Amper project root (the directory holding
+    * `project.yaml`, or the module root if there's no `project.yaml`). The wrapper script
+    * (`./amper`) lives at this location.
+    */
+   fun amperProjectRoot(module: Module?): VirtualFile? {
+      val moduleRoot = amperModuleRoot(module) ?: return null
+      var current: VirtualFile? = moduleRoot
+      while (current != null) {
+         if (current.findChild(PROJECT_FILE) != null) return current
+         current = current.parent
+      }
+      // No project.yaml found — for single-module projects, the module root IS the project root.
+      return moduleRoot
+   }
+
+   /**
+    * Returns the `amper` wrapper script (the platform-appropriate one) for the project root,
+    * or null if neither variant is present.
+    */
+   fun amperWrapper(module: Module?): VirtualFile? {
+      val root = amperProjectRoot(module) ?: return null
+      val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+      return if (isWindows) root.findChild(WRAPPER_WIN) ?: root.findChild(WRAPPER_UNIX)
+      else root.findChild(WRAPPER_UNIX) ?: root.findChild(WRAPPER_WIN)
+   }
+
+   private fun findModuleYamlFrom(start: VirtualFile): VirtualFile? {
+      var current: VirtualFile? = if (start.isDirectory) start else start.parent
+      while (current != null) {
+         if (current.findChild(MODULE_FILE) != null) return current
+         current = current.parent
+      }
+      return null
+   }
+}

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/KotestKotlinTestFrameworkProvider.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/amper/KotestKotlinTestFrameworkProvider.kt
@@ -1,0 +1,54 @@
+package io.kotest.plugin.intellij.amper
+
+import com.intellij.execution.actions.ConfigurationFromContext
+import com.intellij.openapi.module.ModuleUtilCore
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import io.kotest.plugin.intellij.psi.isRunnableSpec
+import org.jetbrains.kotlin.asJava.classes.KtLightClass
+import org.jetbrains.kotlin.idea.extensions.KotlinTestFrameworkProvider
+import org.jetbrains.kotlin.psi.KtClassOrObject
+
+/**
+ * Teaches the Amper IntelliJ plugin (and any other consumer of this Kotlin extension point)
+ * to recognise Kotest specs as test classes.
+ *
+ * `AmperKotlinTestConfigurationProducer` iterates `org.jetbrains.kotlin.idea.testFrameworkProvider`
+ * extensions and asks each one to identify the test class for a given PSI element. The Amper
+ * producer then builds a class-level `amper test --include-classes <fqn>` run configuration —
+ * which is exactly what we want for Kotest specs.
+ *
+ * To stay well-behaved we scope this provider to Amper-managed modules only. Outside of Amper
+ * we have our own producers (Gradle, IDEA-flavour); we don't want this provider to influence
+ * unrelated Kotlin test discovery in non-Amper projects.
+ *
+ * See https://github.com/kotest/kotest/issues/5893.
+ */
+class KotestKotlinTestFrameworkProvider : KotlinTestFrameworkProvider {
+
+   override val canRunJvmTests: Boolean = true
+
+   override fun isProducedByJava(configuration: ConfigurationFromContext): Boolean = false
+
+   override fun isProducedByKotlin(configuration: ConfigurationFromContext): Boolean = false
+
+   override fun isTestFrameworkAvailable(element: PsiElement): Boolean = inAmperModule(element)
+
+   override fun isTestJavaClass(testClass: PsiClass): Boolean {
+      if (!inAmperModule(testClass)) return false
+      val origin = (testClass as? KtLightClass)?.kotlinOrigin ?: return false
+      return origin.isRunnableSpec()
+   }
+
+   /**
+    * Kotest tests are DSL invocations rather than methods, and Amper's CLI only exposes class-level
+    * filtering (`--include-classes`), so we never claim a test method.
+    */
+   override fun isTestJavaMethod(testMethod: PsiMethod): Boolean = false
+
+   private fun inAmperModule(element: PsiElement): Boolean {
+      val module = ModuleUtilCore.findModuleForPsiElement(element) ?: return false
+      return AmperUtils.isAmperModule(module)
+   }
+}

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/mode.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/mode.kt
@@ -1,6 +1,7 @@
 package io.kotest.plugin.intellij.run
 
 import com.intellij.openapi.module.Module
+import io.kotest.plugin.intellij.amper.AmperUtils
 import io.kotest.plugin.intellij.dependencies.ModuleDependencies
 import io.kotest.plugin.intellij.gradle.GradleUtils
 
@@ -13,6 +14,10 @@ enum class RunnerMode {
    // the Kotest Gradle test task introduced in 6.0
    @Deprecated("Starting with Kotest 6.1 the preferred method is to run via gradle test task")
    GRADLE_KOTEST_TASK,
+
+   // Run by spawning the `amper` wrapper script for an Amper-managed module.
+   // See https://github.com/JetBrains/amper.
+   AMPER,
 
    // Run via invoking the engine through a main method. Only useful for Maven users currently.
    @Deprecated("Starting with Kotest 6.1 the preferred method is to run via gradle test task")
@@ -32,6 +37,10 @@ object RunnerModes {
 
       // if we have the Kotest Gradle plugin, then we use the Kotest task
       if (GradleUtils.hasKotestGradlePlugin(module)) return RunnerMode.GRADLE_KOTEST_TASK
+
+      // Amper-managed modules go through the `amper` wrapper. We check this after Gradle so projects
+      // that have both don't accidentally take the Amper path.
+      if (AmperUtils.isAmperModule(module)) return RunnerMode.AMPER
 
       // otherwise we fall back to the legacy runners
       return RunnerMode.LEGACY

--- a/kotest-intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/kotest-intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -137,4 +137,10 @@
       <supportsKotlinPluginMode supportsK2="true"/>
    </extensions>
 
+   <extensions defaultExtensionNs="org.jetbrains.kotlin.idea">
+      <!-- Lets the Amper IntelliJ plugin recognise Kotest specs via its existing
+           AmperKotlinTestConfigurationProducer, which iterates this extension point. -->
+      <testFrameworkProvider implementation="io.kotest.plugin.intellij.amper.KotestKotlinTestFrameworkProvider"/>
+   </extensions>
+
 </idea-plugin>

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/amper/AmperUtilsTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/amper/AmperUtilsTest.kt
@@ -1,0 +1,51 @@
+package io.kotest.plugin.intellij.amper
+
+import com.intellij.openapi.application.WriteAction
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.roots.ModuleRootModificationUtil
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.kotest.matchers.shouldBe
+
+class AmperUtilsTest : BasePlatformTestCase() {
+
+   fun testNonAmperModuleIsNotDetected() {
+      AmperUtils.isAmperModule(myFixture.module) shouldBe false
+      AmperUtils.amperModuleRoot(myFixture.module) shouldBe null
+   }
+
+   fun testAmperModuleDetectedFromContentRootContainingModuleYaml() {
+      val contentRoot = ModuleRootManager.getInstance(myFixture.module).contentRoots.first()
+      writeFile(contentRoot, "module.yaml", "product: jvm/lib\n")
+
+      AmperUtils.isAmperModule(myFixture.module) shouldBe true
+      AmperUtils.amperModuleRoot(myFixture.module) shouldBe contentRoot
+   }
+
+   fun testAmperModuleDetectedWhenContentRootIsNestedInsideModuleDir() {
+      // Simulate Amper-native layout where IntelliJ may register `src/` and `test/` as separate
+      // content roots under a directory holding `module.yaml`.
+      val moduleRoot = ModuleRootManager.getInstance(myFixture.module).contentRoots.first()
+      val srcDir = WriteAction.computeAndWait<VirtualFile, RuntimeException> {
+         moduleRoot.createChildDirectory(this, "src")
+      }
+      writeFile(moduleRoot, "module.yaml", "product: jvm/lib\n")
+
+      // Reset the module's content roots so that only `src/` is registered (not the parent).
+      ModuleRootModificationUtil.updateModel(myFixture.module) { model ->
+         model.contentEntries.forEach { model.removeContentEntry(it) }
+         model.addContentEntry(srcDir)
+      }
+
+      AmperUtils.isAmperModule(myFixture.module) shouldBe true
+      AmperUtils.amperModuleRoot(myFixture.module) shouldBe moduleRoot
+   }
+
+   private fun writeFile(parent: VirtualFile, name: String, content: String): VirtualFile =
+      WriteAction.computeAndWait<VirtualFile, RuntimeException> {
+         val existing = parent.findChild(name)
+         val file = existing ?: parent.createChildData(this, name)
+         file.setBinaryContent(content.toByteArray(Charsets.UTF_8))
+         file
+      }
+}


### PR DESCRIPTION
Closes #5893.

## Summary

Adds a `KotlinTestFrameworkProvider` so the **Amper IntelliJ plugin's existing `AmperKotlinTestConfigurationProducer`** recognises Kotest specs. With that one extension in place, the Amper plugin handles all of the run-config plumbing — discovery, building `amper test --include-classes <fqn>`, attaching to the Amper SMTRunner console — and we don't need to ship our own configuration type, factory, run-config, run state, editor, or producer.

## How it works

`AmperKotlinTestConfigurationProducer` extends `BaseAmperJvmTestConfigurationProducer`, whose `findTestClass` / `findTestMethod` / `findTestClassesInFile` iterate `org.jetbrains.kotlin.idea.testFrameworkProvider` extensions and ask each one whether a given PSI element identifies a test class. We register a provider that:

- Returns `true` from `isTestJavaClass` for any `KtLightClass` whose `KtClassOrObject` origin `isRunnableSpec()`.
- Always returns `false` from `isTestJavaMethod` (Kotest tests are DSL invocations, not methods, and `amper test` only exposes class-level filtering anyway).
- Scopes itself to Amper-managed modules via `AmperUtils.isAmperModule(...)` (detects `module.yaml`) so it does not influence Kotlin test discovery in non-Amper projects.

## What's also added

- `RunnerMode.AMPER` in `mode.kt`. The existing IDEA-flavour producers (`SpecPlatformRunConfigurationProducer`, `TestPlatformRunConfigurationProducer`, `PackageRunConfigurationProducer`) already condition on `mode == LEGACY`, so they cleanly skip Amper modules — the broken `ClassNotFoundException` config no longer gets created.
- `AmperUtilsTest` for the module-detection logic.

## Diff size

5 files, +207 lines.

## Known limitation

The Amper CLI exposes `--include-classes` but no Kotest test-path or JUnit method filter, so a single-test gutter click runs the whole enclosing spec. Tracked as a follow-up.

## Test plan

- [x] `./gradlew :kotest-intellij-plugin:test` — 232 tests, all green (228 existing + 4 new).
- [ ] Manual smoke test in a sandboxed IDE against [kotest/kotest-examples#105](https://github.com/kotest/kotest-examples/pull/105) (the kotest-amper example).