### PR TITLE
fix(kotest-extensions): Restore original System.out/err correctly for nested tests in wire listeners

### DIFF
--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/wireListeners.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/wireListeners.kt
@@ -54,23 +54,24 @@ inline fun captureStandardErr(fn: () -> Unit): String {
 class SystemOutWireListener(private val tee: Boolean = true) : TestListener {
 
    private var buffer = ByteArrayOutputStream()
-   private var previous = System.out
+   private val previous = ArrayDeque<PrintStream>()
 
    fun output(): String = buffer.asCanonicalString()
 
    override suspend fun beforeAny(testCase: TestCase) {
       buffer = ByteArrayOutputStream()
-      previous = System.out
-      previous.flush()
+      val current = System.out
+      previous.addLast(current)
+      current.flush()
       if (tee) {
-         System.setOut(PrintStream(TeeOutputStream(previous, buffer)))
+         System.setOut(PrintStream(TeeOutputStream(current, buffer)))
       } else {
          System.setOut(PrintStream(buffer))
       }
    }
 
    override suspend fun afterAny(testCase: TestCase, result: TestResult) {
-      System.setOut(previous)
+      previous.removeLastOrNull()?.let { System.setOut(it) }
    }
 }
 
@@ -83,23 +84,24 @@ class SystemOutWireListener(private val tee: Boolean = true) : TestListener {
 class SystemErrWireListener(private val tee: Boolean = true) : TestListener {
 
    private var buffer = ByteArrayOutputStream()
-   private var previous = System.err
+   private val previous = ArrayDeque<PrintStream>()
 
    fun output(): String = buffer.asCanonicalString()
 
    override suspend fun beforeAny(testCase: TestCase) {
       buffer = ByteArrayOutputStream()
-      previous = System.err
-      previous.flush()
+      val current = System.err
+      previous.addLast(current)
+      current.flush()
       if (tee) {
-         System.setErr(PrintStream(TeeOutputStream(previous, buffer)))
+         System.setErr(PrintStream(TeeOutputStream(current, buffer)))
       } else {
          System.setErr(PrintStream(buffer))
       }
    }
 
    override suspend fun afterAny(testCase: TestCase, result: TestResult) {
-      System.setErr(previous)
+      previous.removeLastOrNull()?.let { System.setErr(it) }
    }
 }
 

--- a/kotest-extensions/src/jvmTest/kotlin/com/sksamuel/kt/extensions/system/SystemWireListenerNestedTest.kt
+++ b/kotest-extensions/src/jvmTest/kotlin/com/sksamuel/kt/extensions/system/SystemWireListenerNestedTest.kt
@@ -1,0 +1,63 @@
+package com.sksamuel.kt.extensions.system
+
+import io.kotest.core.annotation.Isolate
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.extensions.system.SystemErrWireListener
+import io.kotest.extensions.system.SystemOutWireListener
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+/**
+ * Regression test for nested tests with [SystemOutWireListener] and [SystemErrWireListener].
+ *
+ * The listeners use beforeAny/afterAny, which also fire for containers. Previously a single
+ * `previous` field was overwritten by the nested test's beforeAny, so the container's afterAny
+ * restored the listener's own capture stream instead of the original System.out/System.err,
+ * permanently hijacking standard out/err for the rest of the JVM.
+ */
+@Isolate
+class SystemWireListenerNestedTest : FunSpec() {
+   init {
+
+      test("SystemOutWireListener should restore the original System.out after a spec with nested tests") {
+         val out = System.out
+         TestEngineLauncher()
+            .withSpecRefs(SpecRef.Reference(NestedSystemOutSpec::class))
+            .execute()
+         System.out.shouldBeSameInstanceAs(out)
+      }
+
+      test("SystemErrWireListener should restore the original System.err after a spec with nested tests") {
+         val err = System.err
+         TestEngineLauncher()
+            .withSpecRefs(SpecRef.Reference(NestedSystemErrSpec::class))
+            .execute()
+         System.err.shouldBeSameInstanceAs(err)
+      }
+   }
+}
+
+private class NestedSystemOutSpec : FunSpec() {
+   override val extensions = listOf(SystemOutWireListener())
+
+   init {
+      context("a container") {
+         test("a nested test") {
+            println("hello")
+         }
+      }
+   }
+}
+
+private class NestedSystemErrSpec : FunSpec() {
+   override val extensions = listOf(SystemErrWireListener())
+
+   init {
+      context("a container") {
+         test("a nested test") {
+            System.err.println("hello")
+         }
+      }
+   }
+}


### PR DESCRIPTION
## Bug

`SystemOutWireListener` / `SystemErrWireListener` use `beforeAny`/`afterAny`, which fire for container scopes as well as leaf tests, but each listener kept a single `previous` field:

1. The container's `beforeAny` saves the real stream and installs capture stream 1.
2. The nested test's `beforeAny` overwrites `previous` with capture stream 1 and installs capture stream 2.
3. The nested test's `afterAny` restores capture stream 1.
4. The container's `afterAny` restores `previous` — which is now capture stream 1, not the real stream.

**Consequence:** after any spec with a nested test using these listeners, `System.out`/`System.err` permanently point at the listener's capture stream, silently swallowing all subsequent output for the rest of the JVM.

## Fix

Replace the single `previous` field with an `ArrayDeque` of previous streams, pushed in `beforeAny` and popped in `afterAny`, so nested scopes restore in LIFO order. Buffer semantics for the flat (non-nested) case are unchanged: `output()` still returns the innermost test's captured output. The fields are private, so there is no public API change.

## Tests

Added `SystemWireListenerNestedTest`, which runs specs containing a container + nested test with each listener via `TestEngineLauncher` and asserts that `System.out`/`System.err` are referentially identical to the streams captured before the spec ran. Both tests fail against the old implementation and pass with the fix; the full `:kotest-extensions:jvmTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)