### PR TITLE
Arb.slice should not throw on an empty input list

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt
@@ -113,9 +113,13 @@ fun <A> Arb.Companion.subsequence(list: List<A>): Arb<List<A>> = arbitrary {
  * The returned list has the same order as the input list.
  */
 fun <A> Arb.Companion.slice(list: List<A>): Arb<List<A>> = arbitrary {
-   val startIndex = it.random.nextInt(0, list.size)
-   val size = it.random.nextInt(0, list.size + 1)
-   list.drop(startIndex).take(size)
+   if (list.isEmpty()) {
+      emptyList()
+   } else {
+      val startIndex = it.random.nextInt(0, list.size)
+      val size = it.random.nextInt(0, list.size + 1)
+      list.drop(startIndex).take(size)
+   }
 }
 
 /**

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CombinationsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CombinationsTest.kt
@@ -6,6 +6,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.shuffle
@@ -57,5 +58,12 @@ class CombinationsTest : FunSpec({
       val actual = Arb.slice(listOf(1, 2, 3, 4, 5)).take(10000).toList()
       actual.map { it.size }.distinct().shouldContainAll(0, 1, 2, 3, 4, 5)
       actual.filter { it.isNotEmpty() }.map { it[0] }.distinct().shouldContainAll(1, 2, 3, 4, 5)
+   }
+
+   test("slice of an empty list should not throw and only produce empty lists") {
+      // Regression: previously nextInt(0, 0) threw IllegalArgumentException for an empty input.
+      val actual = Arb.slice(emptyList<Int>()).take(1000).toList()
+      actual.size shouldBe 1000
+      actual.toSet() shouldBe setOf(emptyList())
    }
 })


### PR DESCRIPTION
## Problem

`Arb.slice(list)` threw `IllegalArgumentException` when given an empty input list. The generator body called `it.random.nextInt(0, list.size)` to pick a start index, but when `list.size == 0` this produces an empty range (`0 until 0`), and `Random.nextInt(from, until)` requires `until > from`. As a result, `Arb.slice(emptyList())` failed at sample time instead of yielding an empty slice, even though the KDoc states the generator includes the empty list.

## Fix

In `kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/combinations.kt`, the `slice` function now short-circuits when the input list is empty and returns `emptyList()`. For non-empty lists the existing behavior is unchanged. The fix stays within the `arbitrary { ... }` block, matches the existing return type `Arb<List<A>>`, and uses the project's 3-space indentation.

```kotlin
fun <A> Arb.Companion.slice(list: List<A>): Arb<List<A>> = arbitrary {
   if (list.isEmpty()) {
      emptyList()
   } else {
      val startIndex = it.random.nextInt(0, list.size)
      val size = it.random.nextInt(0, list.size + 1)
      list.drop(startIndex).take(size)
   }
}
```

## Verification

Verified by reading the code: the empty-list path now bypasses the `nextInt(0, 0)` call that previously threw, and the non-empty path is untouched. Compilation is verified by the author / central build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)