### PR TITLE
Fix isSubtreeComplete to check each child result, not the parent

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/TestResults.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/TestResults.kt
@@ -46,7 +46,7 @@ internal class TestResults {
     * Returns true if for a given test case, all started child tests have been completed.
     */
    fun isSubtreeComplete(testCase: TestCase): Boolean {
-      return children(testCase).all { result(testCase) != null }
+      return children(testCase).all { result(it) != null }
    }
 
    fun roots(): Map<TestCase, TestResult?> {


### PR DESCRIPTION
## Problem

`TestResults.isSubtreeComplete(testCase)` is documented to return true only when every started child test has a result. However, the implementation iterated over the children of the test case but ignored the iteration element inside the `all { ... }` lambda, instead re-checking the parent's own result:

```kotlin
return children(testCase).all { result(testCase) != null }
```

This meant the subtree completion check evaluated the parent's result for every child rather than each child's result, so it did not actually verify that the children had completed.

## Fix

Use the lambda's element `it` (the child) when looking up the result:

```kotlin
return children(testCase).all { result(it) != null }
```

This is a single-expression change in `kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/TestResults.kt`. No other code was touched.

## Verification

Verified by reading the surrounding code: `children(testCase)` returns the immediate child test cases, and `result(testCase)` looks up a result by descriptor; the corrected lambda now matches the KDoc contract ("all started child tests have been completed"). Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)