### PR TITLE
Fix until() expectedExceptionsFn default to match its KDoc

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
@@ -134,7 +134,7 @@ class UntilConfigurationBuilder {
     *
     * This function is applied in addition to the values specified by [expectedExceptions].
     */
-   var expectedExceptionsFn: (Throwable) -> Boolean = { true }
+   var expectedExceptionsFn: (Throwable) -> Boolean = { false }
 
    /**
     * A listener that is invoked after each failed invocation, with the iteration count,


### PR DESCRIPTION
## Problem

In `until.kt`, the `UntilConfigurationBuilder.expectedExceptionsFn` property defaulted to `{ true }`. Its KDoc states: "By default, this function returns false for all exceptions, or in other words, no exception is ignored." Returning `true` instead meant every thrown exception was treated as expected/ignored, contradicting the documentation and silently swallowing failures when `until` was used without configuring this function.

The value flows into `EventuallyConfiguration.expectedExceptionsFn` (via `build()` and the `until(config, ...)` overload), so the inverted default affected real retry/swallowing behaviour.

## Fix

Changed the default from `{ true }` to `{ false }` so it matches the documented behaviour (no exception is ignored by default). This was the only change made.

```kotlin
var expectedExceptionsFn: (Throwable) -> Boolean = { false }
```

## Verification

Verified by reading the file: the KDoc on the property explicitly documents a `false` default, and `build()` composes it as `expectedExceptions.any { ... } || expectedExceptionsFn(t)`, so a `false` default correctly leaves only the explicitly-listed `expectedExceptions` as ignored. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)