### PR TITLE
Release lock on exception in JdbcDatabaseContainerProjectExtension.mount

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
@@ -37,22 +37,25 @@ class JdbcDatabaseContainerProjectExtension(
 
    override fun mount(configure: HikariConfig.() -> Unit): HikariDataSource {
       lock.lockInterruptibly()
-      val t = ref.get()
-      if (t == null) {
-         container.start()
-         container.followOutput(config.logConsumer)
-         val config = HikariConfig()
-         config.jdbcUrl = container.jdbcUrl
-         config.username = container.username
-         config.password = container.password
-         config.configure()
-         val ds = HikariDataSource(config)
-         onStart(ds)
-         ref.set(ds)
-      }
+      try {
+         val t = ref.get()
+         if (t == null) {
+            container.start()
+            container.followOutput(config.logConsumer)
+            val config = HikariConfig()
+            config.jdbcUrl = container.jdbcUrl
+            config.username = container.username
+            config.password = container.password
+            config.configure()
+            val ds = HikariDataSource(config)
+            onStart(ds)
+            ref.set(ds)
+         }
 
-      lock.unlock()
-      return ref.get()
+         return ref.get()
+      } finally {
+         lock.unlock()
+      }
    }
 
    override suspend fun afterProject() {


### PR DESCRIPTION
## Problem

`JdbcDatabaseContainerProjectExtension.mount()` acquires a `ReentrantLock` via `lock.lockInterruptibly()` and only releases it with `lock.unlock()` at the very end of the method. If any operation in the critical section throws — e.g. `container.start()`, the Hikari datasource creation (`HikariDataSource(config)`), or the `onStart(ds)` callback — the `unlock()` call is never reached. The lock is then held forever, deadlocking every subsequent `mount()` call across the test suite.

## Fix

Wrap the critical section in `try { ... } finally { lock.unlock() }` so the lock is always released, even when the container start or datasource creation fails. The change is localized to the `mount()` locking only; the `HikariDataSource` lifecycle is intentionally left untouched (handled by a separate change).

```kotlin
override fun mount(configure: HikariConfig.() -> Unit): HikariDataSource {
   lock.lockInterruptibly()
   try {
      val t = ref.get()
      if (t == null) {
         container.start()
         // ... build config + datasource ...
         ref.set(ds)
      }
      return ref.get()
   } finally {
      lock.unlock()
   }
}
```

## Verification

Verified by reading the code: the only mutation of the lock state is now guarded so `unlock()` runs on every path (normal return and exception). Compilation is verified by the author/centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)