### PR TITLE
Make flaky ContinuallyTest case deterministic via per-iteration delay

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/ContinuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/ContinuallyTest.kt
@@ -155,22 +155,30 @@ class ContinuallyTest : FunSpec() {
          }
       }
 
-      test("continually should pass if function completes at least once and then possibly times out").config(
+      test("continually should pass if function completes at least once and then times out").config(
          coroutineTestScope = false
       ) {
+         // First call delays 10ms (well within the 100ms duration so iter 0 succeeds);
+         // subsequent calls delay 1s so continually's remaining-time withTimeout cancels
+         // them before completion. Result: exactly one successful pass followed by a
+         // timed-out second pass.
          val config = continuallyConfig<Int> {
             duration = 100.milliseconds
             intervalFn = DurationFn { 0.milliseconds }
          }
+         val delayFn: (Int) -> Duration = { iteration ->
+            if (iteration == 0) 10.milliseconds else 1.seconds
+         }
          var iteration = 0
          val result = testContinually(config) {
-            delay(59.milliseconds)
+            delay(delayFn(iteration))
             iteration++
-            iteration shouldBeEqual iteration
+            iteration
          }
          assertSoftly {
-            result.invocationTimes.size shouldBeAtLeast 2
-            result.invocationTimes.shouldForAll { it <= 100.milliseconds }
+            result.value shouldBe 1
+            result.invocationTimes shouldHaveSize 2
+            result.invocationTimes.shouldForAll { it <= config.duration }
          }
       }
 


### PR DESCRIPTION
## Summary
- The case `continually should pass if function completes at least once and then possibly times out` used a single 59 ms delay inside a 100 ms duration and asserted `size shouldBeAtLeast 2`. Whether the second invocation happened was at the mercy of real-time scheduler slop, so on a loaded CI the test could see only one invocation.
- Continually deadline checks always use real time, so virtual time is not a fix. Instead the body delay is now driven by a function of the iteration index: the first call delays 10 ms (well inside the 100 ms window so iter 0 succeeds), all subsequent calls delay 1 s (so iter 1 is cancelled by continually remaining-time `withTimeout`). The result is deterministic: exactly one successful pass with `value = 1`, followed by a timed-out second pass.
- Renamed to `... then times out` since the timeout is now guaranteed rather than "possibly".

## Test plan
- [x] `./gradlew :kotest-assertions:kotest-assertions-core:jvmTest --tests "io.kotest.assertions.nondeterministic.ContinuallyTest"` — all 13 cases pass.
- [x] Re-ran the suite 5× with `--rerun-tasks`; all 5 runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)