### PR TITLE
fix(kotest-extensions-testcontainers): Release lock on container start failure in ComposeContainerProjectExtension

### DIFF
--- a/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerProjectExtension.kt
+++ b/kotest-extensions/kotest-extensions-testcontainers/src/jvmMain/kotlin/io/kotest/extensions/testcontainers/ComposeContainerProjectExtension.kt
@@ -36,14 +36,17 @@ class ComposeContainerProjectExtension(
 
    override fun mount(configure: ComposeContainer.() -> Unit): ComposeContainer {
       lock.lockInterruptibly()
-      val t = ref.get()
-      if (t == null) {
-         configure(container)
-         container.start()
-         onStart(container)
-         ref.set(container)
+      try {
+         val t = ref.get()
+         if (t == null) {
+            configure(container)
+            container.start()
+            onStart(container)
+            ref.set(container)
+         }
+      } finally {
+         lock.unlock()
       }
-      lock.unlock()
       return container
    }
 


### PR DESCRIPTION
## Bug

`ComposeContainerProjectExtension.mount` acquires its `ReentrantLock` without a `try`/`finally`. If `configure`, `container.start()`, or `onStart` throws (e.g. compose startup failure), the lock is never released, and every subsequent spec that installs the extension blocks forever — in parallel runs this manifests as a hang instead of a failed build.

## Fix

Wrap the critical section in `try { ... } finally { lock.unlock() }`, mirroring the pattern already used by the sibling extensions in the same package (`TestContainerProjectExtension`, `JdbcDatabaseContainerProjectExtension`). No behavioral change on the happy path; no public API change.

## Verification

- `./gradlew :kotest-extensions:kotest-extensions-testcontainers:compileKotlinJvm` and `compileTestKotlinJvm` pass.
- Existing tests for this module all require Docker and are gated by `@EnabledIf(LinuxOnlyGithubCondition::class)`, so no new test was added for the lock-release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)