### PR TITLE
deps(gradle): Use AGP 9.0.0 final

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ allure-commons = "2.33.0"
 allure-plugin = "3.1.0"
 
 # https://developer.android.com/kotlin/multiplatform/plugin
-agp = "9.0.0-alpha06" # latest supported by IntelliJ 2026.1
+agp = "9.0.0" # latest supported by IntelliJ 2026.1
 
 # https://developer.android.com/jetpack/androidx/versions/all-channel
 androidx-test-runner = "1.7.0"


### PR DESCRIPTION
Otherwise import in IntelliJ IDEA 2026.1.3 fails due to some compatibility issues.

Note that the assumption is that the comment "latest supported by IntelliJ 2026.1" refer to the 9.0.0-line, not to alpha06 specifically.