### PR TITLE
Fix dead AssertionError branch in PropertyErrorMessageBuilder (match throwable, not its KClass)

### DIFF
--- a/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/errors/PropertyErrorMessageBuilder.kt
+++ b/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/errors/PropertyErrorMessageBuilder.kt
@@ -42,7 +42,7 @@ data class PropertyErrorMessageBuilder(
       val finalCause = cause
 
       // don't bother to include the exception type if it's AssertionError
-      val causedBy = when (finalCause::class) {
+      val causedBy = when (finalCause) {
          is AssertionError -> "Caused by: ${finalCause.message?.trim()}"
          else -> "Caused by ${finalCause::class.simpleName}: ${finalCause.message?.trim()}"
       }


### PR DESCRIPTION
## Problem

In `PropertyErrorMessageBuilder.build()` the `causedBy` message was computed with:

```kotlin
val causedBy = when (finalCause::class) {
   is AssertionError -> "Caused by: ${finalCause.message?.trim()}"
   else -> "Caused by ${finalCause::class.simpleName}: ${finalCause.message?.trim()}"
}
```

`finalCause::class` is a `KClass`, which is never an instance of `AssertionError`, so the `is AssertionError` branch was dead code. As a result the exception type prefix was always included, directly contradicting the adjacent comment "don't bother to include the exception type if it's AssertionError".

## Fix

Match the throwable instance itself instead of its `KClass`:

```kotlin
val causedBy = when (finalCause) {
   is AssertionError -> "Caused by: ${finalCause.message?.trim()}"
   else -> "Caused by ${finalCause::class.simpleName}: ${finalCause.message?.trim()}"
}
```

Now an `AssertionError` cause correctly omits the type prefix, matching the intent of the comment and mirroring the sibling logic in `errors.kt` (`ErrorBuilder.build`, which special-cases `"AssertionError"`). Only this one expression was changed; no other edits or reformatting.

## Verification

Compilation is verified centrally by the author. The change is a single-line, behavior-preserving correction of a `when` subject (from `finalCause::class` to `finalCause`); both branch bodies are unchanged and remain type-correct since `finalCause` is a `Throwable`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)