### PR TITLE
 Fix data test run including sibling regular containers                                                                                                 

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineProperties.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineProperties.kt
@@ -145,17 +145,19 @@ object KotestEngineProperties {
    const val KOTEST_TEST_ENABLED_OVERRIDE = "KOTEST_TEST_ENABLED_OVERRIDE"
 
    /**
-    * When set to the path of the regular (non-data-test) container that directly encloses a
-    * data test (e.g. `"parent context -- child context"`), containers with no explicit tags whose
-    * own path-from-root is a prefix of — or exactly equals — this value are allowed to bypass tag
-    * filtering so the engine can traverse them and discover their data test children.
+    * When set, identifies the enclosing regular (non-data-test) containers of a target data test
+    * as a `" -- "`-separated path of raw container names (e.g. `"parent context -- child context"`).
+    * Container names are written as the user entered them, with no spec-style prefixes like `"Given: "`.
     *
-    * The path uses `" -- "` as a level separator and consists of raw container names as written by
-    * the user (no spec-style prefixes like `"Given: "`).
+    * During tag filtering, a container with no explicit tags that would otherwise be excluded is
+    * allowed to run if its own path from the spec root matches one of the named containers in this
+    * value. That is, if it is one of the containers listed in the path, whether outermost or innermost.
+    * For example, given `"parent context -- child context"`, both `context("parent context")` (outer)
+    * and `context("child context")` (inner) are allowed through, but a sibling `describe("other")` is not.
     *
     * This is set by the IntelliJ plugin run producers when the user clicks to run a specific data
-    * test that is nested inside one or more regular containers. Only the exact ancestors are allowed
-    * through; sibling containers at every level remain excluded by tag filtering.
+    * test nested inside regular containers, so the engine can traverse into those containers and
+    * discover the target data test without running any sibling containers along the way.
     */
    internal const val KOTEST_DATA_TEST_ANCESTOR_PATH = "KOTEST_DATA_TEST_ANCESTOR_PATH"
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineProperties.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/KotestEngineProperties.kt
@@ -143,4 +143,19 @@ object KotestEngineProperties {
     * tests marked as disabled (via @Ignored, @DisabledIf, tags, etc.) are still executed.
     */
    const val KOTEST_TEST_ENABLED_OVERRIDE = "KOTEST_TEST_ENABLED_OVERRIDE"
+
+   /**
+    * When set to the path of the regular (non-data-test) container that directly encloses a
+    * data test (e.g. `"parent context -- child context"`), containers with no explicit tags whose
+    * own path-from-root is a prefix of — or exactly equals — this value are allowed to bypass tag
+    * filtering so the engine can traverse them and discover their data test children.
+    *
+    * The path uses `" -- "` as a level separator and consists of raw container names as written by
+    * the user (no spec-style prefixes like `"Given: "`).
+    *
+    * This is set by the IntelliJ plugin run producers when the user clicks to run a specific data
+    * test that is nested inside one or more regular containers. Only the exact ancestors are allowed
+    * through; sibling containers at every level remain excluded by tag filtering.
+    */
+   internal const val KOTEST_DATA_TEST_ANCESTOR_PATH = "KOTEST_DATA_TEST_ANCESTOR_PATH"
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/enabled/TagsEnabledExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/enabled/TagsEnabledExtension.kt
@@ -4,6 +4,7 @@ import io.kotest.common.syspropOrEnv
 import io.kotest.core.Logger
 import io.kotest.core.test.Enabled
 import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestType
 import io.kotest.engine.config.KotestEngineProperties
 import io.kotest.engine.config.TestConfigResolver
 import io.kotest.engine.tags.TagExpression
@@ -19,7 +20,13 @@ import io.kotest.engine.tags.parse
  * - Included tags have been specified, and this test either has no tags
  *   or does not have any of the specified inclusion tags.
  *
- *  Note: tags are attached to tests either through test config or at the spec level.
+ * Note: tags are attached to tests either through test config or at the spec level.
+ *
+ * **Data test ancestor path bypass**: when [KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH] is set
+ * (by the IntelliJ plugin when running a specific data test nested inside regular containers), containers
+ * with no explicit tags whose path-from-root is a prefix of — or exactly equals — that value are allowed
+ * through despite failing the tag filter. This ensures the engine traverses the ancestor containers needed
+ * to discover the target data test, without also running sibling containers at any level.
  */
 internal class TagsEnabledExtension(
    private val tags: TagExpression,
@@ -32,10 +39,44 @@ internal class TagsEnabledExtension(
       if (syspropOrEnv(KotestEngineProperties.KOTEST_TEST_ENABLED_OVERRIDE) == "true") return Enabled.enabled
       val enabledInTags = tags.parse().isActive(testConfigResolver.tags(testCase))
       if (!enabledInTags) {
+         // When the IDE plugin runs a specific data test nested inside a regular container, allow
+         // only the direct ancestor containers (not siblings) to bypass tag filtering so they can
+         // run and discover their data test children.
+         val ancestorPath = syspropOrEnv(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+         if (ancestorPath != null
+            && testCase.type == TestType.Container
+            && testCase.config?.tags.isNullOrEmpty()
+         ) {
+            val containerPath = buildContainerPath(testCase)
+            if (ancestorPath == containerPath || ancestorPath.startsWith("$containerPath -- ")) {
+               return Enabled.enabled
+            }
+         }
          return Enabled
             .disabled("Disabled by tags: ${tags.expression}")
             .also { it.reason?.let { logger.log { it } } }
       }
       return Enabled.enabled
+   }
+
+   /**
+    * Builds a path string for [testCase] by walking up the [TestCase.parent] chain and joining
+    * [io.kotest.core.names.TestName.name] values with `" -- "`.
+    *
+    * Raw names (no spec-style prefix/suffix such as `"Given: "`) are used intentionally so the result
+    * matches the path the IntelliJ plugin builds from PSI source — which also extracts only the string
+    * literal passed to the container function.
+    *
+    * Example: `context("child context")` nested inside `context("parent context")` → `"parent context -- child context"`.
+    * TODO: this is a good candidate for the shared module between IJ plugin and Framework - as this code is done times and times again
+    */
+   private fun buildContainerPath(testCase: TestCase): String {
+      val parts = mutableListOf<String>()
+      var current: TestCase? = testCase
+      while (current != null) {
+         parts.add(0, current.name.name)
+         current = current.parent
+      }
+      return parts.joinToString(" -- ")
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/enabled/TagsEnabledExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/enabled/TagsEnabledExtension.kt
@@ -2,6 +2,7 @@ package io.kotest.engine.test.enabled
 
 import io.kotest.common.syspropOrEnv
 import io.kotest.core.Logger
+import io.kotest.core.descriptors.DescriptorPaths
 import io.kotest.core.test.Enabled
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestType
@@ -47,8 +48,8 @@ internal class TagsEnabledExtension(
             && testCase.type == TestType.Container
             && testCase.config?.tags.isNullOrEmpty()
          ) {
-            val containerPath = buildContainerPath(testCase)
-            if (ancestorPath == containerPath || ancestorPath.startsWith("$containerPath -- ")) {
+            val containerPath = testCase.descriptor.testParts().joinToString(DescriptorPaths.TEST_DELIMITER)
+            if (ancestorPath == containerPath || ancestorPath.startsWith("$containerPath${DescriptorPaths.TEST_DELIMITER}")) {
                return Enabled.enabled
             }
          }
@@ -59,24 +60,4 @@ internal class TagsEnabledExtension(
       return Enabled.enabled
    }
 
-   /**
-    * Builds a path string for [testCase] by walking up the [TestCase.parent] chain and joining
-    * [io.kotest.core.names.TestName.name] values with `" -- "`.
-    *
-    * Raw names (no spec-style prefix/suffix such as `"Given: "`) are used intentionally so the result
-    * matches the path the IntelliJ plugin builds from PSI source — which also extracts only the string
-    * literal passed to the container function.
-    *
-    * Example: `context("child context")` nested inside `context("parent context")` → `"parent context -- child context"`.
-    * TODO: this is a good candidate for the shared module between IJ plugin and Framework - as this code is done times and times again
-    */
-   private fun buildContainerPath(testCase: TestCase): String {
-      val parts = mutableListOf<String>()
-      var current: TestCase? = testCase
-      while (current != null) {
-         parts.add(0, current.name.name)
-         current = current.parent
-      }
-      return parts.joinToString(" -- ")
-   }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/enabled/TagsEnabledExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/enabled/TagsEnabledExtension.kt
@@ -23,10 +23,10 @@ import io.kotest.engine.tags.parse
  * Note: tags are attached to tests either through test config or at the spec level.
  *
  * **Data test ancestor path bypass**: when [KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH] is set
- * (by the IntelliJ plugin when running a specific data test nested inside regular containers), containers
- * with no explicit tags whose path-from-root is a prefix of — or exactly equals — that value are allowed
- * through despite failing the tag filter. This ensures the engine traverses the ancestor containers needed
- * to discover the target data test, without also running sibling containers at any level.
+ * (by the IntelliJ plugin when running a specific data test nested inside regular containers), a container
+ * with no explicit tags that fails the tag filter is still allowed to run if it is one of the containers
+ * named in that path. i.e. it lies on the direct route from the spec root to the target data test.
+ * Sibling containers at every level remain excluded by tag filtering.
  */
 internal class TagsEnabledExtension(
    private val tags: TagExpression,

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/DataTestAncestorPathFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/DataTestAncestorPathFilterTest.kt
@@ -87,7 +87,7 @@ class DataTestAncestorPathFilterTest : FunSpec({
       }
    }
 
-   test("without KOTEST_DATA_TEST_ANCESTOR_PATH ancestor containers are excluded alongside siblings") {
+   test("without KOTEST_DATA_TEST_ANCESTOR_PATH the data tests are not reachable") {
       val listener = CollectingTestEngineListener()
       TestEngineLauncher()
          .withListener(listener)
@@ -98,10 +98,10 @@ class DataTestAncestorPathFilterTest : FunSpec({
 
       val results = listener.tests
 
-      // Without the ancestor path env var, untagged containers are not bypassed
-      results.entries.first { it.key.name.name == "parent context" }.value.isIgnored shouldBe true
-      results.entries.first { it.key.name.name == "child context" }.value.isIgnored shouldBe true
-      results.entries.first { it.key.name.name == "sibling container" }.value.isIgnored shouldBe true
+      // Without the ancestor path, the engine cannot traverse into the ancestor containers
+      // to discover the data tests — so "data1" and "data2" never run at all
+      results.keys.none { it.name.name == "data1" } shouldBe true
+      results.keys.none { it.name.name == "data2" } shouldBe true
    }
 })
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/DataTestAncestorPathFilterTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/DataTestAncestorPathFilterTest.kt
@@ -1,0 +1,117 @@
+package com.sksamuel.kotest.engine.tags
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.Isolate
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.config.KotestEngineProperties
+import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.engine.tags.TagExpression
+import io.kotest.engine.test.TestResult
+import io.kotest.matchers.shouldBe
+
+/**
+ * Tests that [KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH] causes only the direct
+ * ancestor containers of a data test to bypass tag filtering, while sibling containers at any
+ * level remain correctly excluded.
+ *
+ * This is the engine-side complement to the IntelliJ plugin's data test run configuration:
+ * when a user clicks to run a specific data test nested inside regular containers, the plugin
+ * sets [KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH] to the path of the enclosing
+ * regular containers (e.g. "parent context -- child context") so the engine knows exactly
+ * which containers to allow through, without accidentally running sibling containers.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+@Isolate
+class DataTestAncestorPathFilterTest : FunSpec({
+
+   test("ancestor containers bypass tag filter while sibling containers are excluded") {
+      try {
+         System.setProperty(
+            KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH,
+            "parent context -- child context"
+         )
+         val listener = CollectingTestEngineListener()
+         TestEngineLauncher()
+            .withListener(listener)
+            .withSpecRefs(SpecRef.Reference(DataTestWithSiblingContainerSpec::class))
+            .withoutEnvFilters()
+            .withTagExpression(TagExpression("kotest.data"))
+            .execute()
+
+         val results = listener.tests
+
+         // Direct ancestor containers should run (not ignored)
+         results.entries.first { it.key.name.name == "parent context" }.value.isIgnored shouldBe false
+         results.entries.first { it.key.name.name == "child context" }.value.isIgnored shouldBe false
+
+         // The data test items should run
+         results.entries.first { it.key.name.name == "data1" }.value.isIgnored shouldBe false
+         results.entries.first { it.key.name.name == "data2" }.value.isIgnored shouldBe false
+
+         // The sibling container and its test should be excluded
+         results.entries.first { it.key.name.name == "sibling container" }.value.isIgnored shouldBe true
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("only the matching ancestor path is allowed through, not deeper or unrelated containers") {
+      try {
+         // ancestorPath is "parent context" only - so "child context" should NOT be bypassed
+         System.setProperty(
+            KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH,
+            "parent context"
+         )
+         val listener = CollectingTestEngineListener()
+         TestEngineLauncher()
+            .withListener(listener)
+            .withSpecRefs(SpecRef.Reference(DataTestWithSiblingContainerSpec::class))
+            .withoutEnvFilters()
+            .withTagExpression(TagExpression("kotest.data"))
+            .execute()
+
+         val results = listener.tests
+
+         // "parent context" path matches exactly → allowed through
+         results.entries.first { it.key.name.name == "parent context" }.value.isIgnored shouldBe false
+
+         // "child context" path is "parent context -- child context", not a prefix of "parent context" → excluded
+         results.entries.first { it.key.name.name == "child context" }.value.isIgnored shouldBe true
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("without KOTEST_DATA_TEST_ANCESTOR_PATH ancestor containers are excluded alongside siblings") {
+      val listener = CollectingTestEngineListener()
+      TestEngineLauncher()
+         .withListener(listener)
+         .withSpecRefs(SpecRef.Reference(DataTestWithSiblingContainerSpec::class))
+         .withoutEnvFilters()
+         .withTagExpression(TagExpression("kotest.data"))
+         .execute()
+
+      val results = listener.tests
+
+      // Without the ancestor path env var, untagged containers are not bypassed
+      results.entries.first { it.key.name.name == "parent context" }.value.isIgnored shouldBe true
+      results.entries.first { it.key.name.name == "child context" }.value.isIgnored shouldBe true
+      results.entries.first { it.key.name.name == "sibling container" }.value.isIgnored shouldBe true
+   }
+})
+
+private class DataTestWithSiblingContainerSpec : DescribeSpec({
+   context("parent context") {
+      context("child context") {
+         withData("data1", "data2") { }
+         describe("sibling container") {
+            it("test inside sibling") { }
+         }
+      }
+   }
+})

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/TagsEnabledExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/TagsEnabledExtensionTest.kt
@@ -34,7 +34,7 @@ class TagsEnabledExtensionTest : FunSpec({
    )
 
    fun makeContainer(name: String, parent: TestCase? = null) = TestCase(
-      descriptor = TagsEnabledExtensionSpec::class.toDescriptor().append(name),
+      descriptor = (parent?.descriptor ?: TagsEnabledExtensionSpec::class.toDescriptor()).append(name),
       name = TestNameBuilder.builder(name).build(),
       spec = spec,
       test = { },

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/TagsEnabledExtensionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/enabled/TagsEnabledExtensionTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.test.enabled
 
+import io.kotest.core.Tag
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.Isolate
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
@@ -8,6 +9,7 @@ import io.kotest.core.source.SourceRef
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.test.Enabled
 import io.kotest.core.test.TestCase
+import io.kotest.core.test.config.TestConfig
 import io.kotest.core.test.TestType
 import io.kotest.core.descriptors.toDescriptor
 import io.kotest.engine.config.KotestEngineProperties
@@ -31,6 +33,16 @@ class TagsEnabledExtensionTest : FunSpec({
       type = TestType.Test,
    )
 
+   fun makeContainer(name: String, parent: TestCase? = null) = TestCase(
+      descriptor = TagsEnabledExtensionSpec::class.toDescriptor().append(name),
+      name = TestNameBuilder.builder(name).build(),
+      spec = spec,
+      test = { },
+      source = SourceRef.None,
+      type = TestType.Container,
+      parent = parent,
+   )
+
    test("TagsEnabledExtension should disable test when excluded by tag expression") {
       // Expression requires tag "included" but test has no tags, so it should be excluded
       val tags = TagExpression("included")
@@ -48,6 +60,89 @@ class TagsEnabledExtensionTest : FunSpec({
          System.getProperties().remove(KotestEngineProperties.KOTEST_TEST_ENABLED_OVERRIDE)
       }
    }
+
+   test("TagsEnabledExtension should enable container when its path equals KOTEST_DATA_TEST_ANCESTOR_PATH") {
+      try {
+         System.setProperty(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH, "parent context")
+         val resolver = TestConfigResolver()
+         val container = makeContainer("parent context")
+         TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(container) shouldBe Enabled.enabled
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("TagsEnabledExtension should enable ancestor container when its path is a prefix of KOTEST_DATA_TEST_ANCESTOR_PATH") {
+      try {
+         System.setProperty(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH, "parent context -- child context")
+         val resolver = TestConfigResolver()
+         val parentContainer = makeContainer("parent context")
+         TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(parentContainer) shouldBe Enabled.enabled
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("TagsEnabledExtension should enable deepest ancestor container when its path equals KOTEST_DATA_TEST_ANCESTOR_PATH") {
+      try {
+         System.setProperty(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH, "parent context -- child context")
+         val resolver = TestConfigResolver()
+         val parentContainer = makeContainer("parent context")
+         val childContainer = makeContainer("child context", parent = parentContainer)
+         TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(childContainer) shouldBe Enabled.enabled
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("TagsEnabledExtension should not bypass a sibling container whose path does not match KOTEST_DATA_TEST_ANCESTOR_PATH") {
+      try {
+         System.setProperty(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH, "parent context -- child context")
+         val resolver = TestConfigResolver()
+         val parentContainer = makeContainer("parent context")
+         val siblingContainer = makeContainer("sibling", parent = parentContainer)
+         TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(siblingContainer).isDisabled shouldBe true
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("TagsEnabledExtension should not bypass a leaf test even when KOTEST_DATA_TEST_ANCESTOR_PATH matches its name") {
+      try {
+         System.setProperty(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH, "test")
+         val resolver = TestConfigResolver()
+         TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(testCase).isDisabled shouldBe true
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("TagsEnabledExtension should not bypass a container that has explicit tags even when its path matches") {
+      try {
+         System.setProperty(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH, "parent context")
+         val resolver = TestConfigResolver()
+         val taggedContainer = TestCase(
+            descriptor = TagsEnabledExtensionSpec::class.toDescriptor().append("parent context"),
+            name = TestNameBuilder.builder("parent context").build(),
+            spec = spec,
+            test = { },
+            source = SourceRef.None,
+            type = TestType.Container,
+            config = TestConfig(tags = setOf(SomeContainerTag)),
+         )
+         TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(taggedContainer).isDisabled shouldBe true
+      } finally {
+         System.getProperties().remove(KotestEngineProperties.KOTEST_DATA_TEST_ANCESTOR_PATH)
+      }
+   }
+
+   test("TagsEnabledExtension should not bypass a container when KOTEST_DATA_TEST_ANCESTOR_PATH is not set") {
+      val resolver = TestConfigResolver()
+      val container = makeContainer("parent context")
+      TagsEnabledExtension(TagExpression("kotest.data.999"), resolver).isEnabled(container).isDisabled shouldBe true
+   }
 })
+
+private object SomeContainerTag : Tag()
 
 private class TagsEnabledExtensionSpec : FunSpec()

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducer.kt
@@ -229,6 +229,14 @@ class GradleMultiplatformJvmTestTaskRunProducer : GradleTestRunConfigurationProd
    ) {
       dataTestInfoMaybe?.let {
          EnvVarUtil.setKotestTags(runConfiguration.settings, it.tag)
-      } ?: EnvVarUtil.removeKotestTags(runConfiguration.settings)
+         if (it.ancestorTestPath != null) {
+            EnvVarUtil.setKotestDataTestAncestorPath(runConfiguration.settings, it.ancestorTestPath)
+         } else {
+            EnvVarUtil.removeKotestDataTestAncestorPath(runConfiguration.settings)
+         }
+      } ?: run {
+         EnvVarUtil.removeKotestTags(runConfiguration.settings)
+         EnvVarUtil.removeKotestDataTestAncestorPath(runConfiguration.settings)
+      }
    }
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/TestPlatformRunConfigurationProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/TestPlatformRunConfigurationProducer.kt
@@ -73,9 +73,15 @@ class TestPlatformRunConfigurationProducer : LazyRunConfigurationProducer<Kotest
                      if (dataTestInfoMaybe != null) {
                         configuration.setTestPath(dataTestInfoMaybe.ancestorTestPath)
                         EnvVarUtil.setKotestTags(configuration, dataTestInfoMaybe.tag)
+                        if (dataTestInfoMaybe.ancestorTestPath != null) {
+                           EnvVarUtil.setKotestDataTestAncestorPath(configuration, dataTestInfoMaybe.ancestorTestPath)
+                        } else {
+                           EnvVarUtil.removeKotestDataTestAncestorPath(configuration)
+                        }
                      } else {
                         configuration.setTestPath(null)
                         EnvVarUtil.removeKotestTags(configuration)
+                        EnvVarUtil.removeKotestDataTestAncestorPath(configuration)
                      }
                      configuration.setInclude(null)
                   }
@@ -84,6 +90,7 @@ class TestPlatformRunConfigurationProducer : LazyRunConfigurationProducer<Kotest
                      configuration.setTestPath(test.testPath())
                      configuration.setInclude(test.descriptorPath())
                      EnvVarUtil.removeKotestTags(configuration)
+                     EnvVarUtil.removeKotestDataTestAncestorPath(configuration)
                   }
                }
                configuration.setSpecsName(ktclass.fqName?.asString().toString())

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/util/DataTestUtil.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/util/DataTestUtil.kt
@@ -99,25 +99,27 @@ object DataTestUtil {
 
 
    /**
-    * Returns [DataTestInfo] for this data test.
+    * Returns [DataTestInfo] for this data test, or null if this is not a data test or the line number
+    * cannot be determined.
     *
-    * - For root data tests: returns with simple tag `kotest.data.{lineNumber}` and no ancestor path - as these test path is the same as the Spec.
-    * - For nested data tests within other data tests: returns with tag `kotest.data.{parentDataTestLineNumber} & !kotest.data.{siblingLineNumber} and no ancestor path
-    *   builds a chain from the root parent down to this data test, excluding siblings at every level.
-    * - For data tests inside regular containers (like `context("...")`): returns with
-    *   tag expression wrapped in parenthesis with an additional (outside the parenthesis) `| !kotest.data` to allow parent container to run
-    *   effectively excluding all data tests except those in the parenthesis; and the ancestor test path so the filter can target the specific container.
-    * - To support `nonJvm`, where we are unable to attach a `lineNumber` tag at the framework level, because of the lack of `stackTrace`,
-    *   it returns the same tag expression structure as above, and adds `| kotest.data.nonJvm` at the end, so that at least users are able to run all data tests within a block.
+    * **Tag expression** ([DataTestInfo.tag]):
+    * - Root data tests: `(kotest.data.{lineNumber}) | kotest.data.nonJvm`
+    * - Nested inside other data tests: root ancestor tag ANDed with `!kotest.data.{siblingLine}` exclusions
+    *   at every nesting level, e.g. `(kotest.data.10 & !kotest.data.15 & !kotest.data.20) | kotest.data.nonJvm`.
+    * - The `| kotest.data.nonJvm` suffix supports platforms that cannot attach line-number tags (no stack trace),
+    *   allowing users to run all data tests within a block on those targets.
     *
-    * This allows running a specific data test, nested, at any level, by including all ancestors
-    * (if necessary - so they execute and discover children) while excluding sibling data test blocks at each level.
-    *
-    * Returns null early if this is not a data test or line number cannot be determined.
+    * **Ancestor test path** ([DataTestInfo.ancestorTestPath]):
+    * - Non-null only when the data test is nested inside one or more regular (non-data-test) containers
+    *   such as `context("...")` or `describe("...")`. In that case it holds the ` -- ` separated path of
+    *   those containers, e.g. `"parent context -- child context"`.
+    * - The run producers store this value in the `KOTEST_DATA_TEST_ANCESTOR_PATH` environment variable.
+    *   The engine's [io.kotest.engine.test.enabled.TagsEnabledExtension] uses it to allow only the direct
+    *   ancestor containers through tag filtering, so the engine can discover the target data test without
+    *   also running sibling containers or sibling regular tests at any level.
     *
     * @see <a href="https://github.com/kotest/kotest/blob/081125c5f6b0a90d8201b9acea2b698a388984d6/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsBehaviorSpec.kt">
     * Example for full details of the various DataTestInfo generated for different data test nesting scenarios</a>
-    *
     */
    fun dataTestInfoMaybe(isDataTest: Boolean, currentTestPsi: PsiElement): DataTestInfo? {
       if (!isDataTest) return null
@@ -159,17 +161,7 @@ object DataTestUtil {
          }
       }
 
-      // If inside a regular container, we need to add "| !kotest.data"
-      // to allow the parent container to think it is going to run (and therefore generate) all tests within it,
-      // as this data test will have the full container test path, set via regularAncestorPath + this specific data test tag
-      // that will be defined by the baseTag setter above
-      val jvmTag = if (isInsideRegularContainer) {
-         "($baseTag) | !kotest.data"
-      } else {
-         baseTag
-      }
-
-      val finalTag = "($jvmTag) | kotest.data.nonJvm"
+      val finalTag = "($baseTag) | kotest.data.nonJvm"
 
       return DataTestInfo(finalTag, regularAncestorPath)
    }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/util/EnvVarUtil.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/util/EnvVarUtil.kt
@@ -11,6 +11,7 @@ object EnvVarUtil {
    const val KOTEST_IDEA_PLUGIN = "KOTEST_IDEA_PLUGIN"
    const val KOTEST_TAGS = "KOTEST_TAGS"
    const val KOTEST_INVOCATION_COUNT = "KOTEST_INVOCATION_COUNT"
+   const val KOTEST_DATA_TEST_ANCESTOR_PATH = "KOTEST_DATA_TEST_ANCESTOR_PATH"
 
    fun setKotestTestEnabledOverride(settings : ExternalSystemTaskExecutionSettings) {
       settings.env = settings.env + mapOf(KOTEST_TEST_ENABLED_OVERRIDE to "true")
@@ -44,6 +45,22 @@ object EnvVarUtil {
       with(kotestRunConfiguration.envs){
          remove(KOTEST_TAGS)
       }
+   }
+
+   fun setKotestDataTestAncestorPath(settings: ExternalSystemTaskExecutionSettings, ancestorPath: String) {
+      settings.env = settings.env + mapOf(KOTEST_DATA_TEST_ANCESTOR_PATH to ancestorPath)
+   }
+
+   fun setKotestDataTestAncestorPath(kotestRunConfiguration: KotestRunConfiguration, ancestorPath: String) {
+      kotestRunConfiguration.envs[KOTEST_DATA_TEST_ANCESTOR_PATH] = ancestorPath
+   }
+
+   fun removeKotestDataTestAncestorPath(settings: ExternalSystemTaskExecutionSettings) {
+      settings.env.remove(KOTEST_DATA_TEST_ANCESTOR_PATH)
+   }
+
+   fun removeKotestDataTestAncestorPath(kotestRunConfiguration: KotestRunConfiguration) {
+      kotestRunConfiguration.envs.remove(KOTEST_DATA_TEST_ANCESTOR_PATH)
    }
 
    fun setInvocationCount(settings : ExternalSystemTaskExecutionSettings, invocationCount: Int, resetAction: () -> Unit) {

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/util/DataTestUtilTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/util/DataTestUtilTest.kt
@@ -45,7 +45,7 @@ class DataTestUtilTest : LightJavaCodeInsightFixtureTestCase() {
          val firstChildOfChildContext = allDataTestCalls.find { getLineNumber(it) == 16 }.shouldNotBeNull()
          DataTestUtil.dataTestInfoMaybe(isDataTest = true, firstChildOfChildContext).apply {
             this.shouldNotBeNull()
-            tag shouldBe "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm"
+            tag shouldBe "(kotest.data.16) | kotest.data.nonJvm"
             ancestorTestPath shouldBe "parent context -- child context"
          }
 
@@ -54,7 +54,7 @@ class DataTestUtilTest : LightJavaCodeInsightFixtureTestCase() {
          val firstChildOfFirstChildOfChildContext = allDataTestCalls.find { getLineNumber(it) == 17 }.shouldNotBeNull()
          DataTestUtil.dataTestInfoMaybe(isDataTest = true, firstChildOfFirstChildOfChildContext).apply {
             this.shouldNotBeNull()
-            tag shouldBe "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm"
+            tag shouldBe "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm"
             ancestorTestPath shouldBe "parent context -- child context"
          }
 
@@ -63,7 +63,7 @@ class DataTestUtilTest : LightJavaCodeInsightFixtureTestCase() {
          val secondChildOfFirstChildOfChildContext = allDataTestCalls.find { getLineNumber(it) == 20 }.shouldNotBeNull()
          DataTestUtil.dataTestInfoMaybe(isDataTest = true, secondChildOfFirstChildOfChildContext).apply {
             this.shouldNotBeNull()
-            tag shouldBe "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm"
+            tag shouldBe "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm"
             ancestorTestPath shouldBe "parent context -- child context"
          }
 
@@ -73,7 +73,7 @@ class DataTestUtilTest : LightJavaCodeInsightFixtureTestCase() {
             allDataTestCalls.find { getLineNumber(it) == 21 }.shouldNotBeNull()
          DataTestUtil.dataTestInfoMaybe(isDataTest = true, firstChildOfSecondChildOfFirstChildOfChildContext).apply {
             this.shouldNotBeNull()
-            tag shouldBe "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm"
+            tag shouldBe "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm"
             ancestorTestPath shouldBe "parent context -- child context"
          }
 
@@ -81,7 +81,7 @@ class DataTestUtilTest : LightJavaCodeInsightFixtureTestCase() {
          val secondChildOfChildContext = allDataTestCalls.find { getLineNumber(it) == 26 }.shouldNotBeNull()
          DataTestUtil.dataTestInfoMaybe(isDataTest = true, secondChildOfChildContext).apply {
             this.shouldNotBeNull()
-            tag shouldBe "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm"
+            tag shouldBe "(kotest.data.26) | kotest.data.nonJvm"
             ancestorTestPath shouldBe "parent context -- child context"
          }
 
@@ -89,7 +89,7 @@ class DataTestUtilTest : LightJavaCodeInsightFixtureTestCase() {
          val firstChildOfParentContext = allDataTestCalls.find { getLineNumber(it) == 30 }.shouldNotBeNull()
          DataTestUtil.dataTestInfoMaybe(isDataTest = true, firstChildOfParentContext).apply {
             this.shouldNotBeNull()
-            tag shouldBe "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm"
+            tag shouldBe "(kotest.data.30) | kotest.data.nonJvm"
             ancestorTestPath shouldBe "parent context"
          }
 

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsBehaviorSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsBehaviorSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsBehaviorSpec : BehaviorSpec({
 
    context("parent context") {
       given("child context") {
-         withWhens("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withThens("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withWhens("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withThens("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withAnds("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withThens("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withAnds("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withThens("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withAnds("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withAnds("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsDescribeSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsDescribeSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsDescribeSpec : DescribeSpec({
 
    context("parent context") {
       context("child context") {
-         withDescribes("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withIts("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withDescribes("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withIts("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withContexts("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withIts("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withContexts("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withIts("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withContexts("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withContexts("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsExpectSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsExpectSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsExpectSpec : ExpectSpec({
 
    context("parent context") {
       context("child context") {
-         withContexts("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withExpects("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withContexts("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withExpects("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withContexts("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withExpects("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withContexts("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withExpects("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withContexts("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withContexts("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsFeatureSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsFeatureSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsFeatureSpec : FeatureSpec({
 
    feature("parent context") {
       feature("child context") {
-         withFeatures("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withFeatures("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withFeatures("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withFeatures("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withFeatures("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withFeatures("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withFeatures("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withFeatures("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withScenarios("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withScenarios("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withScenarios("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withScenarios("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsFreeSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsFreeSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsFreeSpec : FreeSpec({
 
    "parent context" - {
       "child context" - {
-         withData("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withTests("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withData("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withTests("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withTests("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withTests("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withTests("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withTests("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsFunSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsFunSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsFunSpec : FunSpec({
 
     context("parent context") {
         context("child context") {
-            withData("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withTests("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withData("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withTests("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                   1 + 1 shouldBe 2
                }
-               withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-                  withTests("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+               withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+                  withTests("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                      1 + 1 shouldBe 2
                   }
                }
             }
-            withTests("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withTests("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                 1 + 1 shouldBe 2
             }
         }
-        withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+        withContexts("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
             1 + 1 shouldBe 2
         }
     }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsShouldSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsShouldSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsShouldSpec : ShouldSpec({
 
    context("parent context") {
       context("child context") {
-         withContexts("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withShoulds("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withContexts("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withShoulds("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withShoulds("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withShoulds("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withShoulds("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withShoulds("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withShoulds("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withShoulds("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }

--- a/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsWordSpec.kt
+++ b/kotest-intellij-plugin/src/test/resources/data-test-tags/DataTestTagsWordSpec.kt
@@ -13,21 +13,21 @@ class DataTestTagsWordSpec : WordSpec({
 
    "parent context" When {
       "child context" When {
-         withWhens("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "((kotest.data.16) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-            withShoulds("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.20) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withWhens("firstChildOfChildContext1", "firstChildOfChildContext2") { // tags: "(kotest.data.16) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+            withShoulds("firstChildOfFirstChildOfChildContext1", "firstChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.20) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
                1 + 1 shouldBe 2
             }
-            withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
-               withShoulds("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "((kotest.data.16 & !kotest.data.17) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
+            withData("secondChildOfFirstChildOfChildContext1", "secondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+               withShoulds("firstChildOfSecondChildOfFirstChildOfChildContext1", "firstChildOfSecondChildOfFirstChildOfChildContext2") { // tags: "(kotest.data.16 & !kotest.data.17) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context" (same as parent, no siblings)
                   1 + 1 shouldBe 2
                }
             }
          }
-         withShoulds("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "((kotest.data.26) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
+         withShoulds("secondChildOfChildContext1", "secondChildOfChildContext2") { // tags: "(kotest.data.26) | kotest.data.nonJvm" - ancestorTestPath: "parent context -- child context"
             1 + 1 shouldBe 2
          }
       }
-      withWhens("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "((kotest.data.30) | !kotest.data) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
+      withWhens("firstChildOfParentContext1", "firstChildOfParentContext2") { // tags: "(kotest.data.30) | kotest.data.nonJvm" - ancestorTestPath: "parent context"
          1 + 1 shouldBe 2
       }
    }


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
**Summary**                                                                                                                                              

  When running a specific data test nested inside regular containers (e.g. `context("parent") { context("child") { withData(...) } }`), the IntelliJ plugin  generates a tag expression like `(kotest.data.LINE) | kotest.data.nonJvm`. The enclosing regular containers have no `kotest.data` tag, so without  intervention the tag filter would prevent them from running and the data test would never be discovered.                                               
                                                                                                                                                       
The previous approach appended `| !kotest.data` to the expression so untagged containers could pass the filter — but this matched every untagged test and container at those levels, causing sibling tests and sibling containers (e.g. a `describe("whatever test bame")` next to the `withXXX`) to run alongside the intended target.                                                                                                                                                
                                                                                                                                                       
**Changes:**                                                                                                                                               
   
  - Introduces `KOTEST_DATA_TEST_ANCESTOR_PATH`, an env var set by the plugin run producers to the -- separated path of the regular containers enclosing  the target data test (e.g. `"parent context -- child context"`). Only set when the data test is actually inside regular containers, omitted for root-level data tests.                                                                                                                                 
  - In `TagsEnabledExtension`, when a container fails tag filtering, its path-from-root is built by walking `TestCase.parent` and joining raw `name.name` values. The container is allowed through only if its path equals or is a strict prefix of the ancestor path. Meaning only the direct ancestors of the target data test are let through, while sibling containers at every level remain excluded.
  - Removes the `| !kotest.data` component from tag expressions generated by the plugin for data tests inside regular containers, as it is no longer  needed.                                                                                                                                                 