### PR TITLE
Add builder-style DSL for eventually configuration (#6104)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -422,6 +422,8 @@ public final class io/kotest/assertions/nondeterministic/EventuallyConfiguration
 
 public final class io/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder {
 	public fun <init> ()V
+	public final fun checkingEvery (Lio/kotest/assertions/nondeterministic/DurationFn;)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun checkingEvery-LRDsOJo (J)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
 	public final fun getDuration-UwyO8pc ()J
 	public final fun getExpectedExceptions ()Ljava/util/Set;
 	public final fun getExpectedExceptionsFn ()Lkotlin/jvm/functions/Function1;
@@ -432,6 +434,9 @@ public final class io/kotest/assertions/nondeterministic/EventuallyConfiguration
 	public final fun getListener ()Lkotlin/jvm/functions/Function3;
 	public final fun getRetries ()I
 	public final fun getShortCircuit ()Lkotlin/jvm/functions/Function1;
+	public final fun includingFirstError (Z)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun retryingOn (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun retryingOn ([Lkotlin/reflect/KClass;)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
 	public final fun setDuration-LRDsOJo (J)V
 	public final fun setExpectedExceptions (Ljava/util/Set;)V
 	public final fun setExpectedExceptionsFn (Lkotlin/jvm/functions/Function1;)V
@@ -442,14 +447,22 @@ public final class io/kotest/assertions/nondeterministic/EventuallyConfiguration
 	public final fun setListener (Lkotlin/jvm/functions/Function3;)V
 	public final fun setRetries (I)V
 	public final fun setShortCircuit (Lkotlin/jvm/functions/Function1;)V
+	public final fun shortCircuitOn (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun withInitialDelay-LRDsOJo (J)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun withListener (Lkotlin/jvm/functions/Function3;)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun withRetries (I)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
+	public final fun within-LRDsOJo (J)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
 }
 
 public final class io/kotest/assertions/nondeterministic/EventuallyKt {
 	public static final fun eventually (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventually (Lio/kotest/assertions/nondeterministic/EventuallyConfiguration;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun eventually (Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventually (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun eventually (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventually-KLykuaI (JLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun eventuallyConfig (Lkotlin/jvm/functions/Function1;)Lio/kotest/assertions/nondeterministic/EventuallyConfiguration;
+	public static final fun within-LRDsOJo (J)Lio/kotest/assertions/nondeterministic/EventuallyConfigurationBuilder;
 }
 
 public final class io/kotest/assertions/nondeterministic/ExponentialIntervalFn : io/kotest/assertions/nondeterministic/DurationFn {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
@@ -64,6 +64,39 @@ suspend fun <T> eventually(
    return eventually(durationMs.milliseconds, test)
 }
 
+suspend fun <T> eventually(
+   configure: EventuallyConfigurationBuilder.() -> Unit,
+   test: suspend () -> T,
+): T {
+   val builder = EventuallyConfigurationBuilder()
+   configure(builder)
+   val configuration = builder.build()
+   return eventually(configuration, test)
+}
+
+/**
+ * Runs a function [test] until it doesn't throw, using the configuration accumulated in the
+ * supplied [builder].
+ *
+ * This overload supports the builder-style DSL, for example:
+ *
+ * ```
+ * eventually(within(2.seconds).checkingEvery(100.milliseconds)) {
+ *    item(newId) shouldNotBe null
+ * }
+ * ```
+ *
+ * Note: Eventually is designed to work with real-world delays, such as blocking IO calls, or Thread.sleep.
+ * Even though it will work inside virtual time dispatchers, eg if you are using runTest from `kotlin.test`,
+ * or if you have enabled coroutineTestScope in a Kotest test, the intervals will always run on wall-clock time.
+ */
+suspend fun <T> eventually(
+   builder: EventuallyConfigurationBuilder,
+   test: suspend () -> T,
+): T {
+   return eventually(builder.build(), test)
+}
+
 /**
  * Runs a function [test] until it doesn't throw, using the supplied [config].
  *
@@ -263,7 +296,122 @@ class EventuallyConfigurationBuilder {
     * This is useful for those who don't want to see the first error.
     */
    var includeFirst: Boolean = EventuallyConfigurationDefaults.includeFirst
+
+   /**
+    * Sets the total [duration] that the [eventually] function can take to complete successfully,
+    * returning this builder so that further options can be chained.
+    *
+    * For example: `within(2.seconds).checkingEvery(100.milliseconds)`.
+    */
+   fun within(duration: Duration): EventuallyConfigurationBuilder {
+      this.duration = duration
+      return this
+   }
+
+   /**
+    * Sets the [initialDelay] applied before the first invocation, returning this builder so that
+    * further options can be chained.
+    */
+   fun withInitialDelay(initialDelay: Duration): EventuallyConfigurationBuilder {
+      this.initialDelay = initialDelay
+      return this
+   }
+
+   /**
+    * Sets the [interval] between invocations, returning this builder so that further options can
+    * be chained.
+    *
+    * For example: `within(2.seconds).checkingEvery(100.milliseconds)`.
+    */
+   fun checkingEvery(interval: Duration): EventuallyConfigurationBuilder {
+      this.interval = interval
+      return this
+   }
+
+   /**
+    * Sets the [intervalFn] used to calculate the next interval, returning this builder so that
+    * further options can be chained.
+    *
+    * This can be used to implement [fibonacci] or [exponential] backoff.
+    */
+   fun checkingEvery(intervalFn: DurationFn): EventuallyConfigurationBuilder {
+      this.intervalFn = intervalFn
+      return this
+   }
+
+   /**
+    * Sets the maximum number of [retries] regardless of duration, returning this builder so that
+    * further options can be chained.
+    */
+   fun withRetries(retries: Int): EventuallyConfigurationBuilder {
+      this.retries = retries
+      return this
+   }
+
+   /**
+    * Restricts the retried exceptions to the given [exceptions], returning this builder so that
+    * further options can be chained. Any other exception will immediately fail the [eventually]
+    * function.
+    */
+   fun retryingOn(vararg exceptions: KClass<out Throwable>): EventuallyConfigurationBuilder {
+      this.expectedExceptions = exceptions.toSet()
+      return this
+   }
+
+   /**
+    * Sets a [predicate] used to determine if a thrown exception is expected and the test function
+    * retried, returning this builder so that further options can be chained.
+    *
+    * This predicate is applied only when no values are specified by [retryingOn].
+    */
+   fun retryingOn(predicate: (Throwable) -> Boolean): EventuallyConfigurationBuilder {
+      this.expectedExceptionsFn = predicate
+      return this
+   }
+
+   /**
+    * Sets the [listener] that is invoked after each failed invocation, returning this builder so
+    * that further options can be chained.
+    */
+   fun withListener(listener: EventuallyListener): EventuallyConfigurationBuilder {
+      this.listener = listener
+      return this
+   }
+
+   /**
+    * Sets a [predicate] that, when it returns `true` for a thrown exception, immediately fails the
+    * [eventually] function instead of retrying. Returns this builder so that further options can
+    * be chained.
+    */
+   fun shortCircuitOn(predicate: (Throwable) -> Boolean): EventuallyConfigurationBuilder {
+      this.shortCircuit = predicate
+      return this
+   }
+
+   /**
+    * Controls whether the first error is included in the failure message, returning this builder
+    * so that further options can be chained.
+    */
+   fun includingFirstError(includeFirst: Boolean): EventuallyConfigurationBuilder {
+      this.includeFirst = includeFirst
+      return this
+   }
 }
+
+/**
+ * Creates an [EventuallyConfigurationBuilder] configured with the given total [duration], returning
+ * it so that further options can be chained.
+ *
+ * This is the entry point for the builder-style DSL, for example:
+ *
+ * ```
+ * eventually(within(2.seconds).checkingEvery(100.milliseconds)) {
+ *    item(newId) shouldNotBe null
+ * }
+ * ```
+ */
+fun within(duration: Duration): EventuallyConfigurationBuilder =
+   EventuallyConfigurationBuilder().within(duration)
 
 typealias EventuallyListener = suspend (Int, Throwable) -> Unit
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyDslTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyDslTest.kt
@@ -1,0 +1,116 @@
+@file:Suppress("RETURN_VALUE_NOT_USED_COERCION", "RETURN_VALUE_NOT_USED")
+
+package io.kotest.assertions.nondeterministic
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import java.io.IOException
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class EventuallyDslTest : FunSpec() {
+
+   init {
+
+      test("within sets the duration and returns a builder") {
+         val builder = within(2.seconds)
+         builder.duration shouldBe 2.seconds
+      }
+
+      test("within is the entry point for chaining") {
+         val builder = within(2.seconds).checkingEvery(100.milliseconds)
+         builder.duration shouldBe 2.seconds
+         builder.interval shouldBe 100.milliseconds
+      }
+
+      test("checkingEvery sets the interval") {
+         val builder = EventuallyConfigurationBuilder().checkingEvery(50.milliseconds)
+         builder.interval shouldBe 50.milliseconds
+      }
+
+      test("checkingEvery sets the intervalFn") {
+         val fn = DurationFn { 75.milliseconds }
+         val builder = EventuallyConfigurationBuilder().checkingEvery(fn)
+         builder.intervalFn shouldBe fn
+      }
+
+      test("withInitialDelay sets the initial delay") {
+         val builder = EventuallyConfigurationBuilder().withInitialDelay(30.milliseconds)
+         builder.initialDelay shouldBe 30.milliseconds
+      }
+
+      test("withRetries sets the retries") {
+         val builder = EventuallyConfigurationBuilder().withRetries(7)
+         builder.retries shouldBe 7
+      }
+
+      test("retryingOn sets the expected exceptions") {
+         val builder = EventuallyConfigurationBuilder().retryingOn(IOException::class, IllegalStateException::class)
+         builder.expectedExceptions shouldBe setOf(IOException::class, IllegalStateException::class)
+      }
+
+      test("retryingOn sets the expected exceptions predicate") {
+         val predicate: (Throwable) -> Boolean = { it is IOException }
+         val builder = EventuallyConfigurationBuilder().retryingOn(predicate)
+         builder.expectedExceptionsFn shouldBe predicate
+      }
+
+      test("withListener sets the listener") {
+         val listener: EventuallyListener = { _, _ -> }
+         val builder = EventuallyConfigurationBuilder().withListener(listener)
+         builder.listener shouldBe listener
+      }
+
+      test("shortCircuitOn sets the short circuit predicate") {
+         val predicate: (Throwable) -> Boolean = { it is IOException }
+         val builder = EventuallyConfigurationBuilder().shortCircuitOn(predicate)
+         builder.shortCircuit shouldBe predicate
+      }
+
+      test("includingFirstError sets the includeFirst flag") {
+         val builder = EventuallyConfigurationBuilder().includingFirstError(false)
+         builder.includeFirst shouldBe false
+      }
+
+      test("all builder functions can be chained from within") {
+         val builder = within(2.seconds)
+            .withInitialDelay(10.milliseconds)
+            .checkingEvery(100.milliseconds)
+            .withRetries(5)
+            .retryingOn(IOException::class)
+            .includingFirstError(false)
+
+         builder.duration shouldBe 2.seconds
+         builder.initialDelay shouldBe 10.milliseconds
+         builder.interval shouldBe 100.milliseconds
+         builder.retries shouldBe 5
+         builder.expectedExceptions shouldBe setOf(IOException::class)
+         builder.includeFirst shouldBe false
+      }
+
+      test("eventually accepts a builder and runs the test until it passes") {
+         var count = 0
+         eventually(within(2.seconds).checkingEvery(10.milliseconds)) {
+            count += 1
+            count shouldBe 3
+         }
+         count shouldBe 3
+      }
+
+      test("eventually with a builder respects the configured duration") {
+         var count = 0
+         shouldThrow<AssertionError> {
+            eventually(within(100.milliseconds).checkingEvery(20.milliseconds)) {
+               count += 1
+               error("never passes")
+            }
+         }
+         count shouldBeLessThan 100
+      }
+   }
+}

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RETURN_VALUE_NOT_USED_COERCION", "RETURN_VALUE_NOT_USED")
+
 package io.kotest.assertions.nondeterministic
 
 import io.kotest.assertions.AssertionErrorBuilder
@@ -315,6 +317,17 @@ class EventuallyTest : FunSpec() {
          count.shouldBeLessThan(3)
       }
 
+      test("support inline configuration") {
+         var count = 0
+         eventually({
+            duration = 250.milliseconds
+            interval = 100.milliseconds
+         }) {
+            count += 1
+         }
+         count.shouldBeLessThan(3)
+      }
+
       test("handle shouldNotBeNull") {
          val start = TimeSource.Monotonic.markNow()
          val duration = 100.milliseconds
@@ -544,7 +557,7 @@ class EventuallyTest : FunSpec() {
          ) {
             shouldThrow<AssertionError> {
                eventually(100.milliseconds) {
-                  delay(10)
+                  delay(10.milliseconds)
                   "error" shouldBe "ok"
                }
             }
@@ -568,7 +581,7 @@ class EventuallyTest : FunSpec() {
          ) {
             shouldThrow<AssertionError> {
                eventually(100.milliseconds) {
-                  delay(10)
+                  delay(10.milliseconds)
                   "error" shouldBe "ok"
                }
             }


### PR DESCRIPTION
Closes #6104.

## What

Adds a readable, chainable, builder-style DSL for configuring `eventually`, as requested in #6104 (level 2 of the suggestions):

```kotlin
eventually(within(2.seconds).checkingEvery(100.milliseconds)) {
   item(newId) shouldNotBe null
}
```

## How

- Each new function on `EventuallyConfigurationBuilder` updates a single config var and returns the same builder so calls can be chained:
  - `within(duration)`
  - `withInitialDelay(initialDelay)`
  - `checkingEvery(interval)` and `checkingEvery(intervalFn)`
  - `withRetries(retries)`
  - `retryingOn(vararg KClass)` and `retryingOn(predicate)`
  - `withListener(listener)`
  - `shortCircuitOn(predicate)`
  - `includingFirstError(includeFirst)`
- The verb-style names deliberately differ from the raw property names to read well in a chain and to avoid shadowing the public `var`s.
- A top-level `within(duration)` function is the entry point — it returns a builder pre-configured with that duration.
- A new `eventually(builder, test)` overload accepts the builder directly. It resolves unambiguously against the existing lambda-`configure` overload (instance vs function literal).

## Notes

This PR also includes the previously staged `eventually(configure: EventuallyConfigurationBuilder.() -> Unit, test)` lambda overload (and the small accompanying `EventuallyTest.kt` tidy-ups), which were already in the working tree as part of this same issue.

## Tests

New `EventuallyDslTest` spec covers each function by asserting the builder state it sets, plus two behavioural tests that run `eventually(within(...).checkingEvery(...)) { }` to prove the new overload is wired and respects the configured duration.

`./gradlew :kotest-assertions:kotest-assertions-core:apiDump` was run and the updated `.api` file is committed; `apiCheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)