### PR TITLE
fix(kotest-assertions-core): Fix retry exception classification and cap backoff at remaining timeout

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -2,7 +2,7 @@ package io.kotest.assertions
 
 import io.kotest.common.KotestInternal
 import io.kotest.common.nonDeterministicTestTimeSource
-import io.kotest.common.reflection.bestName
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
@@ -15,6 +15,7 @@ import kotlin.time.TimeSource
  * Retry [f] until it's a success or [maxRetry]/[timeout] is reached.
  *
  * This will treat only [exceptionClass] as a failure, along with [AssertionError].
+ * A [CancellationException] is always rethrown to support cooperative coroutine cancellation.
  *
  * Retry delay will increase exponentially if you choose a [multiplier] value. For example, if you want to configure
  * 5 [maxRetry], with an initial [delay] of 1s between requests, the delay between requests will increase when you
@@ -66,19 +67,23 @@ suspend fun <T> retry(
                   ).withCause(e)
                   .build()
             }
-            // Not the kind of exceptions we were prepared to tolerate
-            e::class.simpleName != "AssertionError" &&
-               config.exceptionClass?.isInstance(e) == false &&
-               e::class.bestName() != "org.opentest4j.AssertionFailedError" &&
-               !e::class.bestName().endsWith("AssertionFailedError") -> throw e
+            // external cancellation must always propagate to support cooperative coroutine cancellation
+            e is CancellationException -> throw e
+            // assertion errors are always retried, as are instances of the configured exception class
+            e is AssertionError || config.exceptionClass?.isInstance(e) == true -> lastError = e
+            // when no exception class is configured, exceptions are retried,
+            // but errors such as OutOfMemoryError are propagated
+            config.exceptionClass == null && e is Exception -> lastError = e
+            // not the kind of failure we were prepared to tolerate
+            else -> throw e
          }
-         lastError = e
-         // else ignore and continue
       }
       attemptedRetries++
       if (attemptedRetries >= config.maxRetry || end.hasPassedNow()) break
-      delay(nextAwaitDuration)
-      delayedTime += nextAwaitDuration
+      // cap the delay at the remaining time budget so the timeout is not overshot
+      val cappedDelay = minOf(nextAwaitDuration, config.timeout - mark.elapsedNow())
+      delay(cappedDelay)
+      delayedTime += cappedDelay
       nextAwaitDuration *= config.multiplier
    }
    val underlyingCause = if (lastError == null) "" else "; underlying cause was ${lastError.message}"
@@ -100,6 +105,11 @@ class RetryConfigBuilder {
    var timeout: Duration = Duration.INFINITE
    var delay: Duration = Duration.ZERO
    var multiplier: Int = 1
+
+   /**
+    * The exception class to treat as a retryable failure, along with [AssertionError].
+    * When null, any [Exception] is retried, but [Error]s other than [AssertionError] are rethrown.
+    */
    var exceptionClass: KClass<out Throwable>? = null
 
    @KotestInternal

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/RetryTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/assertions/RetryTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.kotest.assertions
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.retry
 import io.kotest.assertions.retryConfig
 import io.kotest.assertions.throwables.shouldNotThrow
@@ -15,6 +16,7 @@ import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldMatch
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -109,7 +111,7 @@ class RetryTest : StringSpec() {
             }
          }
          retryTester.calledAtTimeInstance shouldHaveSize 2
-         retryException shouldHaveMessage "Test failed after 800ms; attempted 2 times; underlying cause was expected:<true> but was:<false>"
+         retryException shouldHaveMessage "Test failed after 500ms; attempted 2 times; underlying cause was expected:<true> but was:<false>"
          retryTester.calledAtTimeInstance.shouldContainExactly(
             0.milliseconds,
             400.milliseconds,
@@ -238,7 +240,84 @@ class RetryTest : StringSpec() {
             actualMs shouldBeGreaterThan 10.milliseconds
          }
       }
+
+      "should retry when assertSoftly fails with multiple errors" {
+         var attempts = 0
+         retry(maxRetry = 5, timeout = 500.milliseconds, delay = 100.milliseconds) {
+            attempts++
+            assertSoftly {
+               attempts shouldBeGreaterThan 2
+               attempts shouldBe 3
+            }
+         }
+         attempts shouldBe 3
+      }
+
+      "should retry when a custom AssertionError subclass is thrown" {
+         var attempts = 0
+         retry(maxRetry = 5, timeout = 500.milliseconds, delay = 100.milliseconds) {
+            attempts++
+            if (attempts < 3) throw CustomAssertionError("not ready yet")
+         }
+         attempts shouldBe 3
+      }
+
+      "should rethrow non-assertion errors immediately when no exception class is configured" {
+         val config = retryConfig {
+            maxRetry = 5
+            timeout = 500.milliseconds
+            delay = 100.milliseconds
+         }
+         var attempts = 0
+         shouldThrow<FatalTestError> {
+            retry(config) {
+               attempts++
+               throw FatalTestError("fatal error")
+            }
+         }
+         attempts shouldBe 1
+      }
+
+      "should propagate CancellationException when no exception class is configured" {
+         val config = retryConfig {
+            maxRetry = 5
+            timeout = 500.milliseconds
+            delay = 100.milliseconds
+         }
+         var attempts = 0
+         shouldThrow<CancellationException> {
+            retry(config) {
+               attempts++
+               throw CancellationException("cancelled")
+            }
+         }
+         attempts shouldBe 1
+      }
+
+      "should cap the backoff delay at the remaining timeout" {
+         val testTimeSource = nonDeterministicTestTimeSource()
+         val config = retryConfig {
+            maxRetry = 10
+            timeout = 500.milliseconds
+            delay = 400.milliseconds
+            multiplier = 2
+            timeSource = testTimeSource
+         }
+         val mark = testTimeSource.markNow()
+         val retryException = shouldThrow<AssertionError> {
+            retry(config) {
+               1 shouldBe 2
+            }
+         }
+         // without capping, the second delay would be 800ms and the total time would be 1200ms
+         retryException shouldHaveMessage "Test failed after 500ms; attempted 2 times; underlying cause was expected:<2> but was:<1>"
+         mark.elapsedNow() shouldBe 500.milliseconds
+      }
    }
+
+   private class CustomAssertionError(message: String) : AssertionError(message)
+
+   private class FatalTestError(message: String) : Error(message)
 
    private class RetryTester(
       private val readyAfter: Int,


### PR DESCRIPTION
## Bug A: broken exception classification in `retry`

`retry` decided whether to rethrow or retry an exception using class-name string matching:

```kotlin
e::class.simpleName != "AssertionError" &&
   config.exceptionClass?.isInstance(e) == false &&
   e::class.bestName() != "org.opentest4j.AssertionFailedError" &&
   !e::class.bestName().endsWith("AssertionFailedError") -> throw e
```

This broke in two ways:

1. **AssertionError subclasses were not retried.** Any `AssertionError` subclass whose `simpleName` is not exactly `"AssertionError"` and doesn't end in `"AssertionFailedError"` fell through the name checks. Since `AssertionError` is an `Error` (not an `Exception`), the default `exceptionClass = Exception::class` made the rethrow fire. Repro:

   ```kotlin
   retry(maxRetry = 5, timeout = 1.seconds) {
      assertSoftly {
         a shouldBe x   // two failures -> assertSoftly throws MultiAssertionError
         b shouldBe y
      }
   }
   ```

   `MultiAssertionError` aborted retry on the **first** attempt instead of being retried. The same applied to JUnit4's `ComparisonFailure` and any other custom `AssertionError` subclass. The documented contract is "This will treat only exceptionClass as a failure, along with AssertionError".

2. **With a null `exceptionClass` (the `retryConfig { }` builder default), nothing was ever rethrown.** `config.exceptionClass?.isInstance(e) == false` is always `false` when `exceptionClass` is null, so the conjunction could never be true. `CancellationException` was swallowed and retried (breaking cooperative coroutine cancellation), and fatal errors like `OutOfMemoryError` were silently retried and finally wrapped in an `AssertionError`.

### Fix

Replace the name matching with type checks, mirroring the classification in `eventually`:

- `CancellationException` always propagates (external cancellation must work); the inner `withTimeout`'s `TimeoutCancellationException` is still converted to an `AssertionError` as before.
- `AssertionError` and instances of the configured `exceptionClass` are retried (`org.opentest4j.AssertionFailedError` extends `AssertionError`, so it is still covered).
- When `exceptionClass` is null, any `Exception` is retried, but non-assertion `Error`s are rethrown.
- Everything else is rethrown immediately, preserving the documented behavior for the non-null `exceptionClass` path.

## Bug B: backoff delay not capped at the remaining time budget

```kotlin
if (attemptedRetries >= config.maxRetry || end.hasPassedNow()) break
delay(nextAwaitDuration)
```

With an exponential `multiplier`, the sleep could massively overshoot `timeout` (e.g. timeout=5s, delay=4s, multiplier=2 -> returns at ~12s). The delay is now capped at the remaining budget, mirroring `eventually` (`delay(minOf(lastInterval, config.duration - delayMark))`), and the reported elapsed time tracks the actual capped delays.

## Tests

Added to `RetryTest` (all use the existing virtual-time setup, so the timing test is deterministic):

- `retry { assertSoftly { ... } }` with two failures retries and succeeds on attempt 3 instead of aborting on attempt 1
- a custom `AssertionError` subclass is retried
- with `retryConfig { }` (null `exceptionClass`), a non-assertion `Error` subclass is rethrown immediately after one attempt
- with `retryConfig { }`, `CancellationException` propagates after one attempt
- backoff capping: timeout=500ms, delay=400ms, multiplier=2 finishes at exactly 500ms virtual time (previously ~1200ms); the pre-existing "should not call given assertion beyond given max duration" message assertion was updated from 800ms to 500ms accordingly

All six fail against the old implementation; the full `RetryTest` class (19 tests) passes with the fix. No public signatures changed, so no api dump update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)