### PR TITLE
Add ConstraintsTest case for an always-false custom constraint

### DIFF
--- a/kotest-property/kotest-property-permutations/src/jvmTest/kotlin/io/kotest/permutations/constraints/ConstraintsTest.kt
+++ b/kotest-property/kotest-property-permutations/src/jvmTest/kotlin/io/kotest/permutations/constraints/ConstraintsTest.kt
@@ -46,5 +46,18 @@ class ConstraintsTest : FunSpec() {
          }
          counter shouldBe 5
       }
+
+      test("a custom constraint that always returns false should never execute the property check") {
+         var counter = 0
+         permutations {
+            iterations = 3
+            duration = 100.milliseconds
+            constraints = Constraints { false }
+            forEach {
+               counter++
+            }
+         }
+         counter shouldBe 0
+      }
    }
 }


### PR DESCRIPTION
## Summary
Adds a new case to \`ConstraintsTest\` that supplies \`Constraints { false }\` as a custom constraint and asserts the \`forEach\` body never runs (counter stays at 0). This pins down the guarantee that a constraint can short-circuit the property loop before any iteration is attempted.

## Heads up — master build state
Same caveat as #6022: master's \`kotest-property-permutations\` module doesn't currently compile (api(projects.kotestProperty) was removed in 17b111d68 but commonMain still references it). CI will be red until that gradle change is restored.

## Test plan
- [ ] \`./gradlew :kotest-property:kotest-property-permutations:jvmTest --tests "io.kotest.permutations.constraints.ConstraintsTest"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)