### PR TITLE
FeatureSpec scenario leaf body should run with TestScope, not WordSpecWhenContainerScope

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/FeatureSpecContainerScope.kt
@@ -104,7 +104,7 @@ class FeatureSpecContainerScope(
          TestDefinitionBuilder
             .builder(scenarioName(name), TestType.Test)
             .withXmethod(xmethod)
-            .build { WordSpecWhenContainerScope(this).test() }
+            .build(test)
       )
    }
 


### PR DESCRIPTION
## Problem

The private `scenario(name, xmethod, test)` helper in `FeatureSpecContainerScope` registers a **leaf** test (`TestType.Test`) but built its body as:

```kotlin
.build { WordSpecWhenContainerScope(this).test() }
```

This wrapped the user's scenario body in a WordSpec container DSL scope copied from a different spec style. That leaks WordSpec container extensions into a FeatureSpec leaf test and gives the body the wrong receiver type. A leaf test should run against the plain `TestScope`, exactly like every other spec style's leaf method (e.g. `FunSpec.test()`, `DescribeSpec.it()`), which use `.build(test)`.

## Fix

Changed the leaf scenario helper body from:

```kotlin
.build { WordSpecWhenContainerScope(this).test() }
```

to:

```kotlin
.build(test)
```

The `test` parameter is already typed as `suspend TestScope.() -> Unit`, so it can be passed directly to `.build(...)`.

The container methods (`feature()`/`xfeature()`, which use `TestType.Container` and correctly wrap in `FeatureSpecContainerScope`) were left unchanged. Only the leaf scenario helper was modified.

## Verification

- Confirmed the leaf helper used `TestType.Test` with the WordSpec wrapper, while the container helper correctly used `FeatureSpecContainerScope`.
- `WordSpecWhenContainerScope` lives in the same package, so no import needed removal; after the change it is simply no longer referenced from this file.
- One-line change; minimal and self-contained. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)