### PR TITLE
LazyJvmAssertionError should compute its message lazily (use a getter)

### DIFF
--- a/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.jvm.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.jvm.kt
@@ -17,7 +17,7 @@ private class LazyJvmAssertionError(messageFn: () -> String) : AssertionError() 
    /** Skip the expensive native fillInStackTrace call - stack traces are never shown for per-element errors. */
    override fun fillInStackTrace(): Throwable = this
 
-   override val message: String = lazyMessage
+   override val message: String get() = lazyMessage
 }
 
 /**


### PR DESCRIPTION
## Problem

`LazyJvmAssertionError` (in `kotest-assertions-shared/src/jvmMain/kotlin/io/kotest/assertions/AssertionErrorBuilder.jvm.kt`) is designed to compute its potentially expensive failure message lazily, only when `.message` is first accessed. This matters for inspectors in `InspectorHard` mode, where errors are constructed per element but the message is only needed when the inspector itself fails.

However, the class declared:

```kotlin
override val message: String = lazyMessage
```

This is a property **initializer**, which forces the `by lazy` value at construction time, defeating the optimization entirely. Every per-element error paid the message-building cost regardless of whether the message was ever read.

## Fix

Changed the declaration to a getter so the lazy value is only realized on first access:

```kotlin
override val message: String get() = lazyMessage
```

This matches the existing pattern already used in the nonjvm sibling (`AssertionErrorBuilder.nonjvm.kt`, line 6). Only that single declaration was changed; no other modifications or reformatting.

## Verification

Compilation is verified centrally by the parent build. The change is a one-line, behavior-preserving fix that aligns the JVM implementation with the already-correct nonjvm sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)