### PR TITLE
disable return-value-checker for releases

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
    compilerOptions {
 
       freeCompilerArgs.add("-Xexpect-actual-classes")
-      freeCompilerArgs.add("-Xreturn-value-checker=full")
+      freeCompilerArgs.add("-Xreturn-value-checker=${if (Ci.isRelease) "disable" else "full"}")
       freeCompilerArgs.add("-XXLanguage:+UnnamedLocalVariables")
 
       // See https://mbonnin.net/2026-02-22-kotlin-versions


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
for https://github.com/kotest/kotest/issues/6154
I went with `disable` instead of annotating every method cause the feature is still experimental and I don't want to waste tokens on `@IgnorableReturnValue` if kotlin changes things or comes up with something better.
Before:
<img width="670" height="63" alt="image" src="https://github.com/user-attachments/assets/b7cde0ee-0acf-495a-b702-c71d9ec34377" />

After (with local release of kotest):
<img width="138" height="21" alt="image" src="https://github.com/user-attachments/assets/76307a0a-4262-4416-9284-c8f287a03099" />

