### PR TITLE
Record shrink path on ShrinkResult and print it in failure messages (#3076)

### DIFF
--- a/kotest-property/api/kotest-property.api
+++ b/kotest-property/api/kotest-property.api
@@ -1537,14 +1537,18 @@ public final class io/kotest/property/internal/ShrinkKt {
 
 public final class io/kotest/property/internal/ShrinkResult {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/Object;
 	public final fun component3 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)Lio/kotest/property/internal/ShrinkResult;
-	public static synthetic fun copy$default (Lio/kotest/property/internal/ShrinkResult;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/kotest/property/internal/ShrinkResult;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;)Lio/kotest/property/internal/ShrinkResult;
+	public static synthetic fun copy$default (Lio/kotest/property/internal/ShrinkResult;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;ILjava/lang/Object;)Lio/kotest/property/internal/ShrinkResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCause ()Ljava/lang/Throwable;
 	public final fun getInitial ()Ljava/lang/Object;
+	public final fun getPath ()Ljava/util/List;
 	public final fun getShrink ()Ljava/lang/Object;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1577,13 +1581,17 @@ public final class io/kotest/property/internal/ShrinkfnsKt {
 
 public final class io/kotest/property/internal/StepResult {
 	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;)V
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;)Lio/kotest/property/internal/StepResult;
-	public static synthetic fun copy$default (Lio/kotest/property/internal/StepResult;Ljava/lang/Object;Ljava/lang/Throwable;ILjava/lang/Object;)Lio/kotest/property/internal/StepResult;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;)Lio/kotest/property/internal/StepResult;
+	public static synthetic fun copy$default (Lio/kotest/property/internal/StepResult;Ljava/lang/Object;Ljava/lang/Throwable;Ljava/util/List;ILjava/lang/Object;)Lio/kotest/property/internal/StepResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCause ()Ljava/lang/Throwable;
 	public final fun getFailed ()Ljava/lang/Object;
+	public final fun getPath ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/errors.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/errors.kt
@@ -90,7 +90,15 @@ internal fun propertyTestFailureMessage(
       }
    }
    sb.append("\n")
-   sb.append("Repeat this test by using seed $seed\n\n")
+   sb.append("Repeat this test by using seed $seed\n")
+   // Per-arg shrink paths: positions in [RTree.children] traversed at each level. Printed only
+   // when at least one arg actually shrunk, so non-shrinking cases (Exhaustive, ShrinkingMode.Off)
+   // stay quiet. This lays the groundwork for replay (see #3076 follow-up).
+   val shrinkPaths = results.map { it.path }
+   if (shrinkPaths.any { it.isNotEmpty() }) {
+      sb.append("Shrink paths: $shrinkPaths\n")
+   }
+   sb.append("\n")
 
    // the cause we use in the final result is the result of the last shrinking step, otherwise we use the original
    val finalCause = results.fold(cause) { t, result -> result.cause ?: t }

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/shrink.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/shrink.kt
@@ -39,7 +39,7 @@ suspend fun <A> doShrinking(
    return if (stepResult == null) {
       ShrinkResult(initial.value(), initial.value(), null)
    } else {
-      ShrinkResult(initial.value(), stepResult.failed, stepResult.cause)
+      ShrinkResult(initial.value(), stepResult.failed, stepResult.cause, stepResult.path)
    }
 }
 
@@ -52,10 +52,24 @@ class Counter {
  * The result of shrinking a failed arg.
  * If no shrinking took place, shrink should be set to the same as the initial.
  * Each arg that was part of the failed test will have a [ShrinkResult] associated with it.
+ *
+ * [path] records the sequence of raw child indices (into [RTree.children]) traversed during the
+ * shrinking search. An empty path means no shrinking actually took place. Recording the path
+ * makes it possible for a follow-up to replay a known failure directly — see issue
+ * [#3076](https://github.com/kotest/kotest/issues/3076).
  */
-data class ShrinkResult<out A>(val initial: A, val shrink: A, val cause: Throwable?)
+data class ShrinkResult<out A> @JvmOverloads constructor(
+   val initial: A,
+   val shrink: A,
+   val cause: Throwable?,
+   val path: List<Int> = emptyList(),
+)
 
-data class StepResult<A>(val failed: A, val cause: Throwable)
+data class StepResult<A> @JvmOverloads constructor(
+   val failed: A,
+   val cause: Throwable,
+   val path: List<Int> = emptyList(),
+)
 
 /**
  * Performs shrinking on the given RTree. Recurses into the tree for failing cases.
@@ -74,28 +88,36 @@ suspend fun <A> doStep(
    if (!mode.isShrinking(counter.count)) return null
    val candidates = tree.children.value
 
-   candidates.asSequence()
+   // We iterate over raw indices (not the dedup-filtered sequence) so that the recorded
+   // [StepResult.path] uses positions in [RTree.children] directly. That keeps any future
+   // replay simple: walk `children[path[i]]` at each level without having to reconstruct
+   // the `tested` state we built up during the search.
+   for ((rawIdx, a) in candidates.withIndex()) {
+      val candidate = a.value()
       // shrinkers might generate duplicate candidates so we must filter them out to avoid infinite loops or slow shrinking
-      .filter { tested.add(it.value()) }
-      .forEach { a ->
-         val candidate = a.value()
-         counter.inc()
-         try {
-            test(candidate)
-            if (PropertyTesting.shouldPrintShrinkSteps)
-               sb.append("Shrink #${counter.count}: ${candidate.print().value} pass\n")
-         } catch (_: IterationSkippedException) {
-            // A skipped iteration (from assume()) is not a failure — the shrunk value does not
-            // satisfy the precondition so it is not a valid counterexample. Treat it as a pass.
-            if (PropertyTesting.shouldPrintShrinkSteps)
-               sb.append("Shrink #${counter.count}: ${candidate.print().value} skip\n")
-         } catch (t: Throwable) {
-            if (PropertyTesting.shouldPrintShrinkSteps)
-               sb.append("Shrink #${counter.count}: ${candidate.print().value} fail\n")
-            // this result failed, so we'll recurse in to find further failures otherwise return this candidate
-            return doStep(a, mode, tested, counter, test, sb) ?: StepResult(candidate, t)
+      if (!tested.add(candidate)) continue
+      counter.inc()
+      try {
+         test(candidate)
+         if (PropertyTesting.shouldPrintShrinkSteps)
+            sb.append("Shrink #${counter.count}: ${candidate.print().value} pass\n")
+      } catch (_: IterationSkippedException) {
+         // A skipped iteration (from assume()) is not a failure — the shrunk value does not
+         // satisfy the precondition so it is not a valid counterexample. Treat it as a pass.
+         if (PropertyTesting.shouldPrintShrinkSteps)
+            sb.append("Shrink #${counter.count}: ${candidate.print().value} skip\n")
+      } catch (t: Throwable) {
+         if (PropertyTesting.shouldPrintShrinkSteps)
+            sb.append("Shrink #${counter.count}: ${candidate.print().value} fail\n")
+         // this result failed, so we'll recurse in to find further failures otherwise return this candidate
+         val deeperResult = doStep(a, mode, tested, counter, test, sb)
+         return if (deeperResult != null) {
+            deeperResult.copy(path = listOf(rawIdx) + deeperResult.path)
+         } else {
+            StepResult(candidate, t, listOf(rawIdx))
          }
       }
+   }
 
    return null
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/ForAll2Test.kt
@@ -122,6 +122,7 @@ Caused by: Property passed 8 times (minSuccess rate was 9)"""
 	Arg 1: "r" (shrunk from "rDi")
 
 Repeat this test by using seed 1234
+Shrink paths: [[0], [0, 0]]
 
 Caused by IllegalArgumentException: something unexpected happened"""
    }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ShrinkPathRecordingTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/shrinking/ShrinkPathRecordingTest.kt
@@ -1,0 +1,103 @@
+package com.sksamuel.kotest.property.shrinking
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.RTree
+import io.kotest.property.ShrinkingMode
+import io.kotest.property.assume
+import io.kotest.property.internal.doShrinking
+
+/**
+ * Tests for shrink-path recording on [io.kotest.property.internal.ShrinkResult] — the first half of
+ * the work for [#3076](https://github.com/kotest/kotest/issues/3076). The recorded path is a
+ * sequence of raw child indices into [RTree.children]; replay infrastructure that consumes it lands
+ * in a follow-up PR.
+ */
+class ShrinkPathRecordingTest : FunSpec({
+
+   test("the failing child's raw index is recorded when only one child fails") {
+      // ROOT(10) -> [ child0=0 pass, child1=3 fail, child2=7 pass ]
+      val tree = RTree({ 10 }, lazy {
+         listOf(RTree({ 0 }), RTree({ 3 }), RTree({ 7 }))
+      })
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { n: Int ->
+         if (n == 3) throw AssertionError("3 fails")
+      }
+      result.shrink shouldBe 3
+      result.path shouldBe listOf(1)
+   }
+
+   test("path accumulates as shrinking recurses into a failing child") {
+      // ROOT(10) -> [ child0=5 fail -> [ grand0=2 pass, grand1=4 fail ], child1=8 pass ]
+      val grand0 = RTree({ 2 })
+      val grand1 = RTree({ 4 })
+      val child0 = RTree({ 5 }, lazy { listOf(grand0, grand1) })
+      val child1 = RTree({ 8 })
+      val tree = RTree({ 10 }, lazy { listOf(child0, child1) })
+
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { n: Int ->
+         if (n == 5 || n == 4) throw AssertionError("$n fails")
+      }
+      result.shrink shouldBe 4
+      result.path shouldBe listOf(0, 1)
+   }
+
+   test("path is empty when no child fails") {
+      val tree = RTree({ 10 }, lazy {
+         listOf(RTree({ 0 }), RTree({ 3 }), RTree({ 7 }))
+      })
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { /* always passes */ }
+      result.shrink shouldBe 10
+      result.path shouldBe emptyList()
+   }
+
+   test("path is empty when the tree has no children") {
+      val tree = RTree<Int>({ 10 }, lazy { emptyList() })
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { throw AssertionError("never runs") }
+      result.path shouldBe emptyList()
+   }
+
+   test("IterationSkippedException is not a failure, so it does not contribute to the path") {
+      // ROOT(10) -> [ child0=2 skipped-by-assume, child1=5 fail ]
+      val tree = RTree({ 10 }, lazy {
+         listOf(RTree({ 2 }), RTree({ 5 }))
+      })
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { n: Int ->
+         assume(n >= 4)
+         if (n == 5) throw AssertionError("5 fails")
+      }
+      result.shrink shouldBe 5
+      result.path shouldBe listOf(1)
+   }
+
+   test("duplicate child values filtered by the tested set do not shift the recorded raw indices") {
+      // ROOT -> [ a (pass), a (dup, filtered), b (fail) ] — b's raw index is still 2 even though
+      // the dedup-filtered sequence would have placed it at index 1. Raw indices keep replay
+      // simple: a future doReplay() can use `children[path[i]]` without reconstructing tested state.
+      val tree = RTree({ "root" }, lazy {
+         listOf(RTree({ "a" }), RTree({ "a" }), RTree({ "b" }))
+      })
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { s: String ->
+         if (s == "b") throw AssertionError("b fails")
+      }
+      result.shrink shouldBe "b"
+      result.path shouldBe listOf(2)
+   }
+
+   test("StepResult path is composed into a multi-step path on deep recursion") {
+      // 3 levels: ROOT -> child[2] fails -> grand[0] fails -> greatGrand[1] fails (leaf)
+      val greatGrand0 = RTree({ "leaf0" })
+      val greatGrand1 = RTree({ "leaf1" })
+      val grand = RTree({ "grand" }, lazy { listOf(greatGrand0, greatGrand1) })
+      val child = RTree({ "child" }, lazy { listOf(grand) })
+      val tree = RTree({ "root" }, lazy {
+         listOf(RTree({ "ok-a" }), RTree({ "ok-b" }), child)
+      })
+
+      val result = doShrinking(tree, ShrinkingMode.Unbounded) { s: String ->
+         if (s in listOf("child", "grand", "leaf1")) throw AssertionError("$s fails")
+      }
+      result.shrink shouldBe "leaf1"
+      result.path shouldBe listOf(2, 0, 1)
+   }
+})


### PR DESCRIPTION
Following up on my comment on #3076. This is the small first PR I sketched there — it records the
RTree traversal path on `ShrinkResult` and prints it in the failure message. No replay machinery
here yet; `doReplay` and a `PropTestConfig.shrinkPaths` field that consumes the recorded path will
come in a follow-up.

## What changed

- `ShrinkResult` and `StepResult` gain a `path: List<Int>` field. `@JvmOverloads` on both data
  class primary constructors keeps the existing 3-arg / 2-arg JVM signatures, so callers that
  don't touch the new field stay binary-compatible.
- `doStep` now iterates with `withIndex()` instead of `asSequence().filter().forEach`, accumulates
  the raw child index of each failing step, and propagates it up via the StepResult chain.
- The failure message gets a `Shrink paths: ...` line, but only when at least one arg actually
  shrunk. Exhaustive and `ShrinkingMode.Off` runs keep the existing output.

## Raw vs filtered child index

`doStep` filters duplicate candidates through the `tested` set, so there are two reasonable
choices for what \"index\" the path stores — the raw position in `tree.children.value`, or the
position in the post-dedup sequence. I went with raw indices:

1. Replay later just needs to walk `children[path[i]]` at each level. With filtered indices, the
   replay would have to rebuild the `tested` state and evaluate `RTree.value` lazies in the same
   order, which mixes search semantics into navigation.
2. The dedup filter is a search-time perf trick, not a property of the tree, so it shouldn't leak
   into the recorded path.

`ShrinkPathRecordingTest` pins this — there's a case with `[a, a (dup), b]` where the recorded
path is `[2]`, not `[1]`.

If you'd rather have filtered indices, happy to switch in this PR — that decision is easier to
revisit now than after the replay PR.

## Format I picked for the message line

`Shrink paths: [[2, 0, 1], [0]]` — list of per-arg paths, suitable for copy/paste into a future
`PropTestConfig(shrinkPaths = ...)`. Open to a different label or per-arg lines if you have a
preference. One existing test in `ForAll2Test` (\"should print inputs and perform shrinks\")
already exercises a shrunk run, so I updated its expected message; the Exhaustive-based tests in
the same file were untouched because their messages still won't contain a `Shrink paths` line.

## API dump

Regenerated. The diff is contained to ShrinkResult and StepResult — a new constructor variant on
each, the corresponding `componentN`/`copy`/`getPath`, and the synthetic `DefaultConstructorMarker`
helper. Old signatures are preserved.

## Follow-up

Once this lands I'll open the replay PR with `doReplay`, `PropTestConfig.shrinkPaths`, an
`Eval index:` line for `skipTo`-compatible iteration replay, and the 22 `shrinkfn` / `proptest`
overload changes that come with plumbing the config through.