### PR TITLE
Document Kotest Gradle plugin usage

### DIFF
--- a/documentation/docs/framework/setup.mdx
+++ b/documentation/docs/framework/setup.mdx
@@ -22,6 +22,22 @@ When running the Gradle test task, Gradle will cache the output and report no te
 See the section on rerunning tests for details on how to disable this behavior.
 :::
 
+## Kotest Gradle plugin
+
+The `io.kotest` Gradle plugin is used when Kotest needs additional Gradle integration beyond running tests
+through Gradle's standard JVM `Test` task.
+
+Its main role is on Kotlin Multiplatform test targets, where it wires the Kotest framework symbol processor into
+the relevant KSP configurations. This is used for targets such as JavaScript, WasmJS and Native, where Kotest
+relies on generated metadata for test discovery and execution rather than runtime classpath scanning.
+
+Because the plugin adds the Kotest symbol processor through KSP, projects that apply `io.kotest` should also
+apply the `com.google.devtools.ksp` Gradle plugin.
+
+For JVM-only projects that run Kotest through the JUnit Platform, the `io.kotest` Gradle plugin is usually not
+required. In those projects, configuring the standard Gradle test task with `useJUnitPlatform()` and adding the
+`kotest-runner-junit5` dependency (see the JVM tab) is enough.
+
 <Tabs
 defaultValue="JVM"
 values={[

--- a/documentation/docs/framework/setup.mdx
+++ b/documentation/docs/framework/setup.mdx
@@ -24,19 +24,15 @@ See the section on rerunning tests for details on how to disable this behavior.
 
 ## Kotest Gradle plugin
 
-The `io.kotest` Gradle plugin is used when Kotest needs additional Gradle integration beyond running tests
-through Gradle's standard JVM `Test` task.
+The `io.kotest` Gradle plugin is used when Kotest needs additional Gradle integration beyond running tests through Gradle's standard JVM `Test` task.
 
-Its main role is on Kotlin Multiplatform test targets, where it wires the Kotest framework symbol processor into
-the relevant KSP configurations. This is used for targets such as JavaScript, WasmJS and Native, where Kotest
-relies on generated metadata for test discovery and execution rather than runtime classpath scanning.
+For Kotlin Multiplatform test targets, the plugin wires the Kotest framework symbol processor into KSP configurations. This is useful for targets such as JavaScript, WasmJS and Native, where Kotest relies on generated metadata for test discovery and execution rather than runtime classpath scanning.
 
-Because the plugin adds the Kotest symbol processor through KSP, projects that apply `io.kotest` should also
-apply the `com.google.devtools.ksp` Gradle plugin.
+Because the plugin adds the Kotest symbol processor through KSP, projects that apply `io.kotest` for Kotlin Multiplatform targets should also apply the `com.google.devtools.ksp` Gradle plugin.
 
-For JVM-only projects that run Kotest through the JUnit Platform, the `io.kotest` Gradle plugin is usually not
-required. In those projects, configuring the standard Gradle test task with `useJUnitPlatform()` and adding the
-`kotest-runner-junit5` dependency (see the JVM tab) is enough.
+The plugin is also used for enhanced IntelliJ support, such as jump-to-source and re-running tests from the test results tree. See the Enhanced IDE support section below for details.
+
+For JVM-only projects that run Kotest through the JUnit Platform, the `io.kotest` Gradle plugin is usually not required unless you want the enhanced IDE support described below. In those projects, configuring the standard Gradle test task to use the JUnit Platform and adding the Kotest JUnit5 runner dependency is enough.
 
 <Tabs
 defaultValue="JVM"


### PR DESCRIPTION
Closes #6156.

## Summary

This PR adds setup documentation for the `io.kotest` Gradle plugin.

It explains:

- what the plugin provides
- how it relates to KSP
- when it is useful for Kotlin Multiplatform targets
- why JVM-only projects using the JUnit Platform usually do not need it

## Updated

- `documentation/docs/framework/setup.mdx`

## Verification

- `npm --prefix documentation ci`
- `npm --prefix documentation run build`

The documentation build completed successfully. Existing npm audit warnings and pre-existing broken anchor warnings were reported.