### PR TITLE
MapEq failure message should compute differing keys via the Eq typeclass, not raw ==

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt
@@ -21,12 +21,12 @@ internal object MapEq : Eq<Map<*, *>> {
       try {
          val haveUnequalKeys = EqCompare.compare(actual.keys, expected.keys, context)
          return when (haveUnequalKeys) {
-            is EqResult.Failure -> EqResult.Failure { generateError(actual, expected) }
+            is EqResult.Failure -> EqResult.Failure { generateError(actual, expected, context) }
             EqResult.Success -> {
                val hasDifferentValue = actual.keys.any { key ->
                   EqCompare.compare(actual[key], expected[key], context) is EqResult.Failure
                }
-               if (hasDifferentValue) EqResult.Failure { generateError(actual, expected) }
+               if (hasDifferentValue) EqResult.Failure { generateError(actual, expected, context) }
                else EqResult.Success
             }
          }
@@ -36,17 +36,19 @@ internal object MapEq : Eq<Map<*, *>> {
    }
 }
 
-private fun generateError(actual: Map<*, *>?, expected: Map<*, *>?): Throwable {
+private fun generateError(actual: Map<*, *>?, expected: Map<*, *>?, context: EqContext): Throwable {
    return AssertionErrorBuilder.create()
-      .withMessage(buildFailureMessage(actual, expected))
+      .withMessage(buildFailureMessage(actual, expected, context))
       .withValues(Expected(print(expected)), Actual(print(actual)))
       .build()
 }
 
-private fun buildFailureMessage(actual: Map<*, *>?, expected: Map<*, *>?): String {
+private fun buildFailureMessage(actual: Map<*, *>?, expected: Map<*, *>?, context: EqContext): String {
    return when {
       actual != null && expected != null -> {
-         val keysHavingDifferentValues = actual.keys.filterNot { expected[it] == actual[it] }
+         val keysHavingDifferentValues = actual.keys.filter {
+            EqCompare.compare(actual[it], expected[it], context) is EqResult.Failure
+         }
          "Values differed at keys ${keysHavingDifferentValues.joinToString(limit = AssertionsConfig.mapDiffLimit)}\n"
       }
 


### PR DESCRIPTION
## Problem

`MapEq` decides pass/fail per value using `EqCompare.compare(actual[key], expected[key], context)` (a deep, `Eq`-typeclass comparison). However, the failure message built in `buildFailureMessage` recomputed the differing keys with raw structural equality `expected[it] == actual[it]`.

These two paths disagree for arrays and other types with identity-based `equals`:
- A key whose values are deeply equal (e.g. two equal `IntArray`s) compares `false` under `==` and would be wrongly reported as differing.
- A key whose values differ but happen to be `==`-equal by reference/identity quirks could be omitted.

The result is a "Values differed at keys ..." message that can list keys that are actually equal and miss keys that genuinely differ — i.e. inconsistent with the assertion's own pass/fail decision.

## Fix

In `kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/MapEq.kt`, thread the existing `EqContext` through `generateError` and `buildFailureMessage`, and compute the differing keys using the same comparison used for pass/fail:

```kotlin
val keysHavingDifferentValues = actual.keys.filter {
   EqCompare.compare(actual[it], expected[it], context) is EqResult.Failure
}
```

A key is now considered "different" iff the same `EqCompare.compare(...)` that drives the failure returns an `EqResult.Failure` for that key. The message format ("Values differed at keys ...") and the `AssertionsConfig.mapDiffLimit` are unchanged. The change is confined to the failure-message path; the pass/fail logic was already correct and is untouched.

## Verification

Compilation is verified centrally by the author (no build/test run here). The change is minimal and type-correct: `generateError`/`buildFailureMessage` now take the `EqContext` already in scope at every call site inside the `try` block, and reuse the existing `EqCompare`/`EqResult` imports already present in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)