### PR TITLE
Close HikariDataSource in JdbcDatabaseContainerSpecExtension

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerSpecExtension.kt
@@ -32,6 +32,8 @@ class JdbcDatabaseContainerSpecExtension(
    private val onStart: (DataSource) -> Unit = { },
 ) : MountableExtension<HikariConfig, DataSource>, AfterSpecListener {
 
+   private var dataSource: HikariDataSource? = null
+
    override fun mount(configure: HikariConfig.() -> Unit): DataSource {
       container.start()
       container.followOutput(config.logConsumer)
@@ -41,12 +43,14 @@ class JdbcDatabaseContainerSpecExtension(
       config.password = container.password
       config.configure()
       val ds = HikariDataSource(config)
+      dataSource = ds
       onStart(ds)
       return ds
    }
 
    override suspend fun afterSpec(spec: Spec) {
       runInterruptible(Dispatchers.IO) {
+         dataSource?.close()
          container.stop()
       }
    }


### PR DESCRIPTION
## Problem

`JdbcDatabaseContainerSpecExtension.mount()` creates a per-spec `HikariDataSource`, but it was never closed. When the spec completes, `afterSpec` only stopped the container, leaving the Hikari connection pool (and its background threads) open. Across many specs this leaks connection pools and threads.

## Fix

The created `HikariDataSource` instance is now retained in a private field and closed in `afterSpec` (inside the existing `runInterruptible(Dispatchers.IO)` block) before stopping the container. The exact datasource instance returned from `mount()` is the one closed, and container start/stop behaviour is unchanged.

```kotlin
private var dataSource: HikariDataSource? = null
// ... in mount(): dataSource = ds
// ... in afterSpec(): dataSource?.close(); container.stop()
```

## Verification

Verified by reading the source: `mount()` produces exactly one `HikariDataSource` per extension instance, and `afterSpec` is the sole lifecycle teardown hook, so closing there is correct and balanced. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)