### PR TITLE
allow building all targets via dispatch of kotest-test-examples

### DIFF
--- a/.github/workflows/test-kotest-examples.yml
+++ b/.github/workflows/test-kotest-examples.yml
@@ -30,6 +30,9 @@ concurrency:
 
 env:
    GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+   # On non-master branches isMaster=false in Ci.kt, so Apple targets are skipped.
+   # This flag re-enables them so macOS publish jobs can produce iOS/tvOS/watchOS artifacts.
+   KOTEST_EXAMPLES_WORKFLOW: ${{ github.ref_name != 'master' && 'true' || '' }}
 
 jobs:
    publish-local-linux:

--- a/buildSrc/src/main/kotlin/Ci.kt
+++ b/buildSrc/src/main/kotlin/Ci.kt
@@ -40,9 +40,10 @@ object Ci {
 
    /**
     * We only include watchos, tvsos and ios builds if it's a non-CI build or if it's master build
-    * due to the limited availability of the github macos runners
+    * due to the limited availability of the github macos runners.
+    * Can be overridden by setting KOTEST_EXAMPLES_WORKFLOW=true (set by test-kotest-examples.yml on non-master branches).
     */
-   val shouldRunWatchTvIosModules = isLocal || isMaster
+   val shouldRunWatchTvIosModules = isLocal || isMaster || System.getenv("KOTEST_EXAMPLES_WORKFLOW").toBoolean()
    val shouldAddLinuxTargets = isLocal || isLinuxRunner
 
    /**


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
- allow building all targets via dispatch of kotest-test-examples
