### PR TITLE
Keep the ISO-8601 Z designator in the JUnit XML timestamp

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/reports/JUnitXmlReportGenerator.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/reports/JUnitXmlReportGenerator.kt
@@ -7,6 +7,7 @@ import nl.adaptivity.xmlutil.core.XmlVersion
 import nl.adaptivity.xmlutil.serialization.XML
 import kotlin.reflect.KClass
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * @target the Kotlin KMP target this report is generated for. If set will be prefixed to each test name.
@@ -29,10 +30,10 @@ class JUnitXmlReportGenerator(
    }
 
    private fun generate(spec: KClass<*>, tests: Map<TestCase, TestResult>): TestSuite {
+      val now = clock.now()
       // Instant.toString() is ISO-8601 in UTC, always ending in 'Z', and only contains a '.' when there
       // is a sub-second component. Drop fractional seconds while preserving the 'Z' UTC designator.
-      val now = clock.now().toString()
-      val timestamp = if (now.contains('.')) now.substringBefore('.') + "Z" else now
+      val timestamp = Instant.fromEpochSeconds(now.epochSeconds).toString()
       return TestSuite(
          name = spec.bestName(),
          tests = tests.size,

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/reports/JUnitXmlReportGenerator.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/reports/JUnitXmlReportGenerator.kt
@@ -29,13 +29,17 @@ class JUnitXmlReportGenerator(
    }
 
    private fun generate(spec: KClass<*>, tests: Map<TestCase, TestResult>): TestSuite {
+      // Instant.toString() is ISO-8601 in UTC, always ending in 'Z', and only contains a '.' when there
+      // is a sub-second component. Drop fractional seconds while preserving the 'Z' UTC designator.
+      val now = clock.now().toString()
+      val timestamp = if (now.contains('.')) now.substringBefore('.') + "Z" else now
       return TestSuite(
          name = spec.bestName(),
          tests = tests.size,
          failures = tests.filter { it.value.isFailure }.count(),
          errors = tests.filter { it.value.isError }.count(),
          skipped = tests.filter { it.value.isIgnored }.count(),
-         timestamp = clock.now().toString().substringBeforeLast("."), // time without nanos
+         timestamp = timestamp,
          hostname = hostname ?: "",
          time = tests.map { it.value.duration.inWholeMilliseconds / 1_000.0 }.sum(),
          cases = tests.map { (test, result) ->

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/reports/JUnitXmlReportGeneratorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/reports/JUnitXmlReportGeneratorTest.kt
@@ -43,6 +43,26 @@ class JUnitXmlReportGeneratorTest : FunSpec() {
          xml shouldContain """<testcase name="com.sksamuel.kotest.engine.reports.JUnitXmlReportGeneratorTest/successful test" classname="com.sksamuel.kotest.engine.reports.JUnitXmlReportGeneratorTest" time="1.0" />"""
       }
 
+      test("should drop fractional seconds but keep the ISO-8601 Z designator in the timestamp") {
+
+         // a clock whose instant has a sub-second component, so Instant.toString() contains a '.'
+         val clock = FixedClock(Instant.parse("2023-01-01T12:00:00.123Z"))
+         val generator = JUnitXmlReportGenerator(
+            clock = clock,
+            includeStackTraces = true,
+            hostname = "localhost",
+            target = null
+         )
+
+         val testCase = createTestCase("successful test")
+         val testResult = TestResult.Success(1.seconds)
+         val tests = mapOf(testCase to testResult)
+
+         val xml = generator.xml(JUnitXmlReportGeneratorTest::class, tests)
+         xml shouldContain """timestamp="2023-01-01T12:00:00Z""""
+         xml shouldNotContain """timestamp="2023-01-01T12:00:00""""" // must not be left without the Z
+      }
+
       test("should generate XML for failed tests") {
 
          val clock = FixedClock()


### PR DESCRIPTION
**Problem**

In `JUnitXmlReportGenerator`, the `<testsuite>` `timestamp` was computed as `clock.now().toString().substringBeforeLast(".")`. The intent was to drop fractional seconds, but `substringBeforeLast(".")` also strips the trailing `Z` UTC designator whenever a sub-second component is present (e.g. `2023-01-01T12:00:00.123Z` becomes `2023-01-01T12:00:00`). The result is a non-ISO-8601 timestamp in the generated XML report. `kotlin.time.Instant.toString()` is always UTC (ends in `Z`) and only contains a `.` when there is a sub-second component, so the existing whole-second test clock never exercised the buggy path.

**Fix**

Compute the timestamp once and only split on `.` when present, re-appending `Z`:

```kotlin
val now = clock.now().toString()
val timestamp = if (now.contains('.')) now.substringBefore('.') + "Z" else now
```

Whole-second instants are passed through unchanged (still ending in `Z`); sub-second instants drop the fractional part while preserving `Z`. The XML structure is otherwise unchanged.

**Verification**

Added a focused test `should drop fractional seconds but keep the ISO-8601 Z designator in the timestamp` using a `FixedClock` seeded with `2023-01-01T12:00:00.123Z`. It asserts the output contains `timestamp="2023-01-01T12:00:00Z"` and does not contain the Z-less `timestamp="2023-01-01T12:00:00"`. The four existing tests already assert the `...Z` form for whole-second clocks and remain valid. Tests were not run locally (parent compiles and runs centrally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)