### PR TITLE
Remove usages of K1's KtUltraLightClass from kotest plugin sources

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/implicits/SpecImplicitUsageProvider.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/implicits/SpecImplicitUsageProvider.kt
@@ -4,7 +4,6 @@ import com.intellij.codeInsight.daemon.ImplicitUsageProvider
 import com.intellij.psi.PsiElement
 import io.kotest.plugin.intellij.psi.isSpec
 import org.jetbrains.kotlin.asJava.classes.KtLightClass
-import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
@@ -22,7 +21,6 @@ class SpecImplicitUsageProvider : ImplicitUsageProvider {
    override fun isImplicitUsage(element: PsiElement): Boolean {
       val ktclass = when (element) {
          is KtClassOrObject -> element
-         is KtUltraLightClass -> element
          is KtLightClass -> when (val origin = element.kotlinOrigin) {
             is KtClassOrObject -> origin
             else -> null

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/psi/specs.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/psi/specs.kt
@@ -8,15 +8,8 @@ import org.jetbrains.kotlin.analysis.api.permissions.KaAllowAnalysisFromWriteAct
 import org.jetbrains.kotlin.analysis.api.permissions.KaAllowAnalysisOnEdt
 import org.jetbrains.kotlin.analysis.api.permissions.allowAnalysisFromWriteAction
 import org.jetbrains.kotlin.analysis.api.permissions.allowAnalysisOnEdt
-import org.jetbrains.kotlin.asJava.classes.KtLightClass
-import org.jetbrains.kotlin.asJava.classes.KtUltraLightClass
 import org.jetbrains.kotlin.name.FqName
-import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtClass
-import org.jetbrains.kotlin.psi.KtClassOrObject
-import org.jetbrains.kotlin.psi.KtLambdaArgument
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
-import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
@@ -48,18 +41,6 @@ fun KtClassOrObject.isSpecEdt(): Boolean {
       is KtClass -> this.specStyleOnEdt() != null
       else -> false
    }
-}
-
-/**
- * Returns true if this element is a kotlin class, and it is a subclass of a spec.
- *
- * See [isSpec]
- */
-fun PsiElement.isSpec(): Boolean = when (this) {
-   is KtUltraLightClass -> kotlinOrigin.isSpec()
-   is KtLightClass -> kotlinOrigin?.isSpec() ?: false
-   is KtClassOrObject -> isSpec()
-   else -> false
 }
 
 /**


### PR DESCRIPTION
Removes usages of K1's `KtUltraLightClass` from the in-repo IntelliJ plugin sources.

Otherwise a `ClassNotFoundException` would happen with IJ 2026.2+ where K1 classes are not bundled anymore.

`KtUltraLightClass` inherits `KtLightClass`, so the change is compatible with the K1 plugin for old versions of IJ (only 2024.X should be affected, because starting with 2025.1 K2 was the default mode).

This mirrors the same change made upstream in the standalone plugin repo: https://github.com/kotest/kotest-intellij-plugin/pull/407

🤖 Generated with [Claude Code](https://claude.com/claude-code)