### PR TITLE
Make fibonacci interval functions public

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -469,6 +469,13 @@ public final class io/kotest/assertions/nondeterministic/ExponentialIntervalFnKt
 	public static synthetic fun exponential-4_FzEXg$default (JDLkotlin/time/Duration;ILjava/lang/Object;)Lio/kotest/assertions/nondeterministic/ExponentialIntervalFn;
 }
 
+public final class io/kotest/assertions/nondeterministic/FibonacciIntervalFn : io/kotest/assertions/nondeterministic/DurationFn {
+	public static final field Companion Lio/kotest/assertions/nondeterministic/FibonacciIntervalFn$Companion;
+	public synthetic fun <init> (JILkotlin/time/Duration;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun next-5sfh64U (I)J
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/kotest/assertions/nondeterministic/FibonacciIntervalFn$Companion {
 	public final fun getDefaultMax-UwyO8pc ()J
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/FibonacciIntervalFn.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/FibonacciIntervalFn.kt
@@ -1,6 +1,5 @@
 package io.kotest.assertions.nondeterministic
 
-import io.kotest.common.KotestInternal
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.milliseconds
@@ -16,7 +15,6 @@ import kotlin.time.Duration.Companion.milliseconds
  * @param base The duration that is multiplied by the fibonacci value
  * @param max the maximum duration to clamp the resulting duration to defaults to [FibonacciIntervalFn.defaultMax]
  */
-@KotestInternal
 class FibonacciIntervalFn(private val base: Duration, private val offset: Int, private val max: Duration?) : DurationFn {
 
    init {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/FibonacciIntervalTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/FibonacciIntervalTest.kt
@@ -6,7 +6,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
 @EnabledIf(LinuxOnlyGithubCondition::class)
@@ -70,6 +72,17 @@ class FibonacciIntervalTest : FunSpec() {
                u shouldBeGreaterThan max
             }
          }
+      }
+
+      // https://github.com/kotest/kotest/issues/6130
+      // The eventually docs recommend `intervalFn = 100.milliseconds.fibonacci()`. This must
+      // compile and run without any @OptIn, i.e. fibonacci() and the type it returns
+      // (FibonacciIntervalFn) are public, non-opt-in API.
+      test("fibonacci() is usable as a public eventuallyConfig intervalFn without opt-in") {
+         val config = eventuallyConfig {
+            intervalFn = 100.milliseconds.fibonacci()
+         }
+         config.intervalFn.shouldBeInstanceOf<FibonacciIntervalFn>()
       }
    }
 }


### PR DESCRIPTION
## Summary

The `eventually` docs recommend configuring a fibonacci backoff with
`eventuallyConfig { intervalFn = 100.milliseconds.fibonacci() }`, but as of 6.1.x the
`FibonacciIntervalFn` class in `io.kotest.assertions.nondeterministic` is annotated
`@KotestInternal`. `Duration.fibonacci()` is already public, yet the type it returns is
not, so following the docs requires a `@OptIn(KotestInternal::class)`. For consumers that
compile with `allWarningsAsErrors = true` this is a hard build failure. In Kotest 5 the
equivalent usage was public API.

This removes the `@KotestInternal` annotation (and the now-unused
`io.kotest.common.KotestInternal` import) from `FibonacciIntervalFn`, bringing it in line
with the sibling `ExponentialIntervalFn`, which is already public and implements the same
public `DurationFn` interface. The internal `fibonacci(n: Int)` helper stays `internal`.

The binary-compatibility signature file `kotest-assertions-core.api` was regenerated with
`./gradlew :kotest-assertions:kotest-assertions-core:apiDump` (not hand-edited) to add the
now-public `FibonacciIntervalFn` entry, mirroring the existing `ExponentialIntervalFn`
entry.

## Why this matters

Following the published `eventually` documentation should not require an opt-in to an
internal API, and should not break builds that treat warnings as errors. The documented
extension point (`intervalFn` / `DurationFn`) is already the designed public surface, and a
fibonacci growth curve is a sensible built-in alongside the already-public exponential one.

https://github.com/kotest/kotest/issues/6130

## Testing

- `./gradlew :kotest-assertions:kotest-assertions-core:compileKotlinJvm -PjvmOnly=true` - passes.
- `./gradlew :kotest-assertions:kotest-assertions-core:jvmTest --tests "io.kotest.assertions.nondeterministic.FibonacciIntervalTest" -PjvmOnly=true` - passes, including a new case asserting that `eventuallyConfig { intervalFn = 100.milliseconds.fibonacci() }` compiles and runs with no `@OptIn` and yields a `FibonacciIntervalFn`.
- `./gradlew :kotest-assertions:kotest-assertions-core:apiCheck -PjvmOnly=true` - passes after the `apiDump` regeneration, so binary-compatibility validation stays green.

Fixes #6130
