### PR TITLE
beEqualToUsingFields failure message should list the fields actually compared

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -136,7 +136,7 @@ fun <T : Any, V: Any> beEqualToUsingFields(other: V, vararg fields: KProperty<*>
       val fieldsToBeConsidered: List<KProperty<*>> = fields.toList().takeUnless { it.isEmpty() }
          ?: value::class.memberProperties.filter { it.visibility == KVisibility.PUBLIC }
       val failed = checkEqualityOfFields(fieldsToBeConsidered, value, other)
-      val fieldsString = fields.joinToString(", ", "[", "]") { it.name }
+      val fieldsString = fieldsToBeConsidered.joinToString(", ", "[", "]") { it.name }
 
       return MatcherResult(
          failed.isEmpty(),


### PR DESCRIPTION
## Problem

`beEqualToUsingFields` (in `kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt`) accepts an optional `fields` vararg. When called with no explicit fields, `fieldsToBeConsidered` correctly falls back to all public member properties and those are what get compared. However, the failure message's `fieldsString` was built from the raw (empty) `fields` vararg, so the message printed `using fields []` even though every public field was actually compared. This is misleading.

## Fix

Build `fieldsString` from `fieldsToBeConsidered` instead of `fields`:

```kotlin
val fieldsString = fieldsToBeConsidered.joinToString(", ", "[", "]") { it.name }
```

This is a one-line change to `beEqualToUsingFields` only. The visually similar line in `beEqualToIgnoringFields` (where `fields` correctly represents the ignored fields) is intentionally left unchanged. Nothing else was modified.

## Verification

Compilation is verified centrally by the author. The change is a pure message-string fix that uses the already-computed `fieldsToBeConsidered` list; matching/comparison behavior is unchanged. With the fix, a no-fields invocation now reports the actual public fields compared (e.g. `using fields [id, description]`) instead of `using fields []`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)