### PR TITLE
Propagate beforeInvocation/afterInvocation listener failures

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestInvocationInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/TestInvocationInterceptor.kt
@@ -88,10 +88,12 @@ internal class TestInvocationInterceptor(
    ) {
       val executeWithBeforeAfter = NextTestExecutionInterceptor { tc, sc ->
          try {
-            testExtensions.beforeInvocation(tc, times)
+            // if any before-invocation listener fails, surface the exception and skip the test body
+            testExtensions.beforeInvocation(tc, times).getOrThrow()
             test(tc, sc)
          } finally {
-            testExtensions.afterInvocation(tc, times)
+            // if any after-invocation listener fails, surface the exception
+            testExtensions.afterInvocation(tc, times).getOrThrow()
          }
       }
 


### PR DESCRIPTION
## Problem

In `TestInvocationInterceptor.runBeforeTestAfter`, the calls to `testExtensions.beforeInvocation(tc, times)` and `testExtensions.afterInvocation(tc, times)` each return a `Result<TestCase>` that captures (via `runCatching`) any exception thrown by a user `BeforeInvocationListener` / `AfterInvocationListener` callback. The returned `Result` was discarded, so a failing invocation listener was silently swallowed and the test was incorrectly reported as passing. A failing `beforeInvocation` also did not prevent the test body from running.

## Fix

Call `.getOrThrow()` on both results so listener exceptions propagate:

- A failure from `beforeInvocation` now throws before `test(tc, sc)` runs, skipping the test body and surfacing the listener exception.
- A failure from `afterInvocation` (invoked in the `finally` block) now also surfaces.

The propagated exception flows up through `invokeWithRetry` and is converted into a failing `TestResult` by the top-level `intercept` try/catch, mirroring the semantics of `LifecycleInterceptor`, which folds the listener `Result` and lets the exception become the test result. The existing try/finally structure around the body invocation is preserved.

## Verification

Verified by reading the code: `TestExtensions.beforeInvocation`/`afterInvocation` return `Result<TestCase>` (built via `runCatching` + `mapError`), and `TestInvocationInterceptor.intercept` already wraps execution in a try/catch that converts any thrown `Throwable` into an error `TestResult`. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)