### PR TITLE
fix: attach Fail fast scope tracker for each root test case in instance per spec mode

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerRootSpecExecutor.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/spec/execution/InstancePerRootSpecExecutor.kt
@@ -120,7 +120,7 @@ internal class InstancePerRootSpecExecutor(
       val specContext = SpecContext.create()
 
       // we switch to a new coroutine for each spec instance
-      withContext(CoroutineName("spec-scope-" + spec.hashCode())) {
+      withContext(CoroutineName("spec-scope-" + spec.hashCode()) + FailFastScopeTracker()) {
          pipeline.execute(spec, ref) {
             val result = executeTest(freshRoot, specContext)
             Result.success(mapOf(freshRoot to result))
@@ -152,5 +152,4 @@ internal class InstancePerRootSpecExecutor(
       return result
    }
 }
-
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/FailFastInstancePerRootTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/FailFastInstancePerRootTest.kt
@@ -1,0 +1,91 @@
+package com.sksamuel.kotest.engine.test
+
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.SpecRef
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.engine.TestEngineLauncher
+import io.kotest.engine.listener.CollectingTestEngineListener
+import io.kotest.matchers.shouldBe
+
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class FailFastInstancePerRootTest : FunSpec({
+
+   test("project failfast should not skip sibling roots in InstancePerRoot mode") {
+      val config = object : AbstractProjectConfig() {
+         override val failfast = true
+         override val isolationMode = IsolationMode.InstancePerRoot
+      }
+
+      val listener = CollectingTestEngineListener()
+
+      TestEngineLauncher()
+         .withListener(listener)
+         .withProjectConfig(config)
+         .withSpecRefs(SpecRef.Reference(InstancePerRootProjectFailFastFreeSpec::class))
+         .execute()
+
+      listener.result("Test a")?.isSuccess shouldBe true
+      listener.result("Test b")?.isError shouldBe true
+      listener.result("Test c")?.isIgnored shouldBe true
+
+      listener.result("second test")?.isSuccess shouldBe true
+      listener.result("third test")?.isSuccess shouldBe true
+      listener.result("fourth test")?.isSuccess shouldBe true
+   }
+
+   test("spec failfast should not skip sibling roots in InstancePerRoot mode") {
+      val config = object : AbstractProjectConfig() {
+         override val isolationMode = IsolationMode.InstancePerRoot
+      }
+
+      val listener = CollectingTestEngineListener()
+
+      TestEngineLauncher()
+         .withListener(listener)
+         .withProjectConfig(config)
+         .withSpecRefs(SpecRef.Reference(InstancePerRootSpecFailFastFreeSpec::class))
+         .execute()
+
+      listener.result("spec Test a")?.isSuccess shouldBe true
+      listener.result("spec Test b")?.isError shouldBe true
+      listener.result("spec Test c")?.isIgnored shouldBe true
+
+      listener.result("spec second test")?.isSuccess shouldBe true
+      listener.result("spec third test")?.isSuccess shouldBe true
+      listener.result("spec fourth test")?.isSuccess shouldBe true
+   }
+})
+
+private class InstancePerRootProjectFailFastFreeSpec : FreeSpec({
+   "Test root with failure test" - {
+      "Test a" { }
+      "Test b" { error("fail") }
+      "Test c" {}
+   }
+
+   "Second root test" - {
+      "second test" { }
+      "third test" { }
+      "fourth test" { }
+   }
+})
+
+private class InstancePerRootSpecFailFastFreeSpec : FreeSpec({
+   failfast = true
+
+   "Spec root with failure test" - {
+      "spec Test a" { }
+      "spec Test b" { error("fail") }
+      "spec Test c" {}
+   }
+
+   "Spec second root test" - {
+      "spec second test" { }
+      "spec third test" { }
+      "spec fourth test" { }
+   }
+})


### PR DESCRIPTION
fixes #6157 


In 6.1.11 (pre 6.2) it seems like FailFastInterceptor was directly tied to SpecContext and the state was stored on the context itself. Within The Instance per root spec inspector, a new spec context was created hence tracking was clean.

In the new system the tracking was moved to its own coroutine level context FailFastScopeTracker, and that is not being instantiated fresh in between root spec executions. The errors then share the same fail fast execution tracker (at the seed spec level ), and fail fast gets conflated between root specs.

Wrote two regression tests (the majority of this PR) that verify that both spec level and project level fail fast  do not have the same state conflation issue.


```kt
// verify that a failure in first root spec does not affect the second root spec

private class InstancePerRootProjectFailFastFreeSpec : FreeSpec({
   "Test root with failure test" - {
      "Test a" { }
      "Test b" { error("fail") }
      "Test c" {}
   }

   "Second root test" - {
      "second test" { }
      "third test" { }
      "fourth test" { }
   }
})
```