### PR TITLE
Fix leftover-seconds in console total-time summary

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/ConsoleTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/ConsoleTestEngineListener.kt
@@ -123,8 +123,8 @@ class ConsoleTestEngineListener : AbstractTestEngineListener() {
 
       val str = buildString {
          append("Time:    ")
-         if (duration.inWholeSeconds > 60)
-            append(consoleRenderer.bold("${duration.inWholeMinutes}m ${duration.div(60).inWholeSeconds}s"))
+         if (duration.inWholeSeconds >= 60)
+            append(consoleRenderer.bold("${duration.inWholeMinutes}m ${duration.inWholeSeconds % 60}s"))
          else
             append(consoleRenderer.bold("${duration.inWholeSeconds}s"))
       }


### PR DESCRIPTION
**Problem**

In `ConsoleTestEngineListener.engineFinished`, the total-time summary for runs of a minute or longer computed the seconds component as `duration.div(60).inWholeSeconds`. Dividing the whole duration by 60 yields the number of minutes, not the leftover seconds. As a result a 90-second run printed `1m 1s` instead of `1m 30s` (the seconds part just re-derived the minutes). The threshold also used `> 60`, so an exact 60s run fell into the seconds-only branch and printed `60s`.

**Fix**

In `kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/ConsoleTestEngineListener.kt` (lines ~126-127), changed the seconds component to the remainder `duration.inWholeSeconds % 60` and the branch condition from `> 60` to `>= 60`. The minutes part remains `duration.inWholeMinutes`. No other behaviour was touched.

```
if (duration.inWholeSeconds >= 60)
   append(consoleRenderer.bold("${duration.inWholeMinutes}m ${duration.inWholeSeconds % 60}s"))
```

**Verification**

Manual reasoning over the formatting expression: 90s -> `1m 30s`, 60s -> `1m 0s`, 125s -> `2m 5s`, 59s -> `59s` (seconds-only branch). No existing test encodes the old (incorrect) behaviour; the only test referencing this area (`TestEngineListenerBuilderTest.kt`) exercises the builder, not the time formatting, so no test update was required. Did not run gradle/tests per instructions; parent compiles and tests centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)