### PR TITLE
Fix the "found before" slice in containsInOrder failure message

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -27,7 +27,7 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
 
    val foundBeforeDescription = {
       if (subsequenceIndex == subsequence.size) "" else {
-         val foundBeforeAtIndexes = actual.take(subsequenceIndex).mapIndexedNotNull { index, value ->
+         val foundBeforeAtIndexes = actual.mapIndexedNotNull { index, value ->
             if (value == subsequence[subsequenceIndex]) index else null
          }
          if (foundBeforeAtIndexes.isEmpty()) "" else {


### PR DESCRIPTION
## Problem

In `containsInOrder` (`kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt`), the "found before" diagnostic built its message by slicing the actual collection with `actual.take(subsequenceIndex)`.

`subsequenceIndex` is an index into the **expected subsequence**, not into the **actual** collection, so the two have no meaningful relationship. This sliced an incorrectly-bounded, unrelated region of `actual` when searching for prior occurrences of the unmatched element, producing a misleading "but found it before at index(es) ..." message (it could omit valid indexes or, in general, scan the wrong region). The pass/fail logic was unaffected — only the message was wrong.

## Fix

Search the entire `actual` collection instead of the bogus `take(subsequenceIndex)` slice:

```kotlin
val foundBeforeAtIndexes = actual.mapIndexedNotNull { index, value ->
   if (value == subsequence[subsequenceIndex]) index else null
}
```

This is correct because the matching loop already consumes the whole `actual` collection before a failure is reported (the failing expected element was never matched anywhere in `actual`), so scanning all of `actual` reports every index where the unmatched element occurs. The PASS/FAIL behaviour of the matcher is unchanged; only the failure-message construction is corrected. The change is a single line and keeps the file's existing style.

## Verification

Verified by reading the matcher logic and the existing tests in `InOrderTest.kt` (the "find mismatched element before" case: `[1, 2, 3, 4, 5] should containsInOrder(3, 4, 5, 2)` expects "but found it before at index(es) [1]"). With the corrected slice the index of `2` in the full actual list is still `1`, matching the expected message, and the slice now reflects the correct region generally. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)