### PR TITLE
fix(kotest-assertions-core): Handle null map values in shouldBeEqualUsingFields

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/compare.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/compare.kt
@@ -139,7 +139,21 @@ private fun compareMaps(
       actual.keys.map { key ->
          val a = actual[key]
          val b = expected[key]
-         compareValue(a, b, a!!::class, "$field[$key]", config, prop)
+         val entryName = "$field[$key]"
+         when {
+            a == null && b == null -> CompareResult.empty
+            a == null -> CompareResult.single(
+               entryName,
+               AssertionErrorBuilder.create().withMessage("Expected ${b.print().value} but actual was null").build()
+            )
+
+            b == null -> CompareResult.single(
+               entryName,
+               AssertionErrorBuilder.create().withMessage("Expected null but actual was ${a.print().value}").build()
+            )
+
+            else -> compareValue(a, b, a::class, entryName, config, prop)
+         }
       }.reduce { a, op -> a.reduce(op) }
    }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/EqualToComparingFieldsTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/equality/EqualToComparingFieldsTest.kt
@@ -51,6 +51,7 @@ class EqualToComparingFieldsTest : FunSpec() {
    class MapContainer(val map: Map<String, Box>)
    class NullableListContainer(val list: List<Box>?)
    class NullableMapContainer(val map: Map<String, Box>?)
+   data class NullableValueMapContainer(val map: Map<String, String?>)
 
    data class CompletelyDifferent1(val field1: String, val field2: String)
    class CompletelyDifferent2(numberField: Int) {
@@ -444,6 +445,34 @@ Fields that differ:
          val a = MapContainer(emptyMap())
          val b = MapContainer(emptyMap())
          a shouldBeEqualUsingFields b
+      }
+
+      test("should compare maps with null values") {
+         val a = NullableValueMapContainer(mapOf("foo" to null))
+         val b = NullableValueMapContainer(mapOf("foo" to null))
+         a shouldBeEqualUsingFields b
+      }
+
+      test("should fail when actual map value is null but expected is not") {
+         val a = NullableValueMapContainer(mapOf("foo" to null))
+         val b = NullableValueMapContainer(mapOf("foo" to "bar"))
+         val message = shouldFail {
+            a shouldBeEqualUsingFields b
+         }.message
+         message shouldNotContain "Error using shouldBeEqualUsingFields matcher"
+         message shouldContain """Fields that differ:
+ - map[foo]  =>  Expected "bar" but actual was null"""
+      }
+
+      test("should fail when expected map value is null but actual is not") {
+         val a = NullableValueMapContainer(mapOf("foo" to "bar"))
+         val b = NullableValueMapContainer(mapOf("foo" to null))
+         val message = shouldFail {
+            a shouldBeEqualUsingFields b
+         }.message
+         message shouldNotContain "Error using shouldBeEqualUsingFields matcher"
+         message shouldContain """Fields that differ:
+ - map[foo]  =>  Expected null but actual was "bar""""
       }
 
       test("should handle nullable maps") {


### PR DESCRIPTION
## Bug

`compareMaps` in `compare.kt` used a non-null assertion on the actual map's values:

```kotlin
compareValue(a, b, a!!::class, "$field[$key]", config, prop)
```

If the actual map contains a `null` value (e.g. a `Map<String, String?>` field with `"foo" to null` on both sides), `a!!` throws a `KotlinNullPointerException`. The `runCatching` in `beEqualUsingFields` converts it into a failure with the message "Error using shouldBeEqualUsingFields matcher" — so two equal objects fail `shouldBeEqualUsingFields`.

## Repro

```kotlin
data class Container(val map: Map<String, String?>)
Container(mapOf("foo" to null)) shouldBeEqualUsingFields Container(mapOf("foo" to null))
// fails with "Error using shouldBeEqualUsingFields matcher"
```

## Fix

Handle null map values explicitly, mirroring `compareCollections` directly above:
- both values null → match
- only one side null → reported as a regular field difference (`Expected X but actual was null` / `Expected null but actual was X`)
- otherwise compare as before using `a::class`

## Tests

Added to `EqualToComparingFieldsTest`:
- both maps have a null value at the same key → passes
- actual null / expected non-null at a key → fails with a real field difference
- actual non-null / expected null at a key → fails with a real field difference

All 39 tests in the class pass. No public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)