### PR TITLE
SpringExtension: forward test exception to the test context manager (#6094)

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
@@ -92,7 +92,8 @@ open class SpringExtension(
          testContextManager().beforeTestMethod(testCase.spec, methodName)
          val result = execute(testCase)
          // the spring docs state that afterTestMethod must be called immediately after framework-specific after lifecycle callbacks
-         testContextManager().afterTestMethod(testCase.spec, methodName, null as Throwable?)
+         // forward any exception from the test result so the test context manager (and its listeners) are aware of it
+         testContextManager().afterTestMethod(testCase.spec, methodName, result.errorOrNull)
          result
       } else {
          execute(testCase)
@@ -111,7 +112,8 @@ open class SpringExtension(
       if (testCase.isApplicable()) {
          val methodName = SpringJavaCompatibility.methodHandle(testCase)
          // the spring docs state that afterTestExecution must be called before framework-specific after lifecycle callbacks
-         testContextManager().afterTestExecution(testCase.spec, methodName, null as Throwable?)
+         // forward any exception from the test result so the test context manager (and its listeners) are aware of it
+         testContextManager().afterTestExecution(testCase.spec, methodName, result.errorOrNull)
       }
    }
 

--- a/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTestExceptionTest.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmTest/kotlin/io/kotest/extensions/spring/SpringExtensionTestExceptionTest.kt
@@ -1,0 +1,87 @@
+package io.kotest.extensions.spring
+
+import io.kotest.core.extensions.ApplyExtension
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestContext
+import org.springframework.test.context.TestExecutionListeners
+import org.springframework.test.context.TestExecutionListener as SpringTestExecutionListener
+
+private class TestMethodBoomException(message: String) : RuntimeException(message)
+
+// guards the deliberately-failing test so it only runs inside the in-process launcher below,
+// and is not picked up when the whole suite runs.
+private var includeFailingTest = false
+
+/**
+ * Regression test for https://github.com/kotest/kotest/issues/6094 — an exception thrown by a test
+ * must be forwarded to the Spring test context manager (and therefore to its TestExecutionListeners),
+ * instead of SpringExtension always passing null.
+ */
+class SpringExtensionTestExceptionTest : FunSpec() {
+   init {
+      test("a thrown test exception is forwarded to the spring test context manager callbacks") {
+         ExceptionCapturingTestExecutionListener.reset()
+         includeFailingTest = true
+         try {
+            // run the (deliberately failing) spring spec in an isolated engine so its failure is
+            // collected here rather than failing this spec
+            TestEngineLauncher()
+               .withListener(CollectingTestEngineListener())
+               .withSpecRefs(SpecRef.Reference(ThrowingSpringSpec::class))
+               .execute()
+         } finally {
+            includeFailingTest = false
+         }
+
+         // afterTestMethod must receive the exception thrown by the test (issue #6094)
+         ExceptionCapturingTestExecutionListener.afterTestMethodException
+            .shouldBeInstanceOf<TestMethodBoomException>()
+         ExceptionCapturingTestExecutionListener.afterTestMethodException?.message shouldBe "boom"
+         // afterTestExecution must likewise receive it
+         ExceptionCapturingTestExecutionListener.afterTestExecutionException
+            .shouldBeInstanceOf<TestMethodBoomException>()
+      }
+   }
+}
+
+@TestExecutionListeners(
+   ExceptionCapturingTestExecutionListener::class,
+   mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS,
+)
+@SpringBootTest(classes = [Components::class])
+@ApplyExtension(SpringExtension::class)
+private class ThrowingSpringSpec : FunSpec() {
+   init {
+      if (includeFailingTest) {
+         test("a test that throws") {
+            throw TestMethodBoomException("boom")
+         }
+      }
+   }
+}
+
+class ExceptionCapturingTestExecutionListener : SpringTestExecutionListener {
+
+   override fun afterTestMethod(testContext: TestContext) {
+      afterTestMethodException = testContext.testException
+   }
+
+   override fun afterTestExecution(testContext: TestContext) {
+      afterTestExecutionException = testContext.testException
+   }
+
+   companion object {
+      var afterTestMethodException: Throwable? = null
+      var afterTestExecutionException: Throwable? = null
+      fun reset() {
+         afterTestMethodException = null
+         afterTestExecutionException = null
+      }
+   }
+}


### PR DESCRIPTION
Fixes #6094

## Problem

When a test fails under `SpringExtension`, the thrown exception was **never forwarded** to Spring's `TestContextManager`. Both after-callbacks hard-coded `null`:

```kotlin
testContextManager().afterTestMethod(testCase.spec, methodName, null as Throwable?)
...
testContextManager().afterTestExecution(testCase.spec, methodName, null as Throwable?)
```

As a result, Spring `TestExecutionListener`s (e.g. Camunda's) read `testContext.getTestException()` as `null` and couldn't report the failure.

## Fix

Forward the exception from the test result into both callbacks:

```kotlin
testContextManager().afterTestMethod(testCase.spec, methodName, result.errorOrNull)
...
testContextManager().afterTestExecution(testCase.spec, methodName, result.errorOrNull)
```

(`afterTestExecution` lives in `afterAny(testCase, result)`, which already has the result.)

## Test

Adds `SpringExtensionTestExceptionTest`, which runs a deliberately-failing Spring spec **in-process** via `TestEngineLauncher` (so its failure is collected, not propagated) and registers a `TestExecutionListener` that records `testContext.testException`. It asserts the thrown `TestMethodBoomException` reaches both `afterTestMethod` and `afterTestExecution`.

## Verification

- New test passes with the fix; **fails without it** (verified by reverting both lines → `AssertionFailedError`, exception was `null`).
- `:kotest-extensions-spring:apiCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)