### PR TITLE
Fix shouldBeEmpty crashing on dynamic iterables (#6005)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/empty.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/empty.kt
@@ -142,21 +142,34 @@ internal fun <T> beEmpty(name: String?): Matcher<Iterable<T>> = object : Matcher
       val name = name ?: value.containerName()
       val passed: Boolean
       val sizeReport: String
+      // Captured from the same iterator used for the emptiness check so dynamic iterables
+      // (whose iterator() may return different elements on subsequent calls) don't fail with
+      // NoSuchElementException when the failure message lambda re-iterates.
+      val firstValue: T?
 
       when (value) {
          is Collection -> {
             passed = value.isEmpty()
             sizeReport = "${value.size} elements"
+            firstValue = if (passed) null else value.first()
          }
 
          else -> {
-            passed = !value.iterator().hasNext()
-            sizeReport = "at least one element"
+            val iterator = value.iterator()
+            if (iterator.hasNext()) {
+               passed = false
+               firstValue = iterator.next()
+               sizeReport = "at least one element"
+            } else {
+               passed = true
+               firstValue = null
+               sizeReport = "0 elements"
+            }
          }
       }
       return MatcherResult(
          passed,
-         { "$name should be empty but has $sizeReport, first being: ${value.first().print().value}" },
+         { "$name should be empty but has $sizeReport, first being: ${firstValue.print().value}" },
          { "$name should not be empty" }
       )
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BeEmptyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/BeEmptyTest.kt
@@ -140,6 +140,30 @@ class BeEmptyTest : WordSpec() {
             }.message shouldBe "Range should be empty but has at least one element, first being: 1"
          }
 
+         "fail with a meaningful message for a dynamic iterable whose iterator() returns different elements on subsequent calls" {
+            // regression test for https://github.com/kotest/kotest/issues/6005
+            val iterable: Iterable<Int> = object : Iterable<Int> {
+               private var numbers = listOf(1, 2, 3)
+
+               override fun iterator(): Iterator<Int> {
+                  val currentNumbers = numbers
+                  numbers = emptyList()
+                  return currentNumbers.iterator()
+               }
+            }
+            shouldThrowAny {
+               iterable.shouldBeEmpty()
+            }.message shouldBe "Iterable should be empty but has at least one element, first being: 1"
+         }
+
+         "succeed for a dynamic iterable that is empty on the first iterator() call" {
+            // companion to the above: the empty branch should not need a second iterator() call.
+            val iterable: Iterable<Int> = object : Iterable<Int> {
+               override fun iterator(): Iterator<Int> = emptyList<Int>().iterator()
+            }
+            iterable.shouldBeEmpty()
+         }
+
          "fail for null list reference" {
             val maybeList: List<String>? = null
             shouldThrowAny {


### PR DESCRIPTION
## Summary
Fixes #6005 — `Iterable.shouldBeEmpty()` crashes with `NoSuchElementException` when given a dynamic iterable whose `iterator()` returns different elements on subsequent calls.

`beEmpty`s non-`Collection` branch was:
1. Calling `value.iterator().hasNext()` for the emptiness check.
2. Deferring the first-element lookup to a `failureMessage` lambda that called `value.first()`, opening a second iterator.

For a dynamic iterable that drains its source on the first iteration, that second iterator is empty and `first()` throws.

This PR captures the first element from the same iterator used for the `hasNext()` check, so dynamic iterables now produce the expected `... should be empty but has at least one element, first being: ...` failure message instead of crashing.

## Test plan
- [x] Added a regression test using the iterable from the issue verifying the new error message.
- [x] Added a companion test for an empty dynamic iterable (no second `iterator()` call needed in the success path).
- [x] `./gradlew :kotest-assertions:kotest-assertions-core:jvmTest --tests "com.sksamuel.kotest.matchers.collections.BeEmptyTest"` — all cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
