### PR TITLE
Compare values under PropertyOrder.Strict even when key sets differ

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/comparisons/CompareObjects.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/comparisons/CompareObjects.kt
@@ -31,13 +31,26 @@ internal fun compareObjects(
 
       // when using strict order mode, the order of elements in json matters, normally, we don't care
       when (options.propertyOrder) {
-         PropertyOrder.Strict ->
-            if(expected.elements.keys == actual.elements.keys) {
+         PropertyOrder.Strict -> {
+            if (expected.elements.keys == actual.elements.keys) {
                expected.elements.entries.withIndex().zip(actual.elements.entries).forEach { (e, a) ->
                   if (a.key != e.value.key) add(JsonError.NameOrderDiff(path, e.index, e.value.key, a.key))
                   addAll(compare(path + a.key, e.value.value, a.value, options))
                }
+            } else {
+               // The key sets (or their order) differ. The key-set differences are already reported
+               // above when FieldComparison.Strict is in effect. We still report positional name-order
+               // differences and, crucially, compare the values of keys present in both objects so that
+               // genuine value mismatches are not hidden by the key-order / key-set error.
+               expected.elements.entries.withIndex().zip(actual.elements.entries).forEach { (e, a) ->
+                  if (a.key != e.value.key) add(JsonError.NameOrderDiff(path, e.index, e.value.key, a.key))
+               }
+               expected.elements.entries.forEach { (name, e) ->
+                  val a = actual.elements[name]
+                  if (a != null) addAll(compare(path + name, e, a, options))
+               }
             }
+         }
 
          PropertyOrder.Lenient -> {
             expected.elements.entries.forEach { (name, e) ->


### PR DESCRIPTION
## Problem

In `CompareObjects.kt`, under `PropertyOrder.Strict` the value-comparison block was guarded by `if (expected.elements.keys == actual.elements.keys)`. When the two objects' key sets differed (or were in a different order), this condition was false and the entire branch was skipped. As a result, the comparison short-circuited: it reported only the key-set / key-order error (from the `FieldComparison.Strict` block above) and never compared the values of the keys that WERE present in both objects. This hid genuine value mismatches whenever a key was simultaneously added/removed/reordered.

## Fix

The `PropertyOrder.Strict` arm now has an explicit `else` branch for the case where key sets / order differ:

- It still reports positional name-order differences (`JsonError.NameOrderDiff`) via the same indexed-zip used in the equal-keys path.
- It additionally compares the values of every key present in both objects (`expected.elements.forEach { ... actual.elements[name] }`, recursing through `compare`), so real value mismatches are surfaced.

Key-set differences (extra/missing keys) continue to be reported by the pre-existing `FieldComparison.Strict` block, so no duplicate key-set errors are introduced. The strict key-order error is therefore reported *in addition to*, not *instead of*, value differences. The `PropertyOrder.Lenient` branch is untouched, so lenient behaviour is unchanged.

## Verification

Verified by reading the surrounding code, the `JsonError` definitions in `errors.kt`, and the lenient comparison path to ensure error-message structure and key-set handling are preserved. The change is conservative and reuses the existing comparison helpers and error types. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)