### PR TITLE
docs: add KDoc to ArrayEq

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/ArrayEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/ArrayEq.kt
@@ -5,8 +5,35 @@ import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.assertions.Expected
 import io.kotest.assertions.print.print
 
+/**
+ * An [Eq] typeclass that compares two [Array]s for deep, ordered equality.
+ *
+ * Arrays are compared element by element, in order. Each pair is first checked with the elements'
+ * own `equals`, falling back to Kotest's [EqCompare] so that nested structures (collections, maps,
+ * data classes, etc.) are themselves compared deeply rather than by reference. The resulting
+ * [EqResult.Failure] accrues every difference it can detect:
+ *
+ * - elements that differ at a given index,
+ * - elements present in `actual` but not in `expected` (unexpected, trailing elements),
+ * - elements present in `expected` but not in `actual` (missing, trailing elements).
+ *
+ * Nested arrays are intentionally disallowed: comparing an array nested inside another array does
+ * not have well-defined equality semantics here, so such a case short-circuits with a [DISALLOWED]
+ * failure message advising the use of custom test code instead. This mirrors the "Disallowed"
+ * mechanism in [CollectionEq], which applies the analogous restriction to nested non-`Collection`
+ * iterables.
+ */
 object ArrayEq : Eq<Array<*>> {
 
+   /**
+    * Compares [actual] and [expected] for deep, ordered equality.
+    *
+    * @param context extra context forwarded to nested comparisons, such as strict numeric equality and
+    *                recursion/cycle tracking. See [EqContext].
+    * @return [EqResult.Success] if the arrays are deeply equal, otherwise an [EqResult.Failure] whose
+    *         lazily-built error describes the differing, unexpected and missing indices, or reports a
+    *         disallowed nested array.
+    */
    override fun equals(actual: Array<*>, expected: Array<*>, context: EqContext): EqResult {
 
       val iter1 = actual.iterator()
@@ -94,8 +121,18 @@ object ArrayEq : Eq<Array<*>> {
       } else EqResult.Success
    }
 
+   /**
+    * Base token (`"Disallowed"`) marking a failure message as a disallowed comparison rather than an
+    * ordinary element difference. Used here only to compose [DISALLOWED], which is the prefix actually
+    * matched when these failures are detected and propagated. [CollectionEq] declares its own identical
+    * token for the same purpose.
+    */
    const val TRIGGER = "Disallowed"
 
+   /**
+    * Full prefix of the message raised when an array is found nested inside another array. This is the
+    * prefix [equals] matches on to recognise and short-circuit a disallowed nested-array comparison.
+    */
    private const val DISALLOWED = "$TRIGGER nesting array"
 }
 


### PR DESCRIPTION
## Summary

Adds KDoc to `ArrayEq` in `kotest-assertions-core`:

- Class-level doc describing deep, ordered array equality, the `equals`-then-`EqCompare` fallback, and how `EqResult.Failure` accrues differing / unexpected / missing indices.
- `equals` doc with `@param context` and `@return`.
- Docs for the `TRIGGER` and `DISALLOWED` constants and the nested-array short-circuit, including the parallel to `CollectionEq`.

Docs-only change; verified each claim against the implementation and against `CollectionEq` / `EqContext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)