### PR TITLE
fix(kotest-property): Throw a descriptive error when Arb.distinct exhausts attempts

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/distinct.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/distinct.kt
@@ -24,7 +24,10 @@ fun <A> Arb<A>.distinct(attempts: Int = 100) = object : Arb<A>() {
       var iterations = 0
       return generateSequence {
          if (iterations++ < attempts) this@distinct.sample(rs) else null
-      }.filter { seen.add(it.value) }.first()
+      }.filter { seen.add(it.value) }.firstOrNull()
+         ?: throw NoSuchElementException(
+            "the arb was unable to provide a new distinct value after $attempts attempts"
+         )
    }
 
 }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DistinctTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/DistinctTest.kt
@@ -12,8 +12,10 @@ import io.kotest.property.Arb
 import io.kotest.property.EdgeConfig
 import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.constant
 import io.kotest.property.arbitrary.distinct
 import io.kotest.property.arbitrary.int
+import io.kotest.property.arbitrary.single
 import io.kotest.property.arbitrary.take
 
 @OptIn(DelicateKotest::class)
@@ -54,6 +56,14 @@ class DistinctTest : FunSpec({
       }
       // +1 for the first 0, then +43 for the failures
       count shouldBe 2
+   }
+
+   test("distinct should throw a descriptive error when attempts are exhausted") {
+      val arb = Arb.constant(1).distinct(attempts = 7)
+      arb.single(RandomSource.default()) shouldBe 1
+      shouldThrow<NoSuchElementException> {
+         arb.single(RandomSource.default())
+      }.message shouldBe "the arb was unable to provide a new distinct value after 7 attempts"
    }
 
    test("distinct should also work for edgecases") {


### PR DESCRIPTION
## Bug

When `Arb.distinct()` exhausts its attempts (every sample was a duplicate), the internal `generateSequence { ... }.filter { ... }.first()` ends the sequence and throws a bare `NoSuchElementException: Sequence is empty`, with no mention of distinctness or the attempts limit.

## Fix

Replace `.first()` with `.firstOrNull()` and throw a descriptive `NoSuchElementException` when exhausted:

```
the arb was unable to provide a new distinct value after N attempts
```

The exception type is unchanged (still `NoSuchElementException`), so existing behavior and the existing tests that catch it are unaffected. The success path is identical.

## Test

Added a regression test in `DistinctTest` using `Arb.constant(1).distinct(attempts = 7)`: the first sample succeeds, and the next sample throws with the new message including the attempts count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)