### PR TITLE
Fix inverted kotest.listener.spring.ignore.warning boolean (final-class warning)

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringJavaCompatibility.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringJavaCompatibility.kt
@@ -73,5 +73,5 @@ internal object SpringJavaCompatibility {
 
    private val ignoreFinalWarning =
       ignoreSpringListenerOnFinalClassWarning ||
-         !System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
+         System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
 }

--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringTestExtension.kt
@@ -113,5 +113,5 @@ class SpringTestExtension(private val mode: SpringTestLifecycleMode = SpringTest
 
    private val ignoreFinalWarning =
       ignoreSpringListenerOnFinalClassWarning ||
-         !System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
+         System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
 }


### PR DESCRIPTION
## Problem

In both `SpringJavaCompatibility.kt` and `SpringTestExtension.kt`, the `ignoreFinalWarning` flag was computed as:

```kotlin
ignoreSpringListenerOnFinalClassWarning ||
   !System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
```

The leading `!` inverted the intended meaning. With the default property value of `"false"`, `!false` evaluates to `true`, so the final-class warning was **suppressed by default**. Worse, explicitly setting the property to `"true"` (to ignore the warning) actually **re-enabled** the warning. The behavior was the exact opposite of what the property name implies.

## Fix

Removed the erroneous `!` negation in both files so the expression reads:

```kotlin
ignoreSpringListenerOnFinalClassWarning ||
   System.getProperty(Properties.SPRING_IGNORE_WARNING, "false").toBoolean()
```

Now the warning is shown by default and is only suppressed when `ignoreSpringListenerOnFinalClassWarning` is set or the system property is set to `true`. This is a one-character change per file with no other modifications.

## Verification

Compilation is verified centrally by the parent build (no gradle/tests run locally). The change is a minimal logic correction with no API or signature impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)