### PR TITLE
Avoid unsafe cast of throwable cause in Allure spec-init failure reporting

### DIFF
--- a/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
+++ b/kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt
@@ -177,7 +177,7 @@ class AllureWriter(private val jvmSuiteName: String?) {
       allure.scheduleTestCase(result)
       allure.startTestCase(uuid.toString())
 
-      val instanceError = (t.cause as InvocationTargetException).targetException
+      val instanceError = (t.cause as? InvocationTargetException)?.targetException ?: t.cause ?: t
 
       val details = StatusDetails()
       details.message = instanceError?.message ?: "Unknown error"


### PR DESCRIPTION
## Problem

In `AllureWriter.allureResultSpecInitFailure` (kotest-extensions/kotest-extensions-allure/src/jvmMain/kotlin/io/kotest/extensions/allure/AllureWriter.kt, around line 180), the spec-initialization error was unwrapped with an unchecked cast:

```kotlin
val instanceError = (t.cause as InvocationTargetException).targetException
```

The cause is not guaranteed to be an `InvocationTargetException` — it may be `null` or some other throwable type. When it is not, this line throws an NPE or `ClassCastException` *inside the error reporter itself*, which masks the original spec-init failure and produces a confusing, unrelated error.

## Fix

Safely unwrap the cause using a safe cast with a sensible fallback to the original throwable, so the reporter never throws here:

```kotlin
val instanceError = (t.cause as? InvocationTargetException)?.targetException ?: t.cause ?: t
```

- Normal `InvocationTargetException` case is unchanged: it still resolves to `targetException`.
- When the cause is a different type, that cause is reported directly.
- When there is no cause, the original throwable `t` is reported.

`instanceError` is now a non-null `Throwable`, which the existing downstream usages (`instanceError?.message`, `instanceError.stackTrace?`) handle correctly. The change is a single line; no reformatting or unrelated edits.

## Verification

Compilation is verified centrally by the author. The change is a minimal, type-safe substitution within the same expression and preserves behaviour for the standard `InvocationTargetException` path while eliminating the NPE/ClassCastException risk for null/other cause types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)