### PR TITLE
Close pooled Connection and HikariDataSource in SharedJdbcDatabaseContainerExtension

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedJdbcDatabaseContainerExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/SharedJdbcDatabaseContainerExtension.kt
@@ -69,6 +69,7 @@ class SharedJdbcDatabaseContainerExtension(
    }
 
    override suspend fun afterProject() {
+      ds?.close()
       if (container.isRunning) container.stop()
    }
 
@@ -107,7 +108,9 @@ class SharedJdbcDatabaseContainerExtension(
       config.password = container.password
       config.configure()
       val ds = HikariDataSource(config)
-      runInitScripts(ds.connection, config.dbInitScripts)
+      ds.connection.use { connection ->
+         runInitScripts(connection, config.dbInitScripts)
+      }
       return ds
    }
 }


### PR DESCRIPTION
## Problem

`SharedJdbcDatabaseContainerExtension` leaked two JDBC resources:

1. In `createDataSource()`, a `Connection` was borrowed from the `HikariDataSource` purely to run the init scripts (`runInitScripts(ds.connection, ...)`) and was never closed, permanently checking out a connection from the pool.
2. The `HikariDataSource` itself was never closed. `afterProject()` only stopped the container, leaving the Hikari pool (and its background threads/connections) open after teardown.

## Fix

- Wrap the borrowed connection in a `use { }` block so it is returned to the pool after the init scripts run.
- Close the `HikariDataSource` in `afterProject()` (the shared container's teardown point) before stopping the container, closing the exact instance stored in `ds`.

```kotlin
override suspend fun afterProject() {
   ds?.close()
   if (container.isRunning) container.stop()
}

private fun createDataSource(): HikariDataSource {
   ...
   val ds = HikariDataSource(config)
   ds.connection.use { connection ->
      runInitScripts(connection, config.dbInitScripts)
   }
   return ds
}
```

No other behaviour changed.

## Verification

Verified by reading the code: the borrowed connection is now closed via `use`, and the `ds` instance created in `createDataSource()` is the same instance closed in `afterProject()`. Compilation is verified by the author / central build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)