### PR TITLE
Fix typo in proptest config docs

### DIFF
--- a/documentation/docs/proptest/config.md
+++ b/documentation/docs/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.2.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.2.x/proptest/config.md
@@ -49,7 +49,7 @@ class PropertyExample: StringSpec({
 })
 ```
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.3.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.3.x/proptest/config.md
@@ -49,7 +49,7 @@ class PropertyExample: StringSpec({
 })
 ```
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.4.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.4.x/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.5.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.5.x/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.6.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.6.x/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.7.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.7.x/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.8.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.8.x/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-5.9.x/proptest/config.md
+++ b/documentation/versioned_docs/version-5.9.x/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-6.0/proptest/config.md
+++ b/documentation/versioned_docs/version-6.0/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-6.1/proptest/config.md
+++ b/documentation/versioned_docs/version-6.1/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.

--- a/documentation/versioned_docs/version-6.2/proptest/config.md
+++ b/documentation/versioned_docs/version-6.2/proptest/config.md
@@ -30,7 +30,7 @@ test.
 
 For full details on how the seed is used [click here](seed.md).
 
-### Min Failure
+### Max Failure
 
 By default, Kotest tolerates no failure. Perhaps you want to run some non-deterministic test a bunch of times, and you're happy
 to accept some small number of failures. You can specify that in config.


### PR DESCRIPTION
Change the header for the `maxFailure` configuration property from "Min Failure" to "Max Failure" to mirror the configuration property name.

<img width="855" height="380" alt="image" src="https://github.com/user-attachments/assets/45016e3a-75b2-4fcc-8aad-5cfa47eafc2a" />


<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
