### PR TITLE
Fix UntilTest regression: revert until() expectedExceptionsFn default to { true }

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
@@ -128,13 +128,18 @@ class UntilConfigurationBuilder {
    var expectedExceptions: Set<KClass<out Throwable>> = emptySet()
 
    /**
-    * A function that is invoked to determine if a thrown exception should be ignored.
-    * By default, this function returns false for all exceptions, or in other words, no
-    * exception is ignored.
+    * A function that is invoked to determine if a thrown exception should be ignored (i.e. treated
+    * as a transient failure that should be retried rather than propagated).
+    *
+    * By default this function returns true for all exceptions, so every exception is ignored and the
+    * test is retried until it passes or the duration elapses. This default is required by [until],
+    * which is implemented on top of [eventually] as `eventually { test() shouldBe true }`: when the
+    * boolean predicate is false the `shouldBe true` assertion throws, and that failure must be ignored
+    * for `until` to keep polling.
     *
     * This function is applied in addition to the values specified by [expectedExceptions].
     */
-   var expectedExceptionsFn: (Throwable) -> Boolean = { false }
+   var expectedExceptionsFn: (Throwable) -> Boolean = { true }
 
    /**
     * A listener that is invoked after each failed invocation, with the iteration count,


### PR DESCRIPTION
## Urgent: regression on master

**#6058 (merged) broke `UntilTest` on `master`**, which fails `assertions-core` tests on master and cascades to **every open PR's CI**.

## Root cause

`until { ... }` is implemented on top of `eventually`:

```kotlin
eventually(config) { test() shouldBe true }
```

When the boolean predicate is `false`, `shouldBe true` throws an `AssertionError`. `eventually` only **retries** when the thrown exception is "expected/ignored" (`expectedExceptionsFn` returns true). So the historical default `expectedExceptionsFn = { true }` was **load-bearing** — it's the mechanism that lets `until` keep polling on a false predicate.

#6058 changed the default to `{ false }` to match the KDoc. But the KDoc was simply wrong. With `{ false }`, the very first `false` result propagates the `AssertionError` immediately, so `until` no longer retries → `UntilTest` (and any user `until {}`) breaks.

## Fix

- Revert the default back to `{ true }`.
- Correct the misleading KDoc to explain that all exceptions are ignored by default and *why* (so `until`'s `shouldBe true` failure is retried).

## Verification

`io.kotest.assertions.nondeterministic.UntilTest` → 6 tests, 0 failures (was failing on master). Full `io.kotest.assertions.nondeterministic.*` package passes; `apiCheck` passes.

> Note: this reverts the behavioural change from #6058. Recommend closing/superseding #6058. Apologies — that PR's analysis trusted the KDoc over the actual `until`→`eventually` retry contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)