### PR TITLE
Make CollectingTestEngineListener error state safe for cross-thread reads

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/CollectingTestEngineListener.kt
@@ -9,6 +9,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
 import kotlin.reflect.KClass
 
 /**
@@ -23,6 +24,12 @@ class CollectingTestEngineListener : AbstractTestEngineListener(), Mutex by Mute
    val specs = mutableMapOf<KClass<*>, TestResult>()
    val tests = mutableMapOf<TestCaseKey, TestResult>()
    val names = mutableListOf<String>()
+
+   // Written under [withLock] from test-execution coroutines but read without the lock from
+   // other threads (e.g. the launcher deciding the process exit code, and the scheduler
+   // checking projectWideFailFast after execution), so it must be @Volatile to guarantee the
+   // read observes the latest write rather than a stale cached value.
+   @Volatile
    var errors = false
 
    fun result(descriptor: Descriptor.TestDescriptor): TestResult? = tests.mapKeys { it.key.descriptor }[descriptor]


### PR DESCRIPTION
## Problem

`CollectingTestEngineListener.errors` is a plain `var errors = false` boolean. It is **written** under the listener's coroutine `Mutex` (`withLock`) from test-execution coroutines in `specFinished`, `testFinished`, and `engineFinished`. However, it is **read** without any synchronization from other threads after execution completes:

- `kotest-framework-engine/src/jvmMain/.../launcher/main.kt:111` — `if (collector.errors) exitProcess(1) else exitProcess(0)` decides the process exit code.
- `kotest-framework-engine/src/commonMain/.../TestSuiteScheduler.kt:97` — `if (projectConfigResolver.projectWideFailFast() && collector.errors)` for fail-fast.

Because the write happens on a test-execution thread and the read happens on a different thread without crossing the same memory barrier, the reading thread may observe a stale (cached) `false` value — causing the launcher to report success (exit 0) even though tests failed.

## Fix

Marked the backing field `@Volatile` (using the multiplatform `kotlin.concurrent.Volatile`, valid in `commonMain`), which establishes the happens-before/visibility guarantee so cross-thread reads always observe the latest write. This is the minimal change: the public API is unchanged (still `var errors`), and the already-mutex-guarded maps are left as-is.

## Verification

Verified by reading the code: confirmed the write sites are all under `withLock` and located the two unsynchronized reader sites (launcher exit code and scheduler fail-fast) that run on a different thread after execution. Compilation is verified by the author / central build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)