### PR TITLE
Fix three-valued OR so Exclude is the identity (not absorbing) for OR

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/active.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/active.kt
@@ -99,11 +99,13 @@ enum class TagExpressionResult {
    }
 
    infix fun or(other: TagExpressionResult): TagExpressionResult = when (this) {
+      // Include is absorbing for OR: if either branch is included, the whole expression is included.
       Include -> Include
-      Exclude -> if (other == Include) Include else Exclude
+      // Exclude is the identity for OR: the other branch decides whether the spec is potentially active.
+      Exclude -> other
       Inconclusive -> when (other) {
          Include -> Include
-         Exclude -> Exclude
+         Exclude -> Inconclusive
          Inconclusive -> Inconclusive
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagExpressionResultTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/tags/TagExpressionResultTest.kt
@@ -1,0 +1,61 @@
+package com.sksamuel.kotest.engine.tags
+
+import io.kotest.core.NamedTag
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.tags.Expression
+import io.kotest.engine.tags.TagExpressionResult
+import io.kotest.engine.tags.isPotentiallyActive
+import io.kotest.matchers.shouldBe
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class TagExpressionResultTest : StringSpec() {
+   init {
+
+      // For OR, Include is absorbing and Exclude is the identity (the other branch decides).
+      "or lattice: Include is absorbing" {
+         (TagExpressionResult.Include or TagExpressionResult.Include) shouldBe TagExpressionResult.Include
+         (TagExpressionResult.Include or TagExpressionResult.Exclude) shouldBe TagExpressionResult.Include
+         (TagExpressionResult.Include or TagExpressionResult.Inconclusive) shouldBe TagExpressionResult.Include
+         (TagExpressionResult.Exclude or TagExpressionResult.Include) shouldBe TagExpressionResult.Include
+         (TagExpressionResult.Inconclusive or TagExpressionResult.Include) shouldBe TagExpressionResult.Include
+      }
+
+      "or lattice: Exclude is the identity" {
+         (TagExpressionResult.Exclude or TagExpressionResult.Exclude) shouldBe TagExpressionResult.Exclude
+         (TagExpressionResult.Exclude or TagExpressionResult.Inconclusive) shouldBe TagExpressionResult.Inconclusive
+         (TagExpressionResult.Inconclusive or TagExpressionResult.Exclude) shouldBe TagExpressionResult.Inconclusive
+         (TagExpressionResult.Inconclusive or TagExpressionResult.Inconclusive) shouldBe TagExpressionResult.Inconclusive
+      }
+
+      // For AND, Exclude is absorbing and Include is the identity.
+      "and lattice: Exclude is absorbing" {
+         (TagExpressionResult.Include and TagExpressionResult.Include) shouldBe TagExpressionResult.Include
+         (TagExpressionResult.Include and TagExpressionResult.Exclude) shouldBe TagExpressionResult.Exclude
+         (TagExpressionResult.Include and TagExpressionResult.Inconclusive) shouldBe TagExpressionResult.Inconclusive
+         (TagExpressionResult.Exclude and TagExpressionResult.Include) shouldBe TagExpressionResult.Exclude
+         (TagExpressionResult.Inconclusive and TagExpressionResult.Exclude) shouldBe TagExpressionResult.Exclude
+         (TagExpressionResult.Inconclusive and TagExpressionResult.Include) shouldBe TagExpressionResult.Inconclusive
+         (TagExpressionResult.Inconclusive and TagExpressionResult.Inconclusive) shouldBe TagExpressionResult.Inconclusive
+      }
+
+      // '!linux | windows' on a linux-tagged spec must remain potentially active:
+      // the spec is negated by the left branch, but an inner test could carry the 'windows' tag.
+      "spec-negated OR branch should not eagerly exclude when the other branch is inconclusive" {
+         val expr = Expression.Or(
+            Expression.Not(Expression.Identifier("linux")),
+            Expression.Identifier("windows"),
+         )
+         expr.isPotentiallyActive(setOf(NamedTag("linux"))) shouldBe TagExpressionResult.Inconclusive
+      }
+
+      "OR where both branches exclude the spec should be excluded" {
+         val expr = Expression.Or(
+            Expression.Not(Expression.Identifier("linux")),
+            Expression.Not(Expression.Identifier("linux")),
+         )
+         expr.isPotentiallyActive(setOf(NamedTag("linux"))) shouldBe TagExpressionResult.Exclude
+      }
+   }
+}


### PR DESCRIPTION
**Problem**

`TagExpressionResult.or` implements the 3-valued lattice (Include/Exclude/Inconclusive) used by `isPotentiallyActive` to decide whether a spec may contain active tests before instantiation. For OR, `Exclude` should be the *identity* (the other branch decides). Instead, both `Exclude or Inconclusive` and `Inconclusive or Exclude` returned `Exclude`. This caused a spec to be eagerly excluded from instantiation when one OR branch was spec-negated but the other could still be satisfied by an inner test tag — e.g. `!linux | windows` on a Linux-tagged spec was excluded even though a nested test carrying the `windows` tag would have been active.

**Fix**

In `kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/tags/active.kt`, the OR branch now treats `Include` as absorbing and `Exclude` as the identity:
- `Exclude or other` => `other` (so `Exclude or Inconclusive` => `Inconclusive`, `Exclude or Exclude` => `Exclude`, `Exclude or Include` => `Include`).
- `Inconclusive or Exclude` => `Inconclusive`.

AND (where `Exclude` is absorbing and `Include` is the identity) and `not` were already correct and are left unchanged.

**Verification**

Added a focused test `TagExpressionResultTest` (jvmTest, `com.sksamuel.kotest.engine.tags`) that asserts the full OR and AND lattice tables and exercises the end-to-end case via the internal `Expression.isPotentiallyActive(Set<Tag>)`: `!linux | windows` on a `linux`-tagged spec now yields `Inconclusive` (potentially active), while `!linux | !linux` yields `Exclude`. The parent harness compiles and runs the suite centrally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> ⚠️ **Behavioral change** (spec pre-filtering 3-valued OR) — worth maintainer review.