### PR TITLE
feat(kotest-property): Add Wasm WASI target to kotest-property and kotest-property-permutations

### DIFF
--- a/kotest-property/build.gradle.kts
+++ b/kotest-property/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
    id("kotest-watchos-device-conventions")
    id("kotest-native-conventions")
    id("kotest-js-conventions")
+   id("kotest-wasi-conventions")
    id("kotest-publishing-conventions")
 }
 

--- a/kotest-property/kotest-property-permutations/build.gradle.kts
+++ b/kotest-property/kotest-property-permutations/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
    id("kotest-jvm-conventions")
    id("kotest-js-conventions")
+   id("kotest-wasi-conventions")
    id("kotest-android-native-conventions")
    id("kotest-watchos-device-conventions")
    id("kotest-native-conventions")


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->

Adds the `wasmWasi` target to `kotest-property` and `kotest-property-permutations`, so property-based testing can be used on Wasm WASI projects.

Wasm WASI support was added to the framework, assertions and engine modules in 6.0 (#4015), but the property modules were left out of that rollout. There a no technical blocker anymore:

- Both modules already support `wasmJs`, and all non-JVM `actual` implementations  live in `nonjvmMain` (seed persistence no-ops, `kotlin.uuid.Uuid`,  `KotestAssertionFailedError`, `EmptyArbResolver`), which the `wasmWasi` target
  inherits via the `nonjvm` hierarchy group configured by `kotest-wasi-conventions`.
- All dependencies are wasmWasi-ready: kotest-common, kotest-assertions-core,  kotest-framework-engine, kotlinx-coroutines (since 1.9.0), and `kotlin  0.0.6 (which backs the common `Arb.pattern`) publishes a `wasm-wasi` artifact.

The change is therefore just applying the existing `kotest-wasi-conventions`plugin to both modules — no source changes required.

I considered using kotest pbt when adding Wasm WASI support to the kotlin-csv library, but due to this issue, I have implemented the following workaround.

```
listOf("compileTestKotlinWasmWasi", "wasmWasiTest", "wasmWasiNodeTest").forEach { taskName ->
    tasks.matching { it.name == taskName }.configureEach { enabled = false }
}
```
