### PR TITLE
Preserve duration and discardCheckThreshold in PermutationConfiguration.from()

### DIFF
--- a/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/PermutationConfiguration.kt
+++ b/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/PermutationConfiguration.kt
@@ -140,6 +140,7 @@ class PermutationConfiguration {
       this.shouldPrintShrinkSteps = other.shouldPrintShrinkSteps
       this.shrinkingMode = other.shrinkingMode
       this.maxDiscardPercentage = other.maxDiscardPercentage
+      this.discardCheckThreshold = other.discardCheckThreshold
       this.shouldPrintGeneratedValues = other.shouldPrintGeneratedValues
       this.outputStatistics = other.outputStatistics
       this.statisticsReportMode = other.statisticsReportMode
@@ -149,6 +150,7 @@ class PermutationConfiguration {
       this.seed = other.seed
       this.constraints = other.constraints
       this.iterations = other.iterations
+      this.duration = other.duration
    }
 }
 


### PR DESCRIPTION
## Problem

`PermutationConfiguration.from(other)` copies most fields from the source configuration, but it omitted two: `duration` and `discardCheckThreshold`. As a result, when a configuration was applied via `from()`, any user-set `duration` (duration-based constraints) and `discardCheckThreshold` values were silently dropped and replaced by the receiver's defaults.

## Fix

Added two lines to `from()` so the omitted fields are carried over alongside the others:

```kotlin
this.discardCheckThreshold = other.discardCheckThreshold
this.duration = other.duration
```

The property names match the class definitions (`var duration: Duration?` at line 29 and `var discardCheckThreshold: Int` at line 54). Both fields are already consumed downstream in `toContext()`, so they belong in the carry-over set. No other changes were made.

## Verification

Verified by reading the class: `from()` previously copied 14 of 16 user-facing settings, omitting only `duration` and `discardCheckThreshold`, both of which are read in `toContext()`. Property names and types were confirmed against their declarations. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)