### PR TITLE
Bump KSP to 2.3.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
 kotlin-poet = "2.3.0"
 kotlinx-io-core = "0.9.0"
-ksp = "2.3.6"
+ksp = "2.3.9"
 ktor = "3.4.2"
 
 mockk = "1.14.9"

--- a/kotest-assertions/kotest-assertions-core/build.gradle.kts
+++ b/kotest-assertions/kotest-assertions-core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
    id("kotest-android-native-conventions")
    id("kotest-watchos-device-conventions")
    id("kotest-publishing-conventions")
-   id("com.google.devtools.ksp").version("2.3.6")
+   id("com.google.devtools.ksp").version("2.3.9")
    id("io.kotest").version("6.1.11")
 }
 

--- a/kotest-framework/kotest-framework-engine/build.gradle.kts
+++ b/kotest-framework/kotest-framework-engine/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
    id("kotest-watchos-device-conventions")
    id("kotest-publishing-conventions")
    alias(libs.plugins.kotlin.serialization)
-   id("com.google.devtools.ksp").version("2.3.6")
+   id("com.google.devtools.ksp").version("2.3.9")
    // the Kotest plugin must be a published version and not one in the current build
    id("io.kotest").version("6.1.11")
 }

--- a/kotest-tests/kotest-tests-js/build.gradle.kts
+++ b/kotest-tests/kotest-tests-js/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
    id("kotest-js-conventions")
-   id("com.google.devtools.ksp").version("2.3.6")
+   id("com.google.devtools.ksp").version("2.3.9")
    // the Kotest plugin must be a published version and not one in the current build
    id("io.kotest").version("6.1.11")
 }

--- a/kotest-tests/kotest-tests-wasm-js/build.gradle.kts
+++ b/kotest-tests/kotest-tests-wasm-js/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
    id("kotest-js-conventions")
-   id("com.google.devtools.ksp").version("2.3.6")
+   id("com.google.devtools.ksp").version("2.3.9")
    // the Kotest plugin must be a published version and not one in the current build
    id("io.kotest").version("6.1.11")
 }

--- a/kotest-tests/kotest-tests-wasm-wasi/build.gradle.kts
+++ b/kotest-tests/kotest-tests-wasm-wasi/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 
 plugins {
    id("kotest-wasi-conventions")
-   id("com.google.devtools.ksp").version("2.3.6")
+   id("com.google.devtools.ksp").version("2.3.9")
    // the Kotest plugin must be a published version and not one in the current build
    id("io.kotest").version("6.1.11")
 }

--- a/kotest-tests/kotest-tests-xml/build.gradle.kts
+++ b/kotest-tests/kotest-tests-xml/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
    id("kotlin-conventions")
    // using a published version
    id("io.kotest").version("6.1.11")
-   id("com.google.devtools.ksp").version("2.3.6")
+   id("com.google.devtools.ksp").version("2.3.9")
 }
 
 kotlin {


### PR DESCRIPTION
## What

Bumps the KSP plugin/processor from **2.3.6** to **2.3.9** — the latest release on the 2.3.x line (Maven Central `<release>2.3.9`), which aligns with the Kotlin `2.3.20` used in this repo.

Updated:
- `gradle/libs.versions.toml` — `ksp = "2.3.9"`
- the hardcoded `id("com.google.devtools.ksp").version("...")` in the modules that apply the plugin directly: `kotest-framework-engine`, `kotest-assertions-core`, and `kotest-tests-{xml,js,wasm-js,wasm-wasi}`.

## Verification

`./gradlew :kotest-assertions:kotest-assertions-core:compileKotlinJvm` (which applies KSP 2.3.9 and runs the processor) resolves the new version and compiles cleanly.