### PR TITLE
fix(kotest-property): Make Arb.list repeated-element edgecase actually repeat a single element

### DIFF
--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/collections.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/arbitrary/collections.kt
@@ -63,7 +63,7 @@ fun <A> Arb.Companion.list(gen: Gen<A>, range: IntRange = PropertyTesting.defaul
          }
          val repeatedList: List<A>? = when {
             range.last < 2 -> null // too small for repeats
-            gen is Arb -> List(max(2, range.first)) { (gen.edgecase(rs) ?: gen.sample(rs)).value }
+            gen is Arb -> (gen.edgecase(rs) ?: gen.sample(rs)).value.let { a -> List(max(2, range.first)) { a } }
             gen is Exhaustive -> gen.values.firstOrNull()?.let { a -> List(max(2, range.first)) { a } }
             else -> null
          }

--- a/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
+++ b/kotest-property/src/jvmTest/kotlin/com/sksamuel/kotest/property/arbitrary/CollectionsTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.collections.exist
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveAtLeastSize
 import io.kotest.matchers.collections.shouldHaveAtMostSize
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -95,6 +96,17 @@ class CollectionsTest : DescribeSpec({
          Arb.list(arb).edgecases(1000, RandomSource.seeded(1234L)) shouldContain listOf(edgeCase, edgeCase)
          Arb.list(arb, 4..6).edgecases(1000, RandomSource.seeded(1234L)) shouldContain
             listOf(edgeCase, edgeCase, edgeCase, edgeCase)
+      }
+
+      it("repeat a single element in the repeated-element edge case") {
+         // for range 2..5 the empty and single-element edge cases are filtered out by the range,
+         // so every edge case is the repeated-element one and must contain a single distinct value.
+         // Previously each slot drew its own edge case, e.g. [Int.MIN_VALUE, 0] for Arb.int().
+         repeat(1000) { seed ->
+            Arb.list(Arb.int(), 2..5).edgecases(10, RandomSource.seeded(seed.toLong())).forAll { edge ->
+               edge.distinct() shouldHaveSize 1
+            }
+         }
       }
 
       it("include empty list in edge cases") {


### PR DESCRIPTION
## Problem

The KDoc for `Arb.list` says its edge cases include *"a list with a repeated element (taken as the first edge case from the underlying gen)"*, and the `Exhaustive` branch correctly repeats a single value. But the `Arb` branch invoked the `List` initializer lambda per index, drawing a **different** edge case for each slot:

```kotlin
gen is Arb -> List(max(2, range.first)) { (gen.edgecase(rs) ?: gen.sample(rs)).value }
```

e.g. for `Arb.int()` this can yield `[Int.MIN_VALUE, 0]` — so the duplicate-element edge case (designed to catch `distinct()`-style bugs in user code) was rarely actually produced.

## Fix

Draw the element once and repeat it, matching the `Exhaustive` branch:

```kotlin
gen is Arb -> (gen.edgecase(rs) ?: gen.sample(rs)).value.let { a -> List(max(2, range.first)) { a } }
```

## Test

Added a regression test in `CollectionsTest` that generates edge cases for `Arb.list(Arb.int(), 2..5)` across 1000 seeds and asserts each edge list contains a single distinct value (the range 2..5 filters out the empty and single-element edge cases, so every edge case is the repeated-element one). The test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)