### PR TITLE
fix(kotest-property): Honor discardCheckThreshold in max-discard check

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/assumptions.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/assumptions.kt
@@ -29,6 +29,9 @@ fun assume(assumptions: () -> Unit) {
 }
 
 internal fun PropertyContext.checkMaxDiscards() {
+   // we only start checking the discard percentage once we have hit the threshold of evaluations,
+   // otherwise a small number of discards early on would exceed the percentage
+   if (evals() < PropertyTesting.discardCheckThreshold) return
    if (discardPercentage() > config.maxDiscardPercentage) {
       throw MaxDiscardPercentageException(discardPercentage(), config.maxDiscardPercentage)
    }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/assumptions/AssumptionsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/assumptions/AssumptionsTest.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.string.shouldHaveLength
 import io.kotest.property.Arb
 import io.kotest.property.MaxDiscardPercentageException
 import io.kotest.property.PropTestConfig
+import io.kotest.property.PropertyTesting
 import io.kotest.property.arbitrary.Codepoint
 import io.kotest.property.arbitrary.az
 import io.kotest.property.arbitrary.constant
@@ -49,7 +50,7 @@ class AssumptionsTest : FunSpec() {
          blockingTest = true
       ) {
          shouldThrow<MaxDiscardPercentageException> {
-            checkAll(10, Arb.positiveInt()) {
+            checkAll(100, Arb.positiveInt()) {
                assume(false)
                yield()
             }
@@ -61,7 +62,7 @@ class AssumptionsTest : FunSpec() {
          blockingTest = true
       ) {
          shouldThrow<MaxDiscardPercentageException> {
-            checkAll(10, Arb.positiveInt()) {
+            checkAll(100, Arb.positiveInt()) {
                assume(false)
                yield()
             }
@@ -112,6 +113,34 @@ class AssumptionsTest : FunSpec() {
                withAssumptions(a != b) {
                }
             }
+         }
+      }
+
+      test("discard check should not be enforced below the discardCheckThreshold") {
+         val previousThreshold = PropertyTesting.discardCheckThreshold
+         PropertyTesting.discardCheckThreshold = 50
+         try {
+            // every input is discarded (100% > the default max of 20%), but only 10 evals
+            // occur, which is below the check threshold of 50, so no error should be raised
+            checkAll(10, Arb.positiveInt()) {
+               assume(false)
+            }
+         } finally {
+            PropertyTesting.discardCheckThreshold = previousThreshold
+         }
+      }
+
+      test("discard check should be enforced once evals reach the discardCheckThreshold") {
+         val previousThreshold = PropertyTesting.discardCheckThreshold
+         PropertyTesting.discardCheckThreshold = 10
+         try {
+            shouldThrow<MaxDiscardPercentageException> {
+               checkAll(10, Arb.positiveInt()) {
+                  assume(false)
+               }
+            }
+         } finally {
+            PropertyTesting.discardCheckThreshold = previousThreshold
          }
       }
 


### PR DESCRIPTION
## Bug

`PropertyTesting.discardCheckThreshold` is documented ("the threshold at which we start checking for the max discard percentage") and settable via the `kotest.proptest.discard.threshold` system property, but `checkMaxDiscards()` in `assumptions.kt` never consulted it — only the separate `kotest-property-permutations` module applied the concept.

As a result, low-iteration property tests using `assume()` could fail the max-discard-percentage check even though the run was below the documented threshold. For example:

```kotlin
checkAll(10, Arb.int()) { a ->
   assume(a % 3 == 0) // 3 discards out of 10 evals = 30% > 20% default -> fails
   ...
}
```

fails with `MaxDiscardPercentageException` despite the default threshold of 50 saying discard checking shouldn't kick in that early.

## Fix

`checkMaxDiscards()` now returns early until the number of evaluations reaches `PropertyTesting.discardCheckThreshold`, consistent with the semantics of `MaxDiscardCheck` in the permutations module.

## Tests

- New test: a 10-iteration run that discards every input does not fail when the threshold (50) is above the eval count.
- New test: the same run fails with `MaxDiscardPercentageException` once the threshold is lowered to the eval count.
- Updated the two existing "should not deadlock" tests from 10 to 100 iterations so they remain above the default threshold and still assert the discard failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)