### PR TITLE
Fix AbstractPackageConfig KDoc: implementation class must be named PackageConfig

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/AbstractPackageConfig.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/AbstractPackageConfig.kt
@@ -10,10 +10,10 @@ import io.kotest.engine.concurrency.TestExecutionMode
 import kotlin.time.Duration
 
 /**
- * Concrete implementations of this class with the name `KotestPackageConfig` will be detected at runtime and
+ * Concrete implementations of this class with the name `PackageConfig` will be detected at runtime and
  * used to configure the test engine for specs running in the same or a child package of that spec.
  *
- * For example, creating an instance `com.sksamuel.foo.KotestPackageConfig` will
+ * For example, creating an instance `com.sksamuel.foo.PackageConfig` will
  * mean any tests residing in packages `com.sksamuel.foo`, `com.sksamuel.foo.bar`, `com.sksamuel.foo.baz` and
  * so on will have this config applied.
  *


### PR DESCRIPTION
## Problem

The class KDoc of `AbstractPackageConfig` stated that concrete implementations named `KotestPackageConfig` (e.g. `com.sksamuel.foo.KotestPackageConfig`) are auto-detected at runtime. This is incorrect: the runtime loader `PackageConfigLoader` derives the expected FQN as `"<package>.PackageConfig"`:

```kotlin
private fun packageConfigName(packageName: String) = "$packageName.PackageConfig"
```

So a user following the KDoc would name their class `KotestPackageConfig` and it would never be detected.

## Fix

Documentation-only change in the KDoc of `kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/config/AbstractPackageConfig.kt`:

- `KotestPackageConfig` -> `PackageConfig` in the detection sentence (line 13).
- Example FQN `com.sksamuel.foo.KotestPackageConfig` -> `com.sksamuel.foo.PackageConfig` (line 16).

No code was changed.

## Verification

- Confirmed the loader name derivation in `kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/config/PackageConfigLoader.kt` (`"$packageName.PackageConfig"`).
- Grep confirms no remaining `KotestPackageConfig` occurrences in the file.
- This is a comment/KDoc-only edit; compilation is verified centrally by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)