### PR TITLE
Fix tag expression parser precedence (& must bind tighter than |)

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/rules.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/rules.kt
@@ -22,7 +22,7 @@ internal fun Parser.not(): Expression {
 internal fun Parser.and(): Expression {
    var left = not()
    while (skipIf(TokenType.Ampersand)) {
-      val right = expression()
+      val right = not()
       left = Expression.And(left, right)
    }
    return left
@@ -31,7 +31,7 @@ internal fun Parser.and(): Expression {
 internal fun Parser.or(): Expression {
    var left = and()
    while (skipIf(TokenType.Pipe)) {
-      val right = expression()
+      val right = and()
       left = Expression.Or(left, right)
    }
    return left

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagParserTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagParserTest.kt
@@ -34,14 +34,25 @@ class TagParserTest : FunSpec() {
          Parser.from("!mytag").expression() shouldBe Expression.Not(Expression.Identifier("mytag"))
       }
 
+      // & binds tighter than |, so `a & b | c` parses as Or(And(a, b), c)
+      test("and binds tighter than or") {
+         Parser.from("a & b | c").expression() shouldBe Expression.Or(
+            Expression.And(
+               Expression.Identifier("a"),
+               Expression.Identifier("b")
+            ),
+            Expression.Identifier("c")
+         )
+      }
+
       test("advanced") {
          Parser.from("(mytag & !othertag | thistag) & thattag").expression() shouldBe Expression.And(
-            Expression.And(
-               Expression.Identifier("mytag"),
-               Expression.Or(
-                  Expression.Not(Expression.Identifier("othertag")),
-                  Expression.Identifier("thistag")
-               )
+            Expression.Or(
+               Expression.And(
+                  Expression.Identifier("mytag"),
+                  Expression.Not(Expression.Identifier("othertag"))
+               ),
+               Expression.Identifier("thistag")
             ),
             Expression.Identifier("thattag")
          )
@@ -50,12 +61,12 @@ class TagParserTest : FunSpec() {
       test("odd characters") {
          Parser.from("(my#%#e123!#!@TAG & !____9123231.... | '''',.''/'l/'l/''/'''') & thattag")
             .expression() shouldBe Expression.And(
-            Expression.And(
-               Expression.Identifier("my#%#e123!#!@TAG"),
-               Expression.Or(
-                  Expression.Not(Expression.Identifier("____9123231....")),
-                  Expression.Identifier("'''',.''/'l/'l/''/''''")
-               )
+            Expression.Or(
+               Expression.And(
+                  Expression.Identifier("my#%#e123!#!@TAG"),
+                  Expression.Not(Expression.Identifier("____9123231...."))
+               ),
+               Expression.Identifier("'''',.''/'l/'l/''/''''")
             ),
             Expression.Identifier("thattag")
          )


### PR DESCRIPTION
**Problem**

The recursive-descent tag parser in `kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/rules.kt` inverted `&`/`|` operator precedence. Both `and()` and `or()` recursed back into the top-level `expression()` for their right operand. As a result `a & b | c` parsed as `And(a, Or(b, c))` instead of the correct `Or(And(a, b), c)`. Per `documentation/docs/framework/tags.md` the precedence (descending) is `! > & > |`, so `&` must bind tighter than `|`. The recursion into `expression()` also made the operators right-associative instead of left-associative.

**Fix**

Each grammar rule now descends to the next-higher precedence rule for its right operand:
- `and()`'s loop calls `not()` (was `expression()`)
- `or()`'s loop calls `and()` (was `expression()`)

This makes `&` bind tighter than `|` and makes both operators left-associative, matching the documented grammar (`expression -> or -> and -> not -> primary`). Evaluation logic in `active.kt` is structure-agnostic (it recurses over whatever tree it is given), so no other changes were needed.

**Verification**

Updated `kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagParserTest.kt`. The `advanced` and `odd characters` tests previously encoded the OLD inverted parse for the unparenthesized subexpression `a & !b | c` (asserting `And(a, Or(!b, c))`); these were corrected to the proper precedence `Or(And(a, !b), c)`. Added a focused `and binds tighter than or` test asserting `a & b | c` parses to `Or(And(a, b), c)`. Tests were not run locally (parent compiles and runs tests centrally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ⚠️ **Behavioral change** (tag-expression operator precedence) — worth maintainer review. Existing parser tests were updated to the corrected precedence.