### PR TITLE
Reset accumulated state per spec in JunitXmlReportTestEngineListener

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/reports/JunitXmlReportTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/reports/JunitXmlReportTestEngineListener.kt
@@ -43,6 +43,8 @@ class JunitXmlReportTestEngineListener(
       val testFile = "TEST-${specName}.xml"
       val xml = generator.xml(ref.kclass, results)
       writeFile(testReportsDir, testFile, xml)
+      // clear the accumulated results so the next spec's report only contains its own tests
+      results.clear()
    }
 
    override suspend fun testStarted(testCase: TestCase) {}


### PR DESCRIPTION
## Problem

`JunitXmlReportTestEngineListener` keeps a single mutable `results` map (`private val results = mutableMapOf<TestCase, TestResult>()`) that is populated as tests run (`testIgnored` / `testFinished`). This map was never cleared between specs. As a result, each spec's generated XML report (`generator.xml(ref.kclass, results)` in `specFinished`) accumulated the results of all previously-run specs, producing reports that included tests belonging to other specs.

## Fix

Clear the `results` map in `specFinished` immediately after the report for the current spec has been written. This scopes the accumulation state to a single spec, so each spec's report contains only its own tests. The thread-safety characteristics are unchanged (the same single shared map is reused, just emptied between specs), and the XML format is untouched.

```kotlin
override suspend fun specFinished(ref: SpecRef, result: TestResult) {
   val specName = ref.kclass.bestName()
   val testFile = "TEST-${specName}.xml"
   val xml = generator.xml(ref.kclass, results)
   writeFile(testReportsDir, testFile, xml)
   // clear the accumulated results so the next spec's report only contains its own tests
   results.clear()
}
```

## Verification

Verified by reading the listener code and confirming `results` is only consumed in `specFinished` (via `generator.xml`) before being cleared, so no in-flight data for the current spec is lost. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)