### PR TITLE
NumberEq: handle Double/Long, Float/Long, Float/Short, Float/Byte cross-type comparisons

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt
@@ -60,9 +60,19 @@ object NumberEq : Eq<Number> {
             else -> a == b
          }
          is Short -> when (b) {
+            is Double -> a.toDouble() == b
+            is Float -> a.toFloat() == b
             is Long -> a.toLong() == b
             is Int -> a.toInt() == b
             is Byte -> a == b.toShort()
+            else -> a == b
+         }
+         is Byte -> when (b) {
+            is Double -> a.toDouble() == b
+            is Float -> a.toFloat() == b
+            is Long -> a.toLong() == b
+            is Int -> a.toInt() == b
+            is Short -> a.toShort() == b
             else -> a == b
          }
          else -> a == b

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt
@@ -35,12 +35,16 @@ object NumberEq : Eq<Number> {
          }
          is Float -> when (b) {
             is Double -> a.toDouble() == b
+            is Long -> a.toDouble() == b.toDouble()
             is Int -> a == b.toFloat()
+            is Short -> a == b.toFloat()
+            is Byte -> a == b.toFloat()
             is Float -> a == b
             else -> a == b
          }
          is Double -> when (b) {
             is Float -> a == b.toDouble()
+            is Long -> a == b.toDouble()
             is Int -> a == b.toDouble()
             is Short -> a == b.toDouble()
             is Byte -> a == b.toDouble()
@@ -48,6 +52,8 @@ object NumberEq : Eq<Number> {
             else -> a == b
          }
          is Long -> when (b) {
+            is Double -> a.toDouble() == b
+            is Float -> a.toDouble() == b.toDouble()
             is Int -> a == b.toLong()
             is Short -> a == b.toLong()
             is Byte -> a == b.toLong()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ShouldBeNumericTests.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ShouldBeNumericTests.kt
@@ -41,6 +41,17 @@ class ShouldBeNumericTests : WordSpec({
          42F shouldBe v7
       }
 
+      "support cross-type widening for Double/Long, Float/Long, Float/Short and Float/Byte" {
+         42.0 shouldBe 42L
+         42L shouldBe 42.0
+         42F shouldBe 42L
+         42L shouldBe 42F
+         42F shouldBe 42.toShort()
+         42.toShort() shouldBe 42F
+         42F shouldBe 42.toByte()
+         42.toByte() shouldBe 42F
+      }
+
       "Prints type information on mismatching types" {
          shouldFail {
             1 shouldBe BigInteger.ONE


### PR DESCRIPTION
**Problem**

In non-strict mode (the default for `shouldBe`), `NumberEq.compare()` widens the smaller numeric type to the larger and compares. However the cross-type matrix was incomplete: several pairs fell through to `else -> a == b`, which is a strict cross-type `equals` that is always `false` for different boxed numeric types. As a result valid equalities wrongly failed.

Missing pairs (both directions where applicable):
- Double vs Long
- Float vs Long
- Float vs Short
- Float vs Byte

For example `42.0 shouldBe 42L`, `42F shouldBe 42L`, and `42F shouldBe 42.toShort()` all failed before this change.

**Fix**

In `kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/NumberEq.kt`, added the missing cross-type branches, mirroring the existing widening logic:
- Double branch: `is Long -> a == b.toDouble()` (consistent with sibling `is Int/Short/Byte` cases).
- Long branch: `is Double -> a.toDouble() == b` and `is Float -> a.toDouble() == b.toDouble()`.
- Float branch: `is Long -> a.toDouble() == b.toDouble()`, `is Short -> a == b.toFloat()`, `is Byte -> a == b.toFloat()`.

Float/Long is compared as Double (the wider type) for consistency with how the Double branch already treats Long; Float/Short and Float/Byte are compared as Float per the surrounding pattern. Symmetry is preserved (both directions handled). Strict-mode behaviour (`strictNumberEq`) is untouched.

**Verification**

Added a focused test case in `kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ShouldBeNumericTests.kt` covering all newly handled pairs in both directions. Did not run gradle/tests locally (compiled and run centrally by the parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ⚠️ **Behavioral change** (cross-type numeric `shouldBe` now succeeds for more widened pairs). Note: an additional follow-up commit completed the Short/Byte side of the matrix.