### PR TITLE
Use Kotlin 2.4.0 as the compile toolchain (target stays 2.2)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -185,7 +185,7 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-apache = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
 
-kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.12.1" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:core", version = "0.13.0" } # 0.13.0 updates to Kotlin 2.4.0
 ktor-server-testHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin-core-libaries-version" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 gradleApi = "8.11.1"
 
 # https://mbonnin.net/2026-02-22-kotlin-versions/
-kotlin-gradle-plugin = "2.3.20" # always use the most recent version to leverage the latest tooling
-kotlin-compile-version = "2.3.20"
-kotlin-core-libaries-version = "2.3.20" # the std lib version
+kotlin-gradle-plugin = "2.4.0" # always use the most recent version to leverage the latest tooling
+kotlin-compile-version = "2.4.0" # the compiler version used to build kotest
+kotlin-core-libaries-version = "2.4.0" # the std lib version
 kotlin-language-version = "2.2.0" # the minimum version we support and what is written into kotlin metadata
 
 runtime-kotest = "4.2.0" # intellij plugin

--- a/kotest-tests/kotest-tests-power-assert/src/jvmTest/kotlin/io/kotest/tests/power/assert/PowerAssertTest.kt
+++ b/kotest-tests/kotest-tests-power-assert/src/jvmTest/kotlin/io/kotest/tests/power/assert/PowerAssertTest.kt
@@ -16,10 +16,8 @@ class PowerAssertTest : FunSpec() {
          error.message!!.trim() shouldBe """
 hello.substring(1, 3) shouldBe world.substring(1, 4)
 |     |                        |     |
-|     |                        |     orl
-|     |                        world!
-|     el
-Hello
+|     "el"                     |     "orl"
+"Hello"                        "world!"
 
 expected:<orl> but was:<el>""".trim()
       }


### PR DESCRIPTION
Updates Kotest to **compile** with Kotlin **2.4.0**, while keeping the language/API **target** at 2.2.

## Changes (`gradle/libs.versions.toml`)

| version | before | after |
|---------|--------|-------|
| `kotlin-gradle-plugin` | 2.3.20 | **2.4.0** |
| `kotlin-compile-version` (`compilerVersion`) | 2.3.20 | **2.4.0** |
| `kotlin-core-libaries-version` (stdlib / reflect / compiler-embeddable) | 2.3.20 | **2.4.0** |
| `kotlin-compile-testing` (kctfork) | 0.12.1 | **0.13.0** |
| `kotlin-language-version` (`languageVersion`/`apiVersion`, written into metadata) | 2.2.0 | **2.2.0 (unchanged)** |

Plus a test update for Kotlin 2.4.0's new power-assert diagram format.

## Why each change

- **Gradle plugin → 2.4.0:** bumping only `compilerVersion` fails with `NoSuchMethodError: IrGenerationExtension...` — the 2.3.20 plugin can't drive the 2.4.0 compiler.
- **stdlib → 2.4.0:** klib targets reject a 2.3.0 stdlib against a 2.4.0 compiler (`stdlib ABI 2.3.0 not compatible with compiler ABI level 2.4`).
- **kctfork → 0.13.0:** `kotlin-core-libaries-version` also drives `kotlin-compiler-embeddable`, which `kotest-assertions-compiler` runs via the kotlin-compile-testing fork. kctfork 0.12.1 NPEs against the 2.4.0 compiler; 0.13.0 "Update to Kotlin 2.4.0" fixes `CompilationsMatcherTest`.
- **PowerAssertTest:** Kotlin 2.4.0's power-assert renders string values quoted (`"el"`, `"Hello"`) on a more compact layout; the expected diagram is updated to match.

## Verification

- **Full `./gradlew check -PjvmOnly=true` passes locally** (all JVM/KMP modules) ✓
- engine compiles for **JS** ✓ (the earlier stdlib-ABI failure is resolved)
- `apiCheck` ✓ — dumps unchanged, confirming the target is still 2.2

Full JS/Wasm/Native/Android matrix validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)