### PR TITLE
fix(kotest-assertions-core): Make clear what is the actual string value

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/MapMatchers.kt
@@ -209,7 +209,7 @@ class MapContainsMatcher<K, V>(
       }
       val failureMsg = """
       |
-      |Expected:
+      |Actual:
       |  ${stringify(value)}
       |$expectMsg:
       |  ${stringify(expected)}
@@ -219,7 +219,7 @@ class MapContainsMatcher<K, V>(
       """.trimMargin()
       val negatedFailureMsg = """
       |
-      |Expected:
+      |Actual:
       |  ${stringify(value)}
       |$negatedExpectMsg:
       |  ${stringify(expected)}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/maps/MapMatchersTest.kt
@@ -364,7 +364,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
           |
-          |Expected:
+          |Actual:
           |  mapOf()
           |should contain all of:
           |  mapOf("\${'$'}a" to 1)
@@ -385,7 +385,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
           |
-          |Expected:
+          |Actual:
           |  mapOf("a" to 1)
           |should contain all of:
           |  mapOf("a" to 1L)
@@ -407,7 +407,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
           |
-          |Expected:
+          |Actual:
           |  mapOf("a" to mapOf("b" to 2))
           |should contain all of:
           |  mapOf("a" to mapOf("b" to 3))
@@ -429,7 +429,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
           |
-          |Expected:
+          |Actual:
           |  mapOf("a" to 1, "b" to 2)
           |should not contain all of:
           |  mapOf("a" to 1)
@@ -450,7 +450,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
           |
-          |Expected:
+          |Actual:
           |  mapOf("a" to 1)
           |should be equal to:
           |  mapOf()
@@ -468,7 +468,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
             |
-            |Expected:
+            |Actual:
             |  mapOf(Fruit(name=apple, color=green, taste=sweet) to 1)
             |should be equal to:
             |  mapOf(Fruit(name=pear, color=green, taste=sweet) to 1)
@@ -496,7 +496,7 @@ expected:kotlin.Double<1.5> but was:java.math.BigDecimal<1.5>"""
             }
             e.message shouldBe """
           |
-          |Expected:
+          |Actual:
           |  mapOf("a" to listOf(1))
           |should not be equal to:
           |  mapOf("a" to listOf(1))


### PR DESCRIPTION
Maybe the current message was supposed to be read like "It is expected for <actual> to match <expected>", but the way it was written is misleading WRT to the usual "expected: / "but was:" syntax. So clarify that the first string is not the expected but the actual string.