### PR TITLE
Close the InputStream in KotestPropertiesLoader.loadSystemProps

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/KotestPropertiesLoader.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/KotestPropertiesLoader.kt
@@ -50,7 +50,7 @@ object KotestPropertiesLoader {
          logger.log { "Kotest properties file was not detected" }
          return props
       }
-      props.load(input)
+      input.use { props.load(it) }
       return props
    }
 


### PR DESCRIPTION
## Problem

`KotestPropertiesLoader.loadSystemProps` opened an `InputStream` via `getResourceAsStream(filename)` to load the `kotest.properties` file, but never closed it. After `props.load(input)` completed, the stream was left open, leaking the resource on every invocation.

## Fix

Wrapped the `props.load(...)` call in Kotlin's `.use { }` block so the stream is always closed once loading completes (or if loading throws). The existing null-handling (the resource may be absent, in which case an empty `Properties` is returned) and the return value are preserved unchanged.

```kotlin
input.use { props.load(it) }
return props
```

## Verification

Verified by reading the code and the surrounding function. The change is minimal and only affects the stream lifecycle; behavior and return value are otherwise identical. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)