### PR TITLE
fix(kotest-framework-engine): Queue specIgnored events in PinnedSpecTestEngineListener

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/PinnedSpecTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/PinnedSpecTestEngineListener.kt
@@ -70,7 +70,13 @@ class PinnedSpecTestEngineListener(val listener: TestEngineListener) : TestEngin
    }
 
    override suspend fun specIgnored(kclass: KClass<*>, reason: String?) {
-      listener.specIgnored(kclass, reason)
+      if (runningSpec == null) {
+         listener.specIgnored(kclass, reason)
+      } else {
+         queue {
+            specIgnored(kclass, reason)
+         }
+      }
    }
 
    override suspend fun testStarted(testCase: TestCase) {

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/PinnedSpecTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/PinnedSpecTestEngineListenerTest.kt
@@ -83,6 +83,30 @@ class PinnedSpecTestEngineListenerTest : WordSpec({
          }
       }
 
+      "queue specIgnored while another spec is running" {
+
+         val mock = mockk<TestEngineListener>(relaxed = true)
+         val listener = PinnedSpecTestEngineListener(mock)
+
+         val spec1 = IsolationTestSpec1()
+         val spec2 = IsolationTestSpec2()
+
+         listener.specStarted(SpecRef.Reference(spec1::class))
+         listener.specIgnored(spec2::class, "disabled")
+
+         verify(exactly = 0) { runBlocking { mock.specIgnored(spec2::class, "disabled") } }
+
+         listener.specFinished(SpecRef.Reference(spec1::class), TestResult.Success(0.seconds))
+
+         verifyOrder {
+            runBlocking {
+               mock.specStarted(SpecRef.Reference(spec1::class))
+               mock.specFinished(SpecRef.Reference(spec1::class), TestResult.Success(0.seconds))
+               mock.specIgnored(spec2::class, "disabled")
+            }
+         }
+      }
+
       "run all callbacks without race conditions" {
 
          val mock = mockk<TestEngineListener>(relaxed = true)


### PR DESCRIPTION
### Bug

`PinnedSpecTestEngineListener`'s invariant is that while one spec is pinned, events from other specs are queued and replayed when the pinned spec finishes, so downstream listeners (e.g. the JUnit platform listener) see one spec's events contiguously. `specIgnored` was the only event forwarded immediately regardless of the pinned spec, so under concurrent spec execution an ignored spec's notification could be delivered interleaved inside the currently running spec's event stream.

### Fix

`specIgnored` now follows the same queue-or-forward pattern as the sibling handlers: it is forwarded immediately only when no spec is pinned, and queued for replay otherwise.

### Test

Added a case to `PinnedSpecTestEngineListenerTest` mirroring the existing interleaving tests: while spec A is running, spec B's `specIgnored` arrives — it is not forwarded until A completes, and is forwarded afterwards in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)