### PR TITLE
fix(kotest-assertions-core): Validate tolerance and handle infinities in Float plusOrMinus

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/FloatMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/FloatMatchers.kt
@@ -4,12 +4,29 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import kotlin.math.abs
 
-infix fun Float.plusOrMinus(tolerance: Float): FloatToleranceMatcher = FloatToleranceMatcher(this, tolerance)
+/**
+ * Creates a matcher for the interval [[this] - [tolerance] , [this] + [tolerance]]
+ *
+ *
+ * ```
+ * 0.1f shouldBe (0.4f plusOrMinus 0.5f)   // Assertion passes
+ * 0.1f shouldBe (0.4f plusOrMinus 0.2f)   // Assertion fails
+ * ```
+ */
+infix fun Float.plusOrMinus(tolerance: Float): FloatToleranceMatcher {
+   require(tolerance >= 0 && tolerance.isFinite())
+   return FloatToleranceMatcher(this, tolerance)
+}
 
 class FloatToleranceMatcher(private val expected: Float, private val tolerance: Float) : Matcher<Float> {
 
   override fun test(value: Float): MatcherResult {
-    return if (expected.isNaN() && value.isNaN()) {
+    return if (expected.isInfinite()) {
+       MatcherResult(
+          value == expected,
+          { "$value should be equal to $expected" },
+          { "$value should not be equal to $expected" })
+    } else if (expected.isNaN() && value.isNaN()) {
        println("[WARN] By design, Float.Nan != Float.Nan; see https://stackoverflow.com/questions/8819738/why-does-double-nan-double-nan-return-false/8819776#8819776")
        MatcherResult(
           false,
@@ -26,5 +43,8 @@ class FloatToleranceMatcher(private val expected: Float, private val tolerance: 
     }
   }
 
-  infix fun plusOrMinus(tolerance: Float): FloatToleranceMatcher = FloatToleranceMatcher(expected, tolerance)
+  infix fun plusOrMinus(tolerance: Float): FloatToleranceMatcher {
+     require(tolerance >= 0 && tolerance.isFinite())
+     return FloatToleranceMatcher(expected, tolerance)
+  }
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatToleranceTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/floats/FloatToleranceTest.kt
@@ -1,0 +1,36 @@
+package com.sksamuel.kotest.matchers.floats
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.floats.plusOrMinus
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class FloatToleranceTest : FunSpec({
+
+   test("float with tolerance should match values within the tolerance") {
+      1.0f shouldBe (1.4f plusOrMinus 0.5f)
+      1.0f shouldNotBe (1.5f plusOrMinus 0.4f)
+   }
+
+   test("Refuse negative tolerance") {
+      shouldThrow<IllegalArgumentException> {
+         1.0f plusOrMinus -0.1f
+      }
+   }
+
+   test("Refuse NaN tolerance") {
+      shouldThrow<IllegalArgumentException> {
+         1.0f plusOrMinus Float.NaN
+      }
+   }
+
+   test("infinite float with finite tolerance should equal the same infinite float") {
+      Float.NEGATIVE_INFINITY shouldBe (Float.NEGATIVE_INFINITY plusOrMinus 1f)
+      Float.POSITIVE_INFINITY shouldBe (Float.POSITIVE_INFINITY plusOrMinus 1f)
+   }
+
+   test("infinite float should not equal the opposite infinity") {
+      Float.POSITIVE_INFINITY shouldNotBe (Float.NEGATIVE_INFINITY plusOrMinus 1f)
+   }
+})


### PR DESCRIPTION
## Problem

The Float `plusOrMinus` matcher (`FloatMatchers.kt`) lacked two safeguards that the Double version (`doubles/Tolerance.kt`) already has:

1. **No tolerance validation** — a negative or NaN tolerance silently produced a matcher that always fails (`abs(diff) <= -0.1f` is never true) instead of throwing `IllegalArgumentException`.
2. **No infinity handling** — `Float.POSITIVE_INFINITY shouldBe (Float.POSITIVE_INFINITY plusOrMinus 1f)` failed because `Inf - Inf = NaN`.

## Fix

Mirrors the Double implementation:
- `require(tolerance >= 0 && tolerance.isFinite())` in both `plusOrMinus` overloads (top-level infix and the `FloatToleranceMatcher` member).
- An infinite expected value is compared with direct equality, so an infinity matches itself (and not the opposite infinity).

No public signatures changed, so no API dump update is needed.

## Tests

New `FloatToleranceTest` covering: values within/outside tolerance, negative tolerance throws, NaN tolerance throws, both infinities match themselves, and opposite infinities do not match. Verified with `:kotest-assertions:kotest-assertions-core:jvmTest` (5/5 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)