### PR TITLE
Release lock on exception in TestContainerProjectExtension.mount

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt
@@ -27,15 +27,18 @@ class TestContainerProjectExtension<T : GenericContainer<*>>(
 
    override fun mount(configure: T.() -> Unit): T {
       lock.lockInterruptibly()
-      val t = ref.get()
-      if (t == null) {
-         configure(container)
-         container.start()
-         onStart(container)
-         container.followOutput(config.logConsumer)
-         ref.set(container)
+      try {
+         val t = ref.get()
+         if (t == null) {
+            configure(container)
+            container.start()
+            onStart(container)
+            container.followOutput(config.logConsumer)
+            ref.set(container)
+         }
+      } finally {
+         lock.unlock()
       }
-      lock.unlock()
       return container
    }
 


### PR DESCRIPTION
## Problem

In `TestContainerProjectExtension.mount()`, the code acquired the `ReentrantLock` via `lock.lockInterruptibly()`, started the container, and then called `lock.unlock()`. Because `unlock()` was reached only on the happy path, any exception thrown by `configure()`, `container.start()`, `onStart()`, or `container.followOutput()` would leave the lock permanently held. Every subsequent `mount()` call would then block forever on `lockInterruptibly()`, deadlocking the test suite.

## Fix

Wrapped the critical section in a `try { ... } finally { lock.unlock() }`, acquiring the lock outside the `try` (the standard idiom). The lock is now always released regardless of whether container startup succeeds or throws. No other behaviour changed.

File: `kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/TestContainerProjectExtension.kt`

## Verification

Verified by reading the code: the lock acquisition stays outside the `try`, the protected logic is unchanged, and `unlock()` runs in the `finally`. Compilation is verified by the author (build/test run centrally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)