### PR TITLE
Fix beUpperCase/beLowerCase for non-String CharSequence

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/case.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/case.kt
@@ -19,7 +19,7 @@ fun <A : CharSequence> A?.shouldNotBeUpperCase(): A {
 
 fun beUpperCase(): Matcher<CharSequence?> = neverNullMatcher { value ->
    MatcherResult(
-      value.toString().uppercase() == value,
+      value.toString() == value.toString().uppercase(),
       { "${value.print().value} should be upper case" },
       { "${value.print().value} should not be upper case" }
    )
@@ -37,7 +37,7 @@ fun <A : CharSequence?> A.shouldNotBeLowerCase(): A {
 
 fun beLowerCase(): Matcher<CharSequence?> = neverNullMatcher { value ->
    MatcherResult(
-      value.toString().lowercase() == value,
+      value.toString() == value.toString().lowercase(),
       { "${value.print().value} should be lower case" },
       { "${value.print().value} should not be lower case" }
    )


### PR DESCRIPTION
## Problem

The `beUpperCase()` and `beLowerCase()` matchers in `kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/case.kt` compared a `String` against the original `CharSequence` value using `==`:

```kotlin
value.toString().uppercase() == value   // String == CharSequence
value.toString().lowercase() == value   // String == CharSequence
```

When `value` is a `CharSequence` that is not a `String` (e.g. a `StringBuilder`), `String.equals(CharSequence)` is never `true` because `String.equals` only returns true for another `String`. This caused the matchers to report `false` (not upper/lower case) even for content that is entirely upper/lower case, giving wrong results for any non-`String` `CharSequence`.

## Fix

Compare string content on both sides so the result depends only on the textual content, regardless of the concrete `CharSequence` type:

```kotlin
value.toString() == value.toString().uppercase()
value.toString() == value.toString().lowercase()
```

Both matchers were updated consistently. No other changes were made.

## Verification

Verified by reading the code: both operands are now `String`, so equality reflects content rather than runtime type, fixing the false negative for non-`String` `CharSequence` values. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)