### PR TITLE
Remove unused multiline test names from system property configuration

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3815,7 +3815,6 @@ public final class io/kotest/engine/config/SpecConfigResolver {
 }
 
 public abstract interface class io/kotest/engine/config/SystemPropertyConfiguration {
-	public abstract fun allowMultilineTestName ()Ljava/lang/Boolean;
 	public abstract fun assertionMode ()Lio/kotest/core/test/AssertionMode;
 	public abstract fun concurrencyOrder ()Lio/kotest/engine/concurrency/ConcurrencyOrder;
 	public abstract fun coroutineDebugProbes ()Ljava/lang/Boolean;

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineProperties.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineProperties.kt
@@ -90,8 +90,6 @@ object KotestEngineProperties {
     */
    const val PROJECT_CONFIGURATION_FQN = "kotest.framework.config.fqn"
 
-   internal const val ALLOW_MULTILINE_TEST_NAME = "kotest.framework.testname.multiline"
-
    /**
     *  If set -> filter testCases by this severity level and higher, else running all
     */

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/SystemPropertyConfiguration.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/SystemPropertyConfiguration.kt
@@ -24,7 +24,6 @@ interface SystemPropertyConfiguration {
    fun timeout(): Duration?
    fun invocationTimeout(): Duration?
    fun projectTimeout(): Duration?
-   fun allowMultilineTestName(): Boolean?
    fun globalAssertSoftly(): Boolean?
    fun testNameAppendTags(): Boolean?
    fun tagInheritance(): Boolean?

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/SystemPropertyConfiguration.jvm.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/SystemPropertyConfiguration.jvm.kt
@@ -33,9 +33,6 @@ internal object JvmSystemPropertyConfiguration : SystemPropertyConfiguration {
    override fun invocationTimeout(): Duration? =
       sysprop(KotestEngineProperties.INVOCATION_TIMEOUT)?.toLong()?.milliseconds
 
-   override fun allowMultilineTestName(): Boolean? =
-      sysprop(KotestEngineProperties.ALLOW_MULTILINE_TEST_NAME)?.let { it.uppercase() == "TRUE" }
-
    override fun globalAssertSoftly(): Boolean? =
       sysprop(KotestEngineProperties.GLOBAL_ASSERT_SOFTLY)?.let { it.uppercase() == "TRUE" }
 


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
