### PR TITLE
Path haveExtension/haveNameWithoutExtension should not NPE on root paths

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/names.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/names.kt
@@ -9,12 +9,15 @@ import java.nio.file.Path
 fun Path.shouldHaveExtension(vararg exts: String) = this should haveExtension(*exts)
 fun Path.shouldNotHaveExtension(vararg exts: String) = this shouldNot haveExtension(*exts)
 fun haveExtension(vararg exts: String) = object : Matcher<Path> {
-   override fun test(value: Path) = MatcherResult(
-      exts.any { value.fileName.toString().endsWith(it) },
-      { "Path $value should end with one of ${exts.joinToString(",")}" },
-      {
-         "Path $value should not end with one of ${exts.joinToString(",")}"
-      })
+   override fun test(value: Path): MatcherResult {
+      val filename = value.fileName?.toString() ?: ""
+      return MatcherResult(
+         exts.any { filename.endsWith(it) },
+         { "Path $value should end with one of ${exts.joinToString(",")}" },
+         {
+            "Path $value should not end with one of ${exts.joinToString(",")}"
+         })
+   }
 }
 
 
@@ -22,7 +25,7 @@ infix fun Path.shouldHaveNameWithoutExtension(name: String) = this should haveNa
 infix fun Path.shouldNotHaveNameWithoutExtension(name: String) = this shouldNot haveNameWithoutExtension(name)
 fun haveNameWithoutExtension(name: String) = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult {
-      val filename = value.fileName.toString()
+      val filename = value.fileName?.toString() ?: ""
       val actual = if (filename.contains(".")) filename.split('.').dropLast(1).joinToString(".") else filename
       return MatcherResult(
          actual == name,


### PR DESCRIPTION
## Problem

`haveExtension` and `haveNameWithoutExtension` in `kotest-assertions-core` dereference `value.fileName.toString()`. However, `java.nio.file.Path.getFileName()` returns `null` for a root path (e.g. `Paths.get("/")`). This caused a `NullPointerException` to be thrown instead of producing a clean failed `MatcherResult`.

This is inconsistent with the `File`-based equivalents, which use `File.name` (an empty string for roots) and therefore fail gracefully.

## Fix

In `kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/names.kt`, both matchers now treat a null `fileName` as an empty string via `val filename = value.fileName?.toString() ?: ""`, and use that local for the extension/name checks. Behaviour is unchanged for non-root paths.

## Verification

Compilation is verified centrally by the parent build. The change is a minimal null-safety fix preserving identical behaviour for all non-root paths; for root paths the matchers now return a failed `MatcherResult` (filename treated as empty) rather than throwing an NPE, matching the `File`-based matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)