### PR TITLE
Count TestAbortedException-skipped tests toward failOnIgnoredTests

### DIFF
--- a/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
+++ b/kotest-runner/kotest-runner-junit-platform/src/jvmMain/kotlin/io/kotest/runner/junit/platform/JUnitTestEngineListener.kt
@@ -292,6 +292,10 @@ class JUnitTestEngineListener(
             ?: error("startedTests contains ${testCase.descriptor} but descriptors does not")
          logger.log { Pair(testCase.name.name, "test ignored after start; finalizing as aborted: $reason") }
          results[testCase.descriptor] = TestResult.Ignored(reason)
+         // this test was skipped (via TestAbortedException / assumption), so it must be
+         // accounted for in the ignored-tests tracking that drives failOnIgnoredTests,
+         // consistent with the never-started ignored path below.
+         anyTestIgnored = true
          listener.executionFinished(descriptor, TestExecutionResult.aborted(null))
          return
       }


### PR DESCRIPTION
## Problem

In `JUnitTestEngineListener`, the `failOnIgnoredTests` behavior is driven by the `anyTestIgnored` boolean flag, which `engineFinished` checks to decide whether to fail the build.

A test can reach `testIgnored` along two routes:

1. **Never started** — disabled by a `TestEnabledExtension`, short-circuited by fail-fast, etc. This branch correctly sets `anyTestIgnored = true`.
2. **Started, then aborted** — the test body threw `TestAbortedException` / `IterationSkippedException` (assumptions), which is converted to `TestResult.Ignored` and routed through `testIgnored`. This branch (around lines 290-300) recorded the result as `TestResult.Ignored(reason)` and finalized it as aborted, but it never set `anyTestIgnored`.

As a result, tests skipped after starting via assumptions were under-counted by `failOnIgnoredTests`: a build whose only ignored tests were aborted-after-start would not fail even when `failOnIgnoredTests` was enabled.

## Fix

Set `anyTestIgnored = true` in the aborted-after-start branch, so these skipped tests are accounted for in the ignored-tests tracking consistently with the never-started ignored path. This is a minimal, targeted change confined to the existing `if (testCase.descriptor in startedTests)` block.

## Verification

Verified by reading the code: confirmed `anyTestIgnored` is the sole signal consumed by `engineFinished` for `failOnIgnoredTests`, and that the never-started ignored path already sets it while the aborted-after-start path did not. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)