### PR TITLE
Path containNFiles should fail gracefully on a non-directory instead of throwing

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/nfiles.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/nfiles.kt
@@ -13,10 +13,11 @@ infix fun Path.shouldNotContainNFiles(n: Int) = this shouldNot containNFiles(n)
 
 fun containNFiles(n: Int): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult {
-      val count = Files.newDirectoryStream(value).use { it.count() }
+      val isDir = value.isDirectory()
+      val count = if (isDir) Files.newDirectoryStream(value).use { it.count() } else 0
       return MatcherResult(
-         value.isDirectory() && count == n,
-         { "$value should be a directory and contain $n files (isDir = ${value.isDirectory()}; file count = $count)" },
+         isDir && count == n,
+         { "$value should be a directory and contain $n files (isDir = $isDir; file count = $count)" },
          { "$value should not be a directory containing $n files" }
       )
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/paths/PathMatchersTest.kt
@@ -92,5 +92,26 @@ class PathMatchersTest : FunSpec({
 
          fs.close()
       }
+
+      test("should fail gracefully for a non-directory (isDir = false) instead of throwing") {
+         val fs = Jimfs.newFileSystem(Configuration.unix())
+
+         // a regular file is not a directory
+         val file = fs.getPath("/file.txt")
+         Files.createFile(file)
+         // a non-directory does not contain N files, so shouldNotContainNFiles passes
+         // (before the fix this threw NotDirectoryException from newDirectoryStream)
+         file.shouldNotContainNFiles(0)
+         file.shouldNotContainNFiles(3)
+         // shouldContainNFiles produces a clean failed assertion, not a thrown IOException
+         shouldThrow<AssertionError> { file.shouldContainNFiles(0) }
+
+         // a path that does not exist is likewise not a directory
+         val missing = fs.getPath("/does-not-exist")
+         missing.shouldNotContainNFiles(0)
+         shouldThrow<AssertionError> { missing.shouldContainNFiles(1) }
+
+         fs.close()
+      }
    }
 })


### PR DESCRIPTION
## Problem

The `Path`-based `containNFiles(n)` matcher in `kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/nfiles.kt` unconditionally called `Files.newDirectoryStream(value).use { it.count() }`. When `value` is a regular file or does not exist, `newDirectoryStream` throws `NotDirectoryException` / `NoSuchFileException`. As a result, assertions such as `regularFile.shouldNotContainNFiles(3)` threw an exception instead of passing cleanly.

## Fix

Only open the directory stream when `value.isDirectory()`. Otherwise the file count defaults to `0` and the matcher returns a normal failed/negated `MatcherResult` (no exception). This mirrors the graceful, null-safe approach used by the sibling `File`-based `containNFiles` in `io/kotest/matchers/file/matchers.kt`, which checks `isDirectory` and never throws. The `isDirectory()` result is now computed once and reused in both the predicate and the failure message (which already referenced `isDir`).

## Verification

Compilation is verified centrally by the parent build. The change is minimal and JVM-only, preserving existing message wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)