### PR TITLE
Fix data objects being considered equal in DataClassEq (#6144)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
@@ -48,7 +48,18 @@ internal object DataClassEq : Eq<Any> {
             runCatching {
                val differences = dataClassDiff(actual, expected, context = context)
                if (differences == null || differences.differences.isEmpty()) {
-                  EqResult.Success
+                  // The structural diff only compares primary constructor members. When there are
+                  // none to compare (e.g. data objects), an empty diff does not establish equality,
+                  // so we must honor the equals() result, which already determined they are not equal.
+                  if (reflection.primaryConstructorMembers(expected::class).isEmpty()) {
+                     EqResult.Failure {
+                        AssertionErrorBuilder.create()
+                           .withValues(Expected(expected.print()), Actual(actual.print()))
+                           .build()
+                     }
+                  } else {
+                     EqResult.Success
+                  }
                } else {
                   val detailedDiffMsg = runCatching {
                      formatDifferences(differences) + "\n\n"

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
@@ -57,10 +57,29 @@ object InstantWithoutNanosEq : Eq<Instant> {
    }
 }
 
+sealed class BoolState(val bytes: ByteArray?) {
+   data object True : BoolState(byteArrayOf(1))
+   data object False : BoolState(byteArrayOf(0))
+   data object Unknown : BoolState(null)
+}
+
 class DataClassEqTest : StringSpec({
 
    "respects custom equals implementations in data classes" {
       IntRatio(1, 2) shouldBe IntRatio(2, 4)
+   }
+
+   // https://github.com/kotest/kotest/issues/6144
+   "distinct data objects must not be considered equal" {
+      isDataClassInstance(BoolState.True) shouldBe true
+
+      BoolState.True shouldNotBe BoolState.False
+      BoolState.True shouldNotBe BoolState.Unknown
+      BoolState.False shouldNotBe BoolState.Unknown
+   }
+
+   "the same data object must be considered equal to itself" {
+      BoolState.True shouldBe BoolState.True
    }
 
    "respects custom registered Eq function" {


### PR DESCRIPTION
Fixes #6144

## Problem

Distinct data objects are reported as equal:

```kotlin
sealed class BoolState(bytes: ByteArray?) {
   data object True : BoolState(byteArrayOf(1))
   data object False : BoolState(byteArrayOf(0))
   data object Unknown : BoolState(null)
}

BoolState.True shouldNotBe BoolState.False // fails — they are considered equal
```

## Root cause

`KClass.isData == true` for a `data object`, so `DefaultEqResolver` routes the comparison to `DataClassEq`. `DataClassEq` determines equality from a structural diff over the **primary constructor members**, but a data object has no primary constructor, so the diff is always empty.

Since #5602, an empty diff was treated as `EqResult.Success` (equal). For data classes with members this is correct (it lets a registered custom `Eq` on a field type override a strict `equals`, the #5601 case). For data objects there is nothing to compare, so the empty diff silently overrode the `equals()` verdict and made distinct objects compare equal.

This first shipped in 6.2.0 (regression commit e93a0b660).

## Fix

When `equals()` reports not-equal **and** there are no primary constructor members to compare, the structural diff cannot establish equality, so we honor the `equals()` result and report a failure.

The #5601 custom-field-`Eq` behavior is preserved (those data classes have constructor members and still flow through the diff path) — verified by the existing `InstantWithoutNanosEq` tests.

## Verification

- Added regression tests in `DataClassEqTest` covering distinct data objects and a data object equal to itself.
- Full `com.sksamuel.kotest.eq.*` and `com.sksamuel.kotest.matchers.equality.*` suites pass.
- Confirmed separately that cross-type data classes (`A(1) shouldBe B(1)`) were never affected, so no broader guard is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)