### PR TITLE
Fix FailureFirstSorter comparator violating the Comparator contract

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/sorters.jvm.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/spec/sorters.jvm.kt
@@ -21,7 +21,7 @@ actual val FailureFirstSorter: SpecSorter = object : SpecSorter {
             val bfailed = classnames.contains(b.kclass.qualifiedName)
             when {
                afailed && !bfailed -> -1
-               bfailed -> 1
+               !afailed && bfailed -> 1
                else -> a.kclass.bestName().compareTo(b.kclass.bestName())
             }
          }


### PR DESCRIPTION
## Problem

The `FailureFirstSorter` comparator in `sorters.jvm.kt` ordered previously-failed specs first. Its second branch was:

```kotlin
when {
   afailed && !bfailed -> -1
   bfailed -> 1
   else -> a.kclass.bestName().compareTo(b.kclass.bestName())
}
```

When **both** `a` and `b` had previously failed, `compare(a, b)` returned `1` (via the `bfailed -> 1` branch) and `compare(b, a)` also returned `1`. A consistent comparator requires `compare(a, b)` and `compare(b, a)` to have opposite signs (antisymmetry). This violation can cause the JVM's TimSort to throw `IllegalArgumentException: Comparison method violates its general contract!`, aborting the entire test run.

## Fix

Change the second branch condition so the both-failed case no longer short-circuits and instead falls through to the lexicographic tie-breaker:

```kotlin
when {
   afailed && !bfailed -> -1
   !afailed && bfailed -> 1
   else -> a.kclass.bestName().compareTo(b.kclass.bestName())
}
```

Now only one spec being failed produces a non-zero ordering; when both (or neither) failed, ordering is decided lexicographically, which is itself a valid total order. This restores a consistent comparator. Single-line change, no other modifications.

## Verification

- Reviewed the comparator logic: failed-before-unfailed ordering is preserved (`-1`/`1` branches still fire only when exactly one spec failed); both-failed and neither-failed cases now resolve via the lexicographic `bestName()` comparison, which is antisymmetric and transitive.
- Compilation is verified centrally by the author (no local build/test was run per instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)