### PR TITLE
fix(kotest-framework-engine): Fix Descriptor.depth() off-by-one

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/descriptors/descriptor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/descriptors/descriptor.kt
@@ -94,7 +94,7 @@ sealed interface Descriptor {
     * Returns the depth of this node, where a [SpecDescriptor] has depth of 0,
     * a root test has depth 1 and so on.
     */
-   fun depth() = parents().size - 1
+   fun depth() = parents().size
 
    /**
     * Recursively returns any parent descriptors, with the [SpecDescriptor] being first in the list

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/ConsoleTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/ConsoleTestEngineListener.kt
@@ -154,12 +154,16 @@ class ConsoleTestEngineListener : AbstractTestEngineListener() {
    override suspend fun testIgnored(testCase: TestCase, reason: String?) {
       testsIgnored++
       val str = buildString {
-         append("".padEnd(testCase.descriptor.depth() * 4, ' '))
+         append("".padEnd(indent(testCase), ' '))
          append("- ")
          append(formatter.format(testCase) + consoleRenderer.brightYellowBold(" IGNORED"))
       }
       consoleRenderer.println(str)
    }
+
+   // root tests have a depth of 1 and are printed without indentation, with each
+   // level of nesting indented by a further 4 spaces
+   private fun indent(testCase: TestCase): Int = (testCase.descriptor.depth() - 1) * 4
 
    private fun durationString(duration: Duration): String {
       return when {
@@ -173,7 +177,7 @@ class ConsoleTestEngineListener : AbstractTestEngineListener() {
       // we want to output containers immediately so they appear in the correct order in the console
       if (testCase.type == TestType.Container) {
          val str = buildString {
-            append("".padEnd(testCase.descriptor.depth() * 4, ' '))
+            append("".padEnd(indent(testCase), ' '))
             append("+ ")
             append(formatter.format(testCase))
          }
@@ -202,7 +206,7 @@ class ConsoleTestEngineListener : AbstractTestEngineListener() {
             is TestResult.Ignored -> consoleRenderer.brightYellow(" IGNORED")
          }
          val str = buildString {
-            append("".padEnd(testCase.descriptor.depth() * 4, ' ') + "- " + formatter.format(testCase) + r)
+            append("".padEnd(indent(testCase), ' ') + "- " + formatter.format(testCase) + r)
             if (result.duration > slow) {
                append(" ${durationString(result.duration)}")
             }
@@ -212,7 +216,7 @@ class ConsoleTestEngineListener : AbstractTestEngineListener() {
 
       if (result.errorOrNull != null) {
          consoleRenderer.println()
-         printThrowable(result.errorOrNull, testCase.descriptor.depth() * 4)
+         printThrowable(result.errorOrNull, indent(testCase))
          consoleRenderer.println()
       }
    }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/descriptors/DescriptorTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/descriptors/DescriptorTest.kt
@@ -31,6 +31,18 @@ class DescriptorTest : FunSpec({
    val jsE = jsD.append("e")
    val jsF = jsSpec.append("f")
 
+   test("depth") {
+      // a spec has depth 0, a root test depth 1, and so on
+      spec.depth() shouldBe 0
+      listOf(a, d, f).forAll {
+         it.depth() shouldBe 1
+      }
+      listOf(b, e).forAll {
+         it.depth() shouldBe 2
+      }
+      c.depth() shouldBe 3
+   }
+
    test("isTestCase") {
       spec.isTestCase() shouldBe false
       listOf(a, b, c, d, e, f).forAll {


### PR DESCRIPTION
## Problem

The KDoc for `Descriptor.depth()` documents that "a SpecDescriptor has depth of 0, a root test has depth 1 and so on", but the implementation was `parents().size - 1`. Since `parents()` is empty for a spec and `[spec]` for a root test, a spec actually returned -1 and a root test 0 — both off by one from the documented contract.

## Fix

- `depth()` now returns `parents().size`, matching the KDoc: spec = 0, root test = 1, nested test = 2, etc.
- The only caller in the repo, `ConsoleTestEngineListener`, used `depth() * 4` for indentation and relied on the old values (root test = no indent). It now uses an `indent()` helper computing `(depth() - 1) * 4`, so console output is unchanged.
- Added a `depth` regression test to `DescriptorTest` covering spec, root, and nested descriptors.

No signature changes, so no API dump update is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)