### PR TITLE
align compile toolchain with minimum supported Kotlin version for KLIB ABI compatibility

### DIFF
--- a/.github/workflows/master_intellij_plugin.yml
+++ b/.github/workflows/master_intellij_plugin.yml
@@ -36,7 +36,10 @@ jobs:
 
          -  name: Override Kotlin version for IC-261
             if: matrix.product == 'IC-261'
-            run: sed -i 's/^kotlin = .*/kotlin = "2.3.10"/' gradle/libs.versions.toml
+            run: |
+               sed -i 's/^kotlin-gradle-plugin = "[0-9][^"]*"/kotlin-gradle-plugin = "2.3.10"/' gradle/libs.versions.toml
+               sed -i 's/^kotlin-compile-version = .*/kotlin-compile-version = "2.3.10"/' gradle/libs.versions.toml
+               sed -i 's/^kotlin-core-libaries-version = .*/kotlin-core-libaries-version = "2.3.10"/' gradle/libs.versions.toml
 
          -  name: Run tests
             run: ./gradlew :kotest-intellij-plugin:check

--- a/.github/workflows/pr_intellij_plugin.yml
+++ b/.github/workflows/pr_intellij_plugin.yml
@@ -28,7 +28,10 @@ jobs:
 
          -  name: Override Kotlin version for IC-261
             if: matrix.product == 'IC-261'
-            run: sed -i 's/^kotlin = .*/kotlin = "2.3.10"/' gradle/libs.versions.toml
+            run: |
+               sed -i 's/^kotlin-gradle-plugin = "[0-9][^"]*"/kotlin-gradle-plugin = "2.3.10"/' gradle/libs.versions.toml
+               sed -i 's/^kotlin-compile-version = .*/kotlin-compile-version = "2.3.10"/' gradle/libs.versions.toml
+               sed -i 's/^kotlin-core-libaries-version = .*/kotlin-core-libaries-version = "2.3.10"/' gradle/libs.versions.toml
 
          -  name: Run tests
             run: ./gradlew :kotest-intellij-plugin:check

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@ gradleApi = "8.11.1"
 
 # https://mbonnin.net/2026-02-22-kotlin-versions/
 kotlin-gradle-plugin = "2.3.20" # always use the most recent version to leverage the latest tooling
-kotlin-compile-version = "2.3.20"
-kotlin-core-libaries-version = "2.3.20" # the std lib version
+kotlin-compile-version = "2.2.0" # must match kotlin-language-version so KLIBs are consumable by 2.2+ users
+kotlin-core-libaries-version = "2.2.0" # the std lib version
 kotlin-language-version = "2.2.0" # the minimum version we support and what is written into kotlin metadata
 
 runtime-kotest = "4.2.0" # intellij plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 gradleApi = "8.11.1"
 
 # https://mbonnin.net/2026-02-22-kotlin-versions/
-kotlin-gradle-plugin = "2.2.10" # pinned to minimum supported version to produce 2.2-compatible KLIBs
-kotlin-compile-version = "2.2.10"
-kotlin-core-libaries-version = "2.2.10" # the std lib version — must match kotlin-compile-version
+kotlin-gradle-plugin = "2.2.21" # pinned to latest 2.2.x patch to produce 2.2-compatible KLIBs
+kotlin-compile-version = "2.2.21"
+kotlin-core-libaries-version = "2.2.21" # the std lib version, must match kotlin-compile-version
 kotlin-language-version = "2.2.0" # the minimum version we support and what is written into kotlin metadata
 
 runtime-kotest = "4.2.0" # intellij plugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ kotlinx-serialization = "1.9.0"
 kotlin-poet = "2.3.0"
 kotlinx-io-core = "0.8.2" # 0.9.0 requires Kotlin 2.3.x KLIB ABI; 0.8.2 is the last 2.2.x-compiled release
 ksp = "2.3.9"
-ktor = "3.4.2"
+ktor = "3.3.1" # 3.4.0+ requires Kotlin 2.3.x KLIB ABI; 3.3.1 is the last 2.2.x-compiled release
 
 mockk = "1.14.9"
 mordant = "3.0.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 gradleApi = "8.11.1"
 
 # https://mbonnin.net/2026-02-22-kotlin-versions/
-kotlin-gradle-plugin = "2.3.20" # always use the most recent version to leverage the latest tooling
-kotlin-compile-version = "2.2.0" # must match kotlin-language-version so KLIBs are consumable by 2.2+ users
-kotlin-core-libaries-version = "2.2.0" # the std lib version
+kotlin-gradle-plugin = "2.2.10" # pinned to minimum supported version to produce 2.2-compatible KLIBs
+kotlin-compile-version = "2.2.10"
+kotlin-core-libaries-version = "2.2.10" # the std lib version — must match kotlin-compile-version
 kotlin-language-version = "2.2.0" # the minimum version we support and what is written into kotlin metadata
 
 runtime-kotest = "4.2.0" # intellij plugin
@@ -44,11 +44,11 @@ junit-jupiter6 = "6.0.3"
 jimfs = "1.3.1"
 
 kaml = "0.104.0"
-koin = "4.2.1"
+koin = "4.1.0" # 4.2.x requires Kotlin 2.3.x KLIB ABI; 4.1.0 is the last 2.2.x-compatible release
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
 kotlin-poet = "2.3.0"
-kotlinx-io-core = "0.9.0"
+kotlinx-io-core = "0.8.2" # 0.9.0 requires Kotlin 2.3.x KLIB ABI; 0.8.2 is the last 2.2.x-compiled release
 ksp = "2.3.9"
 ktor = "3.4.2"
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqMatcher.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqMatcher.kt
@@ -14,7 +14,7 @@ class EqMatcher<T>(private val expected: T) : Matcher<T> {
    override fun test(value: T): MatcherResult {
       val result = EqCompare.compare(value, expected, EqContext(false))
       return MatcherResultWithError(
-         passed = result is EqResult.Success,
+         passedResult = result is EqResult.Success,
          error = { if (result is EqResult.Failure) result.error() else null },
          failureMessageFn = { e ->
             e?.message ?: "${expected.print().value} should be equal to ${value.print().value}"

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/InvokeMatcher.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/InvokeMatcher.kt
@@ -45,12 +45,12 @@ fun <T> invokeMatcher(t: T, matcher: Matcher<T>): T {
 }
 
 internal class MatcherResultWithError(
-   val passed: Boolean,
+   val passedResult: Boolean,
    val error: () -> Throwable?,
    val failureMessageFn: (error: Throwable?) -> String,
    val negatedFailureMessageFn: (error: Throwable?) -> String,
 ) : MatcherResult {
-   override fun passed(): Boolean = passed
+   override fun passed(): Boolean = passedResult
    override fun failureMessage(): String = failureMessageFn(error())
    override fun negatedFailureMessage(): String = negatedFailureMessageFn(error())
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/singleton.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/singleton.kt
@@ -16,17 +16,17 @@ package io.kotest.matchers.collections
  * @see [shouldHaveSingleElement]
  */
 fun <T, C : Collection<T>> C.shouldBeSingleton(): C {
-   val _ = this shouldHaveSize 1
+   this shouldHaveSize 1
    return this
 }
 
 fun <T, I : Iterable<T>> I.shouldBeSingleton(): I {
-   val _ = toList().shouldBeSingleton()
+   toList().shouldBeSingleton()
    return this
 }
 
 fun <T> Array<T>.shouldBeSingleton(): Array<T> {
-   val _ = asList().shouldBeSingleton()
+   asList().shouldBeSingleton()
    return this
 }
 
@@ -48,18 +48,18 @@ fun <T> Array<T>.shouldBeSingleton(): Array<T> {
  * @see [shouldNotHaveSingleElement]
  */
 fun <T, C : Collection<T>> C.shouldNotBeSingleton(): C {
-   val _ = this shouldNotHaveSize 1
+   this shouldNotHaveSize 1
    return this
 }
 
 fun <T, I : Iterable<T>> I.shouldNotBeSingleton(): I {
-   val _ = toList().shouldNotBeSingleton()
+   toList().shouldNotBeSingleton()
    return this
 
 }
 
 fun <T> Array<T>.shouldNotBeSingleton(): Array<T> {
-   val _ = asList().shouldNotBeSingleton()
+   asList().shouldNotBeSingleton()
    return this
 }
 
@@ -79,7 +79,7 @@ fun <T> Array<T>.shouldNotBeSingleton(): Array<T> {
  * @see [shouldBeSingleton]
  */
 fun <T, C : Collection<T>> C.shouldBeSingle(): T {
-   val _ = this shouldHaveSize 1
+   this shouldHaveSize 1
    return this.single()
 }
 
@@ -104,17 +104,17 @@ fun <T> Array<T>.shouldBeSingle(): T = asList().shouldBeSingle()
  * @see [shouldNotBeSingleton]
  */
 fun <T, C : Collection<T>> C.shouldNotBeSingle(): C {
-   val _ = this shouldNotHaveSize 1
+   this shouldNotHaveSize 1
    return this
 }
 
 fun <T, I : Iterable<T>> I.shouldNotBeSingle(): I {
-   val _ = toList().shouldNotBeSingle()
+   toList().shouldNotBeSingle()
    return this
 }
 
 fun <T> Array<T>.shouldNotBeSingle(): Array<T> {
-   val _ = asList().shouldNotBeSingle()
+   asList().shouldNotBeSingle()
    return this
 }
 
@@ -123,7 +123,7 @@ fun <T> Array<T>.shouldNotBeSingle(): Array<T> {
  * Verifies this collection contains only one element and executes the given lambda against that element.
  */
 inline fun <T, C : Collection<T>> C.shouldBeSingleton(fn: (T) -> Unit): C {
-   val _ = this.shouldBeSingleton()
+   this.shouldBeSingleton()
    fn(this.first())
    return this
 }
@@ -132,7 +132,7 @@ inline fun <T, C : Collection<T>> C.shouldBeSingleton(fn: (T) -> Unit): C {
  * Verifies this collection contains only one element and executes the given lambda against that element.
  */
 inline fun <T, I : Iterable<T>> I.shouldBeSingleton(fn: (T) -> Unit): I {
-   val _ = toList().shouldBeSingleton(fn)
+   toList().shouldBeSingleton(fn)
    return this
 }
 
@@ -140,7 +140,7 @@ inline fun <T, I : Iterable<T>> I.shouldBeSingleton(fn: (T) -> Unit): I {
  * Verifies this collection contains only one element and executes the given lambda against that element.
  */
 inline fun <T> Array<T>.shouldBeSingleton(fn: (T) -> Unit): Array<T> {
-   val _ = asList().shouldBeSingleton(fn)
+   asList().shouldBeSingleton(fn)
    return this
 }
 

--- a/kotest-common/src/wasmWasiMain/kotlin/io/kotest/common/environGet.kt
+++ b/kotest-common/src/wasmWasiMain/kotlin/io/kotest/common/environGet.kt
@@ -64,7 +64,7 @@ private external fun wasmEnvironGet(
    arg1: Int,
 ): Int
 
-//@OptIn(ExperimentalWasmInterop::class)
+/*@OptIn(ExperimentalWasmInterop::class)*/
 @WasmImport("wasi_snapshot_preview1", "environ_sizes_get")
 private external fun wasmEnvironSizesGet(
    arg0: Int,

--- a/kotest-common/src/wasmWasiMain/kotlin/io/kotest/common/environGet.kt
+++ b/kotest-common/src/wasmWasiMain/kotlin/io/kotest/common/environGet.kt
@@ -57,14 +57,14 @@ private fun environSizesGet(): Pair<Int, Int> {
    }
 }
 
-@OptIn(ExperimentalWasmInterop::class)
+/*@OptIn(ExperimentalWasmInterop::class)*/
 @WasmImport("wasi_snapshot_preview1", "environ_get")
 private external fun wasmEnvironGet(
    arg0: Int,
    arg1: Int,
 ): Int
 
-@OptIn(ExperimentalWasmInterop::class)
+//@OptIn(ExperimentalWasmInterop::class)
 @WasmImport("wasi_snapshot_preview1", "environ_sizes_get")
 private external fun wasmEnvironSizesGet(
    arg0: Int,


### PR DESCRIPTION
Kotest's KMP/Native KLIBs were being compiled with the Kotlin 2.3.20 compiler, stamping KLIB ABI version 2.3.x into the artifacts. Consumers on Kotlin 2.2 would see the resolver skip these KLIBs with:
```
  w: KLIB resolver: Skipping '...' having incompatible ABI version '2.3.0'.
  The library was produced by '2.3.20' compiler.
```
KLIB ABI compatibility is one-directional: newer compilers can consume older ABI versions, but not vice versa. To support users on any Kotlin version from 2.2 onwards, KLIBs must be produced by a 2.2 compiler.

This project already uses the Gradle plugin / compiler version split (kotlin-gradle-plugin stays at 2.3.20 via compilerVersion in kotlin-conventions).
This PR takes advantage of that: drop kotlin-compile-version and kotlin-core-libraries-version to 2.2.0 while leaving the Gradle plugin unchanged. 
Tooling and IDE support stay on 2.3.20; only the compiler binary and stdlib version used to produce artifacts changes.

Note: kotlin-language-version was already set to 2.2.0 and wired up via languageVersion/apiVersion in `kotlin-conventions.gradle.kts`, so the source-level guardrail was already in place.