### PR TITLE
Make FailFastScopeTracker thread-safe for concurrent test execution

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/FailFastScopeTracker.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/FailFastScopeTracker.kt
@@ -1,6 +1,9 @@
 package io.kotest.engine.test
 
 import io.kotest.core.descriptors.Descriptor
+import io.kotest.engine.spec.threadSafeMap
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -13,18 +16,26 @@ import kotlin.coroutines.CoroutineContext
  * This lives in the coroutine context rather than in [io.kotest.engine.spec.interceptor.SpecContext]
  * so that each spec gets an isolated tracker without coupling state to the spec context.
  */
+@OptIn(ExperimentalAtomicApi::class)
 internal class FailFastScopeTracker : CoroutineContext.Element {
 
    companion object Key : CoroutineContext.Key<FailFastScopeTracker>
 
    override val key: CoroutineContext.Key<*> = Key
 
-   // null key = spec/project-level failfast (no test ancestor owns the scope)
-   private val failedScopes = mutableSetOf<Descriptor.TestDescriptor?>()
+   // A single tracker instance is shared across tests that may run concurrently (testExecutionMode
+   // concurrency > 1), so the backing storage must be thread-safe to avoid races between markFailed
+   // and hasFailed. A concurrent map (used here as a set via its keys) provides this; since it does
+   // not permit null keys, the spec/project-level scope (null) is tracked separately by an atomic.
+   private val failedScopes = threadSafeMap<Descriptor.TestDescriptor, Unit>()
+
+   // tracks the spec/project-level failfast scope (no test ancestor owns the scope)
+   private val specLevelFailed = AtomicBoolean(false)
 
    fun markFailed(scope: Descriptor.TestDescriptor?) {
-      failedScopes.add(scope)
+      if (scope == null) specLevelFailed.store(true) else failedScopes[scope] = Unit
    }
 
-   fun hasFailed(scope: Descriptor.TestDescriptor?): Boolean = scope in failedScopes
+   fun hasFailed(scope: Descriptor.TestDescriptor?): Boolean =
+      if (scope == null) specLevelFailed.load() else failedScopes.containsKey(scope)
 }


### PR DESCRIPTION
## Problem

`FailFastScopeTracker` (`kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/test/FailFastScopeTracker.kt`) backed its failed-scope set with a plain `mutableSetOf()`. A single tracker instance is shared across tests that may run concurrently (`testExecutionMode` concurrency > 1), so `markFailed` (add) and `hasFailed` (contains) race on a non-synchronized set, risking `ConcurrentModificationException` or lost updates.

## Fix

Replaced the plain set with the engine's existing thread-safe idiom rather than introducing any new dependency:

- `failedScopes` is now backed by `threadSafeMap<Descriptor.TestDescriptor, Unit>()` — the same `expect/actual threadSafeMap()` helper (JVM actual = `ConcurrentHashMap`) already used in `io.kotest.engine.spec.TestResults`. The map's keys act as a thread-safe set.
- Because concurrent maps do not permit null keys, the special spec/project-level scope (`null`) is tracked separately with `kotlin.concurrent.atomics.AtomicBoolean` — the same atomics API already used in `io.kotest.core.factory.FactoryId`.

`markFailed` / `hasFailed` signatures and the `CoroutineContext.Element` structure are unchanged.

## Verification

Compilation is verified centrally by the author. The fix uses only idioms already present in the engine's `commonMain` (`threadSafeMap`, `kotlin.concurrent.atomics.AtomicBoolean`), so it remains valid across all KMP targets. Behavior is preserved: a scope is "failed" iff it was previously marked, with the null scope handled by the atomic flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)