### PR TITLE
Make flaky "throws FileNotFoundException for some time" eventually test deterministic

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/io/kotest/assertions/nondeterministic/EventuallyTest.kt
@@ -9,7 +9,6 @@ import io.kotest.assertions.withClue
 import io.kotest.core.annotation.EnabledIf
 import io.kotest.core.annotation.LinuxOnlyGithubCondition
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.comparables.shouldBeBetween
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -188,8 +187,6 @@ class EventuallyTest : FunSpec() {
       }
 
       test("pass tests that throws FileNotFoundException for some time") {
-         val start = TimeSource.Monotonic.markNow()
-         val end = start.plus(50.milliseconds)
          var iterations = 0
          val config = eventuallyConfig {
             duration = 5.days
@@ -197,11 +194,12 @@ class EventuallyTest : FunSpec() {
          }
          eventually(config) {
             iterations++
-            if (end.hasNotPassedNow())
+            // throw a transient exception for the first few attempts, then succeed.
+            // counting attempts rather than measuring wall-clock time keeps this deterministic.
+            if (iterations < 5)
                throw FileNotFoundException("foo")
          }
-         // the delay is 10ms so after 50ms should be approx 5 iterations
-         iterations.shouldBeBetween(3, 7)
+         iterations shouldBe 5
       }
 
       test("handle kotlin assertion errors") {


### PR DESCRIPTION
## Problem

`EventuallyTest > "pass tests that throws FileNotFoundException for some time"` is flaky on CI:

```
EventuallyTest[jvm] > pass tests that throws FileNotFoundException for some time  FAILED
   org.opentest4j.AssertionFailedError at Undispatched.kt:66
```

It ran an `eventually` block for 50ms at a 10ms interval and asserted `iterations.shouldBeBetween(3, 7)` ("approx 5 iterations"). The iteration count is wall-clock dependent, so on a loaded runner scheduling jitter (GC, CPU contention) pushes it outside `[3, 7]` and the test fails intermittently. Observed failing in an unrelated PR's CI run.

## Fix

Drive the retry loop by a fixed **attempt count** instead of elapsed time: the block throws a transient `FileNotFoundException` for the first few attempts and then succeeds, and the test asserts the exact attempt count.

This exercises the same behaviour the test was written for — `eventually` keeps retrying through transient exceptions and then passes — but is fully deterministic and has no timing dependence, so it cannot flake.

## Verification

- `EventuallyTest` suite passes, including on `--rerun-tasks`.
- The fix is count-based with no wall-clock component, so the result is invariant to runner load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)