### PR TITLE
fix(kotest-framework-symbol-processor): Do not duplicate specs across KSP processing rounds

### DIFF
--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmMain/kotlin/io/kotest/framework/symbol/processor/KotestSymbolProcessor.kt
@@ -23,9 +23,22 @@ class KotestFileVisitor : KSVisitorVoid() {
    override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
       super.visitClassDeclaration(classDeclaration, data)
       if (isPublic(classDeclaration) && !isAbstract(classDeclaration) && isSpec(classDeclaration)) {
-         specs.add(classDeclaration)
+         addIfAbsent(specs, classDeclaration)
       } else if (isConfig(classDeclaration)) {
-         configs.add(classDeclaration)
+         addIfAbsent(configs, classDeclaration)
+      }
+   }
+
+   /**
+    * Adds [declaration] to [declarations] unless a declaration with the same fully-qualified
+    * name has already been collected. KSP invokes [io.kotest.framework.symbol.processor.KotestSymbolProcessor.process]
+    * once per processing round, so without deduplication a class visited in more than one round
+    * would be registered multiple times in the generated entry point.
+    */
+   private fun addIfAbsent(declarations: MutableList<KSClassDeclaration>, declaration: KSClassDeclaration) {
+      val name = declaration.qualifiedName?.asString() ?: declaration.simpleName.asString()
+      if (declarations.none { (it.qualifiedName?.asString() ?: it.simpleName.asString()) == name }) {
+         declarations.add(declaration)
       }
    }
 
@@ -64,7 +77,9 @@ class KotestSymbolProcessor(private val environment: SymbolProcessorEnvironment)
    val visitor = KotestFileVisitor()
 
    override fun process(resolver: Resolver): List<KSAnnotated> {
-      resolver.getAllFiles().forEach { it.accept(visitor, Unit) }
+      // process is invoked once per KSP round, so only visit files new to this round,
+      // otherwise specs would be collected (and thus registered) once per round
+      resolver.getNewFiles().forEach { it.accept(visitor, Unit) }
       return emptyList()
    }
 

--- a/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/KotestFileVisitorTest.kt
+++ b/kotest-framework/kotest-framework-symbol-processor/src/jvmTest/kotlin/com/sksamuel/kotest/framework/symbol/processor/KotestFileVisitorTest.kt
@@ -179,4 +179,43 @@ class KotestFileVisitorTest : FunSpec({
       )
       visitor.specs shouldBe emptyList()
    }
+
+   test("specs are not duplicated when the same class is visited in multiple ksp rounds") {
+      val spec = SimpleKSClassDeclaration(
+         className = "com.sksamuel.MySpec",
+         supers = listOf(
+            SimpleKSTypeReference(
+               SimpleKSType(
+                  declaration = SimpleKSClassDeclaration(
+                     className = "io.kotest.core.spec.Spec",
+                  )
+               )
+            )
+         ),
+      )
+      val visitor = KotestFileVisitor()
+      // ksp invokes process() once per round, which can visit the same declaration again
+      visitor.visitClassDeclaration(spec, Unit)
+      visitor.visitClassDeclaration(spec, Unit)
+      visitor.specs.map { it.qualifiedName?.asString() } shouldBe listOf("com.sksamuel.MySpec")
+   }
+
+   test("configs are not duplicated when the same class is visited in multiple ksp rounds") {
+      val config = SimpleKSClassDeclaration(
+         className = "com.sksamuel.ProjectConfig",
+         supers = listOf(
+            SimpleKSTypeReference(
+               SimpleKSType(
+                  declaration = SimpleKSClassDeclaration(
+                     className = "io.kotest.core.config.AbstractProjectConfig",
+                  )
+               )
+            )
+         ),
+      )
+      val visitor = KotestFileVisitor()
+      visitor.visitClassDeclaration(config, Unit)
+      visitor.visitClassDeclaration(config, Unit)
+      visitor.configs.map { it.qualifiedName?.asString() } shouldBe listOf("com.sksamuel.ProjectConfig")
+   }
 })


### PR DESCRIPTION
## Bug

`KotestSymbolProcessor.process()` used `resolver.getAllFiles()`, which returns every file in the compilation, while KSP invokes `process()` once per round. The visitor accumulates specs/configs into mutable lists across rounds.

## Consequence

If any other KSP processor in the same compilation generates sources (triggering round 2+), every spec is visited again:

- the generated `launch()` registers each spec multiple times, so tests execute twice (or more)
- a single `AbstractProjectConfig` is counted twice, falsely tripping `validateProjectConfigs()` with `Only one ProjectConfig is allowed, found X;X`

## Fix

- Process only `resolver.getNewFiles()` per round (the canonical KSP pattern; generated spec files still get picked up in the round they appear)
- Defensively deduplicate collected specs/configs by fully-qualified name in `KotestFileVisitor`, guarding against the same declaration being visited twice for any other reason

## Verification

- Added regression tests in `KotestFileVisitorTest` asserting that visiting the same spec/config declaration twice (simulating multiple rounds) collects it only once
- `./gradlew :kotest-framework:kotest-framework-symbol-processor:check` passes
- The `getNewFiles()` multi-round behavior itself was verified by code inspection; the module's unit test harness uses fake KS declarations and has no multi-round KSP compile-testing infrastructure, and the `kotest-tests` modules that apply KSP pin a published plugin version so they do not exercise the local processor

🤖 Generated with [Claude Code](https://claude.com/claude-code)