### PR TITLE
ci: set fail-fast: false on all workflow matrices

### DIFF
--- a/.github/workflows/pr_main.yml
+++ b/.github/workflows/pr_main.yml
@@ -62,6 +62,9 @@ jobs:
       if: ${{ github.repository == 'kotest/kotest' && needs.determine-workflows-to-run.outputs.run_tests == 'true' }}
       needs: [ determine-workflows-to-run, validate-api ]
       strategy:
+         # don't cancel the other matrix legs when one fails, so a single (often flaky)
+         # platform failure doesn't mask the real status of the rest
+         fail-fast: false
          matrix:
             include:
                # JVM-only


### PR DESCRIPTION
## Problem

Several CI matrices (PR `gradle-check`, master `build-primary`, plus the release/eap/intellij workflows) ran with the default `fail-fast: true`. When one matrix leg fails — frequently a flaky JS/Wasm browser disconnect, Android emulator, native, or IntelliJ Maven-resolution failure — the remaining legs are **cancelled**. A single flaky job then paints the whole run red, masks the real status of the other platforms, and (on release/master) cancels the build/publish of the others.

## Change

Set `fail-fast: false` on **every** workflow matrix that lacked it. After this change all matrix strategies across `.github/workflows/` use `fail-fast: false`:

- `pr_main.yml` (gradle-check), `master.yml` (build-primary)
- `master-eap.yml`, `release_base.yml`, `release_intellij_plugin.yml`
- (already `false`: `codeql.yml`, `pr_intellij_plugin.yml`, `master_intellij_plugin.yml`, `release_all.yml`, `test-kotest-examples.yml`)

Each platform leg now runs to completion independently. Verified all workflow YAML is valid and every matrix strategy resolves to `fail-fast: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)