### PR TITLE
Register spec-body afterProject listeners once per project, not once per instance

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -3921,6 +3921,7 @@ public final class io/kotest/engine/extensions/DefaultExtensionRegistry : io/kot
 	public fun get (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public fun isEmpty ()Z
 	public fun isNotEmpty ()Z
+	public fun markAfterProjectListenersRegistered (Lkotlin/reflect/KClass;)Z
 	public fun remove (Lio/kotest/core/extensions/Extension;)V
 	public fun remove (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 }
@@ -3934,6 +3935,7 @@ public final class io/kotest/engine/extensions/EmptyExtensionRegistry : io/kotes
 	public fun get (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public fun isEmpty ()Z
 	public fun isNotEmpty ()Z
+	public fun markAfterProjectListenersRegistered (Lkotlin/reflect/KClass;)Z
 	public fun remove (Lio/kotest/core/extensions/Extension;)V
 	public fun remove (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 }
@@ -4013,6 +4015,7 @@ public abstract interface class io/kotest/engine/extensions/ExtensionRegistry {
 	public abstract fun get (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public abstract fun isEmpty ()Z
 	public abstract fun isNotEmpty ()Z
+	public abstract fun markAfterProjectListenersRegistered (Lkotlin/reflect/KClass;)Z
 	public abstract fun remove (Lio/kotest/core/extensions/Extension;)V
 	public abstract fun remove (Lio/kotest/core/extensions/Extension;Lkotlin/reflect/KClass;)V
 }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
@@ -34,6 +34,16 @@ interface ExtensionRegistry {
    fun remove(extension: Extension)
    fun remove(extension: Extension, kclass: KClass<*>)
 
+   /**
+    * Atomically marks the given spec [kclass] as having had its spec-level afterProject listeners
+    * registered, returning true only the first time it is called for a given class.
+    *
+    * This allows spec-level afterProject listeners to be registered globally exactly once per spec
+    * class, even when (under InstancePerRoot/InstancePerLeaf/InstancePerTest isolation) many fresh
+    * instances of the same spec are inflated, each building new afterProject listener objects.
+    */
+   fun markAfterProjectListenersRegistered(kclass: KClass<*>): Boolean
+
    fun clear()
    fun isEmpty(): Boolean
    fun isNotEmpty(): Boolean
@@ -42,6 +52,10 @@ interface ExtensionRegistry {
 class DefaultExtensionRegistry : ExtensionRegistry {
 
    private val extensions = mutableListOf<Pair<Extension, KClass<*>?>>()
+
+   // tracks which spec classes have already had their spec-level afterProject listeners registered,
+   // so that subsequent instances of the same spec class do not re-register (and thus re-run) them.
+   private val afterProjectRegisteredClasses = mutableSetOf<KClass<*>>()
 
    override fun all(): List<Extension> = extensions.map { it.first }
 
@@ -65,8 +79,12 @@ class DefaultExtensionRegistry : ExtensionRegistry {
       extensions.remove(Pair(extension, kclass))
    }
 
+   override fun markAfterProjectListenersRegistered(kclass: KClass<*>): Boolean =
+      afterProjectRegisteredClasses.add(kclass)
+
    override fun clear() {
       extensions.clear()
+      afterProjectRegisteredClasses.clear()
    }
 
    override fun isEmpty(): Boolean = extensions.isEmpty()
@@ -91,6 +109,8 @@ object EmptyExtensionRegistry : ExtensionRegistry {
 
    override fun remove(extension: Extension, kclass: KClass<*>) {
    }
+
+   override fun markAfterProjectListenersRegistered(kclass: KClass<*>): Boolean = true
 
    override fun clear() {
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecRef.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/SpecRef.kt
@@ -33,8 +33,16 @@ internal class SpecRefInflator(
          .onFailure { extensions.specInstantiationError(ref.kclass, it) }
          .flatMap { spec -> extensions.specInstantiated(spec).map { spec } }
          .onSuccess { spec ->
-            // any spec level AfterProjectListener extensions should now be added to the global registry
-            spec.afterProjectListeners().forEach { registry.add(it) }
+            // Any spec level AfterProjectListener extensions should now be added to the global registry.
+            // The registry is engine-wide and add() does not dedupe, so under InstancePerRoot/
+            // InstancePerLeaf/InstancePerTest isolation - where inflate() runs once per fresh spec
+            // instance and each instance builds new afterProject listener objects - we would otherwise
+            // register (and therefore run) a spec-body afterProject{} block once per instance instead of
+            // once per project. We dedupe by spec class so these listeners are registered at most once,
+            // regardless of how many instances are created (and exactly once for SingleInstance mode).
+            if (registry.markAfterProjectListenersRegistered(ref.kclass)) {
+               spec.afterProjectListeners().forEach { registry.add(it) }
+            }
             // seal the spec to detect adding root tests after execution has started
             if (spec is AbstractSpec) {
                spec.sealed = true


### PR DESCRIPTION
## Problem

`SpecRefInflator.inflate()` in `SpecRef.kt` ran `spec.afterProjectListeners().forEach { registry.add(it) }` on **every** inflate. The `ExtensionRegistry` is engine-wide and its `add()` does not dedupe.

Under `InstancePerRoot` / `InstancePerLeaf` / `InstancePerTest` isolation, `inflate()` is called once per fresh spec instance, and each instance builds **new** `AfterProjectListener` objects from its `DslDrivenSpec.afterProject { }` blocks. As a result, a spec-body `afterProject { }` block was registered (and therefore executed) **once per instance** instead of once per project. `SingleInstance` mode (the default) was correct because the spec is inflated once.

## Fix

Dedupe afterProject registration by spec class, using state held on the engine-wide registry so it works across the multiple `SpecRefInflator` instances created by the isolation executors:

- Added `markAfterProjectListenersRegistered(kclass: KClass<*>): Boolean` to the `ExtensionRegistry` interface. It atomically records the spec class and returns `true` only the first time it is called for that class.
  - `DefaultExtensionRegistry` backs it with a `MutableSet<KClass<*>>` (also cleared in `clear()`).
  - `EmptyExtensionRegistry` returns `true` (it never actually stores extensions; behaviour unchanged).
- In `SpecRefInflator.inflate()`, only register the spec's afterProject listeners when `registry.markAfterProjectListenersRegistered(ref.kclass)` returns `true`.

This guarantees spec-body afterProject listeners are registered at most once per spec class (exactly once across all isolation modes, including SingleInstance). The sealing logic and all other behaviour are untouched. Listeners remain registered as global extensions so they are still picked up by `registry.all()` in `ProjectConfigResolver.extensions()`.

## Verification

- `ExtensionRegistry` has only two implementations (`DefaultExtensionRegistry`, `EmptyExtensionRegistry`); both updated. No anonymous/`by`-delegated implementations exist.
- `ref.kclass` is part of the sealed `SpecRef` interface, available for both `Reference` and `Function` refs.
- Compilation is verified centrally by the author. Note: `ExtensionRegistry` is public API, so `./gradlew apiDump` may need to be run to record the new interface method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)