### PR TITLE
Upgrade mockserver to version 6.0.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ spring = "5.3.39"
 dev-publish-plugin = "0.4.2"
 
 wiremock = "3.13.2"
-mockserver = "5.15.0"
+mockserver = "6.0.0"
 fuel = "2.3.1"
 konform = "0.11.1"
 testcontainers = "2.0.4"


### PR DESCRIPTION
Updated mockserver version from 5.15.0 to 6.0.0.

Fixes #5914

Will see if any breaking changes surface.. [The changelog](https://github.com/mock-server/mockserver-monorepo/blob/master/changelog.md#changed-1) doesn't mention anything that look troubling to me. 