### PR TITLE
fix(kotest-extensions-spring): Remove leftover debug println from SpringExtension

### DIFF
--- a/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
+++ b/kotest-extensions/kotest-extensions-spring/src/jvmMain/kotlin/io/kotest/extensions/spring/SpringExtension.kt
@@ -57,8 +57,6 @@ open class SpringExtension(
       val manager = getTestContextManager(clazz)
       val context = manager.testContext.applicationContext
 
-      println("Creating instance of $clazz")
-
       logger.log { Pair(clazz.simpleName, "Spring extension will try to create autowired instance") }
       return context.autowireCapableBeanFactory.autowire(
          clazz.java,


### PR DESCRIPTION
Removes a leftover debug `println("Creating instance of $clazz")` from `SpringExtension.instantiate`, which was introduced as debug output in #5317 (and had its typo fixed in #5788 rather than being removed). It printed raw to stdout for every Spring-instantiated spec and duplicated the `logger.log` call immediately below it, which is kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)