### PR TITLE
Close HikariDataSource in JdbcDatabaseContainerProjectExtension

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/JdbcDatabaseContainerProjectExtension.kt
@@ -57,6 +57,7 @@ class JdbcDatabaseContainerProjectExtension(
 
    override suspend fun afterProject() {
       runInterruptible(Dispatchers.IO) {
+         ref.getAndSet(null)?.close()
          container.stop()
       }
    }


### PR DESCRIPTION
## Problem

`JdbcDatabaseContainerProjectExtension.mount()` creates a pooled `HikariDataSource` and stores it in `ref`, but the `afterProject()` teardown only stopped the underlying container via `container.stop()`. The `HikariDataSource` was never closed, leaking its connection pool (and the threads/connections it holds) for the lifetime of the JVM after the test suite completed.

## Fix

In `afterProject()`, close the datasource before stopping the container:

```kotlin
override suspend fun afterProject() {
   runInterruptible(Dispatchers.IO) {
      ref.getAndSet(null)?.close()
      container.stop()
   }
}
```

`ref.getAndSet(null)` atomically retrieves and clears the stored datasource, and `?.close()` shuts down the Hikari pool if one was ever created (it may be null if `mount()` was never invoked). The change is fully contained within `afterProject()`; the `mount()` locking logic is intentionally left untouched, as a separate change addresses the lock-release behaviour there.

## Verification

Verified by reading the surrounding code: `ref` is an `AtomicReference<HikariDataSource>` populated only in `mount()`, so closing it in teardown is safe and idempotent (null-safe). Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)