### PR TITLE
Deprecate the test logging API (LogExtension and friends)

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestExtensions.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestExtensions.kt
@@ -154,6 +154,7 @@ internal class TestExtensions(
    /**
     * Returns the [LogExtension]s applicable to this [TestCase].
     */
+   @Suppress("DEPRECATION")
    fun logExtensions(testCase: TestCase): List<LogExtension> {
       return testConfigResolver.extensions(testCase, ExtensionsOrder.LOCAL_FIRST)
          .filterIsInstance<LogExtension>()

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/CoroutineLoggingInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/CoroutineLoggingInterceptor.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.engine.test.interceptors
 
 import io.kotest.common.ExperimentalKotest

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/LogExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/LogExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.engine.test.logging
 
 import io.kotest.common.ExperimentalKotest
@@ -10,6 +12,7 @@ import io.kotest.core.test.TestCase
  *
  * Users can use testId on [TestCase.descriptor] to cross-reference the [TestResult] with the provided logs.
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 interface LogExtension : Extension {
    suspend fun handleLogs(testCase: TestCase, logs: List<LogEntry>)

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/SerialLogExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/SerialLogExtension.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.engine.test.logging
 
 import io.kotest.common.ExperimentalKotest

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/context.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/context.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.engine.test.logging
 
 import io.kotest.common.ExperimentalKotest

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/logger.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/logger.kt
@@ -1,12 +1,21 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.engine.test.logging
 
 import io.kotest.common.ExperimentalKotest
 import io.kotest.core.config.LogLevel
 
+internal const val LOGGING_DEPRECATION_MESSAGE =
+   "The Kotest test logging feature (LogExtension and the trace/debug/info/warn/error log functions) " +
+      "is deprecated and will be removed in a future release."
+
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 typealias LogFn = () -> Any
 
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 data class LogEntry(val level: LogLevel, val message: Any)
 
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 class TestLogger(private val logLevel: LogLevel) {
    internal val logs = mutableListOf<LogEntry>()

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/logs.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/logging/logs.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.kotest.engine.test.logging
 
 import io.kotest.common.ExperimentalKotest
@@ -7,59 +9,69 @@ import io.kotest.core.test.TestScope
 /**
  * Appends to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Trace].
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestScope.trace(message: LogFn) = logger?.maybeLog(message, LogLevel.Trace)
 
 /**
  * Appends to the [TestLogger] reference to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Trace]
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestLogger.trace(message: LogFn) = maybeLog(message, LogLevel.Trace)
 
 /**
  * Appends to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Debug].
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestScope.debug(message: LogFn) = logger?.maybeLog(message, LogLevel.Debug)
 
 /**
  * Appends to the [TestLogger] reference to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Debug]
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestLogger.debug(message: LogFn) = maybeLog(message, LogLevel.Debug)
 
 /**
  * Appends to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Info] or higher.
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestScope.info(message: LogFn) = logger?.maybeLog(message, LogLevel.Info)
 
 /**
  * Appends to the [TestLogger] reference to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Info]
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestLogger.info(message: LogFn) = maybeLog(message, LogLevel.Info)
 
 /**
  * Appends to the [TestScope] log, when the log level is [io.kotest.core.config.LogLevel.Warn] or higher.
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestScope.warn(message: LogFn) = logger?.maybeLog(message, LogLevel.Warn)
 
 /**
  * Appends to the [TestLogger] reference to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Warn]
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestLogger.warn(message: LogFn) = maybeLog(message, LogLevel.Warn)
 
 /**
  * Appends to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Error] or higher.
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestScope.error(message: LogFn) = logger?.maybeLog(message, LogLevel.Error)
 
 /**
  * Appends to the [TestLogger] reference to the [TestScope] log, when the log level is set to [io.kotest.core.config.LogLevel.Error]
  */
+@Deprecated(LOGGING_DEPRECATION_MESSAGE)
 @ExperimentalKotest
 fun TestLogger.error(message: LogFn) = maybeLog(message, LogLevel.Error)


### PR DESCRIPTION
## What

Deprecates the experimental test logging feature, as requested. All symbols get a shared deprecation message and stay functional:

- `LogExtension`
- `TestLogger`, `LogEntry`, `LogFn`
- the `TestScope`/`TestLogger` `trace`/`debug`/`info`/`warn`/`error` extension functions

## Details

- Deprecation level is `WARNING` (not `HIDDEN`), so the binary-compatibility API dump is **unchanged** — `apiCheck` passes with no `apiDump` needed.
- Internal plumbing that still references these symbols — `SerialLogExtension`, `CoroutineLoggingInterceptor`, `TestExtensions.logExtensions`, and the logging coroutine-context element in `context.kt` — is annotated with `@Suppress("DEPRECATION")` / `@file:Suppress("DEPRECATION")` so the engine keeps building cleanly (the project does not treat warnings as errors, but this keeps the build noise-free).
- No external implementers of `LogExtension` exist in the repo; the only consumer is the internal logging interceptor, whose test is already commented out.

## Verification

`:kotest-framework:kotest-framework-engine:compileKotlinJvm` and `:kotest-framework:kotest-framework-engine:apiCheck` both pass.