### PR TITLE
Fix integer enum schema values never matching JSON numbers

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
@@ -108,8 +108,12 @@ private fun validate(
             enumValue == null -> tree is JsonNode.NullNode
             enumValue is String -> tree is JsonNode.StringNode && tree.value == enumValue
             enumValue is Boolean -> tree is JsonNode.BooleanNode && tree.value == enumValue
-            enumValue is Long -> tree is JsonNode.NumberNode && tree.content.toLongOrNull() == enumValue
-            enumValue is Double -> tree is JsonNode.NumberNode && tree.content.toDoubleOrNull() == enumValue
+            // Integral enum values may arrive as any Kotlin integer type (e.g. an Int literal from the
+            // DSL or a Long from schema parsing), so compare on the common Long representation.
+            enumValue is Byte || enumValue is Short || enumValue is Int || enumValue is Long ->
+               tree is JsonNode.NumberNode && tree.content.toLongOrNull() == (enumValue as Number).toLong()
+            enumValue is Float || enumValue is Double ->
+               tree is JsonNode.NumberNode && tree.content.toDoubleOrNull() == (enumValue as Number).toDouble()
             else -> false
          }
       }


### PR DESCRIPTION
## Problem

In `matchSchema.kt`, the `JsonSchema.JsonEnum` handling matched integral enum values only with `enumValue is Long`:

```kotlin
enumValue is Long -> tree is JsonNode.NumberNode && tree.content.toLongOrNull() == enumValue
```

However, integer enum values supplied through the DSL (`JsonSchema.Builder.enum(vararg values: Any?)`, e.g. `enum(1, 2, 3)`) are boxed as Kotlin `Int`, not `Long`. Since `Int` is not `Long`, that branch was never taken and execution fell through to `else -> false`. As a result an integer enum constraint never matched any JSON number, even one that was equal. (Only the schema-parsing path, which deserializes via `longOrNull` into `Long`, happened to work.)

## Fix

Match any integral Kotlin numeric type (`Byte`, `Short`, `Int`, `Long`) and compare on a common `Long` representation; likewise accept `Float` alongside `Double` for the decimal case:

```kotlin
enumValue is Byte || enumValue is Short || enumValue is Int || enumValue is Long ->
   tree is JsonNode.NumberNode && tree.content.toLongOrNull() == (enumValue as Number).toLong()
enumValue is Float || enumValue is Double ->
   tree is JsonNode.NumberNode && tree.content.toDoubleOrNull() == (enumValue as Number).toDouble()
```

String, boolean and null enum handling is left unchanged. This is scoped to the enum-matching bug only; the separate `toLong()` crash on oversized/exponent numbers is intentionally not addressed here.

## Verification

Verified by reading the surrounding enum handling in `matchSchema.kt`, the DSL `enum(vararg values: Any?)` builder in `builder.kt` (which boxes Int literals as `Int`), the `JsonSchemaEnumSerializer` parsing path in `parse.kt` (which produces `Long`), and the `JsonNode.NumberNode(content: String)` representation. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)