### PR TITLE
Quarantine flaky Android instrumentation test from the check lifecycle

### DIFF
--- a/kotest-tests/kotest-tests-android-instrumentation/build.gradle.kts
+++ b/kotest-tests/kotest-tests-android-instrumentation/build.gradle.kts
@@ -77,11 +77,20 @@ kotlin {
    }
 }
 
-// Run instrumented tests on the managed emulator as part of the standard check lifecycle.
-// Use: ./gradlew pixel2Api30DebugAndroidTest
+// The managed-device emulator instrumentation test (pixel6Api34DebugAndroidTest) is flaky on CI
+// infrastructure (emulator boot/timeout), which intermittently fails `check` and therefore the
+// master publish job and PR builds. It is therefore quarantined: it does NOT gate `check` by default.
+//
+// Run it explicitly with:
+//   ./gradlew :kotest-tests:kotest-tests-android-instrumentation:pixel6Api34DebugAndroidTest
+// or wire it back into the check lifecycle (e.g. in a dedicated, allowed-to-fail CI job) with:
+//   ./gradlew check -PandroidInstrumentedTests=true
+//
 // The managed device handles the full AVD lifecycle (download image, boot, test, shutdown).
-tasks.named("check") {
-   dependsOn("pixel6Api34DebugAndroidTest")
+if (providers.gradleProperty("androidInstrumentedTests").orNull?.toBoolean() == true) {
+   tasks.named("check") {
+      dependsOn("pixel6Api34DebugAndroidTest")
+   }
 }
 
 dependencies {


### PR DESCRIPTION
## Problem

`kotest-tests-android-instrumentation` wires its managed-device emulator test directly into `check`:

```kotlin
tasks.named("check") { dependsOn("pixel6Api34DebugAndroidTest") }
```

That emulator test (`pixel6Api34DebugAndroidTest`) is **flaky on CI infrastructure** (AOSP ATD emulator boot/timeout on the GitHub runners). Because it gates `check`, an intermittent emulator failure fails:
- the **master `build-primary` job** (which runs `check publishToAppropriateCentralRepository`), turning `master` red across unrelated commits, and
- **PR `gradle-check`** builds (e.g. it flaked on #6051).

Local JVM/common `check` for assertions-core and the engine pass cleanly — the redness is this emulator test, not a code regression.

## Change

Quarantine the test: gate the `check` dependency behind an opt-in property (default **off**):

```kotlin
if (providers.gradleProperty("androidInstrumentedTests").orNull?.toBoolean() == true) {
   tasks.named("check") { dependsOn("pixel6Api34DebugAndroidTest") }
}
```

- `check` (and therefore the master publish job and PR builds) no longer flakes on the emulator.
- The test is **not deleted** — it still runs on demand:
  `./gradlew :kotest-tests:kotest-tests-android-instrumentation:pixel6Api34DebugAndroidTest`
  and can be re-wired into `check` in a dedicated, allowed-to-fail CI job with `-PandroidInstrumentedTests=true`.

AGP managed-device tests have no clean gradle-level retry, so opt-in quarantine is the pragmatic fix; happy to instead set up a dedicated non-blocking CI job that runs it with the flag if you prefer.

> Note: touches a `master`-gating module build script. I couldn't configure this module locally (no Android SDK in this environment), but the change is standard Gradle DSL (`providers.gradleProperty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)