### PR TITLE
ci: add dedicated non-blocking Android instrumentation workflow

### DIFF
--- a/.github/workflows/android-instrumentation.yml
+++ b/.github/workflows/android-instrumentation.yml
@@ -1,0 +1,27 @@
+name: android-instrumentation
+
+# The pixel6 managed-device emulator instrumentation test is flaky on CI infrastructure
+# (emulator boot/timeout), so it is quarantined out of the normal `check` / publish path
+# (see kotest-tests/kotest-tests-android-instrumentation/build.gradle.kts, gated behind
+# -PandroidInstrumentedTests=true). This dedicated workflow still exercises it on a schedule
+# (and on demand) so genuine regressions surface, WITHOUT blocking PRs or the master publish job.
+# It is intentionally not a required status check; a flaky run here is informational only.
+
+on:
+   schedule:
+      -  cron: "0 6 * * *" # daily at 06:00 UTC
+   workflow_dispatch:
+
+permissions:
+   contents: read
+
+jobs:
+   android-instrumentation:
+      if: github.repository == 'kotest/kotest'
+      uses: ./.github/workflows/run-gradle.yml
+      secrets: inherit
+      with:
+         runs-on: ubuntu-latest
+         task: >
+            -PandroidInstrumentedTests=true
+            :kotest-tests:kotest-tests-android-instrumentation:check


### PR DESCRIPTION
## Context

#6095 quarantined the flaky `pixel6Api34DebugAndroidTest` managed-device emulator test out of the `check` / publish path (gated behind `-PandroidInstrumentedTests=true`, default off) so it stops flaking `master` and PR builds.

This restores coverage by still running it — just not on a blocking path.

## Change

New workflow `.github/workflows/android-instrumentation.yml`:
- **Triggers:** daily schedule (`0 6 * * *` UTC) + `workflow_dispatch` (manual).
- **Runs:** `:kotest-tests:kotest-tests-android-instrumentation:check -PandroidInstrumentedTests=true` on `ubuntu-latest` via the existing reusable `run-gradle.yml` (which already enables KVM for the emulator).
- **Non-blocking:** it's a standalone workflow, not a required status check, so a flaky/failed run is informational and blocks nothing. Restricted to `kotest/kotest` so forks don't run it.

This also exercises the quarantine wiring end-to-end: the `-PandroidInstrumentedTests=true` flag re-adds the emulator test to that module's `check`.

YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)