### PR TITLE
Honor WithDataTestName.dataTestName() on all platforms, not just JVM

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/stable/StableIdents.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/stable/StableIdents.kt
@@ -56,8 +56,9 @@ internal object StableIdents {
    fun getStableIdentifier(t: Any?): String {
       return when {
          t == null -> "<null>"
-         t::class.hasAnnotation<IsStableType>() || platform != Platform.JVM -> t.toString()
+         t::class.hasAnnotation<IsStableType>() -> t.toString()
          t is WithDataTestName -> t.dataTestName()
+         platform != Platform.JVM -> t.toString()
          else -> {
             val psv = platformStableValue(t)
             when {

--- a/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/io/kotest/engine/stable/StableIdentsCommonTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/io/kotest/engine/stable/StableIdentsCommonTest.kt
@@ -34,7 +34,20 @@ class StableIdentsCommonTest : FunSpec({
       StableIdents.getStableIdentifier(element) shouldBe "stable-name"
    }
 
+   test("getStableIdentifier should use toString() for an @IsStableType-annotated type") {
+      // @IsStableType signals the type's toString() is stable and may be used as the identifier.
+      // On the JVM this is resolved via the IsStableType annotation branch; the resulting identifier
+      // (the toString()) is the same on every platform.
+      StableIdents.getStableIdentifier(StableTypeForTest("abc")) shouldBe "stable:abc"
+      StableIdents.getStableIdentifier(StableTypeForTest("xyz")) shouldBe "stable:xyz"
+   }
+
    test("null should be stable on all platforms") {
       StableIdents.getStableIdentifier(null) shouldBe "<null>"
    }
 })
+
+@IsStableType
+private data class StableTypeForTest(val value: String) {
+   override fun toString(): String = "stable:$value"
+}

--- a/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/io/kotest/engine/stable/StableIdentsCommonTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/io/kotest/engine/stable/StableIdentsCommonTest.kt
@@ -1,0 +1,40 @@
+package io.kotest.engine.stable
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.names.WithDataTestName
+import io.kotest.matchers.shouldBe
+
+/**
+ * Multiplatform coverage for [StableIdents.getStableIdentifier].
+ *
+ * These tests run on every target (JVM, JS, Wasm, Native). They guard against the regression
+ * where the non-JVM short-circuit (`platform != Platform.JVM -> toString()`) was evaluated
+ * before the [WithDataTestName] branch, causing a custom [WithDataTestName.dataTestName] to be
+ * silently ignored on all platforms except the JVM.
+ */
+class StableIdentsCommonTest : FunSpec({
+
+   test("getStableIdentifier should use WithDataTestName.dataTestName() on all platforms") {
+      // toString() deliberately differs from dataTestName() so we can tell which one was used.
+      val element = object : WithDataTestName {
+         override fun dataTestName(): String = "custom-data-test-name"
+         override fun toString(): String = "unstable-toString"
+      }
+      StableIdents.getStableIdentifier(element) shouldBe "custom-data-test-name"
+   }
+
+   test("getStableIdentifier should honour WithDataTestName even when toString() is non-deterministic") {
+      var counter = 0
+      val element = object : WithDataTestName {
+         override fun dataTestName(): String = "stable-name"
+         override fun toString(): String = "call-${counter++}"
+      }
+      // Repeated calls must return the same stable identifier regardless of toString() changing.
+      StableIdents.getStableIdentifier(element) shouldBe "stable-name"
+      StableIdents.getStableIdentifier(element) shouldBe "stable-name"
+   }
+
+   test("null should be stable on all platforms") {
+      StableIdents.getStableIdentifier(null) shouldBe "<null>"
+   }
+})


### PR DESCRIPTION
## Problem

In `StableIdents.getStableIdentifier(t)`, the `when` had this branch ordering:

```kotlin
t == null -> "<null>"
t::class.hasAnnotation<IsStableType>() || platform != Platform.JVM -> t.toString()
t is WithDataTestName -> t.dataTestName()
```

Because `platform != Platform.JVM` was OR-ed into the second branch, on JS/Wasm/Native any value implementing `WithDataTestName` short-circuited to `t.toString()` and the `t is WithDataTestName -> t.dataTestName()` branch was never reached. `WithDataTestName.dataTestName()` is a plain interface method that needs no reflection and should work identically on every platform, so the custom data-test name was silently dropped off-JVM.

## Fix

Split the combined condition and reorder so `WithDataTestName` is handled before the non-JVM short-circuit, preserving the documented precedence (`IsStableType` over `WithDataTestName`):

```kotlin
t == null -> "<null>"
t::class.hasAnnotation<IsStableType>() -> t.toString()
t is WithDataTestName -> t.dataTestName()
platform != Platform.JVM -> t.toString()
else -> { /* JVM-only reflection-based stability analysis */ }
```

- `IsStableType` still short-circuits to `toString()` first (takes precedence over `WithDataTestName`, matching the `WithDataTestName` KDoc).
- `WithDataTestName.dataTestName()` is now invoked on all platforms.
- The genuinely JVM-only, reflection-based data-class stability analysis remains gated behind `platform != Platform.JVM -> t.toString()` for the non-`WithDataTestName`, non-`IsStableType` case.

Minimal change: 2 insertions, 1 deletion, no reformatting.

## Verification

Compilation is verified centrally by the author. The change is a pure branch reordering within an existing `when`; no new symbols or imports are introduced, and `dataTestName()` is already a common-source interface method, so it is available on all targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)