### PR TITLE
Fix NPE in RunnerOs conditions when RUNNER_OS is unset

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/annotation/github.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/annotation/github.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.Spec
 import kotlin.reflect.KClass
 
 //The operating system of the runner executing the job. Possible values are Linux, Windows, or macOS.
-private fun runnerOs() = System.getenv("RUNNER_OS").lowercase()
+private fun runnerOs() = System.getenv("RUNNER_OS")?.lowercase()
 
 class LinuxRunnerOsCondition : Condition {
    override fun evaluate(kclass: KClass<out Spec>): Boolean = runnerOs() == "linux"


### PR DESCRIPTION
**Problem**

`runnerOs()` in `kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/annotation/github.kt` did `System.getenv("RUNNER_OS").lowercase()`. The `RUNNER_OS` environment variable is only set on GitHub Actions runners; everywhere else `getenv` returns `null`, so `.lowercase()` throws a `NullPointerException`. Because the public conditions `LinuxRunnerOsCondition`, `MacRunnerOsCondition` and `WindowsRunnerOsCondition` call `runnerOs()` directly, using e.g. `@EnabledIf(LinuxRunnerOsCondition::class)` crashed when running tests locally (outside GitHub Actions).

**Fix**

Made `runnerOs()` return a nullable `String?` via the safe call `System.getenv("RUNNER_OS")?.lowercase()`. The three conditions already compare with `==`, so a missing `RUNNER_OS` now yields `null`, which is `!=` `"linux"`/`"macos"`/`"windows"` and cleanly evaluates to `false` (condition disabled) instead of throwing. When `RUNNER_OS` is present the behaviour is unchanged.

**Verification**

- One-character minimal change (`.lowercase()` -> `?.lowercase()`), 3-space indentation preserved.
- No existing test encoded the old (throwing) behaviour, so no test required updating. A repo-wide search found no other references to `runnerOs`/`RUNNER_OS`/`RunnerOsCondition` outside this file.
- Compilation/tests are run centrally by the parent workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)