### PR TITLE
Cancel the timeout coroutine when the test block completes/fails

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/interceptors/TimeoutInterceptor.kt
@@ -118,15 +118,22 @@ private suspend fun <T> withRealTimeTimeout(
    @OptIn(DelicateCoroutinesApi::class)
    val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
 
-   select {
-      blockDeferred.onAwait { result ->
-         timeoutJob.cancel()
-         result
+   try {
+      select {
+         blockDeferred.onAwait { result ->
+            timeoutJob.cancel()
+            result
+         }
+         timeoutJob.onJoin {
+            blockDeferred.cancel()
+            throw RealTimeTimeoutCancellationException("Timed out waiting for $timeout")
+         }
       }
-      timeoutJob.onJoin {
-         blockDeferred.cancel()
-         throw RealTimeTimeoutCancellationException("Timed out waiting for $timeout")
-      }
+   } finally {
+      // Ensure the watchdog coroutine is always cancelled once the guarded block finishes,
+      // whether it succeeded, threw, or timed out. Otherwise it would leak on GlobalScope
+      // until the timeout elapses (e.g. when the block throws and onAwait rethrows).
+      timeoutJob.cancel()
    }
 }
 
@@ -144,15 +151,22 @@ private suspend fun <T> withRealTimeTimeoutOrNull(
    @OptIn(DelicateCoroutinesApi::class)
    val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
 
-   select {
-      blockDeferred.onAwait { result ->
-         timeoutJob.cancel()
-         result
+   try {
+      select {
+         blockDeferred.onAwait { result ->
+            timeoutJob.cancel()
+            result
+         }
+         timeoutJob.onJoin {
+            blockDeferred.cancel()
+            null
+         }
       }
-      timeoutJob.onJoin {
-         blockDeferred.cancel()
-         null
-      }
+   } finally {
+      // Ensure the watchdog coroutine is always cancelled once the guarded block finishes,
+      // whether it succeeded, threw, or timed out. Otherwise it would leak on GlobalScope
+      // until the timeout elapses (e.g. when the block throws and onAwait rethrows).
+      timeoutJob.cancel()
    }
 }
 


### PR DESCRIPTION
## Problem

`withRealTimeTimeout` and `withRealTimeTimeoutOrNull` in `TimeoutInterceptor.kt` launch a timeout watchdog coroutine on `GlobalScope`:

```kotlin
val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
```

The watchdog is cancelled inside the `select` branches (`blockDeferred.onAwait { timeoutJob.cancel(); ... }`). However, when the guarded `block()` throws, the `blockDeferred` completes exceptionally and `onAwait` rethrows the exception *before* reaching `timeoutJob.cancel()`. As a result the `GlobalScope`-launched watchdog is never cancelled and leaks, staying alive until the full `timeout` duration elapses. With long timeouts and many failing tests, these orphaned coroutines accumulate.

## Fix

Wrap the `select` in a `try { ... } finally { timeoutJob.cancel() }` in both functions so the watchdog job is always cancelled once the guarded block finishes — whether it returned, threw, or actually timed out. `Job.cancel()` is idempotent, so the existing in-branch cancels remain harmless and the timeout semantics are unchanged (a real timeout still throws `RealTimeTimeoutCancellationException` / returns `null` as before).

## Verification

Verified by reading the coroutine control flow: on the success path the result is returned and `finally` cancels an already-completed job (no-op); on the timeout path the exception/`null` propagates through `finally`; on the block-throws path the rethrown exception now passes through `finally`, which cancels the previously-leaked watchdog. No public API or timeout behavior changed. Compilation is verified centrally by the author/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)