### PR TITLE
Drop redundant toList() in UserStackTraceConverter

### DIFF
--- a/kotest-common/src/jvmMain/kotlin/io/kotest/common/stacktrace/UserStackTraceConverter.kt
+++ b/kotest-common/src/jvmMain/kotlin/io/kotest/common/stacktrace/UserStackTraceConverter.kt
@@ -16,10 +16,10 @@ object UserStackTraceConverter {
    * returned.
    */
   private fun Array<StackTraceElement>.dropUntilUserClass(): Array<StackTraceElement> {
-    return toList().dropUntilFirstKotestClass().dropUntilFirstNonKotestClass().toTypedArray()
+    return dropUntilFirstKotestClass().dropUntilFirstNonKotestClass().toTypedArray()
   }
 
-  private fun List<StackTraceElement>.dropUntilFirstKotestClass(): List<StackTraceElement> {
+  private fun Array<StackTraceElement>.dropUntilFirstKotestClass(): List<StackTraceElement> {
     return dropWhile {
       it.isNotKotestClass()
     }


### PR DESCRIPTION
## Summary
- \`Array.dropWhile\` already returns a \`List\`, so the intermediate \`toList()\` in \`dropUntilUserClass()\` was unnecessary.
- Changed \`dropUntilFirstKotestClass\` to be an extension on \`Array<StackTraceElement>\` so the call chain still type-checks.

## Test plan
- [ ] \`./gradlew :kotest-common:jvmTest\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)