### PR TITLE
Actually register shouldBe with Power Assert (functions.add, not functions.map)

### DIFF
--- a/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
+++ b/kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt
@@ -125,7 +125,7 @@ abstract class KotestPlugin : Plugin<Project> {
       project.pluginManager.withPlugin(POWER_ASSERT_PLUGIN_ID) {
          project.extensions.configure(PowerAssertGradleExtension::class.java) {
             // we can add new functions to this later without requiring users to make changes
-            functions.map { it + "io.kotest.matchers.shouldBe" }
+            functions.add("io.kotest.matchers.shouldBe")
          }
 
          // we add the assertions library for users to simplify configuration


### PR DESCRIPTION
## Problem

In `KotestPlugin.configurePowerAssert`, when Power Assert is enabled the plugin tried to add Kotest's `shouldBe` to the set of functions that Power Assert instruments:

```kotlin
project.extensions.configure(PowerAssertGradleExtension::class.java) {
   functions.map { it + "io.kotest.matchers.shouldBe" }
}
```

Here `functions` is a Gradle `SetProperty<String>` on `PowerAssertGradleExtension`. `SetProperty.map { }` returns a new transformed `Provider` and does **not** mutate the underlying `SetProperty`. The returned provider is immediately discarded, so `io.kotest.matchers.shouldBe` was never actually registered with Power Assert. Users who enabled `enablePowerAssert` therefore got no Power Assert instrumentation of `shouldBe` failures.

## Fix

Use `SetProperty.add`, which mutates the property in place:

```kotlin
functions.add("io.kotest.matchers.shouldBe")
```

This is the single-line, minimal change in `kotest-framework/kotest-framework-plugin-gradle/src/main/kotlin/io/kotest/framework/gradle/KotestPlugin.kt` (line ~128). No other code was touched.

## Verification

- Confirmed `functions` is the `SetProperty<String>` on `PowerAssertGradleExtension` and that `.map` on a Gradle provider/property is non-mutating, whereas `.add` mutates the collection property.
- Compilation is verified centrally by the author (no local build was run per instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)