### PR TITLE
Remove @ApplyExtension extensions in a finally block in SpecRefExecutor

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/SpecRefExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/SpecRefExecutor.kt
@@ -90,11 +90,15 @@ internal class SpecRefExecutor(
             context.registry.add(it, ref.kclass)
          }
 
-         invokeSpecRefExtensions(ref)
-
-         extensions.forEach {
-            logger.log { LogLine(ref.fqn, "Removing extension $it") }
-            context.registry.remove(it, ref.kclass)
+         // the registered extensions must always be removed, even if invoking the spec ref extensions
+         // throws, otherwise they would leak into all subsequently executed specs.
+         try {
+            invokeSpecRefExtensions(ref)
+         } finally {
+            extensions.forEach {
+               logger.log { LogLine(ref.fqn, "Removing extension $it") }
+               context.registry.remove(it, ref.kclass)
+            }
          }
 
       } catch (t: Throwable) {


### PR DESCRIPTION
## Problem

In `SpecRefExecutor.applyExtensions(ref)`, extensions declared via `@ApplyExtension` are registered into `context.registry` (which is shared engine-wide), then `invokeSpecRefExtensions(ref)` runs, and only afterwards are the extensions removed from the registry.

If `invokeSpecRefExtensions` throws, control jumps to the outer `catch (t: Throwable)` block and the removal loop is skipped. The registered extensions then leak into every subsequently executed spec, since the registry is shared across the whole engine run.

## Fix

Wrap the `invokeSpecRefExtensions(ref)` call in a `try { ... } finally { ... }` placed inside the existing outer `try`/`catch`. The removal loop is moved into the `finally` block so the registered extensions are always removed, even when invocation throws. Only the extensions that were registered are removed (the same local `extensions` list). The existing outer `catch (t: Throwable)` behaviour (starting and finishing the spec as failed) is left unchanged.

## Verification

Verified by reading the code: the registration loop, the new `try { invoke } finally { remove }` structure, and the unchanged outer `catch` all sit within the original method. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)