### PR TITLE
fix(kotest-framework-engine): Preserve dots in test names when parsing --tests patterns

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/TestPatternParser.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/TestPatternParser.kt
@@ -28,14 +28,16 @@ internal object TestPatternParser {
       require(arg.isNotBlank())
       val parts = arg.split(".")
 
-      val packageParts = parts.takeWhile { it.first().isLowerCase() }
-      val simpleName = parts.dropWhile { it.first().isLowerCase() }.firstOrNull()
+      val packageParts = parts.takeWhile { it.firstOrNull()?.isLowerCase() == true }
+      val simpleName = parts.drop(packageParts.size).firstOrNull()
       if (simpleName === null) return TestPattern(packageParts.joinToString("."), false, null, emptyList())
       if (simpleName == "*") return TestPattern(packageParts.joinToString("."), true, null, emptyList())
 
-      val test = parts.dropWhile { it.first().isLowerCase() } // drop the package parts
+      val test = parts
+         .drop(packageParts.size) // drop the package parts
          .drop(1) // drop the class name
-         .firstOrNull()
+         .joinToString(".") // test names can contain dots, so restore them
+         .ifEmpty { null }
 
       if (test == null) return TestPattern(packageParts.joinToString("."), false, simpleName, emptyList())
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/TestPatternParserTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/extensions/TestPatternParserTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.engine.extensions
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.extensions.TestPattern
 import io.kotest.engine.extensions.TestPatternParser
@@ -38,6 +39,20 @@ class TestPatternParserTest : FunSpec() {
       test("spaces in nested test names") {
          TestPatternParser.parse("io.kotest.MySpec.some method name -- more names") shouldBe
             TestPattern("io.kotest", false, "MySpec", listOf("some method name", "more names"))
+      }
+
+      test("dots in test names") {
+         TestPatternParser.parse("io.kotest.MySpec.returns 1.5 on overflow") shouldBe
+            TestPattern("io.kotest", false, "MySpec", listOf("returns 1.5 on overflow"))
+      }
+
+      test("dots in nested test names") {
+         TestPatternParser.parse("io.kotest.MySpec.returns 1.5 -- when input is 0.5") shouldBe
+            TestPattern("io.kotest", false, "MySpec", listOf("returns 1.5", "when input is 0.5"))
+      }
+
+      test("empty segments should not throw") {
+         shouldNotThrowAny { TestPatternParser.parse("io..kotest.MySpec") }
       }
    }
 }


### PR DESCRIPTION
### Bug

`TestPatternParser.parse` splits the pattern on `.` and, after dropping the package and class segments, kept only the *first* remaining segment as the test context. Any test whose name contains a dot was silently truncated, e.g.:

```
io.kotest.MySpec.returns 1.5 on overflow
```

parsed to the test name `returns 1`, dropping `5 on overflow`. Since `KOTEST_INCLUDE_PATTERN` (set by the Gradle plugin for `--tests`) builds its target descriptor from these contexts, tests with dots in their names could not be selected individually. In addition, `it.first()` on a split segment could throw on empty segments (e.g. doubled dots).

### Fix

- Join the remaining segments after package + class back together with `.`, so the full test name (including any ` -- ` nested separators) is preserved before splitting on the nested-test delimiter.
- Use `firstOrNull()?.isLowerCase() == true` so empty segments don't throw.

Package and class segments are Java identifiers, so splitting on `.` for those parts remains unambiguous; only the test-name remainder can legitimately contain dots.

### Tests

Extended `TestPatternParserTest` with:
- a root test name containing a dot (`returns 1.5 on overflow`)
- nested test names containing dots (`returns 1.5 -- when input is 0.5`)
- empty segments (`io..kotest.MySpec`) do not throw

All existing parser tests pass unchanged (10/10 in `:kotest-framework:kotest-framework-engine:jvmTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)