### PR TITLE
fix(kotest-assertions-core): Fix swapped expected/actual in haveElementAt message and handle negative index

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -16,11 +16,15 @@ fun <T> List<T>.shouldNotHaveElementAt(index: Int, element: T) = this shouldNot 
 
 fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L> {
    override fun test(value: L): MatcherResult {
-      val passed = index < value.size && value[index] == element
-      val listTooShortMsg = if(index < value.size) "" else "But it is too short: only ${value.size} elements"
+      val passed = index in value.indices && value[index] == element
+      val invalidIndexMsg = when {
+         index < 0 -> "But index $index is negative"
+         index < value.size -> ""
+         else -> "But it is too short: only ${value.size} elements"
+      }
       val unexpectedElementMsg = when {
          passed -> ""
-         index < value.size -> "Expected: <${value[index].print().value}>, but was <${element.print().value}>"
+         index in value.indices -> "Expected: <${element.print().value}>, but was <${value[index].print().value}>"
          else -> ""
       }
       val indexesForElement = value.mapIndexedNotNull { index, current ->
@@ -29,7 +33,7 @@ fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L>
       val indexesForElementMsg = if(passed || indexesForElement.isEmpty())
          ""
       else "Element was found at index(es): ${indexesForElement.print().value}"
-      val additionalDescriptions = listOf(listTooShortMsg, unexpectedElementMsg, indexesForElementMsg).filter {
+      val additionalDescriptions = listOf(invalidIndexMsg, unexpectedElementMsg, indexesForElementMsg).filter {
          it.isNotEmpty()
       }
       val additionalDescriptionsMsg = if(additionalDescriptions.isEmpty()) ""

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/CollectionMatchersTest.kt
@@ -102,7 +102,7 @@ class CollectionMatchersTest : WordSpec() {
                listOf("a", "b", "c").shouldHaveElementAt(2, "d")
             }.message shouldBe """
             |Collection ["a", "b", "c"] should contain "d" at index 2
-            |Expected: <"c">, but was <"d">
+            |Expected: <"d">, but was <"c">
             """.trimMargin()
          }
          "print if element found at another index" {
@@ -110,7 +110,7 @@ class CollectionMatchersTest : WordSpec() {
                listOf("a", "b", "c").shouldHaveElementAt(2, "b")
             }.message shouldBe """
             |Collection ["a", "b", "c"] should contain "b" at index 2
-            |Expected: <"c">, but was <"b">
+            |Expected: <"b">, but was <"c">
             |Element was found at index(es): [1]
             """.trimMargin()
          }
@@ -119,8 +119,17 @@ class CollectionMatchersTest : WordSpec() {
                listOf("a", "b", "c", "b").shouldHaveElementAt(2, "b")
             }.message shouldBe """
             |Collection ["a", "b", "c", "b"] should contain "b" at index 2
-            |Expected: <"c">, but was <"b">
+            |Expected: <"b">, but was <"c">
             |Element was found at index(es): [1, 3]
+            """.trimMargin()
+         }
+         "fail with an assertion error for a negative index" {
+            shouldThrow<AssertionError> {
+               listOf("a", "b", "c").shouldHaveElementAt(-1, "a")
+            }.message shouldBe """
+            |Collection ["a", "b", "c"] should contain "a" at index -1
+            |But index -1 is negative
+            |Element was found at index(es): [0]
             """.trimMargin()
          }
       }


### PR DESCRIPTION
Fixes two defects in the List `haveElementAt` matcher:

1. **Swapped message operands**: the failure message read `Expected: <actual>, but was <expected>` because `value[index]` (the actual element) and `element` (the expected one) were reversed. The message now shows the expected element under "Expected" and the actual element under "but was".
2. **Negative index threw IndexOutOfBoundsException**: a negative index passed the `index < value.size` guard, so `value[index]` threw instead of producing a clean assertion failure. Negative indices now fail with an assertion error including `But index <n> is negative`, matching the style of the existing too-short message.

The Sequence version of `haveElementAt` is intentionally untouched (handled separately).

### Tests
- Updated existing message-pinning tests in `CollectionMatchersTest` to assert the corrected expected/actual order.
- Added a test that a negative index produces an `AssertionError` with a clean message (not `IndexOutOfBoundsException`).
- Verified with `:kotest-assertions:kotest-assertions-core:jvmTest --tests CollectionMatchersTest` (130 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)