### PR TITLE
Remove unused details flag from TeamCityTestEngineListener

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -4633,8 +4633,7 @@ public final class io/kotest/engine/teamcity/TeamCityMessage {
 	public final fun build ()Ljava/lang/String;
 	public final fun details (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun duration-LRDsOJo (J)V
-	public final fun exception (Ljava/lang/Throwable;Z)Lio/kotest/engine/teamcity/TeamCityMessage;
-	public static synthetic fun exception$default (Lio/kotest/engine/teamcity/TeamCityMessage;Ljava/lang/Throwable;ZILjava/lang/Object;)Lio/kotest/engine/teamcity/TeamCityMessage;
+	public final fun exception (Ljava/lang/Throwable;)Lio/kotest/engine/teamcity/TeamCityMessage;
 	public final fun expected (Ljava/lang/String;)V
 	public final fun locationHint (Ljava/lang/String;)V
 	public final fun message (Ljava/lang/String;)V

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
@@ -8,9 +8,9 @@ import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
 import io.kotest.engine.errors.ExtensionExceptionExtractor
 import io.kotest.engine.extensions.MultipleExceptions
+import io.kotest.engine.teamcity.Locations
 import io.kotest.engine.teamcity.TeamCityMessage
 import io.kotest.engine.teamcity.TeamCityPathRenderer
-import io.kotest.engine.teamcity.Locations
 import io.kotest.engine.test.TestResult
 import io.kotest.engine.test.names.DisplayNameFormatting
 import kotlin.reflect.KClass
@@ -40,13 +40,11 @@ import kotlin.reflect.KClass
 @KotestInternal
 class TeamCityTestEngineListener(
    private val prefix: String = TeamCityMessage.TEAM_CITY_PREFIX,
-   private val details: Boolean = true,
 ) : TestEngineListener {
 
    private val logger = Logger(TeamCityTestEngineListener::class)
    private var renderer = TeamCityPathRenderer(DisplayNameFormatting(null))
    private val results = mutableMapOf<Descriptor, TestResult>()
-
 
    override suspend fun engineStarted() {
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_REPORTER_ATTACHED) {}.output()
@@ -116,7 +114,7 @@ class TeamCityTestEngineListener(
          if (result.isErrorOrFailure) {
             TeamCityMessage(prefix, TeamCityMessage.Types.TEST_FAILED) {
                name(renderer.testPath(testCase))
-               exception(result.errorOrNull, details)
+               exception(result.errorOrNull)
                result(result)
             }.output()
          }
@@ -151,7 +149,7 @@ class TeamCityTestEngineListener(
 
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_FAILED) {
          name(testPath)
-         exception(cause, details)
+         exception(cause)
       }.output()
 
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_FINISHED) {

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityMessage.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityMessage.kt
@@ -109,22 +109,20 @@ class TeamCityMessage(
    fun result(value: TestResult) = attribute(Attributes.RESULT_STATUS, value.name)
 
    // note it seems that test-failed messages require a message to be included
-   fun exception(error: Throwable?, showDetails: Boolean = true): TeamCityMessage {
+   fun exception(error: Throwable?): TeamCityMessage {
       if (error == null) return this
 
       val line1 = error.message?.trim()?.lines()?.firstOrNull()
       val message = if (line1.isNullOrBlank()) "Test failed" else line1
       message(escapeColonsIn(message))
 
-      if (showDetails) {
-         // stackTraceToString fails if the error is created by a mocking framework, so we should catch
-         val stacktrace: String = try {
-            error.stackTraceToString()
-         } catch (_: Exception) {
-            "StackTrace unavailable (Sometimes caused by a mocked exception)"
-         }
-         details(escapeColonsIn(stacktrace)) // seems to be some limit to the details field
+      // stackTraceToString fails if the error is created by a mocking framework, so we should catch
+      val stacktrace: String = try {
+         error.stackTraceToString()
+      } catch (_: Exception) {
+         "StackTrace unavailable (Sometimes caused by a mocked exception)"
       }
+      details(escapeColonsIn(stacktrace)) // seems to be some limit to the details field
 
       return this
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityPathRenderer.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityPathRenderer.kt
@@ -2,7 +2,6 @@ package io.kotest.engine.teamcity
 
 import io.kotest.core.spec.SpecRef
 import io.kotest.core.test.TestCase
-import io.kotest.engine.teamcity.TeamCityTestNameEscaper
 import io.kotest.engine.test.names.DisplayNameFormatting
 import kotlin.reflect.KClass
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerEmbeddedLocationsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerEmbeddedLocationsTest.kt
@@ -15,7 +15,7 @@ class TeamCityTestEngineListenerEmbeddedLocationsTest : FunSpec() {
    init {
 
       context("!when embedded locations are enabled") {
-         val listener = TeamCityTestEngineListener(prefix = "tc", details = true)
+         val listener = TeamCityTestEngineListener(prefix = "tc")
          val tc = TestCase(
            TeamCityTestEngineListenerEmbeddedLocationsTest::class.toDescriptor().append("a"),
            TestNameBuilder.builder("a").build(),
@@ -57,7 +57,7 @@ class TeamCityTestEngineListenerEmbeddedLocationsTest : FunSpec() {
       }
 
       context("!when embedded locations are disabled") {
-         val listener = TeamCityTestEngineListener(prefix = "tc", details = true)
+         val listener = TeamCityTestEngineListener(prefix = "tc")
          val tc = TestCase(
            TeamCityTestEngineListenerEmbeddedLocationsTest::class.toDescriptor().append("a"),
            TestNameBuilder.builder("a").build(),

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
@@ -20,6 +20,9 @@ import kotlin.time.Duration.Companion.seconds
 @EnabledIf(LinuxOnlyGithubCondition::class)
 class TeamCityTestEngineListenerTest : FunSpec() {
 
+   // Stack traces are non-deterministic; strip the details attribute so the rest of the message can be asserted exactly.
+   private fun stripDetails(output: String): String = output.replace(Regex(" details='[^']*'"), "")
+
    init {
 
       val a = TestCase(
@@ -66,7 +69,7 @@ class TeamCityTestEngineListenerTest : FunSpec() {
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Success']
@@ -76,7 +79,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 
       test("should support errors in tests") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -91,7 +94,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFailed name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' message='boom' result_status='Error']
@@ -102,7 +105,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 
       test("should support ignored tests with reason") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -116,7 +119,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testIgnored name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' locationHint='kotest://foo.bar.Test:33' message='don|'t like it' result_status='Ignored']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
@@ -125,7 +128,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 
       test("should support errors in test suites by adding a placeholder test") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -140,7 +143,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Success']
@@ -153,7 +156,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 
       test("should support errors in specs by adding a placeholder test") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -168,7 +171,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='123' result_status='Success']
@@ -181,7 +184,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 
       test("should support multiline error messages") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -206,7 +209,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFailed name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' message='well this is a' result_status='Error']
@@ -217,7 +220,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
 
       test("should write engine errors as top level failed tests") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -232,7 +235,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(listOf(Exception("big whoop")))
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='555' result_status='Success']
@@ -245,7 +248,7 @@ a[testFinished name='Exception']
 
       test("should write multiple engine errors") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -260,7 +263,7 @@ a[testFinished name='Exception']
             )
             listener.engineFinished(listOf(Exception("big whoop"), Exception("big whoop 2")))
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' duration='555' result_status='Success']
@@ -276,7 +279,7 @@ a[testFinished name='Exception']
 
       test("should clear state between specs") {
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(a)
@@ -294,7 +297,7 @@ a[testFinished name='Exception']
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
@@ -311,7 +314,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
          )
 
          val output = captureStandardOut {
-            val listener = TeamCityTestEngineListener("a", details = false)
+            val listener = TeamCityTestEngineListener("a")
             listener.engineStarted()
             listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
             listener.testStarted(cperiods)
@@ -322,7 +325,7 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
             )
             listener.engineFinished(emptyList())
          }
-         output shouldBe """a[enteredTheMatrix]
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
 a[testStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a b c' locationHint='kotest://foo.bar.Test:17']
 a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a b c' duration='124' result_status='Success']


### PR DESCRIPTION
## Summary
- The `details: Boolean = true` parameter on `TeamCityTestEngineListener` was never set to `false` by any production caller — only by tests that wanted to suppress non-deterministic stack traces. Removed it and dropped the corresponding `showDetails` parameter from `TeamCityMessage.exception()` so the stack trace is unconditionally emitted.
- Tests now strip the dynamic `details='...'` attribute from captured output via a small `stripDetails` helper, so assertions stay exact against the rest of the message.

## Test plan
- [x] `./gradlew :kotest-framework:kotest-framework-engine:compileKotlinJvm :kotest-framework:kotest-framework-engine:compileTestKotlinJvm`
- [x] `./gradlew :kotest-framework:kotest-framework-engine:jvmTest --tests "com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)