### PR TITLE
HtmlReporter should read test results from the configured build dir

### DIFF
--- a/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlReporter.kt
+++ b/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlReporter.kt
@@ -62,7 +62,12 @@ class HtmlReporter(
    }
 
    private fun getTestResults(): Sequence<File> {
-      return File(DEFAULT_RESULTS_LOCATION)
+      val buildDir = System.getProperty(BUILD_DIR_KEY)
+      val resultsDir = if (buildDir != null)
+         Paths.get(buildDir).resolve("test-results/test").toFile()
+      else
+         File(DEFAULT_RESULTS_LOCATION)
+      return resultsDir
          .walk()
          .filter { Files.isRegularFile(it.toPath())}
          .filter { it.toString().endsWith(".xml") }


### PR DESCRIPTION
## Problem

`HtmlReporter.getTestResults()` always walked the hardcoded `DEFAULT_RESULTS_LOCATION` (`"./build/test-results/test"`), ignoring the `gradle.build.dir` system property (`BUILD_DIR_KEY`) that `outputDir()` *does* honour. As a result, reads (test-results XML) and writes (HTML report) used inconsistent base directories. When the Gradle build dir is non-default, the reporter wrote the report under the configured build dir but read the JUnit XML from `./build/test-results/test`, where nothing existed — producing an empty report.

## Fix

`getTestResults()` now mirrors the property-reading logic in `outputDir()`: when `gradle.build.dir` is set it resolves the results directory as `<buildDir>/test-results/test`, otherwise it falls back to `DEFAULT_RESULTS_LOCATION`. The existing walk/filter logic (regular files, `.xml` suffix) is unchanged.

```kotlin
private fun getTestResults(): Sequence<File> {
   val buildDir = System.getProperty(BUILD_DIR_KEY)
   val resultsDir = if (buildDir != null)
      Paths.get(buildDir).resolve("test-results/test").toFile()
   else
      File(DEFAULT_RESULTS_LOCATION)
   return resultsDir
      .walk()
      .filter { Files.isRegularFile(it.toPath())}
      .filter { it.toString().endsWith(".xml") }
}
```

## Verification

Single-file change scoped to `HtmlReporter.kt`. The new branch resolves identically to the old behaviour when `gradle.build.dir` is unset, and now correctly points reads at the configured build dir when it is set — matching where the report is written. Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)