### PR TITLE
Use a data class's own equals() even when it implements Map or Collection (#5202)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DefaultEqResolver.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DefaultEqResolver.kt
@@ -33,12 +33,16 @@ object DefaultEqResolver : EqResolver {
       return when {
          actual == null || expected == null -> NullEq
          actual::class == expected::class && customEqInstances.contains(actual::class) -> customEqInstances[actual::class]!!
-         actual is Map<*, *> && expected is Map<*, *> -> MapEq
+         // A data class that also implements a structural type such as Map or Collection
+         // (e.g. `data class Foo(val name: String, val m: Map<K, V>) : Map<K, V> by m`) must be
+         // compared using its own equals(), not by structural (entry/element) equality. Otherwise
+         // its non-delegated properties would be silently ignored. See #5202.
+         actual is Map<*, *> && expected is Map<*, *> && !isDataClassInstance(actual) -> MapEq
          actual is Map.Entry<*, *> && expected is Map.Entry<*, *> -> MapEntryEq
          actual is Regex && expected is Regex -> RegexEq
          actual is String && expected is String -> StringEq
          actual is Number && expected is Number -> NumberEq
-         actual is Collection<*> && expected is Collection<*> -> CollectionEq
+         actual is Collection<*> && expected is Collection<*> && !isDataClassInstance(actual) -> CollectionEq
          actual is Array<*> && expected is Array<*> -> ArrayEq
          actual is Sequence<*> || expected is Sequence<*> -> SequenceEq
          actual is Throwable && expected is Throwable -> ThrowableEq

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
@@ -1,10 +1,12 @@
 package com.sksamuel.kotest.eq
 
 import io.kotest.assertions.AssertionErrorBuilder
+import io.kotest.assertions.eq.CollectionEq
 import io.kotest.assertions.eq.DefaultEqResolver
 import io.kotest.assertions.eq.Eq
 import io.kotest.assertions.eq.EqContext
 import io.kotest.assertions.eq.EqResult
+import io.kotest.assertions.eq.MapEq
 import io.kotest.assertions.eq.isDataClassInstance
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.StringSpec
@@ -12,6 +14,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldNotStartWith
 import io.kotest.matchers.string.shouldStartWith
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.kotest.matchers.types.shouldNotBeInstanceOf
 import kotlin.time.Duration.Companion.nanoseconds
 import kotlin.time.Instant
 
@@ -30,6 +34,18 @@ data class DataClassWithMultipleConstructors(val a: Int, val b: Float) {
 data class CircularDataClass(val num: Int, val nested: CircularDataClass?)
 
 class RegularClass(val a: Int, val b: Float)
+
+// https://github.com/kotest/kotest/issues/5202
+data class NamedMap(
+   val name: String,
+   val map: Map<String, String>,
+) : Map<String, String> by map
+
+// https://github.com/kotest/kotest/issues/5202
+data class NamedList(
+   val name: String,
+   val list: List<String>,
+) : List<String> by list
 
 data class IntRatio(
    val numerator: Int,
@@ -108,6 +124,32 @@ class DataClassEqTest : StringSpec({
       DefaultEqResolver.register(Instant::class, InstantWithoutNanosEq)
       f1 shouldBe f2
       DefaultEqResolver.unregister(Instant::class)
+   }
+
+   // https://github.com/kotest/kotest/issues/5202
+   "data class delegating to a Map is compared by its own equals, not structurally" {
+      val map1 = NamedMap("map1", mapOf("foo" to "bar"))
+      val map2 = NamedMap("map2", mapOf("foo" to "bar"))
+
+      DefaultEqResolver.resolve(map1, map2).shouldNotBeInstanceOf<MapEq>()
+      map1 shouldNotBe map2
+      map1 shouldBe NamedMap("map1", mapOf("foo" to "bar"))
+   }
+
+   // https://github.com/kotest/kotest/issues/5202
+   "data class delegating to a Collection is compared by its own equals, not structurally" {
+      val list1 = NamedList("list1", listOf("foo"))
+      val list2 = NamedList("list2", listOf("foo"))
+
+      DefaultEqResolver.resolve(list1, list2).shouldNotBeInstanceOf<CollectionEq>()
+      list1 shouldNotBe list2
+      list1 shouldBe NamedList("list1", listOf("foo"))
+   }
+
+   // a plain Map/Collection must still be compared structurally
+   "plain maps and collections are still compared structurally" {
+      DefaultEqResolver.resolve(mapOf("a" to 1), mapOf("a" to 1)).shouldBeInstanceOf<MapEq>()
+      DefaultEqResolver.resolve(listOf(1), listOf(1)).shouldBeInstanceOf<CollectionEq>()
    }
 
    "Data class instances are determined to be dataclasses" {


### PR DESCRIPTION
Fixes #5202.

### Problem
`DefaultEqResolver` selects `MapEq`/`CollectionEq` for any value that is a `Map`/`Collection`. A data class that delegates to a map or list is *also* a `Map`/`Collection`, so it was compared structurally (by entries/elements) and its other properties were ignored:

```kotlin
data class NamedMap(val name: String, val map: Map<String, String>) : Map<String, String> by map

val map1 = NamedMap("map1", mapOf("foo" to "bar"))
val map2 = NamedMap("map2", mapOf("foo" to "bar"))
map1 shouldNotBe map2   // failed — treated as equal maps, `name` ignored
```

The failure message also used the delegate map's `toString()` instead of the data class's.

### Fix
Skip the structural `MapEq`/`CollectionEq` branches when the actual value is a data class instance, so it falls through to the existing data-class / default equality path and its own generated `equals()` is used. Plain maps and collections are unaffected.

### Tests
Added cases in `DataClassEqTest` for a data class delegating to a `Map` and to a `Collection` (resolver selection + `shouldBe`/`shouldNotBe`), plus a guard that plain maps/collections still resolve to `MapEq`/`CollectionEq`. The full `com.sksamuel.kotest.eq.*` suite passes. No public-API change, so no `apiDump` update is needed.

_Drafted with AI assistance (Claude) and reviewed/verified by me._
