### PR TITLE
Fix Permutation.iteration always being 0

### DIFF
--- a/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/PermutationExecutor.kt
+++ b/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/PermutationExecutor.kt
@@ -23,7 +23,7 @@ internal class PermutationExecutor(
 ) {
 
    internal suspend fun execute(
-      test: suspend PermutationContext.() -> Unit
+      test: suspend PermutationContext.(iteration: Int) -> Unit
    ): PermutationResult {
 
       ConfigWriter.writeIfEnabled(context)
@@ -49,7 +49,7 @@ internal class PermutationExecutor(
 
             context.registry.reset()
             context.beforePermutation()
-            test(context)
+            test(context, invocations - 1)
             context.afterPermutation()
 
             successes++ // we know the test was successful

--- a/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/dsl.kt
+++ b/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/dsl.kt
@@ -45,7 +45,9 @@ suspend fun permutations(
 
    val context = configuration.toContext()
    val executor = PermutationExecutor(context)
-   val result = executor.execute { context.test.invoke(Permutation(0, context.rs, context.classifications)) }
+   val result = executor.execute { iteration ->
+      context.test.invoke(Permutation(iteration, context.rs, context.classifications))
+   }
    return result
 }
 


### PR DESCRIPTION
## Problem

In `kotest-property-permutations`, the per-iteration `Permutation` context exposed via the `permutations { ... }` DSL always reported `iteration == 0`. The `Permutation` object was constructed in `dsl.kt` with a hardcoded literal `0`:

```kotlin
executor.execute { context.test.invoke(Permutation(0, context.rs, context.classifications)) }
```

The actual loop counter lives in `PermutationExecutor.execute`, but the `execute` callback signature (`suspend PermutationContext.() -> Unit`) never received the current iteration index, so the DSL had no way to obtain it and passed a constant instead. As a result, any test relying on `Permutation.iteration` saw `0` on every invocation.

## Fix

Thread the executor's loop counter into the `execute` callback:

- `PermutationExecutor.execute` now takes `suspend PermutationContext.(iteration: Int) -> Unit` and invokes it with `invocations - 1`, giving a 0-based iteration index. This matches the existing `Constraints` convention (`Constraints.iterations(k) = it.iteration < k`), where `Iteration.iteration` is 0-based at the point the constraint is evaluated (top of the loop, before the counter is incremented).
- `dsl.kt` now uses the supplied `iteration` value when constructing `Permutation` instead of the hardcoded `0`.

The change is minimal and touches only the two files required for a compiling fix (the DSL construction site and the executor that owns the loop counter).

## Verification

Verified by reading `dsl.kt`, `PermutationExecutor.kt`, `Permutation.kt`, `PermutationContext.kt`, and `constraints/constraints.kt` to confirm the iteration semantics (0-based, consistent with the `Constraints` evaluation). Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)