### PR TITLE
Null the server field after stopping in MockServerListener.afterSpec

### DIFF
--- a/kotest-extensions/kotest-extensions-mockserver/src/jvmMain/kotlin/io/kotest/extensions/mockserver/MockServerListener.kt
+++ b/kotest-extensions/kotest-extensions-mockserver/src/jvmMain/kotlin/io/kotest/extensions/mockserver/MockServerListener.kt
@@ -34,6 +34,9 @@ class MockServerListener(
 
    override suspend fun afterSpec(spec: Spec) {
       mockServer?.stop()
+      // clear the reference so a fresh server is created on the next beforeSpec/beforeTest
+      // if this listener instance is reused across specs
+      mockServer = null
    }
 
    override fun close() {


### PR DESCRIPTION
## Problem

`MockServerListener.afterSpec` stopped the mock server (`mockServer?.stop()`) but left the stored `mockServer` reference in place. The `beforeSpec`/`beforeTest` callbacks only create a new server when `mockServer == null`. As a result, if a single listener instance is reused across specs, the stale, already-stopped server reference was reused and never recreated, breaking every subsequent spec.

## Fix

After stopping the server in `afterSpec`, set `mockServer = null`. The field was already nullable (`ClientAndServer?`), so no type change was needed. This ensures `beforeSpec`/`beforeTest` create a fresh server on the next run when the listener instance is reused. Behaviour is otherwise unchanged.

```kotlin
override suspend fun afterSpec(spec: Spec) {
   mockServer?.stop()
   // clear the reference so a fresh server is created on the next beforeSpec/beforeTest
   // if this listener instance is reused across specs
   mockServer = null
}
```

## Verification

Verified by reading the code: `beforeSpec` and `beforeTest` guard server creation on `mockServer == null`, confirming the stale-reference reuse bug and that nulling the field restores correct recreation behaviour. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)