### PR TITLE
Fix typo in setup documentation

### DIFF
--- a/documentation/docs/framework/setup.mdx
+++ b/documentation/docs/framework/setup.mdx
@@ -51,7 +51,7 @@ tasks.withType<Test>().configureEach {
 }
 ```
 
-Andd then add the following dependency to your build:
+And then add the following dependency to your build:
 
 ```kotlin
 dependencies {

--- a/documentation/versioned_docs/version-6.1/framework/setup.mdx
+++ b/documentation/versioned_docs/version-6.1/framework/setup.mdx
@@ -56,7 +56,7 @@ tasks.withType<Test>().configureEach {
 }
 ```
 
-Andd then add the following dependency to your build:
+And then add the following dependency to your build:
 
 ```kotlin
 dependencies {


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
