### PR TITLE
Detect Spec subclasses in KotestFileVisitor instead of a name list

### DIFF
--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
@@ -13,19 +13,6 @@ import com.google.devtools.ksp.symbol.Modifier
 
 class KotestFileVisitor : KSVisitorVoid() {
 
-   private val specTypes = setOf(
-      "AnnotationSpec",
-      "BehaviorSpec",
-      "DescribeSpec",
-      "ExpectSpec",
-      "FeatureSpec",
-      "FreeSpec",
-      "FunSpec",
-      "ShouldSpec",
-      "StringSpec",
-      "WordSpec",
-   )
-
    internal val specs = mutableListOf<KSClassDeclaration>()
    internal val configs = mutableListOf<KSClassDeclaration>()
 
@@ -54,10 +41,16 @@ class KotestFileVisitor : KSVisitorVoid() {
    internal fun isAbstract(declaration: KSClassDeclaration): Boolean =
       declaration.modifiers.contains(Modifier.ABSTRACT) || declaration.modifiers.contains(Modifier.SEALED)
 
+   /**
+    * Returns true for subclasses of [io.kotest.core.spec.Spec]. Every spec style
+    * (FunSpec, StringSpec, AnnotationSpec, ...) ultimately extends Spec, so this
+    * detects them all — including user-defined intermediate base specs — without
+    * having to enumerate the built-in style names.
+    */
    internal fun isSpec(declaration: KSClassDeclaration): Boolean =
       declaration.getAllSuperTypes().map { it.declaration }
          .filterIsInstance<KSClassDeclaration>()
-         .any { specTypes.contains(it.simpleName.asString()) }
+         .any { it.qualifiedName?.asString() == "io.kotest.core.spec.Spec" }
 
    internal fun isConfig(declaration: KSClassDeclaration): Boolean {
       return declaration.getAllSuperTypes().map { it.declaration }

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/KotestFileVisitorTest.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/KotestFileVisitorTest.kt
@@ -16,7 +16,7 @@ import io.kotest.matchers.shouldBe
 
 class KotestFileVisitorTest : FunSpec({
 
-   context("isSpec should detect all spec types") {
+   context("isSpec should detect subclasses of Spec via any spec style") {
       withTests(
          FunSpec::class,
          DescribeSpec::class,
@@ -28,6 +28,7 @@ class KotestFileVisitorTest : FunSpec({
          StringSpec::class,
          BehaviorSpec::class
       ) { type ->
+         // models com.sksamuel.MySpec -> <spec style> -> io.kotest.core.spec.Spec
          KotestFileVisitor().isSpec(
             SimpleKSClassDeclaration(
                className = "com.sksamuel.MySpec",
@@ -36,6 +37,15 @@ class KotestFileVisitorTest : FunSpec({
                      SimpleKSType(
                         declaration = SimpleKSClassDeclaration(
                            className = type.qualifiedName!!,
+                           supers = listOf(
+                              SimpleKSTypeReference(
+                                 SimpleKSType(
+                                    declaration = SimpleKSClassDeclaration(
+                                       className = "io.kotest.core.spec.Spec",
+                                    )
+                                 )
+                              )
+                           ),
                         )
                      )
                   )
@@ -43,6 +53,40 @@ class KotestFileVisitorTest : FunSpec({
             )
          ) shouldBe true
       }
+   }
+
+   test("isSpec should detect a direct subclass of Spec") {
+      KotestFileVisitor().isSpec(
+         SimpleKSClassDeclaration(
+            className = "com.sksamuel.MySpec",
+            supers = listOf(
+               SimpleKSTypeReference(
+                  SimpleKSType(
+                     declaration = SimpleKSClassDeclaration(
+                        className = "io.kotest.core.spec.Spec",
+                     )
+                  )
+               )
+            ),
+         )
+      ) shouldBe true
+   }
+
+   test("isSpec should return false for classes that do not extend Spec") {
+      KotestFileVisitor().isSpec(
+         SimpleKSClassDeclaration(
+            className = "com.sksamuel.NotASpec",
+            supers = listOf(
+               SimpleKSTypeReference(
+                  SimpleKSType(
+                     declaration = SimpleKSClassDeclaration(
+                        className = "kotlin.Any",
+                     )
+                  )
+               )
+            ),
+         )
+      ) shouldBe false
    }
 
    test("isConfig should detect subclasses of AbstractProjectConfig") {
@@ -116,6 +160,15 @@ class KotestFileVisitorTest : FunSpec({
                   SimpleKSType(
                      declaration = SimpleKSClassDeclaration(
                         className = FunSpec::class.qualifiedName!!,
+                        supers = listOf(
+                           SimpleKSTypeReference(
+                              SimpleKSType(
+                                 declaration = SimpleKSClassDeclaration(
+                                    className = "io.kotest.core.spec.Spec",
+                                 )
+                              )
+                           )
+                        ),
                      )
                   )
                )


### PR DESCRIPTION
## What

`KotestFileVisitor.isSpec` matched against a hardcoded set of the built-in spec style **simple names**:

```kotlin
private val specTypes = setOf("AnnotationSpec", "BehaviorSpec", "DescribeSpec", ...)
...
.any { specTypes.contains(it.simpleName.asString()) }
```

Every spec style ultimately extends `io.kotest.core.spec.Spec`, so this checks the supertype chain for `Spec` directly — mirroring how `isConfig` already detects `AbstractProjectConfig` subclasses:

```kotlin
.any { it.qualifiedName?.asString() == "io.kotest.core.spec.Spec" }
```

## Why

- Removes a list that has to be kept in sync with the set of built-in styles.
- Correctly detects **user-defined intermediate base specs** (e.g. `abstract class MyBaseSpec : FunSpec()` then `class MyTest : MyBaseSpec()`) without enumerating style names.
- Uses a fully-qualified name rather than a simple name, so an unrelated class that merely shares a name with a spec style can't false-positive.

## Tests

`KotestFileVisitorTest` updated to model the `MySpec -> <style> -> Spec` supertype chain across all nine styles, plus added cases for a direct `Spec` subclass and a non-`Spec` class. All 17 tests pass (`:kotest-framework:kotest-framework-symbol-processor:jvmTest`).

`isSpec` is `internal`, so the public API dump is unchanged.