### PR TITLE
Add AllowCustomSeedBeforeCheckTest

### DIFF
--- a/kotest-property/kotest-property-permutations/src/jvmTest/kotlin/io/kotest/permutations/checks/AllowCustomSeedBeforeCheckTest.kt
+++ b/kotest-property/kotest-property-permutations/src/jvmTest/kotlin/io/kotest/permutations/checks/AllowCustomSeedBeforeCheckTest.kt
@@ -1,0 +1,29 @@
+@file:OptIn(ExperimentalKotest::class)
+
+package io.kotest.permutations.checks
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.common.ExperimentalKotest
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.permutations.PermutationConfiguration
+import io.kotest.permutations.toContext
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class AllowCustomSeedBeforeCheckTest : FunSpec({
+
+   test("should throw when a custom seed is set and failOnSeed is true") {
+      val context = PermutationConfiguration().apply {
+         seed = 12345L
+         failOnSeed = true
+         forEach { }
+      }.toContext()
+
+      val ex = shouldThrow<IllegalStateException> {
+         AllowCustomSeedBeforeCheck.check(context)
+      }
+      ex.message shouldBe "A seed is specified on this permutation but failOnSeed is true"
+   }
+})


### PR DESCRIPTION
## Summary
Adds a focused unit test for \`AllowCustomSeedBeforeCheck\` that asserts an \`IllegalStateException\` is thrown when the permutation context has a custom seed and \`failOnSeed = true\`.

## Heads up — master build state
This test compiles and runs locally only after restoring \`api(projects.kotestProperty)\` to \`kotest-property-permutations/build.gradle.kts\` (it was dropped in 17b111d68 but commonMain still references types from \`kotest-property\` like \`ShrinkingMode\`, \`PropertyTesting\`, \`LabelOrder\`, etc.). Without that fix this PR's CI — and any other change to this module — will not compile.

## Test plan
- [ ] \`./gradlew :kotest-property:kotest-property-permutations:jvmTest --tests "io.kotest.permutations.checks.AllowCustomSeedBeforeCheckTest"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)