### PR TITLE
FloatToleranceMatcher (plusOrMinus) should handle infinite values like Double

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/FloatMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/FloatMatchers.kt
@@ -9,7 +9,12 @@ infix fun Float.plusOrMinus(tolerance: Float): FloatToleranceMatcher = FloatTole
 class FloatToleranceMatcher(private val expected: Float, private val tolerance: Float) : Matcher<Float> {
 
   override fun test(value: Float): MatcherResult {
-    return if (expected.isNaN() && value.isNaN()) {
+    return if (expected.isInfinite()) {
+       MatcherResult(
+          value == expected,
+          { "$value should be equal to $expected" },
+          { "$value should not be equal to $expected" })
+    } else if (expected.isNaN() && value.isNaN()) {
        println("[WARN] By design, Float.Nan != Float.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776")
        MatcherResult(
           false,


### PR DESCRIPTION
## Problem

`FloatToleranceMatcher` only special-cased NaN. For infinite expected values it fell through to the finite tolerance path and computed `abs(value - expected)`. Since `abs(inf - inf)` evaluates to `NaN`, and `NaN <= tolerance` is `false`, an assertion like:

```kotlin
Float.POSITIVE_INFINITY shouldBe (Float.POSITIVE_INFINITY plusOrMinus 1f)
```

wrongly **failed**, even though both values are equal infinities. The Double counterpart (`ToleranceMatcher` in `io/kotest/matchers/doubles/Tolerance.kt`) already guards against this with an `expected.isInfinite()` check that compares using `value == expected`.

## Fix

Added the equivalent infinite-value guard to `FloatToleranceMatcher.test`, placed before the NaN handling and finite tolerance path, mirroring the Double implementation:

```kotlin
return if (expected.isInfinite()) {
   MatcherResult(
      value == expected,
      { "$value should be equal to $expected" },
      { "$value should not be equal to $expected" })
} else if (expected.isNaN() && value.isNaN()) {
   ...
```

This makes two equal infinities match, while differing infinities (`+inf` vs `-inf`) and finite-vs-infinite comparisons correctly fail via `value == expected`. The NaN handling and finite tolerance path are unchanged.

File: `kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/FloatMatchers.kt`

## Verification

Compilation is verified centrally by the parent build. The change is a minimal, direct port of the already-tested Double `ToleranceMatcher` infinite guard, so behavior matches the Double semantics: equal infinities pass, differing/finite-vs-infinite combinations fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)