### PR TITLE
remove KotestInternal in TestFactory

### DIFF
--- a/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
+++ b/kotest-framework/kotest-framework-engine/api/kotest-framework-engine.api
@@ -1285,6 +1285,27 @@ public final class io/kotest/core/factory/FactoryId$Companion {
 	public final fun next ()Lio/kotest/core/factory/FactoryId;
 }
 
+public final class io/kotest/core/factory/TestFactory {
+	public fun <init> (Lio/kotest/core/factory/FactoryId;Ljava/util/List;Ljava/util/Set;Lio/kotest/core/test/AssertionMode;Ljava/util/List;Lio/kotest/core/factory/TestFactoryConfiguration;)V
+	public final fun component1 ()Lio/kotest/core/factory/FactoryId;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Set;
+	public final fun component4 ()Lio/kotest/core/test/AssertionMode;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lio/kotest/core/factory/TestFactoryConfiguration;
+	public final fun copy (Lio/kotest/core/factory/FactoryId;Ljava/util/List;Ljava/util/Set;Lio/kotest/core/test/AssertionMode;Ljava/util/List;Lio/kotest/core/factory/TestFactoryConfiguration;)Lio/kotest/core/factory/TestFactory;
+	public static synthetic fun copy$default (Lio/kotest/core/factory/TestFactory;Lio/kotest/core/factory/FactoryId;Ljava/util/List;Ljava/util/Set;Lio/kotest/core/test/AssertionMode;Ljava/util/List;Lio/kotest/core/factory/TestFactoryConfiguration;ILjava/lang/Object;)Lio/kotest/core/factory/TestFactory;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAssertionMode ()Lio/kotest/core/test/AssertionMode;
+	public final fun getConfiguration ()Lio/kotest/core/factory/TestFactoryConfiguration;
+	public final fun getExtensions ()Ljava/util/List;
+	public final fun getFactoryId ()Lio/kotest/core/factory/FactoryId;
+	public final fun getTags ()Ljava/util/Set;
+	public final fun getTests ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class io/kotest/core/factory/TestFactoryConfiguration : io/kotest/core/TestConfiguration, io/kotest/core/spec/style/scopes/RootScope {
 	public fun <init> ()V
 	public fun add (Lio/kotest/core/spec/RootTest;)V

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/factory/TestFactory.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/factory/TestFactory.kt
@@ -15,7 +15,6 @@ import io.kotest.core.test.AssertionMode
  * Factories are useful if you want to group tests together with some callbacks and settings
  * and inject them into specs as a unit.
  */
-@KotestInternal
 data class TestFactory(
    val factoryId: FactoryId,
    val tests: List<TestDefinition>,


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
