### PR TITLE
Add per-call Eq overrides via withEqs DSL

### DIFF
--- a/documentation/docs/assertions/shouldbe.md
+++ b/documentation/docs/assertions/shouldbe.md
@@ -135,4 +135,15 @@ rates withEqs {
 An override only fires when the runtime types of `actual` and `expected` match, mirroring the
 type-match guard used by the global resolver.
 
+`withEqs` also composes with `shouldNotBe` for negative comparisons under the same overrides:
+
+```kotlin
+val a = BigDecimal("1.00")
+val b = BigDecimal("2")
+
+a withEqs {
+   register<BigDecimal>(BigDecimalIgnoreScaleEq)
+} shouldNotBe b
+```
+
 

--- a/documentation/docs/assertions/shouldbe.md
+++ b/documentation/docs/assertions/shouldbe.md
@@ -75,7 +75,9 @@ automatically generated too.
 
 Then we register it with Kotest, specifying the type that we want to use it for. Here we are
 using [project config](../framework/project_config.md) to set it up before any tests are run. We could do this at the
-spec level too, but bear in mind if you are running tests in parallel then the registration will be non-deterministic.
+spec level too, but bear in mind that this registration is global, so if you are running tests in parallel a per-spec
+registration will be non-deterministic. See [per-call overrides with `withEqs`](#per-call-overrides-with-witheqs) below
+for a parallel-safe alternative scoped to a single comparison.
 
 ```kotlin
 class ProjectConfig : AbstractProjectConfig() {
@@ -97,5 +99,40 @@ test("custom eq should be selected if both sides are the same type") {
 Custom `Eq` instances are only selected if both sides of the call are the type specified when registered. Also the type
 must be exact, subclasses are not selected automatically and must also be registered
 :::
+
+### Per-call overrides with `withEqs`
+
+The global `DefaultEqResolver.register(...)` API mutates a shared map, so it cannot safely express
+*"this `BigDecimal` comparison should ignore scale, but the next one should not"* — especially when
+specs run in parallel. `withEqs` provides per-call `Eq` overrides that are scoped to a single
+comparison and never touch the global resolver.
+
+```kotlin
+val a = BigDecimal("3.14")
+val b = BigDecimal("3.140")
+
+a shouldNotBe b                                          // default Eq compares with scale
+
+a withEqs {
+   register<BigDecimal>(BigDecimalIgnoreScaleEq)
+} shouldBe b                                             // ignores scale only for this line
+
+a shouldNotBe b                                          // back to default
+```
+
+Overrides propagate through nested collection, map and data-class comparisons because they ride on
+the `EqContext` that's threaded through every recursive `Eq` call:
+
+```kotlin
+val rates = mapOf("USD" to BigDecimal("3.14"), "EUR" to BigDecimal("2.99"))
+val expected = mapOf("USD" to BigDecimal("3.140"), "EUR" to BigDecimal("2.990"))
+
+rates withEqs {
+   register<BigDecimal>(BigDecimalIgnoreScaleEq)
+} shouldBe expected
+```
+
+An override only fires when the runtime types of `actual` and `expected` match, mirroring the
+type-match guard used by the global resolver.
 
 

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -198,6 +198,7 @@ public abstract interface annotation class io/kotest/assertions/eq/EqOverridesDs
 
 public final class io/kotest/assertions/eq/EqOverridesDslKt {
 	public static final fun shouldBe (Lio/kotest/assertions/eq/WithEqs;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun shouldNotBe (Lio/kotest/assertions/eq/WithEqs;Ljava/lang/Object;)Ljava/lang/Object;
 	public static final fun withEqs (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/eq/WithEqs;
 }
 

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -149,10 +149,10 @@ public final class io/kotest/assertions/eq/CollectionEq : io/kotest/assertions/e
 	public fun equals (Ljava/util/Collection;Ljava/util/Collection;Lio/kotest/assertions/eq/EqContext;)Lio/kotest/assertions/eq/EqResult;
 }
 
-public final class io/kotest/assertions/eq/DefaultEqResolver {
+public final class io/kotest/assertions/eq/DefaultEqResolver : io/kotest/assertions/eq/EqResolver {
 	public static final field INSTANCE Lio/kotest/assertions/eq/DefaultEqResolver;
 	public final fun register (Lkotlin/reflect/KClass;Lio/kotest/assertions/eq/Eq;)V
-	public final fun resolve (Ljava/lang/Object;Ljava/lang/Object;)Lio/kotest/assertions/eq/Eq;
+	public fun resolve (Ljava/lang/Object;Ljava/lang/Object;)Lio/kotest/assertions/eq/Eq;
 	public final fun unregister (Lkotlin/reflect/KClass;)V
 }
 
@@ -169,6 +169,8 @@ public final class io/kotest/assertions/eq/EqContext {
 	public static final field MAX_DEPTH I
 	public fun <init> ()V
 	public fun <init> (Z)V
+	public fun <init> (ZLio/kotest/assertions/eq/EqResolver;)V
+	public final fun getResolver ()Lio/kotest/assertions/eq/EqResolver;
 	public final fun getStrictNumberEq ()Z
 	public final fun isVisited (Ljava/lang/Object;Ljava/lang/Object;)Z
 	public final fun pop ()Lkotlin/Pair;
@@ -184,6 +186,19 @@ public final class io/kotest/assertions/eq/EqMatcher : io/kotest/matchers/Matche
 	public fun invert ()Lio/kotest/matchers/Matcher;
 	public fun invertIf (Z)Lio/kotest/matchers/Matcher;
 	public fun test (Ljava/lang/Object;)Lio/kotest/matchers/MatcherResult;
+}
+
+public final class io/kotest/assertions/eq/EqOverrides {
+	public fun <init> ()V
+	public final fun put (Lkotlin/reflect/KClass;Lio/kotest/assertions/eq/Eq;)V
+}
+
+public abstract interface annotation class io/kotest/assertions/eq/EqOverridesDsl : java/lang/annotation/Annotation {
+}
+
+public final class io/kotest/assertions/eq/EqOverridesDslKt {
+	public static final fun shouldBe (Lio/kotest/assertions/eq/WithEqs;Ljava/lang/Object;)Ljava/lang/Object;
+	public static final fun withEqs (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/eq/WithEqs;
 }
 
 public abstract interface class io/kotest/assertions/eq/EqResolver {
@@ -220,6 +235,12 @@ public final class io/kotest/assertions/eq/IsOrderedSetKt {
 	public static final fun isOrderedSet (Ljava/lang/Iterable;)Z
 }
 
+public final class io/kotest/assertions/eq/LayeredEqResolver : io/kotest/assertions/eq/EqResolver {
+	public fun <init> (Ljava/util/Map;Lio/kotest/assertions/eq/EqResolver;)V
+	public synthetic fun <init> (Ljava/util/Map;Lio/kotest/assertions/eq/EqResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun resolve (Ljava/lang/Object;Ljava/lang/Object;)Lio/kotest/assertions/eq/Eq;
+}
+
 public final class io/kotest/assertions/eq/NumberEq : io/kotest/assertions/eq/Eq {
 	public static final field INSTANCE Lio/kotest/assertions/eq/NumberEq;
 	public fun equals (Ljava/lang/Number;Ljava/lang/Number;Lio/kotest/assertions/eq/EqContext;)Lio/kotest/assertions/eq/EqResult;
@@ -242,6 +263,9 @@ public final class io/kotest/assertions/eq/ThrowableEq : io/kotest/assertions/eq
 	public static final field INSTANCE Lio/kotest/assertions/eq/ThrowableEq;
 	public synthetic fun equals (Ljava/lang/Object;Ljava/lang/Object;Lio/kotest/assertions/eq/EqContext;)Lio/kotest/assertions/eq/EqResult;
 	public fun equals (Ljava/lang/Throwable;Ljava/lang/Throwable;Lio/kotest/assertions/eq/EqContext;)Lio/kotest/assertions/eq/EqResult;
+}
+
+public final class io/kotest/assertions/eq/WithEqs {
 }
 
 public final class io/kotest/assertions/equals/CommutativeEquality : io/kotest/assertions/equals/Equality {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DefaultEqResolver.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DefaultEqResolver.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KClass
  * [Eq] instance available for that type.
  */
 @Suppress("DEPRECATION")
-object DefaultEqResolver {
+object DefaultEqResolver : EqResolver {
 
    private val customEqInstances = mutableMapOf<KClass<*>, Eq<*>>()
 
@@ -28,7 +28,7 @@ object DefaultEqResolver {
     * Returns the [Eq] to use for comparison for the given values.
     * If both values are nullable, then [NullEq] will be returned.
     */
-   fun resolve(actual: Any?, expected: Any?): Eq<out Any?> {
+   override fun resolve(actual: Any?, expected: Any?): Eq<out Any?> {
       // if we have null and non-null, usually that's a failure, but people can override equals to allow it
       return when {
          actual == null || expected == null -> NullEq

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqCompare.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqCompare.kt
@@ -2,17 +2,18 @@ package io.kotest.assertions.eq
 
 /**
  * An [EqCompare] is used to compare two values of the same type by looking up an [Eq] instance.
- * The appropriate [Eq] is resolved using the [DefaultEqResolver] class.
+ * The [Eq] is resolved via the [EqResolver] carried on the supplied [EqContext]; this defaults
+ * to [DefaultEqResolver] but is replaced by a [LayeredEqResolver] when `withEqs { ... }` supplies
+ * per-call overrides.
  */
 object EqCompare {
    /**
-    * @param context extra context used during comparison such as cyclic references and strict mode.
-    *
-    * See [EqContext].
+    * @param context extra context used during comparison such as cyclic references, strict mode,
+    *                and the active [EqResolver]. See [EqContext].
     */
    @Suppress("UNCHECKED_CAST")
    internal fun <T> compare(actual: T, expected: T, context: EqContext): EqResult {
-      val eq = DefaultEqResolver.resolve(actual, expected) as Eq<T>
+      val eq = context.resolver.resolve(actual, expected) as Eq<T>
       return eq.equals(actual, expected, context)
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqContext.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqContext.kt
@@ -2,10 +2,14 @@ package io.kotest.assertions.eq
 
 /**
  * @param strictNumberEq used by number types to determine if they should be compared using == or by converting to the larger type.
+ * @param resolver resolves the [Eq] instance for each comparison; defaults to the global [DefaultEqResolver]
+ *                 but is replaced by a [LayeredEqResolver] when `withEqs { ... }` supplies per-call overrides.
  */
-class EqContext(val strictNumberEq: Boolean) {
+class EqContext(val strictNumberEq: Boolean, val resolver: EqResolver) {
 
-   constructor() : this(false)
+   constructor() : this(false, DefaultEqResolver)
+
+   constructor(strictNumberEq: Boolean) : this(strictNumberEq, DefaultEqResolver)
 
    private val visited = mutableListOf<Pair<Any?, Any?>>()
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
@@ -21,6 +21,12 @@ class EqOverrides {
 
    internal val eqs: MutableMap<KClass<*>, Eq<*>> = mutableMapOf()
 
+   /**
+    * Registers an [Eq] instance for type [T] within the scope of the enclosing [withEqs] block.
+    *
+    * Calling this multiple times for the same type is allowed; the last call wins, matching the
+    * builder semantics used elsewhere in Kotest (e.g. `TestConfig`).
+    */
    inline fun <reified T : Any> register(eq: Eq<T>) {
       put(T::class, eq)
    }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
@@ -1,0 +1,72 @@
+package io.kotest.assertions.eq
+
+import kotlin.reflect.KClass
+
+@DslMarker
+annotation class EqOverridesDsl
+
+/**
+ * Type-safe builder used inside `withEqs { ... }` to register per-call [Eq] overrides.
+ *
+ * ```
+ * actual withEqs {
+ *    register<BigDecimal>(BigDecimalIgnoreScaleEq)
+ *    register<Money>(MoneyEq)
+ * } shouldBe expected
+ * ```
+ */
+@EqOverridesDsl
+class EqOverrides {
+
+   internal val eqs: MutableMap<KClass<*>, Eq<*>> = mutableMapOf()
+
+   inline fun <reified T : Any> register(eq: Eq<T>) {
+      put(T::class, eq)
+   }
+
+   @PublishedApi
+   internal fun put(type: KClass<*>, eq: Eq<*>) {
+      eqs[type] = eq
+   }
+}
+
+/**
+ * Carries the actual value together with the [Eq] overrides supplied via [withEqs], waiting for a
+ * matching [shouldBe] (or [shouldNotBe]) to drive the comparison.
+ */
+class WithEqs<T> internal constructor(
+   internal val actual: T,
+   internal val overrides: Map<KClass<*>, Eq<*>>,
+)
+
+/**
+ * Builds [Eq] overrides scoped to a single comparison, leaving [DefaultEqResolver] untouched.
+ *
+ * The returned [WithEqs] composes with [shouldBe] and [shouldNotBe]:
+ *
+ * ```
+ * mapOf("USD" to BigDecimal("3.14")) withEqs {
+ *    register<BigDecimal>(BigDecimalIgnoreScaleEq)
+ * } shouldBe mapOf("USD" to BigDecimal("3.140"))
+ * ```
+ *
+ * Overrides flow through nested collection, map and data-class comparisons because the
+ * [LayeredEqResolver] travels on the [EqContext] threaded through every recursive [EqCompare]
+ * call.
+ */
+infix fun <T> T.withEqs(block: EqOverrides.() -> Unit): WithEqs<T> {
+   val overrides = EqOverrides().apply(block)
+   return WithEqs(this, overrides.eqs.toMap())
+}
+
+/**
+ * Asserts that the value carried by [this] equals [expected] under the overrides supplied via
+ * [withEqs]. Throws an [AssertionError] on mismatch and returns the actual value on success.
+ */
+infix fun <T> WithEqs<T>.shouldBe(expected: T?): T {
+   val context = EqContext(strictNumberEq = false, resolver = LayeredEqResolver(overrides))
+   @Suppress("UNCHECKED_CAST")
+   val result = EqCompare.compare(actual, expected as T, context)
+   if (result is EqResult.Failure) throw result.error()
+   return actual
+}

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
@@ -1,5 +1,6 @@
 package io.kotest.assertions.eq
 
+import io.kotest.assertions.print.print
 import kotlin.reflect.KClass
 
 @DslMarker
@@ -68,5 +69,20 @@ infix fun <T> WithEqs<T>.shouldBe(expected: T?): T {
    @Suppress("UNCHECKED_CAST")
    val result = EqCompare.compare(actual, expected as T, context)
    if (result is EqResult.Failure) throw result.error()
+   return actual
+}
+
+/**
+ * Asserts that the value carried by [this] does not equal [expected] under the overrides supplied
+ * via [withEqs]. Throws an [AssertionError] when the comparison reports equality and returns the
+ * actual value otherwise.
+ */
+infix fun <T> WithEqs<T>.shouldNotBe(expected: T?): T {
+   val context = EqContext(strictNumberEq = false, resolver = LayeredEqResolver(overrides))
+   @Suppress("UNCHECKED_CAST")
+   val result = EqCompare.compare(actual, expected as T, context)
+   if (result is EqResult.Success) {
+      throw AssertionError("${expected.print().value} should not equal ${actual.print().value}")
+   }
    return actual
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/LayeredEqResolver.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/LayeredEqResolver.kt
@@ -1,0 +1,27 @@
+package io.kotest.assertions.eq
+
+import kotlin.reflect.KClass
+
+/**
+ * An [EqResolver] that consults a map of per-call [Eq] overrides before delegating to a
+ * [fallback] resolver (the global [DefaultEqResolver] by default).
+ *
+ * An override applies only when `actual::class == expected::class`; this mirrors the type-match
+ * guard used by [DefaultEqResolver] for its own custom registrations and keeps existing cross-type
+ * dispatch (e.g. `Int` vs `Long`, `null` vs non-null) intact.
+ *
+ * Used internally by [withEqs] to install per-call overrides on the active [EqContext] without
+ * touching any global state.
+ */
+class LayeredEqResolver(
+   private val overrides: Map<KClass<*>, Eq<*>>,
+   private val fallback: EqResolver = DefaultEqResolver,
+) : EqResolver {
+
+   override fun resolve(actual: Any?, expected: Any?): Eq<out Any?> {
+      if (actual != null && expected != null && actual::class == expected::class) {
+         overrides[actual::class]?.let { return it }
+      }
+      return fallback.resolve(actual, expected)
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/WithEqsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/WithEqsTest.kt
@@ -159,6 +159,16 @@ class WithEqsTest : FunSpec() {
             DefaultEqResolver.unregister(BigDecimal::class)
          }
       }
+
+      test("register can be called multiple times for the same type — last call wins") {
+         val a = BigDecimal("1.00")
+         val b = BigDecimal("1")
+
+         a withEqs {
+            register<BigDecimal>(RejectAllBigDecimalsEq)
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe b
+      }
    }
 }
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/WithEqsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/WithEqsTest.kt
@@ -6,6 +6,7 @@ import io.kotest.assertions.eq.Eq
 import io.kotest.assertions.eq.EqContext
 import io.kotest.assertions.eq.EqResult
 import io.kotest.assertions.eq.shouldBe
+import io.kotest.assertions.eq.shouldNotBe
 import io.kotest.assertions.eq.withEqs
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.FunSpec
@@ -113,6 +114,49 @@ class WithEqsTest : FunSpec() {
             a withEqs {
                register<BigDecimal>(BigDecimalIgnoreScaleEq)
             } shouldBe b
+         }
+      }
+
+      test("withEqs shouldNotBe throws when override reports equality, returns actual otherwise") {
+         val a = BigDecimal("1.00")
+         val b = BigDecimal("1")
+         val c = BigDecimal("2")
+
+         shouldThrowAny {
+            a withEqs {
+               register<BigDecimal>(BigDecimalIgnoreScaleEq)
+            } shouldNotBe b
+         }
+
+         a withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldNotBe c
+      }
+
+      test("withEqs shouldNotBe override propagates into nested data class properties") {
+         val barA = Bar(Foo("hello"), "world", BigDecimal("1"))
+         val barB = Bar(Foo("hello"), "world", BigDecimal("1.00"))
+
+         shouldThrowAny {
+            barA withEqs {
+               register<BigDecimal>(BigDecimalIgnoreScaleEq)
+            } shouldNotBe barB
+         }
+      }
+
+      test("withEqs shouldNotBe override wins over a globally registered Eq for the same type") {
+         try {
+            DefaultEqResolver.register(BigDecimal::class, RejectAllBigDecimalsEq)
+
+            BigDecimal("1") shouldNotBe BigDecimal("1")
+
+            shouldThrowAny {
+               BigDecimal("1.00") withEqs {
+                  register<BigDecimal>(BigDecimalIgnoreScaleEq)
+               } shouldNotBe BigDecimal("1")
+            }
+         } finally {
+            DefaultEqResolver.unregister(BigDecimal::class)
          }
       }
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/WithEqsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/WithEqsTest.kt
@@ -1,0 +1,128 @@
+package com.sksamuel.kotest.eq
+
+import io.kotest.assertions.AssertionErrorBuilder
+import io.kotest.assertions.eq.DefaultEqResolver
+import io.kotest.assertions.eq.Eq
+import io.kotest.assertions.eq.EqContext
+import io.kotest.assertions.eq.EqResult
+import io.kotest.assertions.eq.shouldBe
+import io.kotest.assertions.eq.withEqs
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.math.BigDecimal
+
+class WithEqsTest : FunSpec() {
+   init {
+
+      test("withEqs overrides apply only for the single comparison they are attached to") {
+         val a = BigDecimal("1.00")
+         val b = BigDecimal("1")
+
+         a shouldNotBe b
+
+         a withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe b
+
+         a shouldNotBe b
+      }
+
+      test("withEqs overrides propagate into nested data class properties") {
+         val barA = Bar(Foo("hello"), "world", BigDecimal("1"))
+         val barB = Bar(Foo("hello"), "world", BigDecimal("1.00"))
+
+         barA shouldNotBe barB
+
+         barA withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe barB
+      }
+
+      test("withEqs overrides propagate into Map values") {
+         val a = mapOf("USD" to BigDecimal("3.14"), "EUR" to BigDecimal("2.99"))
+         val b = mapOf("USD" to BigDecimal("3.140"), "EUR" to BigDecimal("2.990"))
+
+         a shouldNotBe b
+
+         a withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe b
+      }
+
+      test("withEqs overrides propagate into Collection elements") {
+         val a = listOf(BigDecimal("1.00"), BigDecimal("2.00"))
+         val b = listOf(BigDecimal("1"), BigDecimal("2"))
+
+         a shouldNotBe b
+
+         a withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe b
+      }
+
+      test("withEqs overrides survive deeper nesting (Map -> data class -> BigDecimal)") {
+         val a = mapOf("rate" to Bar(Foo("hello"), "world", BigDecimal("1")))
+         val b = mapOf("rate" to Bar(Foo("hello"), "world", BigDecimal("1.00")))
+
+         a shouldNotBe b
+
+         a withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe b
+      }
+
+      test("withEqs failure path still throws on mismatch") {
+         shouldThrowAny {
+            BigDecimal("1.00") withEqs {
+               register<BigDecimal>(BigDecimalIgnoreScaleEq)
+            } shouldBe BigDecimal("2")
+         }
+      }
+
+      test("withEqs does not leak overrides to subsequent global comparisons") {
+         BigDecimal("1.00") withEqs {
+            register<BigDecimal>(BigDecimalIgnoreScaleEq)
+         } shouldBe BigDecimal("1")
+
+         BigDecimal("1.00") shouldNotBe BigDecimal("1")
+      }
+
+      test("withEqs override wins over a globally registered Eq for the same type") {
+         try {
+            DefaultEqResolver.register(BigDecimal::class, RejectAllBigDecimalsEq)
+
+            shouldThrowAny {
+               BigDecimal("1") shouldBe BigDecimal("1")
+            }
+
+            BigDecimal("1.00") withEqs {
+               register<BigDecimal>(BigDecimalIgnoreScaleEq)
+            } shouldBe BigDecimal("1")
+         } finally {
+            DefaultEqResolver.unregister(BigDecimal::class)
+         }
+      }
+
+      test("withEqs override does not apply when runtime types of actual and expected differ") {
+         val a: Number = BigDecimal("1.00")
+         val b: Number = 1L
+
+         shouldThrowAny {
+            a withEqs {
+               register<BigDecimal>(BigDecimalIgnoreScaleEq)
+            } shouldBe b
+         }
+      }
+   }
+}
+
+private object RejectAllBigDecimalsEq : Eq<BigDecimal> {
+   override fun equals(actual: BigDecimal, expected: BigDecimal, context: EqContext): EqResult =
+      EqResult.Failure {
+         AssertionErrorBuilder.create()
+            .withMessage("RejectAllBigDecimalsEq rejects everything")
+            .build()
+      }
+}


### PR DESCRIPTION
## Summary

`DefaultEqResolver.register(...)` mutates a shared map under the hood, so any per-spec custom `Eq` registration races as soon as specs run in parallel — the existing docs already call this out:

> *We could do this at the spec level too, but bear in mind if you are running tests in parallel then the registration will be non-deterministic.*

This adds a per-call `withEqs { ... } shouldBe expected` DSL that scopes overrides to a single comparison and leaves the global resolver alone.

```kotlin
val a = mapOf("USD" to BigDecimal("3.14"), "EUR" to BigDecimal("2.99"))
val b = mapOf("USD" to BigDecimal("3.140"), "EUR" to BigDecimal("2.990"))

a withEqs {
   register<BigDecimal>(BigDecimalIgnoreScaleEq)
} shouldBe b
```

## How it works

`EqContext` gains a `resolver: EqResolver` field (default `DefaultEqResolver`, plus a backward-compat constructor with the old single-arg shape). `EqCompare.compare` now goes through `context.resolver.resolve(...)` instead of calling `DefaultEqResolver` directly. `withEqs` wraps the actual value in a `WithEqs<T>` together with the override map, and the matching `shouldBe` builds an `EqContext` carrying a `LayeredEqResolver(overrides, fallback = DefaultEqResolver)`.

Because the context is already threaded through every recursive compare in `MapEq`, `CollectionEq`, `DataClassEq`, `ArrayEq`, and `MapEntryEq`, overrides propagate into nested values automatically — no extra plumbing in those classes.

`LayeredEqResolver` only applies an override when `actual::class == expected::class`, mirroring the type-match guard `DefaultEqResolver` uses for its own custom registrations. Existing cross-type dispatch (e.g. `null` vs non-null, `Int` vs `Long`) keeps working.

This is the infix-builder variant of shape #2 from the issue discussion — same infix surface, but a reified `register<T>(eq)` builder for type safety instead of vararg `Pair<KClass<*>, Eq<*>>`. Spec-level scoping can layer on top in a follow-up PR if larger suites need it.

## Test plan

- [x] New `WithEqsTest` covers: scoping (override doesn't leak to subsequent comparisons), nested data-class / Map / Collection propagation, deep nesting, failure path, precedence over a global registration, and the runtime-type-mismatch fallback.
- [x] Existing `CustomEqTest` (6 tests) and the rest of `:kotest-assertions:kotest-assertions-core:jvmTest` stay green — backward-compat for `DefaultEqResolver.register` / `unregister` is preserved.
- [x] `./gradlew :kotest-assertions:kotest-assertions-core:apiDump` — added entries are the new public surface only (`EqContext` extra constructor + `resolver` getter, `EqOverrides`, `LayeredEqResolver`, `WithEqs`, top-level `withEqs` / `shouldBe`).

Fixes https://github.com/kotest/kotest/issues/5910
