### PR TITLE
fix(kotest-framework-engine): Invoke package config extensions for spec-level callbacks

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/SpecConfigResolver.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/config/SpecConfigResolver.kt
@@ -103,12 +103,14 @@ class SpecConfigResolver(
    /**
     * Returns all [Extension]s applicable to a [Spec]. This includes extensions via
     * function overrides, those registered explicitly in the spec as part of the DSL,
+    * package level extensions from [io.kotest.core.config.AbstractPackageConfig]s,
     * and project wide extensions from configuration.
     */
    fun extensions(spec: Spec): List<Extension> {
       return spec.extensions + // overriding the extensions val in the spec
          spec.functionOverrideCallbacks() + // dsl
          spec.extensions() + // added to the spec via the `extension` functions which is also called by mountable extensions
+         loadPackageConfigs(spec).flatMap { it.extensions } + // package level extensions
          (projectConfig?.extensions ?: emptyList()) + // extensions defined at the project level
          registry.all() // globals
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/specextensions/PackageConfigSpecExtensionsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/config/specextensions/PackageConfigSpecExtensionsTest.kt
@@ -1,0 +1,80 @@
+package com.sksamuel.kotest.engine.config.specextensions
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.config.AbstractPackageConfig
+import io.kotest.core.extensions.Extension
+import io.kotest.core.extensions.SpecExtension
+import io.kotest.core.listeners.AfterSpecListener
+import io.kotest.core.listeners.BeforeSpecListener
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Detected by [io.kotest.engine.config.PackageConfigLoader] for specs in this package.
+ */
+class PackageConfig : AbstractPackageConfig() {
+   override val extensions: List<Extension> = listOf(PackageWideSpecListener, PackageWideSpecExtension)
+}
+
+private object PackageWideSpecListener : BeforeSpecListener, AfterSpecListener {
+
+   val beforeSpecCounter = AtomicInteger(0)
+   val afterSpecCounter = AtomicInteger(0)
+
+   override suspend fun beforeSpec(spec: Spec) {
+      beforeSpecCounter.incrementAndGet()
+   }
+
+   override suspend fun afterSpec(spec: Spec) {
+      afterSpecCounter.incrementAndGet()
+   }
+}
+
+private object PackageWideSpecExtension : SpecExtension {
+
+   val interceptCounter = AtomicInteger(0)
+
+   override suspend fun intercept(spec: Spec, execute: suspend (Spec) -> Unit) {
+      interceptCounter.incrementAndGet()
+      execute(spec)
+   }
+}
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class PackageConfigSpecExtensionsTest : FunSpec() {
+   init {
+
+      beforeTest {
+         PackageWideSpecListener.beforeSpecCounter.set(0)
+         PackageWideSpecListener.afterSpecCounter.set(0)
+         PackageWideSpecExtension.interceptCounter.set(0)
+      }
+
+      test("spec level extensions declared in a package config should be invoked") {
+
+         val collector = CollectingTestEngineListener()
+         TestEngineLauncher()
+            .withoutEnvFilters()
+            .withListener(collector)
+            .withSpecRefs(SpecRef.Reference(PackageConfigTargetSpec::class))
+            .execute()
+
+         collector.tests.size shouldBe 1
+         PackageWideSpecListener.beforeSpecCounter.get() shouldBe 1
+         PackageWideSpecListener.afterSpecCounter.get() shouldBe 1
+         PackageWideSpecExtension.interceptCounter.get() shouldBe 1
+      }
+   }
+}
+
+private class PackageConfigTargetSpec : FunSpec() {
+   init {
+      test("a") {}
+   }
+}


### PR DESCRIPTION
## Bug

`SpecConfigResolver.extensions(spec)` did not include extensions declared in an `AbstractPackageConfig`. Since this resolver is used by `SpecExtensions` for `beforeSpec` / `afterSpec` / `specInstantiated` / `intercept` and enabled-checks, any `BeforeSpecListener`, `AfterSpecListener`, `SpecExtension` or `EnabledExtension` declared in a `PackageConfig` was silently never invoked — contradicting the `AbstractPackageConfig.extensions` KDoc ("package wide Extension instances"). `TestConfigResolver.extensions(testCase, ...)` already included package configs, so only test-level callbacks worked.

## Fix

Mirror `TestConfigResolver`'s package config loading in `SpecConfigResolver.extensions(spec)`, inserting package config extensions between spec-level and project-level extensions, consistent with the precedence ordering used by `TestConfigResolver` (spec > package > project > global registry).

## Tests

Added `PackageConfigSpecExtensionsTest` (engine jvmTest) with a `PackageConfig` in a dedicated test package declaring a `BeforeSpecListener`/`AfterSpecListener` and a `SpecExtension`, verifying all are invoked exactly once when a spec in that package is executed via a nested `TestEngineLauncher`. The test fails without the fix and passes with it; the full `:kotest-framework:kotest-framework-engine:jvmTest` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)