### PR TITLE
fix(kotest-common): Cancel the wall-clock watchdog coroutine when the block throws

### DIFF
--- a/kotest-common/build.gradle.kts
+++ b/kotest-common/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
       jvmTest {
          dependencies {
             implementation(projects.kotestFramework.kotestFrameworkEngine)
+            implementation(libs.kotlinx.coroutines.debug)
          }
       }
    }

--- a/kotest-common/src/commonMain/kotlin/io/kotest/common/withNonVirtualTimeout.kt
+++ b/kotest-common/src/commonMain/kotlin/io/kotest/common/withNonVirtualTimeout.kt
@@ -55,15 +55,22 @@ internal suspend fun <T> withWallClockTimeout(
    @OptIn(DelicateCoroutinesApi::class)
    val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
 
-   select {
-      blockDeferred.onAwait { result ->
-         timeoutJob.cancel()
-         result
+   try {
+      select {
+         blockDeferred.onAwait { result ->
+            timeoutJob.cancel()
+            result
+         }
+         timeoutJob.onJoin {
+            blockDeferred.cancel()
+            throw NonDeterministicRealTimeTimeoutCancellationException("Timeout after $timeout")
+         }
       }
-      timeoutJob.onJoin {
-         blockDeferred.cancel()
-         throw NonDeterministicRealTimeTimeoutCancellationException("Timeout after $timeout")
-      }
+   } finally {
+      // Ensure the watchdog coroutine is always cancelled once the guarded block finishes,
+      // whether it succeeded, threw, or timed out. Otherwise it would leak on GlobalScope
+      // until the timeout elapses (e.g. when the block throws and onAwait rethrows).
+      timeoutJob.cancel()
    }
 }
 

--- a/kotest-common/src/jvmTest/kotlin/io/kotest/common/WallClockTimeoutTest.kt
+++ b/kotest-common/src/jvmTest/kotlin/io/kotest/common/WallClockTimeoutTest.kt
@@ -2,8 +2,16 @@ package io.kotest.common
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.debug.DebugProbes
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class WallClockTimeoutTest : FreeSpec() {
    init {
       "withWallClockTimeout should use wall-clock time even if virtual time is enabled".config(coroutineTestScope = true) {
@@ -11,6 +19,31 @@ class WallClockTimeoutTest : FreeSpec() {
             withWallClockTimeout(1.milliseconds) {
                Thread.sleep(1000)
             }
+         }
+      }
+
+      "withWallClockTimeout should cancel the watchdog coroutine when the block throws" {
+         DebugProbes.install()
+         try {
+            shouldThrow<IllegalStateException> {
+               withWallClockTimeout(Duration.INFINITE) {
+                  error("boom")
+               }
+            }
+            // the watchdog runs on GlobalScope/Dispatchers.Default, so give it a moment to
+            // start in case it was leaked rather than cancelled
+            delay(100.milliseconds)
+            // cancellation is asynchronous, so poll until any started watchdog has terminated
+            fun watchdogs() = DebugProbes.dumpCoroutinesInfo().filter { info ->
+               info.lastObservedStackTrace().any { it.className.contains("withWallClockTimeout") }
+            }
+            val mark = TimeSource.Monotonic.markNow()
+            while (watchdogs().isNotEmpty() && mark.elapsedNow() < 5.seconds) {
+               delay(20.milliseconds)
+            }
+            watchdogs().shouldBeEmpty()
+         } finally {
+            DebugProbes.uninstall()
          }
       }
    }


### PR DESCRIPTION
## Problem

`withWallClockTimeout` in `kotest-common` (used by `withNonVirtualTimeout`, which `eventually` uses whenever a `TestCoroutineScheduler` is active, i.e. `coroutineTestScope = true`) launches a timeout watchdog on `GlobalScope`:

```kotlin
val timeoutJob = GlobalScope.launch(Dispatchers.Default) { delay(timeout) }
```

The watchdog is only cancelled inside the `select`'s `onAwait` clause. When the guarded block throws — the normal failure path for `eventually` — `onAwait` rethrows the exception before the clause body runs, so `timeoutJob.cancel()` is never reached. The watchdog is deliberately not a child of the surrounding `coroutineScope`, so it leaks until `delay(timeout)` elapses. Since `eventually`'s default duration is `Duration.INFINITE`, every failing `eventually { }` under `coroutineTestScope = true` leaked a coroutine permanently.

## Fix

Wrap the `select` in `try { ... } finally { timeoutJob.cancel() }` so the watchdog is always cancelled whether the block returned, threw, or timed out. This is exactly the fix already applied to the identical Turbine-derived copy in the engine's `TimeoutInterceptor` in #6051; `Job.cancel()` is idempotent so the in-branch cancel remains harmless and timeout semantics are unchanged.

## Testing

Added a regression test to `WallClockTimeoutTest` that runs `withWallClockTimeout(Duration.INFINITE)` with a throwing block and uses `kotlinx-coroutines-debug` `DebugProbes` to assert no coroutine remains suspended inside `withWallClockTimeout`. Verified the test fails against the unfixed code and passes with the fix; full `:kotest-common:jvmTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)