### PR TITLE
fix(kotest-property): Handle degenerate ranges and inclusive max bounds in yearMonth/localTime/double/float arbs

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/doubles.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/doubles.kt
@@ -74,7 +74,8 @@ fun Arb.Companion.double(
    )).distinct() + getNonFiniteEdgeCases(range, includeNaNs),
    DoubleShrinker
 ) {
-   it.random.nextDouble(range.start, range.endInclusive)
+   if (range.start == range.endInclusive) range.start
+   else it.random.nextDouble(range.start, range.endInclusive)
 }
 
 /**
@@ -111,7 +112,7 @@ fun Arb.Companion.numericDouble(
    max: Double = Double.MAX_VALUE
 ): Arb<Double> = arbitrary(
    (numericEdgeCases.filter { it in (min..max) } + listOf(min, max)).distinct(), DoubleShrinker
-) { it.random.nextDouble(min, max) }
+) { if (min == max) min else it.random.nextDouble(min, max) }
 
 /**
  * Returns an [Arb] that produces [DoubleArray]s where [length] produces the length of the arrays and

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/floats.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/floats.kt
@@ -39,7 +39,8 @@ fun Arb.Companion.float(range: ClosedFloatingPointRange<Float> = -Float.MAX_VALU
       (numericEdgeCases.filter { it in range } + listOf(range.start, range.endInclusive)).distinct() + getNonFiniteEdgeCases(range, includeNaNs),
       FloatShrinker
    ) {
-      it.random.nextDouble(range.start.toDouble(), range.endInclusive.toDouble()).toFloat()
+      if (range.start == range.endInclusive) range.start
+      else it.random.nextDouble(range.start.toDouble(), range.endInclusive.toDouble()).toFloat()
    }
 
 /**
@@ -69,7 +70,7 @@ fun Arb.Companion.numericFloat(
    min: Float = -Float.MAX_VALUE,
    max: Float = Float.MAX_VALUE
 ): Arb<Float> = arbitrary((numericEdgeCases.filter { it in min..max } + listOf(min, max)).distinct(), FloatShrinker) {
-   it.random.nextDouble(min.toDouble(), max.toDouble()).toFloat()
+   if (min == max) min else it.random.nextDouble(min.toDouble(), max.toDouble()).toFloat()
 }
 
 /**

--- a/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
+++ b/kotest-property/src/jvmMain/kotlin/io/kotest/property/arbitrary/dates.kt
@@ -122,9 +122,10 @@ fun Arb.Companion.localTime(
    startTime: LocalTime = LocalTime.MIN,
    endTime: LocalTime = LocalTime.MAX,
 ): Arb<LocalTime> {
+   if (startTime == endTime) return Arb.constant(startTime)
    val (durationInNanoSeconds, edgeCases) = getLocalDateArbParams(startTime, endTime)
    return arbitrary(edgeCases) {
-      startTime.plus(it.random.nextLong(durationInNanoSeconds), ChronoUnit.NANOS)
+      startTime.plus(it.random.nextLong(durationInNanoSeconds + 1), ChronoUnit.NANOS)
    }
 }
 
@@ -270,11 +271,15 @@ fun Arb.Companion.yearMonth(
    minYearMonth: YearMonth = YearMonth.of(1970, 1),
    maxYearMonth: YearMonth = YearMonth.of(2030, 12)
 ): Arb<YearMonth> {
+   require(minYearMonth <= maxYearMonth) { "minYearMonth must be before or equal to maxYearMonth" }
+   if (minYearMonth == maxYearMonth) return Arb.constant(minYearMonth)
+
    val leapYears = (minYearMonth.year..maxYearMonth.year).filter { isLeap(it.toLong()) }
    val february = leapYears.map { YearMonth.of(it, 2) }
 
    return arbitrary(february + minYearMonth + maxYearMonth) {
-      minYearMonth.plusMonths(it.random.nextLong(ChronoUnit.MONTHS.between(minYearMonth, maxYearMonth)))
+      val monthsBetween = ChronoUnit.MONTHS.between(minYearMonth, maxYearMonth)
+      minYearMonth.plusMonths(it.random.nextLong(monthsBetween + 1))
    }.filter { it in minYearMonth..maxYearMonth }
 }
 

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DateTest.kt
@@ -368,6 +368,17 @@ class DateTest : WordSpec({
             2
          )
       }
+
+      "generate the single YearMonth when minYearMonth equals maxYearMonth" {
+         val yearMonth = YearMonth.of(2021, 5)
+         Arb.yearMonth(yearMonth, yearMonth).take(100).toSet() shouldBe setOf(yearMonth)
+      }
+
+      "generate both YearMonths of a two-month range via random samples" {
+         val min = YearMonth.of(2021, 5)
+         val max = YearMonth.of(2021, 6)
+         Arb.yearMonth(min, max).take(1000).toSet() shouldBe setOf(min, max)
+      }
    }
 
    "Arb.offsetDateTime(minLocalDateTime, maxLocalDateTime, zoneOffset)" should {
@@ -564,6 +575,18 @@ class DateTest : WordSpec({
          timesBeforeMidnight.shouldNotBeEmpty()
          timesBeforeMidnight.min() shouldBe start
          times.filter { it > end && it < start }.shouldBeEmpty()
+      }
+
+      "generate the single LocalTime when startTime equals endTime" {
+         val time = LocalTime.of(10, 30, 15)
+         Arb.localTime(time, time).take(100).toSet() shouldBe setOf(time)
+      }
+
+      "generate the inclusive endTime via random samples for a small range" {
+         val start = LocalTime.of(10, 0)
+         val end = start.plusNanos(3)
+         val times = Arb.localTime(start, end).take(1000).toSet()
+         times shouldBe setOf(start, start.plusNanos(1), start.plusNanos(2), end)
       }
    }
    "getLocalDateArbParams" should {

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DoubleTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DoubleTest.kt
@@ -75,4 +75,12 @@ class DoubleTest : FunSpec({
    test("NaNs should not be included regardless of range when includeNaNs is false") {
       Arb.double(0.0..100.0, includeNaNs = false).edgecases(1000).toList().none { it.isNaN() }
    }
+
+   test("double should support a degenerate range where min == max") {
+      Arb.double(5.0..5.0).take(100).toSet() shouldContainExactly setOf(5.0)
+   }
+
+   test("numericDouble should support a degenerate range where min == max") {
+      Arb.numericDouble(5.0, 5.0).take(100).toSet() shouldContainExactly setOf(5.0)
+   }
 })

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FloatTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/FloatTest.kt
@@ -75,4 +75,12 @@ class FloatTest : FunSpec({
    test("NaNs should not be included regardless of range when includeNaNs is false") {
       Arb.float(0F..100F, includeNaNs = false).edgecases(1000).toList().none { it.isNaN() }
    }
+
+   test("float should support a degenerate range where min == max") {
+      Arb.float(5F..5F).take(100).toSet() shouldContainExactly setOf(5F)
+   }
+
+   test("numericFloat should support a degenerate range where min == max") {
+      Arb.numericFloat(5F, 5F).take(100).toSet() shouldContainExactly setOf(5F)
+   }
 })


### PR DESCRIPTION
## Problem

A cluster of generators used half-open random bounds against documented-inclusive ranges, and crashed on degenerate `min == max` ranges:

- **`Arb.yearMonth`**: `minYearMonth.plusMonths(random.nextLong(MONTHS.between(min, max)))` — `nextLong(until)` is half-open, so `maxYearMonth` was never produced by random sampling, and `Arb.yearMonth(x, x)` threw `IllegalArgumentException: Random range is empty`.
- **`Arb.localTime(startTime, endTime)`**: `endTime` is documented as inclusive but `nextLong(durationInNanoSeconds)` made it unreachable via random samples, and `Arb.localTime(t, t)` threw on `nextLong(0)`.
- **`Arb.double(5.0..5.0)`, `Arb.numericDouble(5.0, 5.0)`, `Arb.float(5f..5f)`, `Arb.numericFloat(5f, 5f)`**: `Random.nextDouble(from, until)` requires `until > from`, so every sample threw `IllegalArgumentException` (the integral arbs like `Arb.int(5..5)` handle this fine).

## Fix

- `Arb.yearMonth` now mirrors the existing `Arb.localDate` pattern: equal bounds return `Arb.constant(min)`, and random sampling uses `nextLong(monthsBetween + 1)` so the max is reachable. Also added the same `require(min <= max)` guard as `Arb.localDate`.
- `Arb.localTime(startTime, endTime)`: equal bounds return `Arb.constant(startTime)`, and sampling uses `nextLong(durationInNanoSeconds + 1)` so `endTime` is reachable (this also works for ranges spanning midnight, where `LocalTime.plus` wraps to exactly `endTime`).
- `Arb.double`/`Arb.numericDouble`/`Arb.float`/`Arb.numericFloat`: `min == max` now returns that value instead of crashing. (No attempt to make the floating-point upper bound inclusive in general — that boundary has measure zero; this just fixes the crash.)

## Tests

- `Arb.yearMonth(x, x)` samples only `x`; a two-month range produces both months via random samples (1000 samples).
- `Arb.localTime(t, t)` samples only `t`; a 3-nano range produces all four values including the inclusive `endTime` (1000 samples).
- Degenerate-range tests for `Arb.double`, `Arb.numericDouble`, `Arb.float`, `Arb.numericFloat` asserting 100 samples all equal the single value.

No public API signature changes, so no apiDump needed. Verified with the full `:kotest-property:jvmTest` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)