### PR TITLE
Propagate expected/actual diff values to property test errors (#5909)

### DIFF
--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -23,6 +23,7 @@ kotlin {
       jvmMain {
          dependencies {
             implementation(libs.diffutils)
+            implementation(libs.opentest4j) // used to propagate expected/actual diffs to outer property errors
             api(libs.rgxgen)
          }
       }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/errors.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/errors.kt
@@ -1,6 +1,5 @@
 package io.kotest.property.internal
 
-import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.print.print
 
 /**
@@ -32,6 +31,10 @@ fun throwPropertyTestAssertionError(
 /**
  * Generates an [AssertionError] for a failed property test.
  *
+ * If the failure cause carries expected/actual diff values (e.g. from a matcher backed by OpenTest4J
+ * on the JVM, or [io.kotest.assertions.KotestAssertionFailedError] on other platforms), those values
+ * are propagated to the resulting error so that IDEs such as IntelliJ display a "click to see diff" link.
+ *
  * @param e the test failure cause
  * @param attempt the iteration count at the time of failure
  * @param results the inputs that the test failed for
@@ -43,11 +46,16 @@ internal fun propertyAssertionError(
    results: List<ShrinkResult<Any?>>,
    outputHexForUnprintableChars: Boolean,
 ): Throwable {
-   return AssertionErrorBuilder.create()
-      .withMessage(propertyTestFailureMessage(attempt, results, seed, e, outputHexForUnprintableChars))
-      .withCause(e)
-      .build()
+   val finalCause = results.fold(e) { t, result -> result.cause ?: t }
+   val message = propertyTestFailureMessage(attempt, results, seed, e, outputHexForUnprintableChars)
+   return createPropertyAssertionError(message, finalCause)
 }
+
+/**
+ * Creates an [AssertionError] for a property test failure, preserving any expected/actual
+ * values present on [cause] so that IDEs can render a diff for the outer error.
+ */
+internal expect fun createPropertyAssertionError(message: String, cause: Throwable): AssertionError
 
 /**
  * Generates a property test failure message with details of the args that failed, any shrinks

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/internal/errors.jvm.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/internal/errors.jvm.kt
@@ -1,0 +1,16 @@
+package io.kotest.property.internal
+
+import org.opentest4j.AssertionFailedError
+
+internal actual fun createPropertyAssertionError(message: String, cause: Throwable): AssertionError {
+   // if the underlying failure is an OpenTest4J AssertionFailedError carrying expected/actual values,
+   // propagate them to the outer error so IntelliJ can render a "click to see diff" link
+   val opentestCause = cause as? AssertionFailedError
+   val expected = opentestCause?.takeIf { it.isExpectedDefined }?.expected?.value
+   val actual = opentestCause?.takeIf { it.isActualDefined }?.actual?.value
+   return if (expected != null || actual != null) {
+      AssertionFailedError(message, expected, actual, cause)
+   } else {
+      AssertionFailedError(message, cause)
+   }
+}

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropertyAssertionFailedErrorTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/PropertyAssertionFailedErrorTest.kt
@@ -1,0 +1,38 @@
+package com.sksamuel.kotest.property
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.int
+import io.kotest.property.checkAll
+import org.opentest4j.AssertionFailedError
+
+class PropertyAssertionFailedErrorTest : FunSpec({
+
+   test("checkAll should propagate expected/actual values from cause to support IntelliJ diff") {
+      val error = shouldThrow<AssertionFailedError> {
+         checkAll(Arb.int(0..0)) { input ->
+            input.shouldBeEqual(input + 1)
+         }
+      }
+      // expected/actual should be propagated from the underlying matcher failure
+      // so IntelliJ can render a "click to see diff" link on the outer error
+      error.isExpectedDefined shouldBe true
+      error.isActualDefined shouldBe true
+      error.expected.value shouldNotBe null
+      error.actual.value shouldNotBe null
+   }
+
+   test("checkAll should still work when cause has no expected/actual values") {
+      val error = shouldThrow<AssertionFailedError> {
+         checkAll(Arb.int(0..0)) {
+            error("boom")
+         }
+      }
+      error.isExpectedDefined shouldBe false
+      error.isActualDefined shouldBe false
+   }
+})

--- a/kotest-property/src/nativeTest/kotlin/io/kotest/property/PropertyAssertionFailedErrorTest.kt
+++ b/kotest-property/src/nativeTest/kotlin/io/kotest/property/PropertyAssertionFailedErrorTest.kt
@@ -1,0 +1,40 @@
+package io.kotest.property
+
+import io.kotest.assertions.KotestAssertionFailedError
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.property.arbitrary.int
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+
+class PropertyAssertionFailedErrorTest {
+
+   @Test
+   fun propagatesExpectedAndActualFromCause() {
+      runBlocking {
+         val error = shouldThrow<KotestAssertionFailedError> {
+            checkAll(Arb.int(0..0)) { input ->
+               input.shouldBeEqual(input + 1)
+            }
+         }
+         // expected/actual should be propagated from the underlying matcher failure
+         // so tooling/TeamCity service messages can render a diff for the outer error
+         error.expected shouldBe "1"
+         error.actual shouldBe "0"
+      }
+   }
+
+   @Test
+   fun doesNotSetExpectedAndActualWhenCauseHasNone() {
+      runBlocking {
+         val error = shouldThrow<AssertionError> {
+            checkAll(Arb.int(0..0)) {
+               error("boom")
+            }
+         }
+         // when the underlying failure isn't a KotestAssertionFailedError we fall back to a plain AssertionError
+         (error is KotestAssertionFailedError) shouldBe false
+      }
+   }
+}

--- a/kotest-property/src/nonjvmMain/kotlin/io/kotest/property/internal/errors.nonjvm.kt
+++ b/kotest-property/src/nonjvmMain/kotlin/io/kotest/property/internal/errors.nonjvm.kt
@@ -1,0 +1,19 @@
+package io.kotest.property.internal
+
+import io.kotest.assertions.KotestAssertionFailedError
+
+internal actual fun createPropertyAssertionError(message: String, cause: Throwable): AssertionError {
+   // if the underlying failure carries expected/actual values, propagate them to the outer error
+   // so IDEs and TeamCity service messages can render a diff for the outer error
+   val kotestCause = cause as? KotestAssertionFailedError
+   return if (kotestCause != null) {
+      KotestAssertionFailedError(
+         message = message,
+         cause = cause,
+         expected = kotestCause.expected,
+         actual = kotestCause.actual,
+      )
+   } else {
+      AssertionError(message, cause)
+   }
+}


### PR DESCRIPTION
## Summary

- When a matcher with expected/actual values (e.g. `shouldBeEqual`, `shouldBe`) failed inside `checkAll` / `forAll`, the outer `AssertionError` built by the property runner discarded those values. IntelliJ's OpenTest4J integration uses `AssertionFailedError.expected/actual` to render the "click to see difference" link, so the diff link was missing on property test failures.
- The outer error is now constructed directly via `AssertionFailedError(message, expected, actual, cause)` on the JVM (and `KotestAssertionFailedError` on non-JVM), preserving the diff values from the cause without modifying the message text.

Fixes #5909

## Test plan
- [x] Added `PropertyAssertionFailedErrorTest` covering both the diff-bearing and non-diff cases.
- [x] `:kotest-property:jvmTest` passes — existing `ForAll2Test` message-format expectations still match.
- [x] `compileKotlinJs`, `compileKotlinLinuxX64`, `compileKotlinWasmJs` succeed for the non-JVM actual.
- [ ] Verify the diff link renders in IntelliJ on the repro snippet from the issue.