### PR TITLE
Fix inverted Path/File shouldNotEqualJson (config-block overload)

### DIFF
--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt
@@ -39,7 +39,8 @@ infix fun Path.shouldNotEqualJson(@Language("json") expected: String): Path {
 infix fun Path.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): Path {
    val options = CompareJsonOptions()
    val expected = configureAndProvideExpected(options)
-   this shouldNot (exist() and aFile() and equalJson(expected, options).contramap<Path> { it.readText() }.invert())
+   this should (exist() and aFile())
+   this.readText() shouldNot equalJson(expected, options)
    return this
 }
 


### PR DESCRIPTION
## Problem

The config-block overload `Path.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String)` in `kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt` was implemented as:

```kotlin
this shouldNot (exist() and aFile() and equalJson(expected, options).contramap<Path> { it.readText() }.invert())
```

Since `x shouldNot M` is equivalent to `x should M.invert()`, the `equalJson` matcher was inverted twice (once via `.invert()`, once via `shouldNot`) and the composite `and` chain negated. The net effect was an assertion that **passed when the JSON WAS equal** — the exact opposite of intended. It also negated the `exist()` / `aFile()` checks, so a passing case could mean the file simply did not exist.

The `File.*` config-block overload and `shouldNotEqualSpecifiedJson` delegate to this overload, so both were affected transitively.

## Fix

Mirror the structure of the correct plain-string overload immediately above (`Path.shouldNotEqualJson(expected: String)`): assert existence and file-ness positively, then assert the content does NOT equal the expected JSON.

```kotlin
this should (exist() and aFile())
this.readText() shouldNot equalJson(expected, options)
```

This now correctly fails when the file exists, is a file, and its content equals the expected JSON; it passes only when the content does NOT equal. All required imports (`should`, `shouldNot`, `exist`, `aFile`, `and`) were already present. Only the config-block `Path.shouldNotEqualJson` overload in this file was changed.

## Verification

Compilation is verified centrally by the author. Logic review: the new form is identical in shape to the proven-correct plain-string `shouldNotEqualJson` overload in the same file, with the positive `exist()`/`aFile()` assertions retained from the original intent. The double-inversion is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)