### PR TITLE
Fix flaky TestTimeoutExceptionTest (timeout message wording race)

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutExceptionTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/timeout/TestTimeoutExceptionTest.kt
@@ -1,10 +1,13 @@
 package com.sksamuel.kotest.engine.test.timeout
 
+import io.kotest.assertions.withClue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.test.TestResult
-import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import kotlinx.coroutines.delay
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -22,7 +25,17 @@ class TestTimeoutExceptionTest : FunSpec() {
 
       aroundTest { (test, execute) ->
          val result = execute(test)
-         result.errorOrNull?.message shouldBe "Test 'timeout exception should use the value that caused the test to fail' did not complete within 23ms"
+         // The reported timeout must be the test-level 23ms, not the spec-level 250ms. The exact
+         // wording is non-deterministic: depending on a timing race the engine surfaces either its
+         // own TestTimeoutException ("... did not complete within 23ms") or the underlying coroutine
+         // TimeoutCancellationException ("Timed out waiting for 23 ms"). Assert on the timeout value
+         // rather than the exact message so the test is not flaky.
+         val message = result.errorOrNull?.message
+         withClue("actual timeout message: $message") {
+            message.shouldNotBeNull()
+            message shouldContain Regex("23\\s?ms")
+            message shouldNotContain "250"
+         }
          TestResult.Success(0.milliseconds)
       }
    }


### PR DESCRIPTION
## Problem

`TestTimeoutExceptionTest` intermittently fails CI (observed flaking PR builds, e.g. [run on #6044](https://github.com/kotest/kotest/actions/runs/26723798303/job/78756105473)). The build-report artifact shows:

```
expected:<Test '...' did not complete within 23ms>
but was: <Timed out waiting for 23 ms>
```

The test always times out at the correct **23ms** (the per-test `config(timeout = 23.milliseconds)`, not the spec-level `250`), but the **error-message wording is non-deterministic**: depending on a timing race the engine surfaces either

- its own `TestTimeoutException` → `"... did not complete within 23ms"`, or
- the underlying coroutine `TimeoutCancellationException` → `"Timed out waiting for 23 ms"`.

The assertion pinned the exact `TestTimeoutException` string, so whenever the coroutine variant won the race the test failed.

## Fix

Assert on the timeout **value** rather than the exact message — the message must reference `23ms` and must not reference the spec-level `250` — which preserves the test's intent ("the timeout uses the value that caused the test to fail") while removing the wording dependency:

```kotlin
val message = result.errorOrNull?.message
withClue("actual timeout message: $message") {
   message.shouldNotBeNull()
   message shouldContain Regex("23\\s?ms")
   message shouldNotContain "250"
}
```

## Verification

`:kotest-framework-engine:compileTestKotlinJvm` passes. The test is `@EnabledIf(LinuxOnlyGithubCondition)` so it only executes on GitHub Linux CI; this PR's run will exercise it. The assertion now accepts both timeout-message forms, both of which correctly report `23ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)