### PR TITLE
HtmlWriter should flag error-only result rows with the failure CSS class

### DIFF
--- a/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlWriter.kt
+++ b/kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlWriter.kt
@@ -93,7 +93,7 @@ class HtmlWriter(
          row.addContent(Element("td").setContent(Text(skipped.toString())))
 
          if ((errors + failures + skipped) == 0) row.setAttribute("class", "success")
-         if (failures > 0) row.setAttribute("class", "failure")
+         if (failures > 0 || errors > 0) row.setAttribute("class", "failure")
 
          table.addContent(row)
       }


### PR DESCRIPTION
## Problem

In `HtmlWriter.generateTestSummaryTable` the summary row's status CSS class was assigned as follows:

```kotlin
if ((errors + failures + skipped) == 0) row.setAttribute("class", "success")
if (failures > 0) row.setAttribute("class", "failure")
```

A row representing a class with `errors > 0` but `failures == 0` did not satisfy either branch: the success branch is skipped because `errors + failures + skipped != 0`, and the failure branch is skipped because `failures == 0`. As a result, error-only result rows received **no** status class and were not visually flagged in the HTML report, even though they represent a problem.

## Fix

Treat errors the same as failures for the status-class decision in `generateTestSummaryTable`:

```kotlin
if (failures > 0 || errors > 0) row.setAttribute("class", "failure")
```

This is the minimal change. The success branch is left unchanged (it still only applies when there are zero errors, failures, and skipped). Rows with errors but no failures now correctly get the existing `failure` class.

File: `kotest-extensions/kotest-extensions-htmlreporter/src/jvmMain/kotlin/io/kotest/extensions/htmlreporter/HtmlWriter.kt` (line 96).

## Verification

Logic walkthrough of the status-class assignment after the change:
- No errors/failures/skipped -> `success` (unchanged).
- `failures > 0` -> `failure` (unchanged).
- `errors > 0`, `failures == 0` -> now `failure` (previously no class).
- `skipped > 0` only -> no status class (unchanged; out of scope for this fix).

The reused class name `failure` matches the only other failure styling used by the reporter (see `generateTestClassTable`). Compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)