### PR TITLE
ci: raise Karma browser timeouts to fix flaky wasmJs/js browser tests

### DIFF
--- a/buildSrc/src/main/kotlin/kotest-js-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotest-js-conventions.gradle.kts
@@ -10,14 +10,39 @@ val kotestSettings = extensions.getByType<KotestBuildLogicSettings>()
 
 kotlin {
    if (!project.hasProperty(Ci.JVM_ONLY) && kotestSettings.enableKotlinJs.get()) {
+
+      // Shared Karma config (repo-root/karma.config.d) used by every browser test task. It raises the
+      // Karma disconnect / no-activity timeouts so slow or loaded CI runners don't fail with a spurious
+      // "Disconnected ... because no message in 30000 ms" while the large JS/WasmJS test bundle starts
+      // up in the headless browser.
+      val karmaConfigDir = rootDir.resolve("karma.config.d")
+
       js {
-         browser()
+         browser {
+            testTask {
+               useKarma {
+                  // providing a custom useKarma block clears the default browser, so re-add the
+                  // Chrome Headless browser the plugin would otherwise configure by default
+                  useChromeHeadless()
+                  useConfigDirectory(karmaConfigDir)
+               }
+            }
+         }
          nodejs()
       }
 
       @OptIn(ExperimentalWasmDsl::class)
       wasmJs {
-         browser()
+         browser {
+            testTask {
+               useKarma {
+                  // providing a custom useKarma block clears the default browser, so re-add the
+                  // Chrome Headless browser the plugin would otherwise configure by default
+                  useChromeHeadless()
+                  useConfigDirectory(karmaConfigDir)
+               }
+            }
+         }
          nodejs()
       }
 

--- a/karma.config.d/kotest-karma-timeouts.js
+++ b/karma.config.d/kotest-karma-timeouts.js
@@ -1,0 +1,16 @@
+// Shared Karma configuration for all Kotest JS / WasmJS browser test tasks.
+//
+// CI runners are frequently slow or heavily loaded, and the JS/WasmJS test bundles are large, so the
+// headless browser can sit idle for longer than Karma's default 30s `browserNoActivityTimeout` while a
+// bundle compiles/loads. That produced spurious failures such as:
+//   "Disconnected (0 times) , because no message in 30000 ms."
+// Raise the disconnect / no-activity / capture timeouts (and allow a couple of disconnect retries) so a
+// slow startup no longer fails the build. These only affect how long Karma waits — a genuinely failing
+// or hanging test is still bounded by the Gradle test task timeout.
+config.set({
+   browserDisconnectTimeout: 120000,
+   browserDisconnectTolerance: 3,
+   browserNoActivityTimeout: 120000,
+   pingTimeout: 120000,
+   captureTimeout: 120000,
+});


### PR DESCRIPTION
## Problem

Browser test tasks intermittently fail in CI with:

```
Disconnected (0 times) , because no message in 30000 ms.
java.lang.IllegalStateException: :kotest-property:kotest-property-arrow:wasmJsBrowserTest exited with errors (exit code: 1)
```

(e.g. [this run](https://github.com/kotest/kotest/actions/runs/26730836121/job/78775191324)).

`30000 ms` is Karma's default `browserNoActivityTimeout`. On slow/loaded CI runners the large JS/WasmJS test bundle can take longer than 30s to compile/load and hand control to the headless browser, so Karma declares the browser disconnected and fails the task. It's pure infrastructure flakiness — not a test defect — and it can hit any module's `jsBrowserTest`/`wasmJsBrowserTest`.

## Fix

Point every browser test task (js + wasmJs) at a shared repo-root `karma.config.d` via `useKarma { useConfigDirectory(...) }` in the `kotest-js-conventions` build plugin, and add `karma.config.d/kotest-karma-timeouts.js` that raises the relevant timeouts:

```js
config.set({
   browserDisconnectTimeout: 120000,
   browserDisconnectTolerance: 3,
   browserNoActivityTimeout: 120000,
   pingTimeout: 120000,
   captureTimeout: 120000,
});
```

Because providing a custom `useKarma {}` block clears the plugin's default browser, Chrome Headless (the default, and what CI already uses) is re-added explicitly with `useChromeHeadless()`.

These only change how long Karma *waits*; a genuinely hanging/failing test is still bounded by the Gradle test-task timeout. This is repo-wide, so it covers every JS-browser module, not just the one that flaked.

## Verification

Locally (JS enabled): `:kotest-property-arrow:jsBrowserTest` and `:wasmJsBrowserTest` both pass with `--rerun-tasks`, and the generated `karma.conf.js` for both targets contains `"browsers": ["ChromeHeadless"]` and the raised `browserNoActivityTimeout`/`browserDisconnectTimeout`/`captureTimeout`. Confirmed the default browser was being cleared before re-adding `useChromeHeadless()` (without it the task failed "No browsers configured").

🤖 Generated with [Claude Code](https://claude.com/claude-code)