### PR TITLE
fix(kotest-framework-engine): Use display-name rendering for ignored tests in TeamCity listener

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
@@ -97,7 +97,7 @@ class TeamCityTestEngineListener(
 
    override suspend fun testIgnored(testCase: TestCase, reason: String?) {
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_IGNORED) {
-         name(testCase.descriptor.path().value)
+         name(renderer.testPath(testCase))
          locationHint(Locations.location(testCase.source))
          message(reason)
          result(TestResult.Ignored(reason))

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerEmbeddedLocationsTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerEmbeddedLocationsTest.kt
@@ -18,7 +18,7 @@ import io.kotest.matchers.string.shouldStartWith
  * The engine no longer wraps test names with `<kotest>...</kotest>` location tags - jump-to-source
  * navigation now flows via the JUnit Platform `MethodSource` (and `proxy.locationUrl`).  This test
  * pins the resulting [TeamCityTestEngineListener] output: every lifecycle message names the test
- * by its plain descriptor path, with no embedded `<kotest>` tag and no legacy ` -- ` separator
+ * via the display-name renderer, with no embedded `<kotest>` tag and no legacy ` -- ` separator
  * between nested segments.
  */
 class TeamCityTestEngineListenerEmbeddedLocationsTest : FunSpec() {
@@ -54,7 +54,7 @@ class TeamCityTestEngineListenerEmbeddedLocationsTest : FunSpec() {
          stdout shouldNotContain "<kotest>"
          stdout shouldNotContain " -- "
          stdout shouldStartWith "tc[testIgnored "
-         stdout shouldContain "name='$specFqn/a'"
+         stdout shouldContain "name='$specFqn.a'"
          stdout shouldContain "result_status='Ignored'"
       }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
@@ -121,7 +121,26 @@ a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngine
          }
          stripDetails(output) shouldBe """a[enteredTheMatrix]
 a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
-a[testIgnored name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest/a -- b -- c' locationHint='kotest://foo.bar.Test:33' message='don|'t like it' result_status='Ignored']
+a[testIgnored name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33' message='don|'t like it' result_status='Ignored']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+"""
+      }
+
+      test("should use display name rendering for nested ignored tests when parents were not started") {
+         val output = captureStandardOut {
+            val listener = TeamCityTestEngineListener("a")
+            listener.engineStarted()
+            listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
+            listener.testIgnored(c, "skipped")
+            listener.specFinished(
+               SpecRef.Reference(TeamCityTestEngineListenerTest::class),
+               TestResult.Success(0.seconds)
+            )
+            listener.engineFinished(emptyList())
+         }
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testIgnored name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest.a ⇢ b ⇢ c' locationHint='kotest://foo.bar.Test:33' message='skipped' result_status='Ignored']
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }


### PR DESCRIPTION
## Bug

`TeamCityTestEngineListener.testIgnored` emitted the raw descriptor path (`fqn/name -- child`) via `testCase.descriptor.path().value`, while `testStarted`/`testFinished` use `renderer.testPath(testCase)` (display-name formatting, `@DisplayName` support, TeamCity name escaping, flattened `fqn.name ⇢ child` form). As a result, ignored tests appeared in IntelliJ under a different, unformatted name than the same test when it runs, and bypassed display-name formatting entirely.

## Fix

`testIgnored` now renders the test name via the same `TeamCityPathRenderer` path as started/finished events. The renderer builds the flattened parent chain from the `TestCase` itself, so ignored tests render consistently even when their parents never emitted start events.

## Tests

- Updated `TeamCityTestEngineListenerTest` "should support ignored tests with reason" to expect the formatted `fqn.a ⇢ b ⇢ c` name (matching what started/finished would produce for the same test).
- Added a case for a nested ignored test whose parents were never started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)