### PR TITLE
Annotate matchers with @IgnorableReturnValue and re-enable the return value checker for releases

### DIFF
--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
    compilerOptions {
 
       freeCompilerArgs.add("-Xexpect-actual-classes")
-      freeCompilerArgs.add("-Xreturn-value-checker=${if (Ci.isRelease) "disable" else "full"}")
+      freeCompilerArgs.add("-Xreturn-value-checker=full")
       freeCompilerArgs.add("-XXLanguage:+UnnamedLocalVariables")
 
       // See https://mbonnin.net/2026-02-22-kotlin-versions

--- a/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCase.kt
+++ b/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/ExitCase.kt
@@ -7,6 +7,7 @@ import kotlin.contracts.contract
 import kotlinx.coroutines.CancellationException
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun ExitCase.shouldBeCancelled(
   failureMessage: (ExitCase) -> String = { "Expected ExitCase.Cancelled, but found $it" }
 ): ExitCase.Cancelled {
@@ -21,6 +22,7 @@ public fun ExitCase.shouldBeCancelled(
 }
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun ExitCase.shouldBeCancelled(cancelled: CancellationException): ExitCase.Cancelled {
   contract {
     returns() implies (this@shouldBeCancelled is ExitCase.Cancelled)
@@ -31,6 +33,7 @@ public fun ExitCase.shouldBeCancelled(cancelled: CancellationException): ExitCas
 }
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun ExitCase.shouldBeCompleted(
   failureMessage: (ExitCase) -> String = { "Expected ExitCase.Completed, but found $it" }
 ): ExitCase.Completed {
@@ -45,6 +48,7 @@ public fun ExitCase.shouldBeCompleted(
 }
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun ExitCase.shouldBeFailure(
   failureMessage: (ExitCase) -> String = { "Expected ExitCase.Failure, but found $it" }
 ): ExitCase.Failure {
@@ -59,6 +63,7 @@ public fun ExitCase.shouldBeFailure(
 }
 
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun ExitCase.shouldBeFailure(throwable: Throwable): ExitCase.Failure {
   contract {
     returns() implies (this@shouldBeFailure is ExitCase.Failure)

--- a/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/Resource.kt
+++ b/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/Resource.kt
@@ -3,11 +3,13 @@ package io.kotest.assertions.arrow.fx.coroutines
 import arrow.fx.coroutines.Resource
 import arrow.fx.coroutines.resourceScope
 
+@IgnorableReturnValue
 public suspend infix fun <A> Resource<A>.shouldBeResource(a: A): A =
   resourceScope {
     bind() shouldBe a
   }
 
+@IgnorableReturnValue
 public suspend infix fun <A> Resource<A>.shouldBeResource(expected: Resource<A>): A =
   resourceScope {
     bind() shouldBe expected.bind()

--- a/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/shouldBe.kt
+++ b/kotest-assertions/kotest-assertions-arrow-fx-coroutines/src/commonMain/kotlin/io/kotest/assertions/arrow/fx/coroutines/shouldBe.kt
@@ -2,6 +2,7 @@ package io.kotest.assertions.arrow.fx.coroutines
 
 import io.kotest.matchers.shouldBe as coreShouldBe
 
+@IgnorableReturnValue
 internal infix fun <A> A.shouldBe(a: A): A =
   also {
     this coreShouldBe a

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/Utils.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/Utils.kt
@@ -3,6 +3,7 @@ package io.kotest.assertions.arrow
 import io.kotest.matchers.shouldBe as coreShouldBe
 import io.kotest.matchers.shouldNotBe as coreShouldNotBe
 
+@IgnorableReturnValue
 internal infix fun <A> A.shouldBe(a: A): A {
   this coreShouldBe a
   return this

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Either.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Either.kt
@@ -31,6 +31,7 @@ import kotlin.contracts.contract
  * ```
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A, B> Either<A, B>.shouldBeRight(failureMessage: (A) -> String = { "Expected Either.Right, but found Either.Left with value $it" }): B {
    contract {
       returns() implies (this@shouldBeRight is Right<B>)
@@ -43,9 +44,11 @@ public fun <A, B> Either<A, B>.shouldBeRight(failureMessage: (A) -> String = { "
    }
 }
 
+@IgnorableReturnValue
 public infix fun <A, B> Either<A, B>.shouldBeRight(b: B): B =
    shouldBeRight().shouldBe(b)
 
+@IgnorableReturnValue
 public infix fun <A, B> Either<A, B>.shouldNotBeRight(b: B): B =
    shouldBeRight().shouldNotBe(b)
 
@@ -67,6 +70,7 @@ public infix fun <A, B> Either<A, B>.shouldNotBeRight(b: B): B =
  * ```
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A, B> Either<A, B>.shouldBeLeft(failureMessage: (B) -> String = { "Expected Either.Left, but found Either.Right with value $it" }): A {
    contract {
       returns() implies (this@shouldBeLeft is Left<A>)
@@ -79,9 +83,11 @@ public fun <A, B> Either<A, B>.shouldBeLeft(failureMessage: (B) -> String = { "E
    }
 }
 
+@IgnorableReturnValue
 public infix fun <A, B> Either<A, B>.shouldBeLeft(a: A): A =
    shouldBeLeft().shouldBe(a)
 
+@IgnorableReturnValue
 public infix fun <A, B> Either<A, B>.shouldNotBeLeft(a: A): A =
    shouldBeLeft().shouldNotBe(a)
 

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Ior.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.should
  * smart casts to [Ior.Right] and fails with [failureMessage] otherwise.
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A, B>) -> String = { "Expected Ior.Right, but found ${it::class.simpleName}" }): B {
    contract {
       returns() implies (this@shouldBeRight is Right<B>)
@@ -30,9 +31,11 @@ public fun <A, B> Ior<A, B>.shouldBeRight(failureMessage: (Ior<A, B>) -> String 
    }
 }
 
+@IgnorableReturnValue
 public infix fun <A, B> Ior<A, B>.shouldBeRight(b: B): B =
    shouldBeRight().shouldBe(b)
 
+@IgnorableReturnValue
 public infix fun <A, B> Ior<A, B>.shouldNotBeRight(b: B): B =
    shouldBeRight().shouldNotBe(b)
 
@@ -40,6 +43,7 @@ public infix fun <A, B> Ior<A, B>.shouldNotBeRight(b: B): B =
  * smart casts to [Ior.Left] and fails with [failureMessage] otherwise.
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A, B>) -> String = { "Expected Ior.Left, but found ${it::class.simpleName}" }): A {
    contract {
       returns() implies (this@shouldBeLeft is Left<A>)
@@ -52,9 +56,11 @@ public fun <A, B> Ior<A, B>.shouldBeLeft(failureMessage: (Ior<A, B>) -> String =
    }
 }
 
+@IgnorableReturnValue
 public infix fun <A, B> Ior<A, B>.shouldBeLeft(a: A): A =
    shouldBeLeft().shouldBe(a)
 
+@IgnorableReturnValue
 public infix fun <A, B> Ior<A, B>.shouldNotBeLeft(a: A): A =
    shouldBeLeft().shouldNotBe(a)
 
@@ -70,6 +76,7 @@ public fun <A, B> beBoth(): Matcher<Ior<A, B>> = Matcher { ior ->
  * smart casts to [Ior.Both]
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A, B> Ior<A, B>.shouldBeBoth(): Ior.Both<A, B> {
    contract {
       returns() implies (this@shouldBeBoth is Ior.Both<A, B>)

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Nel.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Nel.kt
@@ -24,76 +24,100 @@ import io.kotest.matchers.collections.shouldNotHaveElementAt
 import io.kotest.matchers.collections.shouldNotHaveSingleElement
 import io.kotest.matchers.collections.shouldNotHaveSize
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldContainOnlyNulls(): NonEmptyList<A> =
   apply { all.shouldContainOnlyNulls() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotContainOnlyNulls(): NonEmptyList<A> =
   apply { all.shouldNotContainOnlyNulls() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldContainNull(): NonEmptyList<A> =
   apply { all.shouldContainNull() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotContainNull(): NonEmptyList<A> =
   apply { all.shouldNotContainNull() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldHaveElementAt(index: Int, element: A): Unit =
   all.shouldHaveElementAt(index, element)
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotHaveElementAt(index: Int, element: A): Unit =
   all.shouldNotHaveElementAt(index, element)
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldContainNoNulls(): NonEmptyList<A> =
   apply { all.shouldContainNoNulls() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotContainNoNulls(): NonEmptyList<A> =
   apply { all.shouldNotContainNoNulls() }
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldContain(a: A): Unit {
   all.shouldContain(a)
 }
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldNotContain(a: A): Unit {
   all.shouldNotContain(a)
 }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldBeUnique(): NonEmptyList<A> =
   apply { all.shouldBeUnique() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotBeUnique(): NonEmptyList<A> =
   apply { all.shouldNotBeUnique() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldContainDuplicates(): NonEmptyList<A> =
   apply { all.shouldContainDuplicates() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotContainDuplicates(): NonEmptyList<A> =
   apply { all.shouldNotContainDuplicates() }
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldContainAll(vararg ts: A): Collection<A> =
   all.shouldContainAll(*ts)
 
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.shouldNotContainAll(vararg ts: A): Collection<A> =
   all.shouldNotContainAll(*ts)
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldContainAll(ts: List<A>): Collection<A> =
   all.shouldContainAll(ts)
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldNotContainAll(ts: List<A>): Collection<A> =
   all.shouldNotContainAll(ts)
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldHaveSize(size: Int): NonEmptyList<A> =
   apply { all.shouldHaveSize(size) }
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldNotHaveSize(size: Int): NonEmptyList<A> =
   apply { all.shouldNotHaveSize(size) }
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldHaveSingleElement(a: A): NonEmptyList<A> =
   apply { all.shouldHaveSingleElement(a) }
 
+@IgnorableReturnValue
 public infix fun <A> NonEmptyList<A>.shouldNotHaveSingleElement(a: A): NonEmptyList<A> =
   apply { all.shouldNotHaveSingleElement(a) }
 
+@IgnorableReturnValue
 public fun <A : Comparable<A>> NonEmptyList<A>.shouldBeSorted(): NonEmptyList<A> =
   apply { all.shouldBeSorted() }
 
+@IgnorableReturnValue
 public fun <A : Comparable<A>> NonEmptyList<A>.shouldNotBeSorted(): NonEmptyList<A> =
   apply { all.shouldNotBeSorted() }

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Nelnspectors.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Nelnspectors.kt
@@ -16,6 +16,7 @@ import io.kotest.inspectors.forSome
   "use Kotest's Collection<A>.forAll.",
   ReplaceWith("forAll", "io.kotest.inspectors.forAll")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forAll(f: (A) -> Unit): Unit {
   all.forAll(f)
 }
@@ -24,6 +25,7 @@ public fun <A> NonEmptyList<A>.forAll(f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forOne.",
   ReplaceWith("forOne", "io.kotest.inspectors.forOne")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forOne(f: (A) -> Unit): Unit {
   all.forOne(f)
 }
@@ -32,6 +34,7 @@ public fun <A> NonEmptyList<A>.forOne(f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forExactly.",
   ReplaceWith("forExactly", "io.kotest.inspectors.forExactly")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forExactly(k: Int, f: (A) -> Unit): Unit {
   all.forExactly(k, f)
 }
@@ -40,6 +43,7 @@ public fun <A> NonEmptyList<A>.forExactly(k: Int, f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forSome.",
   ReplaceWith("forSome", "io.kotest.inspectors.forSome")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forSome(f: (A) -> Unit): Unit {
   all.forSome(f)
 }
@@ -48,6 +52,7 @@ public fun <A> NonEmptyList<A>.forSome(f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forAny.",
   ReplaceWith("forAny", "io.kotest.inspectors.forAny")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forAny(f: (A) -> Unit): Unit {
   all.forAny(f)
 }
@@ -56,6 +61,7 @@ public fun <A> NonEmptyList<A>.forAny(f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forAtLeastOne.",
   ReplaceWith("forAtLeastOne", "io.kotest.inspectors.forAtLeastOne")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forAtLeastOne(f: (A) -> Unit): Unit {
   all.forAtLeastOne(f)
 }
@@ -64,6 +70,7 @@ public fun <A> NonEmptyList<A>.forAtLeastOne(f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forAtLeast.",
   ReplaceWith("forAtLeast", "io.kotest.inspectors.forAtLeast")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forAtLeast(k: Int, f: (A) -> Unit): Unit {
   all.forAtLeast(k, f)
 }
@@ -72,6 +79,7 @@ public fun <A> NonEmptyList<A>.forAtLeast(k: Int, f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forAtMostOne.",
   ReplaceWith("forAtMostOne", "io.kotest.inspectors.forAtMostOne")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forAtMostOne(f: (A) -> Unit): Unit {
   all.forAtMostOne(f)
 }
@@ -80,6 +88,7 @@ public fun <A> NonEmptyList<A>.forAtMostOne(f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forAtMost.",
   ReplaceWith("forAtMost", "io.kotest.inspectors.forAtMost")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forAtMost(k: Int, f: (A) -> Unit): Unit {
   all.forAtMost(k, f)
 }
@@ -88,6 +97,7 @@ public fun <A> NonEmptyList<A>.forAtMost(k: Int, f: (A) -> Unit): Unit {
   "use Kotest's Collection<A>.forNone.",
   ReplaceWith("forNone", "io.kotest.inspectors.forNone")
 )
+@IgnorableReturnValue
 public fun <A> NonEmptyList<A>.forNone(f: (A) -> Unit): Unit {
   all.forNone(f)
 }

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Option.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Option.kt
@@ -29,6 +29,7 @@ import kotlin.contracts.contract
  * ```
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A> Option<A>.shouldBeSome(failureMessage: () -> String = { "Expected Some, but found None" }): A {
    contract {
       returns() implies (this@shouldBeSome is Some<A>)
@@ -41,9 +42,11 @@ public fun <A> Option<A>.shouldBeSome(failureMessage: () -> String = { "Expected
    }
 }
 
+@IgnorableReturnValue
 public infix fun <A> Option<A>.shouldBeSome(a: A): A =
    shouldBeSome().shouldBe(a)
 
+@IgnorableReturnValue
 public infix fun <A> Option<A>.shouldNotBeSome(a: A): A =
    shouldBeSome().shouldNotBe(a)
 
@@ -66,6 +69,7 @@ public infix fun <A> Option<A>.shouldNotBeSome(a: A): A =
  * ```
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 public fun <A> Option<A>.shouldBeNone(failureMessage: (Some<A>) -> String = { "Expected None, but found Some with value ${it.value}" }): None {
    contract {
       returns() implies (this@shouldBeNone is None)

--- a/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Raise.kt
+++ b/kotest-assertions/kotest-assertions-arrow/src/commonMain/kotlin/io/kotest/assertions/arrow/core/Raise.kt
@@ -18,6 +18,7 @@ import io.kotest.assertions.assertionCounter
  * }
  * ```
  */
+@IgnorableReturnValue
 public inline fun <reified T> shouldRaise(block: Raise<Any?>.() -> Any?): T {
    assertionCounter.inc()
 
@@ -43,6 +44,7 @@ public inline fun <reified T> shouldRaise(block: Raise<Any?>.() -> Any?): T {
  * }
  * ```
  */
+@IgnorableReturnValue
 public inline fun <T> shouldNotRaise(block: Raise<Any?>.() -> T): T {
    assertionCounter.inc()
 

--- a/kotest-assertions/kotest-assertions-compiler/src/jvmMain/kotlin/io/kotest/matchers/compilation/compileCodeSnippet.kt
+++ b/kotest-assertions/kotest-assertions-compiler/src/jvmMain/kotlin/io/kotest/matchers/compilation/compileCodeSnippet.kt
@@ -187,6 +187,7 @@ fun codeSnippet(sourceFiles: List<SourceFile>): CodeSnippet {
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [String.shouldNotCompile]
  * */
+@IgnorableReturnValue
 fun String.shouldCompile() = codeSnippet(this).shouldCompile()
 
 /**
@@ -200,6 +201,7 @@ fun String.shouldCompile() = codeSnippet(this).shouldCompile()
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [String.shouldCompile]
  * */
+@IgnorableReturnValue
 fun String.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(this).shouldNotCompile(expectedMessage)
 
 /**
@@ -208,6 +210,7 @@ fun String.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(this)
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [Map.shouldNotCompile]
  * */
+@IgnorableReturnValue
 fun Map<String, String>.shouldCompile() = codeSnippet(
    this.map { (k, v) -> SourceFile.kotlin(k, v) }
 ).shouldCompile()
@@ -225,6 +228,7 @@ fun Map<String, String>.shouldCompile() = codeSnippet(
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [Map.shouldCompile]
  * */
+@IgnorableReturnValue
 fun Map<String, String>.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(
    this.map { (k, v) -> SourceFile.kotlin(k, v) }
 ).shouldNotCompile(expectedMessage)
@@ -235,6 +239,7 @@ fun Map<String, String>.shouldNotCompile(expectedMessage: String? = null) = code
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [File.shouldNotCompile]
  * */
+@IgnorableReturnValue
 fun File.shouldCompile() = codeSnippet(readText()).shouldCompile()
 
 /**
@@ -248,6 +253,7 @@ fun File.shouldCompile() = codeSnippet(readText()).shouldCompile()
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [File.shouldCompile]
  * */
+@IgnorableReturnValue
 fun File.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(readText()).shouldNotCompile(expectedMessage)
 
 /**
@@ -257,6 +263,7 @@ fun File.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(readTex
  * @see [List.shouldNotCompile]
  * */
 @JvmName("shouldCompileFiles")
+@IgnorableReturnValue
 fun List<File>.shouldCompile() = codeSnippet(
    this.map { file -> SourceFile.kotlin(file.name, file.readText()) }
 ).shouldCompile()
@@ -268,6 +275,7 @@ fun List<File>.shouldCompile() = codeSnippet(
  * @see [List.shouldNotCompile]
  * */
 @JvmName("shouldCompileSourceFiles")
+@IgnorableReturnValue
 fun List<SourceFile>.shouldCompile() = codeSnippet(this).shouldCompile()
 
 /**
@@ -282,6 +290,7 @@ fun List<SourceFile>.shouldCompile() = codeSnippet(this).shouldCompile()
  * @see [List.shouldCompile]
  * */
 @JvmName("shouldNotCompileFiles")
+@IgnorableReturnValue
 fun List<File>.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(
    this.map { file -> SourceFile.kotlin(file.name, file.readText()) }
 ).shouldNotCompile(expectedMessage)
@@ -298,6 +307,7 @@ fun List<File>.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(
  * @see [List.shouldCompile]
  * */
 @JvmName("shouldNotCompileSourceFiles")
+@IgnorableReturnValue
 fun List<SourceFile>.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(this).shouldNotCompile(expectedMessage)
 
 /**
@@ -306,6 +316,7 @@ fun List<SourceFile>.shouldNotCompile(expectedMessage: String? = null) = codeSni
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [Path.shouldNotCompile]
  * */
+@IgnorableReturnValue
 fun Path.shouldCompile() = codeSnippet(readText()).shouldCompile()
 
 /**
@@ -319,6 +330,7 @@ fun Path.shouldCompile() = codeSnippet(readText()).shouldCompile()
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [Path.shouldCompile]
  * */
+@IgnorableReturnValue
 fun Path.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(readText()).shouldNotCompile(expectedMessage)
 
 /**
@@ -328,6 +340,7 @@ fun Path.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(readTex
  * @see [List.shouldNotCompile]
  * */
 @JvmName("shouldCompilePaths")
+@IgnorableReturnValue
 fun List<Path>.shouldCompile() = codeSnippet(
    this.map { file -> SourceFile.kotlin(file.name, file.readText()) }
 ).shouldCompile()
@@ -344,6 +357,7 @@ fun List<Path>.shouldCompile() = codeSnippet(
  * @see [List.shouldCompile]
  * */
 @JvmName("shouldNotCompilePaths")
+@IgnorableReturnValue
 fun List<Path>.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(
    this.map { file -> SourceFile.kotlin(file.name, file.readText()) }
 ).shouldNotCompile(expectedMessage)
@@ -354,6 +368,7 @@ fun List<Path>.shouldNotCompile(expectedMessage: String? = null) = codeSnippet(
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [CodeSnippet.shouldNotCompile]
  * */
+@IgnorableReturnValue
 fun CodeSnippet.shouldCompile() = this should compileMatcher
 
 /**
@@ -367,6 +382,7 @@ fun CodeSnippet.shouldCompile() = this should compileMatcher
  * so that dependencies available to the calling process are also available to the code snippet.
  * @see [CodeSnippet.shouldCompile]
  * */
+@IgnorableReturnValue
 fun CodeSnippet.shouldNotCompile(expectedMessage: String? = null) {
    if (expectedMessage == null) {
       this shouldNot compileMatcher

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/Retry.kt
@@ -28,6 +28,7 @@ import kotlin.time.TimeSource
  *
  * If either [timeout] or [maxRetry] is reached, the execution will be aborted and an exception will be thrown.
  */
+@IgnorableReturnValue
 suspend fun <T> retry(
    maxRetry: Int,
    timeout: Duration,
@@ -39,6 +40,7 @@ suspend fun <T> retry(
    return retry(RetryConfig(maxRetry, timeout, delay, multiplier, exceptionClass), f)
 }
 
+@IgnorableReturnValue
 suspend fun <T> retry(
    config: RetryConfig,
    test: suspend () -> T,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/all.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/all.kt
@@ -69,6 +69,7 @@ suspend fun <T> all(t: T, assertions: suspend T.(T) -> Unit): T {
    }
 }
 
+@IgnorableReturnValue
 inline fun <T> assertSoftly(t: T, assertions: T.(T) -> Unit): T {
    return withSubject(t) {
       assertSoftly {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/async/timeout.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/async/timeout.kt
@@ -22,6 +22,7 @@ import kotlin.time.measureTime
  *   (2+2) shouldBe 4
  * }
  */
+@IgnorableReturnValue
 suspend fun shouldTimeout(
    duration: Duration,
    operation: suspend () -> Unit,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/clues.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/clues.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.TimeoutCancellationException
  * @param thunk the code with assertions to be executed
  * @return the return value of the supplied [thunk]
  */
+@IgnorableReturnValue
 inline fun <R> withClue(clue: Any?, thunk: () -> R): R {
    return clue.asClue { thunk() }
 }
@@ -21,6 +22,7 @@ inline fun <R> withClue(clue: Any?, thunk: () -> R): R {
  * @param thunk the code with assertions to be executed
  * @return the return value of the supplied [thunk]
  */
+@IgnorableReturnValue
 inline fun <R> withClue(crossinline clue: () -> Any?, thunk: () -> R): R {
    val collector = errorCollector
    try {
@@ -56,6 +58,7 @@ inline fun <R> withClue(crossinline clue: () -> Any?, thunk: () -> R): R {
  * @return the return value of the supplied [block]
  */
 @Suppress("USELESS_CAST")
+@IgnorableReturnValue
 inline fun <T, R> T.asClue(block: (T) -> R): R =
    withClue(
       // The cast is needed to avoid calling withClue(Any)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/EqOverridesDsl.kt
@@ -70,6 +70,7 @@ infix fun <T> T.withEqs(block: EqOverrides.() -> Unit): WithEqs<T> {
  * Asserts that the value carried by [this] equals [expected] under the overrides supplied via
  * [withEqs]. Throws an [AssertionError] on mismatch and returns the actual value on success.
  */
+@IgnorableReturnValue
 infix fun <T> WithEqs<T>.shouldBe(expected: T?): T {
    val context = EqContext(strictNumberEq = false, resolver = LayeredEqResolver(overrides))
    @Suppress("UNCHECKED_CAST")
@@ -83,6 +84,7 @@ infix fun <T> WithEqs<T>.shouldBe(expected: T?): T {
  * via [withEqs]. Throws an [AssertionError] when the comparison reports equality and returns the
  * actual value otherwise.
  */
+@IgnorableReturnValue
 infix fun <T> WithEqs<T>.shouldNotBe(expected: T?): T {
    val context = EqContext(strictNumberEq = false, resolver = LayeredEqResolver(overrides))
    @Suppress("UNCHECKED_CAST")

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/fail.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/fail.kt
@@ -22,6 +22,7 @@ import io.kotest.matchers.shouldBe
  * @see shouldThrow
  * @see shouldThrowExactly
  */
+@IgnorableReturnValue
 inline fun shouldFail(block: () -> Any?): AssertionError = shouldThrow(block)
 
 /**
@@ -44,6 +45,7 @@ inline fun shouldFail(block: () -> Any?): AssertionError = shouldThrow(block)
  * @see shouldThrow
  * @see shouldThrowExactly
  */
+@IgnorableReturnValue
 inline fun shouldFailWithMessage(message: String, block: () -> Any?): AssertionError =
    shouldFail(block).also { t ->
       t.message shouldBe message

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/continually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/continually.kt
@@ -15,6 +15,7 @@ import kotlin.time.Duration.Companion.seconds
  *
  * To supply more options to continually, use the overload that accepts a [ContinuallyConfiguration].
  */
+@IgnorableReturnValue
 suspend fun <T> continually(
    duration: Duration,
    test: suspend () -> T,
@@ -29,6 +30,7 @@ suspend fun <T> continually(
  *
  * To supply more options to continually, use the overload that accepts a [ContinuallyConfiguration].
  */
+@IgnorableReturnValue
 suspend fun <T> continually(
    durationMs: Long,
    test: suspend () -> T,
@@ -40,6 +42,7 @@ suspend fun <T> continually(
  * Runs the [test] function continually using the given [config], failing if an exception is
  * thrown during any invocation.
  */
+@IgnorableReturnValue
 suspend fun <T> continually(
    config: ContinuallyConfiguration<T>,
    test: suspend () -> T,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/eventually.kt
@@ -24,6 +24,7 @@ import kotlin.time.TimeMark
  * Even though it will work inside virtual time dispatchers, eg if you are using runTest from `kotlin.test`,
  * or if you have enabled coroutineTestScope in a Kotest test, the intervals will always run on wall-clock time.
  */
+@IgnorableReturnValue
 suspend fun <T> eventually(
    test: suspend () -> T,
 ): T {
@@ -40,6 +41,7 @@ suspend fun <T> eventually(
  * Even though it will work inside virtual time dispatchers, eg if you are using runTest from `kotlin.test`,
  * or if you have enabled coroutineTestScope in a Kotest test, the intervals will always run on wall-clock time.
  */
+@IgnorableReturnValue
 suspend fun <T> eventually(
    duration: Duration,
    test: suspend () -> T,
@@ -57,6 +59,7 @@ suspend fun <T> eventually(
  * Even though it will work inside virtual time dispatchers, eg if you are using runTest from `kotlin.test`,
  * or if you have enabled coroutineTestScope in a Kotest test, the intervals will always run on wall-clock time.
  */
+@IgnorableReturnValue
 suspend fun <T> eventually(
    durationMs: Long,
    test: suspend () -> T,
@@ -71,6 +74,7 @@ suspend fun <T> eventually(
  * Even though it will work inside virtual time dispatchers, eg if you are using runTest from `kotlin.test`,
  * or if you have enabled coroutineTestScope in a Kotest test, the intervals will always run on wall-clock time.
  */
+@IgnorableReturnValue
 suspend fun <T> eventually(
    config: EventuallyConfiguration,
    test: suspend () -> T,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/nondeterministic/until.kt
@@ -11,6 +11,7 @@ import kotlin.time.Duration.Companion.seconds
  *
  * To supply more options to until, use the overload that accepts an [UntilConfiguration].
  */
+@IgnorableReturnValue
 suspend fun until(
    duration: Duration,
    test: suspend () -> Boolean,
@@ -24,6 +25,7 @@ suspend fun until(
  *
  * To supply more options to until, use the overload that accepts an [UntilConfiguration].
  */
+@IgnorableReturnValue
 suspend fun until(
    durationMs: Long,
    test: suspend () -> Boolean,
@@ -34,6 +36,7 @@ suspend fun until(
 /**
  * Runs a function [test] until it returns true, using the supplied [config].
  */
+@IgnorableReturnValue
 suspend fun until(
    config: UntilConfiguration,
    test: suspend () -> Boolean,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/throwables/AnyThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/throwables/AnyThrowableHandling.kt
@@ -20,6 +20,7 @@ import io.kotest.assertions.errorCollector
  *
  * @see [shouldThrowAny]
  */
+@IgnorableReturnValue
 inline fun shouldThrowAnyUnit(block: () -> Unit) = shouldThrowAny(block)
 
 /**
@@ -37,6 +38,7 @@ inline fun shouldThrowAnyUnit(block: () -> Unit) = shouldThrowAny(block)
  * @see [shouldNotThrowUnit]
  *
  */
+@IgnorableReturnValue
 inline fun shouldNotThrowAnyUnit(block: () -> Unit) {
    assertionCounter.inc()
 
@@ -80,6 +82,7 @@ inline fun shouldNotThrowAnyUnit(block: () -> Unit) {
  *
  * @see [shouldThrowAnyUnit]
  */
+@IgnorableReturnValue
 inline fun shouldThrowAny(block: () -> Any?): Throwable {
    assertionCounter.inc()
    val thrownException = try {
@@ -112,6 +115,7 @@ inline fun shouldThrowAny(block: () -> Any?): Throwable {
  * @see [shouldNotThrow]
  *
  */
+@IgnorableReturnValue
 inline fun <T> shouldNotThrowAny(block: () -> T): T {
    assertionCounter.inc()
 
@@ -133,6 +137,7 @@ inline fun <T> shouldNotThrowAny(block: () -> T): T {
  *
  * @see [shouldNotThrowMessage]
  * */
+@IgnorableReturnValue
 inline fun <T> shouldThrowMessage(message: String, block: () -> T) {
    assertionCounter.inc()
 
@@ -158,6 +163,7 @@ inline fun <T> shouldThrowMessage(message: String, block: () -> T) {
 /**
  * Verifies that a block of code does not throws any [Throwable] with given [message].
 * */
+@IgnorableReturnValue
 inline fun <T> shouldNotThrowMessage(message: String, block: () -> T) {
    assertionCounter.inc()
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/throwables/CovariantThrowableHandling.kt
@@ -35,6 +35,7 @@ import io.kotest.assertions.errorCollector
  *
  * @see [shouldThrow]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrowUnit(block: () -> Unit): T = shouldThrow { block() }
 
 /**
@@ -62,6 +63,7 @@ inline fun <reified T : Throwable> shouldThrowUnit(block: () -> Unit): T = shoul
  *
  * @see [shouldThrowWithMessage]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrowUnitWithMessage(message: String, block: () -> Unit): T =
    shouldThrowUnit<T>(block).let {
       when (it.message) {
@@ -100,6 +102,7 @@ inline fun <reified T : Throwable> shouldThrowUnitWithMessage(message: String, b
  * @see [shouldNotThrow]
  *
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldNotThrowUnit(block: () -> Unit) = shouldNotThrow<T>(block)
 
 /**
@@ -128,6 +131,7 @@ inline fun <reified T : Throwable> shouldNotThrowUnit(block: () -> Unit) = shoul
  *
  * @see [shouldThrowUnit]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrow(block: () -> Any?): T {
    assertionCounter.inc()
    val expectedExceptionClass = T::class
@@ -167,6 +171,7 @@ inline fun <reified T : Throwable> shouldThrow(block: () -> Any?): T {
  * errors are only thrown at the end of the block, rather than immediately. Therefore, the signature cannot return
  * the throwable type, as in the case of a failure, there would be neither an immediate throws, nor a type to return.
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrowSoftly(block: () -> Any?) {
    require(errorCollector.getCollectionMode() == ErrorCollectionMode.Soft)
 
@@ -217,6 +222,7 @@ inline fun <reified T : Throwable> shouldThrowSoftly(block: () -> Any?) {
  *
  * @see [shouldThrowUnitWithMessage]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrowWithMessage(message: String, block: () -> Any?): T =
    shouldThrow<T>(block).let {
       when (it.message) {
@@ -256,6 +262,7 @@ inline fun <reified T : Throwable> shouldThrowWithMessage(message: String, block
  *
  * @see [shouldNotThrowUnit]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldNotThrow(block: () -> Any?) {
    assertionCounter.inc()
    val thrown = tryRunning(block) ?: return

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/throwables/StrictThrowableHandling.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/throwables/StrictThrowableHandling.kt
@@ -28,6 +28,7 @@ import io.kotest.assertions.assertionCounter
  *
  * @see [shouldThrowExactly]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrowExactlyUnit(block: () -> Unit): T = shouldThrowExactly { block() }
 
 
@@ -57,6 +58,7 @@ inline fun <reified T : Throwable> shouldThrowExactlyUnit(block: () -> Unit): T 
  * @see [shouldNotThrowExactly]
  *
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldNotThrowExactlyUnit(block: () -> Unit) = shouldNotThrowExactly<T>(block)
 
 /**
@@ -88,6 +90,7 @@ inline fun <reified T : Throwable> shouldNotThrowExactlyUnit(block: () -> Unit) 
  *
  * @see [shouldThrowExactly]
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldThrowExactly(block: () -> Any?): T {
    assertionCounter.inc()
    val expectedExceptionClass = T::class
@@ -140,6 +143,7 @@ inline fun <reified T : Throwable> shouldThrowExactly(block: () -> Any?): T {
  * @see [shouldNotThrowExactlyUnit]
  *
  */
+@IgnorableReturnValue
 inline fun <reified T : Throwable> shouldNotThrowExactly(block: () -> Any?) {
    assertionCounter.inc()
    val thrown = try {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/inspectors/InspectorAliases.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/inspectors/InspectorAliases.kt
@@ -1,100 +1,130 @@
 package io.kotest.inspectors
 
 /** Alias for [Sequence.forAll] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
 
 /** Alias for [Array.forAll] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
 
 /** Alias for [Collection.forAll] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForAll(fn: (T) -> Unit) = forAll(fn)
 
 
 /** Alias for [Sequence.forOne] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
 
 /** Alias for [Array.forOne] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
 
 /** Alias for [Collection.forOne] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForOne(fn: (T) -> Unit) = forOne(fn)
 
 
 /** Alias for [Sequence.forExactly] */
+@IgnorableReturnValue
 inline fun <T> Sequence<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
 
 /** Alias for [Array.forExactly] */
+@IgnorableReturnValue
 inline fun <T> Array<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
 
 /** Alias for [Collection.forExactly] */
+@IgnorableReturnValue
 inline fun <T> Collection<T>.shouldForExactly(k: Int, fn: (T) -> Unit) = forExactly(k, fn)
 
 
 /** Alias for [Sequence.forSome] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
 
 /** Alias for [Array.forSome] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
 
 /** Alias for [Collection.forSome] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForSome(fn: (T) -> Unit) = forSome(fn)
 
 
 /** Alias for [Sequence.forAny] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
 
 /** Alias for [Array.forAny] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
 
 /** Alias for [Collection.forAny] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForAny(fn: (T) -> Unit) = forAny(fn)
 
 
 /** Alias for [Sequence.forAtLeastOne] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
 
 /** Alias for [Array.forAtLeastOne] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
 
 /** Alias for [Collection.forAtLeastOne] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForAtLeastOne(fn: (T) -> Unit) = forAtLeastOne(fn)
 
 
 /** Alias for [Sequence.forAtLeast] */
+@IgnorableReturnValue
 inline fun <T> Sequence<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
 
 /** Alias for [Array.forAtLeast] */
+@IgnorableReturnValue
 inline fun <T> Array<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
 
 /** Alias for [Collection.forAtLeast] */
+@IgnorableReturnValue
 inline fun <T> Collection<T>.shouldForAtLeast(k: Int, fn: (T) -> Unit) = forAtLeast(k, fn)
 
 
 /** Alias for [Sequence.forAtMostOne] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
 
 /** Alias for [Array.forAtMostOne] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
 
 /** Alias for [Collection.forAtMostOne] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForAtMostOne(fn: (T) -> Unit) = forAtMostOne(fn)
 
 
 /** Alias for [Sequence.forAtMost] */
+@IgnorableReturnValue
 inline fun <T> Sequence<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
 
 /** Alias for [Array.forAtMost] */
+@IgnorableReturnValue
 inline fun <T> Array<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
 
 /** Alias for [Collection.forAtMost] */
+@IgnorableReturnValue
 inline fun <T> Collection<T>.shouldForAtMost(k: Int, fn: (T) -> Unit) = forAtMost(k, fn)
 
 
 /** Alias for [Sequence.forNone] */
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
 
 /** Alias for [Array.forNone] */
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)
 
 /** Alias for [Collection.forNone] */
+@IgnorableReturnValue
 inline infix fun <T> Collection<T>.shouldForNone(fn: (T) -> Unit) = forNone(fn)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/inspectors/Inspectors.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/inspectors/Inspectors.kt
@@ -3,8 +3,11 @@ package io.kotest.inspectors
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.common.ExperimentalKotest
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAllValues(fn: (V) -> Unit): C = apply { values.forAll(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAllKeys(fn: (K) -> Unit): C = apply { keys.forAll(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAll(fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -14,9 +17,13 @@ inline infix fun <K, V, C : Map<K, V>> C.forAll(fn: (Map.Entry<K, V>) -> Unit): 
    }
 }
 
+@IgnorableReturnValue
 inline infix fun CharSequence.forAll(fn: (Char) -> Unit): CharSequence = apply { toList().forAll(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forAll(fn: (T) -> Unit): Sequence<T> = apply { toList().forAll(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forAll(fn: (T) -> Unit): Array<T> = apply { asList().forAll(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forAll(fn: (T) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<T>>()
@@ -26,17 +33,25 @@ inline infix fun <T, C : Collection<T>> C.forAll(fn: (T) -> Unit): C = apply {
    }
 }
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forOneValue(fn: (V) -> Unit): C = apply { values.forExactly(1, fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forOneKey(fn: (K) -> Unit): C = apply { keys.forExactly(1, fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forOne(fn: (Map.Entry<K, V>) -> Unit): C = apply { forExactly(1, fn) }
 
+@IgnorableReturnValue
 inline infix fun CharSequence.forOne(fn: (Char) -> Unit): CharSequence = apply { toList().forOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forOne(fn: (T) -> Unit): Sequence<T> = apply { toList().forOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forOne(fn: (T) -> Unit): Array<T> = apply { asList().forOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forOne(fn: (T) -> Unit): C = forExactly(1, fn)
 
 inline fun <K, V, C : Map<K, V>> C.forValuesExactly(k: Int, fn: (V) -> Unit): C = apply { values.forExactly(k, fn) }
 inline fun <K, V, C : Map<K, V>> C.forKeysExactly(k: Int, fn: (K) -> Unit): C = apply { keys.forExactly(k, fn) }
+@IgnorableReturnValue
 inline fun <K, V, C : Map<K, V>> C.forExactly(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -46,9 +61,13 @@ inline fun <K, V, C : Map<K, V>> C.forExactly(k: Int, fn: (Map.Entry<K, V>) -> U
    }
 }
 
+@IgnorableReturnValue
 inline fun CharSequence.forExactly(k: Int, fn: (Char) -> Unit): CharSequence = apply { toList().forExactly(k, fn) }
+@IgnorableReturnValue
 inline fun <T> Sequence<T>.forExactly(k: Int, fn: (T) -> Unit): Sequence<T> = apply { toList().forExactly(k, fn) }
+@IgnorableReturnValue
 inline fun <T> Array<T>.forExactly(k: Int, fn: (T) -> Unit): Array<T> = apply { toList().forExactly(k, fn) }
+@IgnorableReturnValue
 inline fun <T, C : Collection<T>> C.forExactly(k: Int, fn: (T) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<T>>()
@@ -58,8 +77,11 @@ inline fun <T, C : Collection<T>> C.forExactly(k: Int, fn: (T) -> Unit): C = app
    }
 }
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forSomeValues(fn: (V) -> Unit): C = apply { values.forSome(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forSomeKeys(fn: (K) -> Unit): C = apply { keys.forSome(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forSome(fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -70,9 +92,13 @@ inline infix fun <K, V, C : Map<K, V>> C.forSome(fn: (Map.Entry<K, V>) -> Unit):
    }
 }
 
+@IgnorableReturnValue
 inline infix fun CharSequence.forSome(fn: (Char) -> Unit): CharSequence = apply { toList().forSome(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forSome(fn: (T) -> Unit): Sequence<T> = apply { toList().forSome(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forSome(fn: (T) -> Unit): Array<T> = apply { toList().forSome(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forSome(fn: (T) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<T>>()
@@ -83,24 +109,39 @@ inline infix fun <T, C : Collection<T>> C.forSome(fn: (T) -> Unit): C = apply {
    }
 }
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAnyValue(fn: (V) -> Unit): C = apply { values.forAny(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAnyKey(fn: (K) -> Unit): C = apply { keys.forAny(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAny(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtLeastOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forAny(fn: (T) -> Unit): Sequence<T> = apply { toList().forAny(fn) }
+@IgnorableReturnValue
 inline infix fun CharSequence.forAny(fn: (Char) -> Unit): CharSequence = apply { toList().forAny(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forAny(fn: (T) -> Unit): Array<T> = apply { toList().forAny(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forAny(fn: (T) -> Unit): C = apply { forAtLeastOne(fn) }
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAtLeastOneValue(fn: (V) -> Unit): C = apply { values.forAtLeastOne(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAtLeastOneKey(fn: (K) -> Unit): C = apply { keys.forAtLeastOne(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAtLeastOne(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtLeast(1, fn) }
+@IgnorableReturnValue
 inline infix fun CharSequence.forAtLeastOne(fn: (Char) -> Unit): CharSequence = apply { toList().forAtLeast(1, fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forAtLeastOne(fn: (T) -> Unit): Sequence<T> = apply { toList().forAtLeastOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forAtLeastOne(fn: (T) -> Unit): Array<T> = apply { toList().forAtLeastOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forAtLeastOne(f: (T) -> Unit) = forAtLeast(1, f)
 
 inline fun <K, V, C : Map<K, V>> C.forValuesAtLeast(k: Int, fn: (V) -> Unit): C = apply { values.forAtLeast(k, fn) }
 inline fun <K, V, C : Map<K, V>> C.forKeysAtLeast(k: Int, fn: (K) -> Unit): C = apply { keys.forAtLeast(k, fn) }
+@IgnorableReturnValue
 inline fun <K, V, C : Map<K, V>> C.forAtLeast(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -110,9 +151,13 @@ inline fun <K, V, C : Map<K, V>> C.forAtLeast(k: Int, fn: (Map.Entry<K, V>) -> U
    }
 }
 
+@IgnorableReturnValue
 inline fun CharSequence.forAtLeast(k: Int, fn: (Char) -> Unit): CharSequence = apply { toList().forAtLeast(k, fn) }
+@IgnorableReturnValue
 inline fun <T> Sequence<T>.forAtLeast(k: Int, fn: (T) -> Unit): Sequence<T> = apply { toList().forAtLeast(k, fn) }
+@IgnorableReturnValue
 inline fun <T> Array<T>.forAtLeast(k: Int, fn: (T) -> Unit): Array<T> = apply { toList().forAtLeast(k, fn) }
+@IgnorableReturnValue
 inline fun <T, C : Collection<T>> C.forAtLeast(k: Int, fn: (T) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<T>>()
@@ -122,16 +167,24 @@ inline fun <T, C : Collection<T>> C.forAtLeast(k: Int, fn: (T) -> Unit): C = app
    }
 }
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAtMostOneValue(fn: (V) -> Unit): C = apply { values.forAtMostOne(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAtMostOneKey(fn: (K) -> Unit): C = apply { keys.forAtMostOne(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forAtMostOne(fn: (Map.Entry<K, V>) -> Unit): C = apply { forAtMost(1, fn) }
+@IgnorableReturnValue
 inline infix fun CharSequence.forAtMostOne(fn: (Char) -> Unit): CharSequence = apply { toList().forAtMost(1, fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forAtMostOne(fn: (T) -> Unit): Sequence<T> = apply { toList().forAtMostOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forAtMostOne(fn: (T) -> Unit): Array<T> = apply { toList().forAtMostOne(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forAtMostOne(fn: (T) -> Unit) = forAtMost(1, fn)
 
 inline fun <K, V, C : Map<K, V>> C.forValuesAtMost(k: Int, fn: (V) -> Unit): C = apply { values.forAtMost(k, fn) }
 inline fun <K, V, C : Map<K, V>> C.forKeysAtMost(k: Int, fn: (K) -> Unit): C = apply { keys.forAtMost(k, fn) }
+@IgnorableReturnValue
 inline fun <K, V, C : Map<K, V>> C.forAtMost(k: Int, fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -141,9 +194,13 @@ inline fun <K, V, C : Map<K, V>> C.forAtMost(k: Int, fn: (Map.Entry<K, V>) -> Un
    }
 }
 
+@IgnorableReturnValue
 inline fun CharSequence.forAtMost(k: Int, fn: (Char) -> Unit): CharSequence = apply { toList().forAtMost(k, fn) }
+@IgnorableReturnValue
 inline fun <T> Sequence<T>.forAtMost(k: Int, fn: (T) -> Unit): Sequence<T> = apply { toList().forAtMost(k, fn) }
+@IgnorableReturnValue
 inline fun <T> Array<T>.forAtMost(k: Int, fn: (T) -> Unit): Array<T> = apply { toList().forAtMost(k, fn) }
+@IgnorableReturnValue
 inline fun <T, C : Collection<T>> C.forAtMost(k: Int, fn: (T) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<T>>()
@@ -153,8 +210,11 @@ inline fun <T, C : Collection<T>> C.forAtMost(k: Int, fn: (T) -> Unit): C = appl
    }
 }
 
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forNoneValue(fn: (V) -> Unit): C = apply { values.forNone(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forNoneKey(fn: (K) -> Unit): C = apply { keys.forNone(fn) }
+@IgnorableReturnValue
 inline infix fun <K, V, C : Map<K, V>> C.forNone(fn: (Map.Entry<K, V>) -> Unit): C = apply {
    val results = runTests(this, fn)
    val passed = results.filterIsInstance<ElementPass<Map.Entry<K, V>>>()
@@ -164,9 +224,13 @@ inline infix fun <K, V, C : Map<K, V>> C.forNone(fn: (Map.Entry<K, V>) -> Unit):
    }
 }
 
+@IgnorableReturnValue
 inline infix fun CharSequence.forNone(fn: (Char) -> Unit): CharSequence = apply { toList().forNone(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Sequence<T>.forNone(fn: (T) -> Unit): Sequence<T> = apply { toList().forNone(fn) }
+@IgnorableReturnValue
 inline infix fun <T> Array<T>.forNone(fn: (T) -> Unit): Array<T> = apply { toList().forNone(fn) }
+@IgnorableReturnValue
 inline infix fun <T, C : Collection<T>> C.forNone(f: (T) -> Unit): C = apply {
    val results = runTests(this, f)
    val passed = results.filterIsInstance<ElementPass<T>>()
@@ -180,18 +244,21 @@ inline infix fun <T, C : Collection<T>> C.forNone(f: (T) -> Unit): C = apply {
  * Checks that [Sequence] consists of a single element, which passes the given assertion block [fn]
  * and returns the element
  * */
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.forSingle(fn: (T) -> Unit): T = toList().forSingle(fn)
 
 /**
  * Checks that [Array] consists of a single element, which passes the given assertion block [fn]
  * and returns the element
  * */
+@IgnorableReturnValue
 infix fun <T> Array<T>.forSingle(fn: (T) -> Unit): T = toList().forSingle(fn)
 
 /**
  * Checks that [Collection] consists of a single element, which passes the given assertion block [f]
  * and returns the element
  * */
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.forSingle(f: (T) -> Unit): T = run {
    val results = runTests(this, f)
    when (results.size) {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/InvokeMatcher.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/InvokeMatcher.kt
@@ -9,6 +9,7 @@ import io.kotest.assertions.collectOrThrow
 import io.kotest.assertions.createLazyAssertionError
 import io.kotest.assertions.errorCollector
 
+@IgnorableReturnValue
 fun <T> invokeMatcher(t: T, matcher: Matcher<T>): T {
    assertionCounter.inc()
    val result = matcher.test(t)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/booleans/BooleanMatchers.kt
@@ -25,6 +25,7 @@ import kotlin.contracts.contract
  * @see [Boolean?.shouldBeFalse]
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 fun Boolean?.shouldBeTrue(): Boolean {
    contract {
       returns() implies (this@shouldBeTrue != null)
@@ -50,6 +51,7 @@ fun Boolean?.shouldBeTrue(): Boolean {
  * @see [Boolean?.shouldBeFalse]
  * @see [Boolean?.shouldNotBeFalse]
  */
+@IgnorableReturnValue
 fun Boolean?.shouldNotBeTrue(): Boolean? {
    this shouldNot beTrue()
    return this
@@ -73,6 +75,7 @@ fun Boolean?.shouldNotBeTrue(): Boolean? {
  * @see [Boolean?.shouldBeTrue]
  */
 @OptIn(ExperimentalContracts::class)
+@IgnorableReturnValue
 fun Boolean?.shouldBeFalse(): Boolean {
    contract {
       returns() implies (this@shouldBeFalse != null)
@@ -99,6 +102,7 @@ fun Boolean?.shouldBeFalse(): Boolean {
  * @see [Boolean?.shouldBeTrue]
  * @see [Boolean?.shouldNotBeTrue]
  */
+@IgnorableReturnValue
 fun Boolean?.shouldNotBeFalse(): Boolean? {
    this shouldNot beFalse()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/bytes/byte.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/bytes/byte.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
    "Byte-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Byte import `io.kotest.matchers.bytes.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(lower, upper)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun Byte.shouldBeBetween(lower: Byte, upper: Byte): Byte {
    this shouldBe between(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/bytes/ubyte.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/bytes/ubyte.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
    "UByte-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the UByte import `io.kotest.matchers.bytes.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(lower, upper)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun UByte.shouldBeBetween(lower: UByte, upper: UByte): UByte {
    this shouldBe between(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/char/CharMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/char/CharMatchers.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNot
  * @see [shouldNotBeInRange]
  * @see [beInRange]
  * */
+@IgnorableReturnValue
 infix fun Char.shouldBeInRange(range: CharRange): Char {
    this should beInRange(range)
    return this
@@ -22,6 +23,7 @@ infix fun Char.shouldBeInRange(range: CharRange): Char {
  * @see [shouldBeInRange]
  * @see [beInRange]
  * */
+@IgnorableReturnValue
 infix fun Char.shouldNotBeInRange(range: CharRange): Char {
    this shouldNot beInRange(range)
    return this
@@ -47,6 +49,7 @@ fun beInRange(range: CharRange) = object : Matcher<Char> {
    "Char-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Char import `io.kotest.matchers.char.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(from, to)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun Char.shouldBeBetween(from: Char, to: Char): Char {
    this should between(from, to)
    return this
@@ -62,6 +65,7 @@ fun Char.shouldBeBetween(from: Char, to: Char): Char {
    "Char-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Char import `io.kotest.matchers.char.shouldNotBeBetween` manually.",
    ReplaceWith("shouldNotBeBetween(from, to)", "io.kotest.matchers.comparables.shouldNotBeBetween")
 )
+@IgnorableReturnValue
 fun Char.shouldNotBeBetween(from: Char, to: Char): Char {
    this shouldNot between(from, to)
    return this
@@ -79,6 +83,7 @@ fun between(from: Char, to: Char): Matcher<Char> = between(from, to)
  * @see [shouldNotBeEqualToIgnoreCase]
  * @see [beEqualIgnoreCase]
  * */
+@IgnorableReturnValue
 infix fun Char.shouldBeEqualToIgnoreCase(other: Char): Char {
    this should beEqualIgnoreCase(other)
    return this
@@ -90,6 +95,7 @@ infix fun Char.shouldBeEqualToIgnoreCase(other: Char): Char {
  * @see [shouldBeEqualToIgnoreCase]
  * @see [beEqualIgnoreCase]
  * */
+@IgnorableReturnValue
 infix fun Char.shouldNotBeEqualToIgnoreCase(other: Char): Char {
    this shouldNot beEqualIgnoreCase(other)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/char/case.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/char/case.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldNot
  * @see [shouldNotBeUpperCaseChar]
  * @see [beUpperCaseChar]
  */
+@IgnorableReturnValue
 fun Char.shouldBeUpperCaseChar(): Char {
    this should beUpperCaseChar()
    return this
@@ -21,6 +22,7 @@ fun Char.shouldBeUpperCaseChar(): Char {
  * @see [shouldBeUpperCaseChar]
  * @see [beUpperCaseChar]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeUpperCaseChar(): Char {
    this shouldNot beUpperCaseChar()
    return this
@@ -38,6 +40,7 @@ fun beUpperCaseChar(): Matcher<Char> = charCaseMatcher("upper") { it.uppercaseCh
  * @see [shouldNotBeLowerCaseChar]
  * @see [beLowerCaseChar]
  */
+@IgnorableReturnValue
 fun Char.shouldBeLowerCaseChar(): Char {
    this should beLowerCaseChar()
    return this
@@ -48,6 +51,7 @@ fun Char.shouldBeLowerCaseChar(): Char {
  * @see [shouldBeLowerCaseChar]
  * @see [beLowerCaseChar]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeLowerCaseChar(): Char {
    this shouldNot beLowerCaseChar()
    return this
@@ -65,6 +69,7 @@ fun beLowerCaseChar(): Matcher<Char> = charCaseMatcher("lower") { it.lowercaseCh
  * @see [shouldNotBeTitleCaseChar]
  * @see [beTitleCaseChar]
  */
+@IgnorableReturnValue
 fun Char.shouldBeTitleCaseChar(): Char {
    this should beTitleCaseChar()
    return this
@@ -75,6 +80,7 @@ fun Char.shouldBeTitleCaseChar(): Char {
  * @see [shouldBeTitleCaseChar]
  * @see [beTitleCaseChar]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeTitleCaseChar(): Char {
    this shouldNot beTitleCaseChar()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/char/value.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/char/value.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldNot
  * @see [shouldNotBeLetter]
  * @see [beLetter]
  */
+@IgnorableReturnValue
 fun Char.shouldBeLetter(): Char {
    this should beLetter()
    return this
@@ -21,6 +22,7 @@ fun Char.shouldBeLetter(): Char {
  * @see [shouldBeLetter]
  * @see [beLetter]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeLetter(): Char {
    this shouldNot beLetter()
    return this
@@ -39,6 +41,7 @@ fun beLetter(): Matcher<Char> = charValueMatcher("a letter") { it.isLetter() }
  * @see [shouldNotBeLetterOrDigit]
  * @see [beLetterOrDigit]
  */
+@IgnorableReturnValue
 fun Char.shouldBeLetterOrDigit(): Char {
    this should beLetterOrDigit()
    return this
@@ -49,6 +52,7 @@ fun Char.shouldBeLetterOrDigit(): Char {
  * @see [shouldBeLetterOrDigit]
  * @see [beLetterOrDigit]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeLetterOrDigit(): Char {
    this shouldNot beLetterOrDigit()
    return this
@@ -67,6 +71,7 @@ fun beLetterOrDigit(): Matcher<Char> = charValueMatcher("a letter or digit") { i
  * @see [shouldNotBeDigit]
  * @see [beDigit]
  */
+@IgnorableReturnValue
 fun Char.shouldBeDigit(): Char {
    this should beDigit()
    return this
@@ -77,6 +82,7 @@ fun Char.shouldBeDigit(): Char {
  * @see [shouldBeDigit]
  * @see [beDigit]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeDigit(): Char {
    this shouldNot beDigit()
    return this
@@ -95,6 +101,7 @@ fun beDigit(): Matcher<Char> = charValueMatcher("a digit") { it.isDigit() }
  * @see [shouldNotBeWhitespace]
  * @see [beWhitespace]
  */
+@IgnorableReturnValue
 fun Char.shouldBeWhitespace(): Char {
    this should beWhitespace()
    return this
@@ -105,6 +112,7 @@ fun Char.shouldBeWhitespace(): Char {
  * @see [shouldBeWhitespace]
  * @see [beWhitespace]
  */
+@IgnorableReturnValue
 fun Char.shouldNotBeWhitespace(): Char {
    this shouldNot beWhitespace()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/ContainExactCopies.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/ContainExactCopies.kt
@@ -7,21 +7,37 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun BooleanArray.shouldContainExactCopies(element: Boolean, copies: Int): BooleanArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun BooleanArray.shouldNotContainExactCopies(element: Boolean, copies: Int): BooleanArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun ByteArray.shouldContainExactCopies(element: Byte, copies: Int): ByteArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun ByteArray.shouldNotContainExactCopies(element: Byte, copies: Int): ByteArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun ShortArray.shouldContainExactCopies(element: Short, copies: Int): ShortArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun ShortArray.shouldNotContainExactCopies(element: Short, copies: Int): ShortArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun CharArray.shouldContainExactCopies(element: Char, copies: Int): CharArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun CharArray.shouldNotContainExactCopies(element: Char, copies: Int): CharArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun IntArray.shouldContainExactCopies(element: Int, copies: Int): IntArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun IntArray.shouldNotContainExactCopies(element: Int, copies: Int): IntArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun LongArray.shouldContainExactCopies(element: Long, copies: Int): LongArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun LongArray.shouldNotContainExactCopies(element: Long, copies: Int): LongArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun FloatArray.shouldContainExactCopies(element: Float, copies: Int): FloatArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun FloatArray.shouldNotContainExactCopies(element: Float, copies: Int): FloatArray = apply { asList().shouldNotContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun DoubleArray.shouldContainExactCopies(element: Double, copies: Int): DoubleArray = apply { asList().shouldContainExactCopies(element, copies) }
+@IgnorableReturnValue
 fun DoubleArray.shouldNotContainExactCopies(element: Double, copies: Int): DoubleArray = apply { asList().shouldNotContainExactCopies(element, copies) }
 
 /**
@@ -32,6 +48,7 @@ fun DoubleArray.shouldNotContainExactCopies(element: Double, copies: Int): Doubl
  *
  * @see [containExactCopies]
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotContainExactCopies(element: T, copies: Int): I = apply {
    toList() shouldNot containExactCopies(element, copies)
 }
@@ -44,6 +61,7 @@ fun <T, I : Iterable<T>> I.shouldNotContainExactCopies(element: T, copies: Int):
  *
  * @see [containExactCopies]
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainExactCopies(element: T, copies: Int): Array<T> = apply {
    asList().shouldNotContainExactCopies(element, copies)
 }
@@ -61,6 +79,7 @@ fun <T> Array<T>.shouldNotContainExactCopies(element: T, copies: Int): Array<T> 
  * @see [containExactCopies]
  */
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldContainExactCopies(element: T, copies: Int): I = apply {
    toList() should containExactCopies(element, copies)
 }
@@ -77,6 +96,7 @@ fun <T, I : Iterable<T>> I.shouldContainExactCopies(element: T, copies: Int): I 
  *
  * @see [containExactCopies]
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainExactCopies(element: T, copies: Int): Array<T> = apply {
    asList().shouldContainExactCopies(element, copies)
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bein.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bein.kt
@@ -20,6 +20,7 @@ import kotlin.jvm.JvmName
  * @see [shouldNotBeIn]
  * @see [beIn]
  */
+@IgnorableReturnValue
 infix fun <T> T.shouldBeIn(collection: Collection<T>): T {
    this should beIn(collection)
    return this
@@ -37,6 +38,7 @@ infix fun <T> T.shouldBeIn(collection: Collection<T>): T {
  * @see [shouldNotBeIn]
  * @see [beIn]
  */
+@IgnorableReturnValue
 infix fun <T> T.shouldNotBeIn(collection: Collection<T>): T {
    this shouldNot beIn(collection.toList())
    return this
@@ -54,6 +56,7 @@ infix fun <T> T.shouldNotBeIn(collection: Collection<T>): T {
  * @see [shouldNotBeIn]
  * @see [beIn]
  */
+@IgnorableReturnValue
 fun <T> T.shouldBeIn(vararg any: T): T {
    this should beIn(any.toList())
    return this
@@ -71,6 +74,7 @@ fun <T> T.shouldBeIn(vararg any: T): T {
  * @see [shouldNotBeIn]
  * @see [beIn]
  */
+@IgnorableReturnValue
 fun <T> T.shouldNotBeIn(vararg any: T): T {
    this shouldNot beIn(any.toList())
    return this
@@ -90,6 +94,7 @@ fun <T> T.shouldNotBeIn(vararg any: T): T {
  * @see [beIn]
  */
 @JvmName("shouldBeInArray")
+@IgnorableReturnValue
 infix fun <T> T.shouldBeIn(array: Array<T>): T {
    this should beIn(array.toList())
    return this
@@ -108,86 +113,103 @@ infix fun <T> T.shouldBeIn(array: Array<T>): T {
  * @see [beIn]
  */
 @JvmName("shouldNotBeInArray")
+@IgnorableReturnValue
 infix fun <T> T.shouldNotBeIn(array: Array<T>): T {
    this shouldNot beIn(array.toList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeIn(array: IntArray): Int {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldNotBeIn(array: IntArray): Int {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeIn(array: LongArray): Long {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldNotBeIn(array: LongArray): Long {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldBeIn(array: FloatArray): Float {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldNotBeIn(array: FloatArray): Float {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Double.shouldBeIn(array: DoubleArray): Double {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Double.shouldNotBeIn(array: DoubleArray): Double {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Byte.shouldBeIn(array: ByteArray): Byte {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Byte.shouldNotBeIn(array: ByteArray): Byte {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Short.shouldBeIn(array: ShortArray): Short {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Short.shouldNotBeIn(array: ShortArray): Short {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Char.shouldBeIn(array: CharArray): Char {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Char.shouldNotBeIn(array: CharArray): Char {
    this shouldNot beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Boolean.shouldBeIn(array: BooleanArray): Boolean {
    this should beIn(array.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Boolean.shouldNotBeIn(array: BooleanArray): Boolean {
    this shouldNot beIn(array.asList())
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/bounds.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.should
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldHaveUpperBound(value: Byte): ByteArray {
    asList() should haveUpperBound(value, "ByteArray")
    return this
@@ -30,6 +31,7 @@ infix fun ByteArray.shouldHaveUpperBound(value: Byte): ByteArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun ShortArray.shouldHaveUpperBound(value: Short): ShortArray {
    asList() should haveUpperBound(value, "ShortArray")
    return this
@@ -43,6 +45,7 @@ infix fun ShortArray.shouldHaveUpperBound(value: Short): ShortArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun CharArray.shouldHaveUpperBound(value: Char): CharArray {
    asList() should haveUpperBound(value, "CharArray")
    return this
@@ -56,6 +59,7 @@ infix fun CharArray.shouldHaveUpperBound(value: Char): CharArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun IntArray.shouldHaveUpperBound(value: Int): IntArray {
    asList() should haveUpperBound(value, "IntArray")
    return this
@@ -69,6 +73,7 @@ infix fun IntArray.shouldHaveUpperBound(value: Int): IntArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun LongArray.shouldHaveUpperBound(value: Long): LongArray {
    asList() should haveUpperBound(value, "LongArray")
    return this
@@ -82,6 +87,7 @@ infix fun LongArray.shouldHaveUpperBound(value: Long): LongArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun FloatArray.shouldHaveUpperBound(value: Float): FloatArray {
    asList() should haveUpperBound(value, "FloatArray")
    return this
@@ -95,6 +101,7 @@ infix fun FloatArray.shouldHaveUpperBound(value: Float): FloatArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun DoubleArray.shouldHaveUpperBound(value: Double): DoubleArray {
    asList() should haveUpperBound(value, "DoubleArray")
    return this
@@ -108,6 +115,7 @@ infix fun DoubleArray.shouldHaveUpperBound(value: Double): DoubleArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(value: T): Array<T> {
    asList() should haveUpperBound(value, "Array")
    return this
@@ -121,6 +129,7 @@ infix fun <T : Comparable<T>> Array<T>.shouldHaveUpperBound(value: T): Array<T> 
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveUpperBound(value: T): I {
    this should haveUpperBound(value, null)
    return this
@@ -159,6 +168,7 @@ private fun <T : Comparable<T>, I : Iterable<T>> haveUpperBound(t: T, name: Stri
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldHaveLowerBound(value: Byte): ByteArray {
    asList() should haveLowerBound(value, "ByteArray")
    return this
@@ -172,6 +182,7 @@ infix fun ByteArray.shouldHaveLowerBound(value: Byte): ByteArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun ShortArray.shouldHaveLowerBound(value: Short): ShortArray {
    asList() should haveLowerBound(value, "ShortArray")
    return this
@@ -185,6 +196,7 @@ infix fun ShortArray.shouldHaveLowerBound(value: Short): ShortArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun CharArray.shouldHaveLowerBound(value: Char): CharArray {
    asList() should haveLowerBound(value, "CharArray")
    return this
@@ -198,6 +210,7 @@ infix fun CharArray.shouldHaveLowerBound(value: Char): CharArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun IntArray.shouldHaveLowerBound(value: Int): IntArray {
    asList() should haveLowerBound(value, "IntArray")
    return this
@@ -211,6 +224,7 @@ infix fun IntArray.shouldHaveLowerBound(value: Int): IntArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun LongArray.shouldHaveLowerBound(value: Long): LongArray {
    asList() should haveLowerBound(value, "LongArray")
    return this
@@ -224,6 +238,7 @@ infix fun LongArray.shouldHaveLowerBound(value: Long): LongArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun FloatArray.shouldHaveLowerBound(value: Float): FloatArray {
    asList() should haveLowerBound(value, "FloatArray")
    return this
@@ -237,6 +252,7 @@ infix fun FloatArray.shouldHaveLowerBound(value: Float): FloatArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun DoubleArray.shouldHaveLowerBound(value: Double): DoubleArray {
    asList() should haveLowerBound(value, "DoubleArray")
    return this
@@ -250,6 +266,7 @@ infix fun DoubleArray.shouldHaveLowerBound(value: Double): DoubleArray {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(value: T): Array<T> {
    asList() should haveLowerBound(value, "Array")
    return this
@@ -263,6 +280,7 @@ infix fun <T : Comparable<T>> Array<T>.shouldHaveLowerBound(value: T): Array<T> 
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>, I : Iterable<T>> I.shouldHaveLowerBound(value: T): I {
    this should haveLowerBound(value, null)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/contain.kt
@@ -9,43 +9,67 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
 // Primitive array overloads
+@IgnorableReturnValue
 infix fun BooleanArray.shouldContain(t: Boolean): BooleanArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotContain(t: Boolean): BooleanArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun ByteArray.shouldContain(t: Byte): ByteArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotContain(t: Byte): ByteArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun ShortArray.shouldContain(t: Short): ShortArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotContain(t: Short): ShortArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun CharArray.shouldContain(t: Char): CharArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun CharArray.shouldNotContain(t: Char): CharArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun IntArray.shouldContain(t: Int): IntArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun IntArray.shouldNotContain(t: Int): IntArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun LongArray.shouldContain(t: Long): LongArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun LongArray.shouldNotContain(t: Long): LongArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun FloatArray.shouldContain(t: Float): FloatArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotContain(t: Float): FloatArray = apply { asList().shouldNotContain(t) }
+@IgnorableReturnValue
 infix fun DoubleArray.shouldContain(t: Double): DoubleArray = apply { asList().shouldContain(t) }
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotContain(t: Double): DoubleArray = apply { asList().shouldNotContain(t) }
 
 // Infix
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotContain(t: T): I = shouldNotContain(t, Equality.default())
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContain(t: T): Array<T> = shouldNotContain(t, Equality.default())
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldContain(t: T): I = shouldContain(t, Equality.default())
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldContain(t: T): Array<T> = shouldContain(t, Equality.default())
 
 // Should not
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotContain(t: T, comparator: Equality<T>): I = apply {
    toList() shouldNot contain(t, comparator)
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContain(t: T, comparator: Equality<T>): Array<T> = apply {
    asList().shouldNotContain(t, comparator)
 }
 
 // Should
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldContain(t: T, comparator: Equality<T>): I = apply {
    toList() should contain(t, comparator)
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContain(t: T, comparator: Equality<T>): Array<T> = apply {
    asList().shouldContain(t, comparator)
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAll.kt
@@ -13,12 +13,14 @@ import kotlin.jvm.JvmName
  * Verifies that the given [Iterable] contains all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldContainAll(vararg ts: T) = toList().shouldContainAll(*ts)
 
 /**
  * Verifies that the given [Array] contains all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainAll(vararg ts: T): Array<T> {
    asList().shouldContainAll(*ts)
    return this
@@ -28,6 +30,7 @@ fun <T> Array<T>.shouldContainAll(vararg ts: T): Array<T> {
  * Verifies that the given [Collection] contains all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T> Collection<T>.shouldContainAll(vararg ts: T): Collection<T> {
    this should containAll(*ts)
    return this
@@ -37,12 +40,14 @@ fun <T> Collection<T>.shouldContainAll(vararg ts: T): Collection<T> {
  * Verifies that the given [Iterable] contains all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldContainAll(ts: Collection<T>) = toList().shouldContainAll(ts)
 
 /**
  * Verifies that the given [Array] contains all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldContainAll(ts: Collection<T>): Array<T> {
    asList().shouldContainAll(ts)
    return this
@@ -52,6 +57,7 @@ infix fun <T> Array<T>.shouldContainAll(ts: Collection<T>): Array<T> {
  * Verifies that the given [Collection] contains all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T> Collection<T>.shouldContainAll(ts: Collection<T>): Collection<T> {
    this should containAll(ts)
    return this
@@ -61,6 +67,7 @@ infix fun <T> Collection<T>.shouldContainAll(ts: Collection<T>): Collection<T> {
  * Verifies that the given [Iterable] does not contain all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldNotContainAll(vararg ts: T): Iterable<T> {
    toList().shouldNotContainAll(*ts)
    return this
@@ -70,6 +77,7 @@ fun <T> Iterable<T>.shouldNotContainAll(vararg ts: T): Iterable<T> {
  * Verifies that the given [Array] does not contain all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainAll(vararg ts: T): Array<T> {
    asList().shouldNotContainAll(*ts)
    return this
@@ -79,6 +87,7 @@ fun <T> Array<T>.shouldNotContainAll(vararg ts: T): Array<T> {
  * Verifies that the given [Collection] does not contain all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T> Collection<T>.shouldNotContainAll(vararg ts: T): Collection<T> {
    this shouldNot containAll(*ts)
    return this
@@ -88,12 +97,14 @@ fun <T> Collection<T>.shouldNotContainAll(vararg ts: T): Collection<T> {
  * Verifies that the given [Iterable] does not contain all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotContainAll(ts: Collection<T>) = toList().shouldNotContainAll(ts)
 
 /**
  * Verifies that the given [Array] does not contain all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContainAll(ts: Collection<T>): Array<T> {
    asList().shouldNotContainAll(ts)
    return this
@@ -103,6 +114,7 @@ infix fun <T> Array<T>.shouldNotContainAll(ts: Collection<T>): Array<T> {
  * Verifies that the given [Collection] does not contain all the specified elements in given order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T> Collection<T>.shouldNotContainAll(ts: Collection<T>): Collection<T> {
    this shouldNot containAll(ts)
    return this
@@ -110,67 +122,99 @@ infix fun <T> Collection<T>.shouldNotContainAll(ts: Collection<T>): Collection<T
 
 
 // BooleanArray
+@IgnorableReturnValue
 fun BooleanArray.shouldContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_booleanArray_infix")
+@IgnorableReturnValue
 infix fun BooleanArray.shouldContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun BooleanArray.shouldNotContainAll(vararg expected: Boolean): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_booleanArray_infix")
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotContainAll(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // ByteArray
+@IgnorableReturnValue
 fun ByteArray.shouldContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_byteArray_infix")
+@IgnorableReturnValue
 infix fun ByteArray.shouldContainAll(expected: ByteArray): ByteArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun ByteArray.shouldNotContainAll(vararg expected: Byte): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_byteArray_infix")
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotContainAll(expected: ByteArray): ByteArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // ShortArray
+@IgnorableReturnValue
 fun ShortArray.shouldContainAll(vararg expected: Short): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_shortArray_infix")
+@IgnorableReturnValue
 infix fun ShortArray.shouldContainAll(expected: ShortArray): ShortArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun ShortArray.shouldNotContainAll(vararg expected: Short): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_shortArray_infix")
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotContainAll(expected: ShortArray): ShortArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // CharArray
+@IgnorableReturnValue
 fun CharArray.shouldContainAll(vararg expected: Char): CharArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_charArray_infix")
+@IgnorableReturnValue
 infix fun CharArray.shouldContainAll(expected: CharArray): CharArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun CharArray.shouldNotContainAll(vararg expected: Char): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_charArray_infix")
+@IgnorableReturnValue
 infix fun CharArray.shouldNotContainAll(expected: CharArray): CharArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // IntArray
+@IgnorableReturnValue
 fun IntArray.shouldContainAll(vararg expected: Int): IntArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_intArray_infix")
+@IgnorableReturnValue
 infix fun IntArray.shouldContainAll(expected: IntArray): IntArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun IntArray.shouldNotContainAll(vararg expected: Int): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_intArray_infix")
+@IgnorableReturnValue
 infix fun IntArray.shouldNotContainAll(expected: IntArray): IntArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // LongArray
+@IgnorableReturnValue
 fun LongArray.shouldContainAll(vararg expected: Long): LongArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_longArray_infix")
+@IgnorableReturnValue
 infix fun LongArray.shouldContainAll(expected: LongArray): LongArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun LongArray.shouldNotContainAll(vararg expected: Long): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_longArray_infix")
+@IgnorableReturnValue
 infix fun LongArray.shouldNotContainAll(expected: LongArray): LongArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // FloatArray
+@IgnorableReturnValue
 fun FloatArray.shouldContainAll(vararg expected: Float): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_floatArray_infix")
+@IgnorableReturnValue
 infix fun FloatArray.shouldContainAll(expected: FloatArray): FloatArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun FloatArray.shouldNotContainAll(vararg expected: Float): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_floatArray_infix")
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotContainAll(expected: FloatArray): FloatArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 // DoubleArray
+@IgnorableReturnValue
 fun DoubleArray.shouldContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
 @JvmName("shouldContainAll_doubleArray_infix")
+@IgnorableReturnValue
 infix fun DoubleArray.shouldContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldContainAll(expected.asList()) }
+@IgnorableReturnValue
 fun DoubleArray.shouldNotContainAll(vararg expected: Double): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
 @JvmName("shouldNotContainAll_doubleArray_infix")
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotContainAll(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainAll(expected.asList()) }
 
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAllInAnyOrder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containAllInAnyOrder.kt
@@ -10,9 +10,11 @@ import io.kotest.matchers.sequences.UnorderedCollectionsDifference
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldNotContainAllInAnyOrder(expected: C) =
    this shouldNot containAllInAnyOrder(expected)
 
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C?.shouldNotContainAllInAnyOrder(vararg expected: T) =
    this shouldNot containAllInAnyOrder(*expected)
 
@@ -20,6 +22,7 @@ fun <T, C : Collection<T>> C?.shouldNotContainAllInAnyOrder(vararg expected: T) 
  * Verifies that the given [Collection] contains all the specified elements in any order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldContainAllInAnyOrder(expected: C) =
    this should containAllInAnyOrder(expected)
 
@@ -27,6 +30,7 @@ infix fun <T, C : Collection<T>> C?.shouldContainAllInAnyOrder(expected: C) =
  * Verifies that the given [Collection] contains all the specified elements in any order.
  * The collection may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C?.shouldContainAllInAnyOrder(vararg expected: T) =
    this should containAllInAnyOrder(*expected)
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactly.kt
@@ -19,6 +19,7 @@ import kotlin.jvm.JvmName
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
  */
 @JvmName("shouldContainExactly_iterable")
+@IgnorableReturnValue
 infix fun <T> Iterable<T>?.shouldContainExactly(expected: Iterable<T>) =
    this?.toList() should containExactly(expected.toList())
 
@@ -26,29 +27,34 @@ infix fun <T> Iterable<T>?.shouldContainExactly(expected: Iterable<T>) =
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
  */
 @JvmName("shouldContainExactly_array")
+@IgnorableReturnValue
 infix fun <T> Array<T>?.shouldContainExactly(expected: Array<T>) =
    this?.asList() should containExactly(*expected)
 
 /**
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
  */
+@IgnorableReturnValue
 fun <T> Iterable<T>?.shouldContainExactly(vararg expected: T) =
    this?.toList() should containExactly(*expected)
 
 /**
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
  */
+@IgnorableReturnValue
 fun <T> Array<T>?.shouldContainExactly(vararg expected: T) =
    this?.asList() should containExactly(*expected)
 
 /**
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
  */
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldContainExactly(expected: C) = this should containExactly(expected)
 
 /**
  * Assert that a collection contains exactly, and only, the given elements, in the same order.
  */
+@IgnorableReturnValue
 fun <T> Collection<T>?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)
 
 /**
@@ -182,82 +188,120 @@ internal fun<T> matchCollectionsWithVerifier(
 internal class CollectionMismatchWithCustomVerifier(message: String): Exception(message)
 
 @JvmName("shouldNotContainExactly_iterable")
+@IgnorableReturnValue
 infix fun <T> Iterable<T>?.shouldNotContainExactly(expected: Iterable<T>) =
    this?.toList() shouldNot containExactly(expected.toList())
 
 @JvmName("shouldNotContainExactly_array")
+@IgnorableReturnValue
 infix fun <T> Array<T>?.shouldNotContainExactly(expected: Array<T>) = this?.asList() shouldNot containExactly(*expected)
 
+@IgnorableReturnValue
 fun <T> Iterable<T>?.shouldNotContainExactly(vararg expected: T) = this?.toList() shouldNot containExactly(*expected)
+@IgnorableReturnValue
 fun <T> Array<T>?.shouldNotContainExactly(vararg expected: T) = this?.asList() shouldNot containExactly(*expected)
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
+@IgnorableReturnValue
 fun <T> Collection<T>?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
 
 // region Primitive array overloads
 
 @JvmName("shouldContainExactly_booleanArray")
+@IgnorableReturnValue
 infix fun BooleanArray?.shouldContainExactly(expected: BooleanArray): BooleanArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun BooleanArray?.shouldContainExactly(vararg expected: Boolean): BooleanArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_booleanArray")
+@IgnorableReturnValue
 infix fun BooleanArray?.shouldNotContainExactly(expected: BooleanArray): BooleanArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun BooleanArray?.shouldNotContainExactly(vararg expected: Boolean): BooleanArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_byteArray")
+@IgnorableReturnValue
 infix fun ByteArray?.shouldContainExactly(expected: ByteArray): ByteArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun ByteArray?.shouldContainExactly(vararg expected: Byte): ByteArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_byteArray")
+@IgnorableReturnValue
 infix fun ByteArray?.shouldNotContainExactly(expected: ByteArray): ByteArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun ByteArray?.shouldNotContainExactly(vararg expected: Byte): ByteArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_shortArray")
+@IgnorableReturnValue
 infix fun ShortArray?.shouldContainExactly(expected: ShortArray): ShortArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun ShortArray?.shouldContainExactly(vararg expected: Short): ShortArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_shortArray")
+@IgnorableReturnValue
 infix fun ShortArray?.shouldNotContainExactly(expected: ShortArray): ShortArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun ShortArray?.shouldNotContainExactly(vararg expected: Short): ShortArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_charArray")
+@IgnorableReturnValue
 infix fun CharArray?.shouldContainExactly(expected: CharArray): CharArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun CharArray?.shouldContainExactly(vararg expected: Char): CharArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_charArray")
+@IgnorableReturnValue
 infix fun CharArray?.shouldNotContainExactly(expected: CharArray): CharArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun CharArray?.shouldNotContainExactly(vararg expected: Char): CharArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_intArray")
+@IgnorableReturnValue
 infix fun IntArray?.shouldContainExactly(expected: IntArray): IntArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun IntArray?.shouldContainExactly(vararg expected: Int): IntArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_intArray")
+@IgnorableReturnValue
 infix fun IntArray?.shouldNotContainExactly(expected: IntArray): IntArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun IntArray?.shouldNotContainExactly(vararg expected: Int): IntArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_longArray")
+@IgnorableReturnValue
 infix fun LongArray?.shouldContainExactly(expected: LongArray): LongArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun LongArray?.shouldContainExactly(vararg expected: Long): LongArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_longArray")
+@IgnorableReturnValue
 infix fun LongArray?.shouldNotContainExactly(expected: LongArray): LongArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun LongArray?.shouldNotContainExactly(vararg expected: Long): LongArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_floatArray")
+@IgnorableReturnValue
 infix fun FloatArray?.shouldContainExactly(expected: FloatArray): FloatArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun FloatArray?.shouldContainExactly(vararg expected: Float): FloatArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_floatArray")
+@IgnorableReturnValue
 infix fun FloatArray?.shouldNotContainExactly(expected: FloatArray): FloatArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun FloatArray?.shouldNotContainExactly(vararg expected: Float): FloatArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 @JvmName("shouldContainExactly_doubleArray")
+@IgnorableReturnValue
 infix fun DoubleArray?.shouldContainExactly(expected: DoubleArray): DoubleArray? = apply { this?.asList() should containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun DoubleArray?.shouldContainExactly(vararg expected: Double): DoubleArray? = apply { this?.asList() should containExactly(expected.asList()) }
 
 @JvmName("shouldNotContainExactly_doubleArray")
+@IgnorableReturnValue
 infix fun DoubleArray?.shouldNotContainExactly(expected: DoubleArray): DoubleArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
+@IgnorableReturnValue
 fun DoubleArray?.shouldNotContainExactly(vararg expected: Double): DoubleArray? = apply { this?.asList() shouldNot containExactly(expected.asList()) }
 
 // endregion

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactlyInAnyOrder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containExactlyInAnyOrder.kt
@@ -28,6 +28,7 @@ import io.kotest.matchers.shouldNot
  * then calling the hashCode method on each of the two objects must produce the same integer result.
  *
  */
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldContainExactlyInAnyOrder(expected: Array<T>): Array<T> {
    asList().shouldContainExactlyInAnyOrder(expected.asList())
    return this
@@ -48,6 +49,7 @@ infix fun <T> Array<T>.shouldContainExactlyInAnyOrder(expected: Array<T>): Array
  * then calling the hashCode method on each of the two objects must produce the same integer result.
  *
  */
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldContainExactlyInAnyOrder(expected: Collection<T>?): C? {
    expected.shouldNotBeNull()
    this should containExactlyInAnyOrder(expected)
@@ -69,6 +71,7 @@ infix fun <T, C : Collection<T>> C?.shouldContainExactlyInAnyOrder(expected: Col
  * then calling the hashCode method on each of the two objects must produce the same integer result.
  *
  */
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C?.shouldContainExactlyInAnyOrder(vararg expected: T): C? {
    this should containExactlyInAnyOrder(*expected)
    return this
@@ -92,17 +95,20 @@ fun <T, C : Collection<T>> C?.shouldContainExactlyInAnyOrder(vararg expected: T)
 fun <T> containExactlyInAnyOrder(vararg expected: T): Matcher<Collection<T>?> =
    containExactlyInAnyOrder(expected.asList())
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContainExactlyInAnyOrder(expected: Array<T>): Array<T> {
    asList().shouldNotContainExactlyInAnyOrder(expected.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldNotContainExactlyInAnyOrder(expected: Collection<T>?): C? {
    expected.shouldNotBeNull()
    this shouldNot containExactlyInAnyOrder(expected)
    return this
 }
 
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C?.shouldNotContainExactlyInAnyOrder(vararg expected: T): C? {
    this shouldNot containExactlyInAnyOrder(*expected)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containOnly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containOnly.kt
@@ -15,6 +15,7 @@ import kotlin.jvm.JvmName
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldContainOnly_iterable")
+@IgnorableReturnValue
 infix fun <T> Iterable<T>?.shouldContainOnly(expected: Iterable<T>) =
    this?.toList() should containOnly(expected.toList())
 
@@ -28,6 +29,7 @@ infix fun <T> Iterable<T>?.shouldContainOnly(expected: Iterable<T>) =
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldContainOnly_array")
+@IgnorableReturnValue
 infix fun <T> Array<T>?.shouldContainOnly(expected: Array<T>): Array<T>? {
    this?.asList() should containOnly(*expected)
    return this
@@ -42,6 +44,7 @@ infix fun <T> Array<T>?.shouldContainOnly(expected: Array<T>): Array<T>? {
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 fun <T> Iterable<T>?.shouldContainOnly(vararg expected: T) =
    this?.toList() should containOnly(*expected)
 
@@ -54,6 +57,7 @@ fun <T> Iterable<T>?.shouldContainOnly(vararg expected: T) =
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 fun <T> Array<T>?.shouldContainOnly(vararg expected: T) =
    this?.asList() should containOnly(*expected)
 
@@ -66,6 +70,7 @@ fun <T> Array<T>?.shouldContainOnly(vararg expected: T) =
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldContainOnly(expected: C) = this should containOnly(expected)
 
 /**
@@ -77,6 +82,7 @@ infix fun <T, C : Collection<T>> C?.shouldContainOnly(expected: C) = this should
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 fun <T> Collection<T>?.shouldContainOnly(vararg expected: T) = this should containOnly(*expected)
 
 /**
@@ -136,6 +142,7 @@ fun <T, C : Collection<T>> containOnly(
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldNotContainOnly_iterable")
+@IgnorableReturnValue
 infix fun <T> Iterable<T>?.shouldNotContainOnly(expected: Iterable<T>) =
    this?.toList() shouldNot containOnly(expected.toList())
 
@@ -149,6 +156,7 @@ infix fun <T> Iterable<T>?.shouldNotContainOnly(expected: Iterable<T>) =
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldNotContainOnly_array")
+@IgnorableReturnValue
 infix fun <T> Array<T>?.shouldNotContainOnly(expected: Array<T>) = this?.asList() shouldNot containOnly(*expected)
 
 /**
@@ -160,6 +168,7 @@ infix fun <T> Array<T>?.shouldNotContainOnly(expected: Array<T>) = this?.asList(
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 fun <T> Iterable<T>?.shouldNotContainOnly(vararg expected: T) = this?.toList() shouldNot containOnly(*expected)
 
 /**
@@ -171,6 +180,7 @@ fun <T> Iterable<T>?.shouldNotContainOnly(vararg expected: T) = this?.toList() s
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 fun <T> Array<T>?.shouldNotContainOnly(vararg expected: T) = this?.asList() shouldNot containOnly(*expected)
 
 /**
@@ -182,6 +192,7 @@ fun <T> Array<T>?.shouldNotContainOnly(vararg expected: T) = this?.asList() shou
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C?.shouldNotContainOnly(expected: C) = this shouldNot containOnly(expected)
 
 /**
@@ -193,4 +204,5 @@ infix fun <T, C : Collection<T>> C?.shouldNotContainOnly(expected: C) = this sho
  *
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
+@IgnorableReturnValue
 fun <T> Collection<T>?.shouldNotContainOnly(vararg expected: T) = this shouldNot containOnly(*expected)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containSlice.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/containSlice.kt
@@ -18,6 +18,7 @@ import kotlin.jvm.JvmName
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldContainSlice_iterable")
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldContainSlice(expected: Iterable<T>) =
    this.toList() should containSlice(expected.toList())
 
@@ -31,6 +32,7 @@ infix fun <T> Iterable<T>.shouldContainSlice(expected: Iterable<T>) =
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldNotContainSlice_iterable")
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotContainSlice(expected: Iterable<T>) =
    this.toList() shouldNot containSlice(expected.toList())
 
@@ -44,6 +46,7 @@ infix fun <T> Iterable<T>.shouldNotContainSlice(expected: Iterable<T>) =
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldContainSlice_array")
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldContainSlice(expected: Iterable<T>) =
    this.toList() should containSlice(expected.toList())
 
@@ -57,6 +60,7 @@ infix fun <T> Array<T>.shouldContainSlice(expected: Iterable<T>) =
  *  Note: Comparison is via the standard Java equals and hash code methods.
  */
 @JvmName("shouldNotContainSlice_array")
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContainSlice(expected: Iterable<T>) =
    this.toList() shouldNot containSlice(expected.toList())
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/decreasing.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/decreasing.kt
@@ -6,131 +6,163 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeMonotonicallyDecreasing(): I {
    toList().shouldBeMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldBeMonotonicallyDecreasing(): Array<T> {
    asList().shouldBeMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, S : Sequence<T>> S.shouldBeMonotonicallyDecreasing(): S {
    asIterable().shouldBeMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldBeMonotonicallyDecreasing(): List<T> {
    this should beMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldNotBeMonotonicallyDecreasing(): I {
    toList().shouldNotBeMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldNotBeMonotonicallyDecreasing(): Array<T> {
    asList().shouldNotBeMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, S : Sequence<T>> S.shouldNotBeMonotonicallyDecreasing(): S {
    asIterable().shouldNotBeMonotonicallyDecreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldNotBeMonotonicallyDecreasing(): List<T> {
    this shouldNot beMonotonicallyDecreasing<T>()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): List<T> {
    this should beMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): I {
    toList().shouldBeMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldBeMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): List<T> {
    this shouldNot beMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): I {
    toList().shouldNotBeMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldNotBeMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotBeMonotonicallyDecreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldNotBeMonotonicallyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Iterable<T>.shouldBeStrictlyDecreasing() = toList().shouldBeStrictlyDecreasing()
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldBeStrictlyDecreasing() = this should beStrictlyDecreasing()
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldBeStrictlyDecreasing() = toList().shouldBeStrictlyDecreasing()
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldBeStrictlyDecreasing() = toList().shouldBeStrictlyDecreasing()
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Iterable<T>.shouldNotBeStrictlyDecreasing() = toList().shouldNotBeStrictlyDecreasing()
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldNotBeStrictlyDecreasing() = this shouldNot beStrictlyDecreasing()
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldNotBeStrictlyDecreasing() = this.asIterable().shouldNotBeStrictlyDecreasing()
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldNotBeStrictlyDecreasing() = toList().shouldNotBeStrictlyDecreasing()
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldBeStrictlyDecreasingWith(comparator: Comparator<in T>): List<T> {
    this should beStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldBeStrictlyDecreasingWith(comparator: Comparator<in T>): I {
    toList().shouldBeStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldBeStrictlyDecreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldBeStrictlyDecreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldBeStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotBeStrictlyDecreasingWith(comparator: Comparator<in T>): List<T> {
    this shouldNot beStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotBeStrictlyDecreasingWith(comparator: Comparator<in T>): I {
    toList().shouldNotBeStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotBeStrictlyDecreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldNotBeStrictlyDecreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotBeStrictlyDecreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldNotBeStrictlyDecreasingWith(comparator)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/duplicates.kt
@@ -6,101 +6,121 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun BooleanArray.shouldContainDuplicates(): BooleanArray {
    asList() should ContainDuplicatesMatcher("BooleanArray")
    return this
 }
 
+@IgnorableReturnValue
 fun BooleanArray.shouldNotContainDuplicates(): BooleanArray {
    asList() shouldNot ContainDuplicatesMatcher("BooleanArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ByteArray.shouldContainDuplicates(): ByteArray {
    asList() should ContainDuplicatesMatcher("ByteArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ByteArray.shouldNotContainDuplicates(): ByteArray {
    asList() shouldNot ContainDuplicatesMatcher("ByteArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ShortArray.shouldContainDuplicates(): ShortArray {
    asList() should ContainDuplicatesMatcher("ShortArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ShortArray.shouldNotContainDuplicates(): ShortArray {
    asList() shouldNot ContainDuplicatesMatcher("ShortArray")
    return this
 }
 
+@IgnorableReturnValue
 fun CharArray.shouldContainDuplicates(): CharArray {
    asList() should ContainDuplicatesMatcher("CharArray")
    return this
 }
 
+@IgnorableReturnValue
 fun CharArray.shouldNotContainDuplicates(): CharArray {
    asList() shouldNot ContainDuplicatesMatcher("CharArray")
    return this
 }
 
+@IgnorableReturnValue
 fun IntArray.shouldContainDuplicates(): IntArray {
    asList() should ContainDuplicatesMatcher("IntArray")
    return this
 }
 
+@IgnorableReturnValue
 fun IntArray.shouldNotContainDuplicates(): IntArray {
    asList() shouldNot ContainDuplicatesMatcher("IntArray")
    return this
 }
 
+@IgnorableReturnValue
 fun LongArray.shouldContainDuplicates(): LongArray {
    asList() should ContainDuplicatesMatcher("LongArray")
    return this
 }
 
+@IgnorableReturnValue
 fun LongArray.shouldNotContainDuplicates(): LongArray {
    asList() shouldNot ContainDuplicatesMatcher("LongArray")
    return this
 }
 
+@IgnorableReturnValue
 fun FloatArray.shouldContainDuplicates(): FloatArray {
    asList() should ContainDuplicatesMatcher("FloatArray")
    return this
 }
 
+@IgnorableReturnValue
 fun FloatArray.shouldNotContainDuplicates(): FloatArray {
    asList() shouldNot ContainDuplicatesMatcher("FloatArray")
    return this
 }
 
+@IgnorableReturnValue
 fun DoubleArray.shouldContainDuplicates(): DoubleArray {
    asList() should ContainDuplicatesMatcher("DoubleArray")
    return this
 }
 
+@IgnorableReturnValue
 fun DoubleArray.shouldNotContainDuplicates(): DoubleArray {
    asList() shouldNot ContainDuplicatesMatcher("DoubleArray")
    return this
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainDuplicates(): Array<T> {
    asList() should ContainDuplicatesMatcher("Array")
    return this
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainDuplicates(): Array<T> {
    asList() shouldNot ContainDuplicatesMatcher("Array")
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldContainDuplicates(): I {
    this should ContainDuplicatesMatcher(null)
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotContainDuplicates(): I {
    this shouldNot ContainDuplicatesMatcher(null)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/empty.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/empty.kt
@@ -7,120 +7,140 @@ import io.kotest.matchers.invokeMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun BooleanArray?.shouldBeEmpty(): BooleanArray {
    if (this == null) fail("BooleanArray")
    asList() should beEmpty("BooleanArray")
    return this
 }
 
+@IgnorableReturnValue
 fun BooleanArray?.shouldNotBeEmpty(): BooleanArray {
    if (this == null) fail("BooleanArray")
    asList() shouldNot beEmpty("BooleanArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ByteArray?.shouldBeEmpty(): ByteArray {
    if (this == null) fail("ByteArray")
    asList() should beEmpty("ByteArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ByteArray?.shouldNotBeEmpty(): ByteArray {
    if (this == null) fail("ByteArray")
    asList() shouldNot beEmpty("ByteArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ShortArray?.shouldBeEmpty(): ShortArray {
    if (this == null) fail("ShortArray")
    asList() should beEmpty("ShortArray")
    return this
 }
 
+@IgnorableReturnValue
 fun ShortArray?.shouldNotBeEmpty(): ShortArray {
    if (this == null) fail("ShortArray")
    asList() shouldNot beEmpty("ShortArray")
    return this
 }
 
+@IgnorableReturnValue
 fun CharArray?.shouldBeEmpty(): CharArray {
    if (this == null) fail("CharArray")
    asList() should beEmpty("CharArray")
    return this
 }
 
+@IgnorableReturnValue
 fun CharArray?.shouldNotBeEmpty(): CharArray {
    if (this == null) fail("CharArray")
    asList() shouldNot beEmpty("CharArray")
    return this
 }
 
+@IgnorableReturnValue
 fun IntArray?.shouldBeEmpty(): IntArray {
    if (this == null) fail("IntArray")
    asList() should beEmpty("IntArray")
    return this
 }
 
+@IgnorableReturnValue
 fun IntArray?.shouldNotBeEmpty(): IntArray {
    if (this == null) fail("IntArray")
    asList() shouldNot beEmpty("IntArray")
    return this
 }
 
+@IgnorableReturnValue
 fun LongArray?.shouldBeEmpty(): LongArray {
    if (this == null) fail("LongArray")
    asList() should beEmpty("LongArray")
    return this
 }
 
+@IgnorableReturnValue
 fun LongArray?.shouldNotBeEmpty(): LongArray {
    if (this == null) fail("LongArray")
    asList() shouldNot beEmpty("LongArray")
    return this
 }
 
+@IgnorableReturnValue
 fun FloatArray?.shouldBeEmpty(): FloatArray {
    if (this == null) fail("FloatArray")
    asList() should beEmpty("FloatArray")
    return this
 }
 
+@IgnorableReturnValue
 fun FloatArray?.shouldNotBeEmpty(): FloatArray {
    if (this == null) fail("FloatArray")
    asList() shouldNot beEmpty("FloatArray")
    return this
 }
 
+@IgnorableReturnValue
 fun DoubleArray?.shouldBeEmpty(): DoubleArray {
    if (this == null) fail("DoubleArray")
    asList() should beEmpty("DoubleArray")
    return this
 }
 
+@IgnorableReturnValue
 fun DoubleArray?.shouldNotBeEmpty(): DoubleArray {
    if (this == null) fail("DoubleArray")
    asList() shouldNot beEmpty("DoubleArray")
    return this
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>?.shouldBeEmpty(): Array<T> {
    if (this == null) fail("Array")
    asList() should beEmpty("Array")
    return this
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>?.shouldNotBeEmpty(): Array<T> {
    if (this == null) fail("Array")
    asList() shouldNot beEmpty("Array")
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I?.shouldBeEmpty(): I {
    if (this == null) fail("Iterable")
    this should beEmpty(null)
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I?.shouldNotBeEmpty(): I {
    if (this == null) fail("Iterable")
    this shouldNot beEmpty(null)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/increasing.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/increasing.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNot
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeStrictlyIncreasing(): I {
    toList().shouldBeStrictlyIncreasing()
    return this
@@ -23,6 +24,7 @@ fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeStrictlyIncreasing(): I {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldBeStrictlyIncreasing(): Array<T> {
    asList().shouldBeStrictlyIncreasing()
    return this
@@ -34,6 +36,7 @@ fun <T : Comparable<T>> Array<T>.shouldBeStrictlyIncreasing(): Array<T> {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldBeStrictlyIncreasing(): Sequence<T> {
    asIterable().shouldBeStrictlyIncreasing()
    return this
@@ -45,31 +48,37 @@ fun <T : Comparable<T>> Sequence<T>.shouldBeStrictlyIncreasing(): Sequence<T> {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldBeStrictlyIncreasing(): List<T> {
    this should beStrictlyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldNotBeStrictlyIncreasing(): I {
    toList().shouldNotBeStrictlyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldNotBeStrictlyIncreasing(): Array<T> {
    asList().shouldNotBeStrictlyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldNotBeStrictlyIncreasing(): Sequence<T> {
    asIterable().shouldNotBeStrictlyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldNotBeStrictlyIncreasing(): List<T> {
    this shouldNot beStrictlyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeMonotonicallyIncreasing(): I {
    toList().shouldBeMonotonicallyIncreasing()
    return this
@@ -81,6 +90,7 @@ fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeMonotonicallyIncreasing(): I 
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldBeMonotonicallyIncreasing(): Array<T> {
    asList().shouldBeMonotonicallyIncreasing()
    return this
@@ -92,6 +102,7 @@ fun <T : Comparable<T>> Array<T>.shouldBeMonotonicallyIncreasing(): Array<T> {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldBeMonotonicallyIncreasing(): Sequence<T> {
    asIterable().shouldBeMonotonicallyIncreasing()
    return this
@@ -103,26 +114,31 @@ fun <T : Comparable<T>> Sequence<T>.shouldBeMonotonicallyIncreasing(): Sequence<
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldBeMonotonicallyIncreasing(): List<T> {
    this should beMonotonicallyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldNotBeMonotonicallyIncreasing(): I {
    toList().shouldNotBeMonotonicallyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldNotBeMonotonicallyIncreasing(): Array<T> {
    asList().shouldNotBeMonotonicallyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldNotBeMonotonicallyIncreasing(): Sequence<T> {
    asIterable().shouldNotBeMonotonicallyIncreasing()
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldNotBeMonotonicallyIncreasing(): List<T> {
    this shouldNot beMonotonicallyIncreasing()
    return this
@@ -134,6 +150,7 @@ fun <T : Comparable<T>> List<T>.shouldNotBeMonotonicallyIncreasing(): List<T> {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): List<T> {
    this should beMonotonicallyIncreasingWith(comparator)
    return this
@@ -145,6 +162,7 @@ infix fun <T> List<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldBeMonotonicallyIncreasingWith(comparator)
    return this
@@ -156,6 +174,7 @@ infix fun <T> Sequence<T>.shouldBeMonotonicallyIncreasingWith(comparator: Compar
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): I {
    toList().shouldBeMonotonicallyIncreasingWith(comparator)
    return this
@@ -167,26 +186,31 @@ infix fun <T, I : Iterable<T>> I.shouldBeMonotonicallyIncreasingWith(comparator:
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): List<T> {
    this shouldNot beMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): I {
    toList().shouldNotBeMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldNotBeMonotonicallyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotBeMonotonicallyIncreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldNotBeMonotonicallyIncreasingWith(comparator)
    return this
@@ -198,6 +222,7 @@ infix fun <T> Sequence<T>.shouldNotBeMonotonicallyIncreasingWith(comparator: Com
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): List<T> {
    this should beStrictlyIncreasingWith(comparator)
    return this
@@ -209,6 +234,7 @@ infix fun <T> List<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): I {
    toList().shouldBeStrictlyIncreasingWith(comparator)
    return this
@@ -220,6 +246,7 @@ infix fun <T, I : Iterable<T>> I.shouldBeStrictlyIncreasingWith(comparator: Comp
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeStrictlyIncreasingWith(comparator)
    return this
@@ -231,26 +258,31 @@ infix fun <T> Array<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in 
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldBeStrictlyIncreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldBeStrictlyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotBeStrictlyIncreasingWith(comparator: Comparator<in T>): List<T> {
    this shouldNot beStrictlyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotBeStrictlyIncreasingWith(comparator: Comparator<in T>): I {
    toList().shouldNotBeStrictlyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotBeStrictlyIncreasingWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldNotBeStrictlyIncreasingWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotBeStrictlyIncreasingWith(comparator: Comparator<in T>): Sequence<T> {
    asIterable().shouldNotBeStrictlyIncreasingWith(comparator)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/inorder.kt
@@ -43,78 +43,121 @@ fun <T> containsInOrder(subsequence: List<T>): Matcher<Collection<T>?> = neverNu
    )
 }
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldContainInOrder(vararg ts: T) = toList().shouldContainInOrder(*ts)
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainInOrder(vararg ts: T) = asList().shouldContainInOrder(*ts)
+@IgnorableReturnValue
 fun <T> List<T>.shouldContainInOrder(vararg ts: T) = this.shouldContainInOrder(ts.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldContainInOrder(expected: List<T>) = toList().shouldContainInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldContainInOrder(expected: List<T>) = asList().shouldContainInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldContainInOrder(expected: List<T>) = this should containsInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotContainInOrder(expected: Iterable<T>) = toList().shouldNotContainInOrder(expected.toList())
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContainInOrder(expected: Array<T>) = asList().shouldNotContainInOrder(expected.asList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotContainInOrder(expected: List<T>) = toList().shouldNotContainInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContainInOrder(expected: List<T>) = asList().shouldNotContainInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotContainInOrder(expected: List<T>) = this shouldNot containsInOrder(expected)
 
 // BooleanArray
+@IgnorableReturnValue
 fun BooleanArray.shouldContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderBooleanArray_infix")
+@IgnorableReturnValue
 infix fun BooleanArray.shouldContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun BooleanArray.shouldNotContainInOrder(vararg ts: Boolean): BooleanArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderBooleanArray_infix")
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotContainInOrder(expected: BooleanArray): BooleanArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // ByteArray
+@IgnorableReturnValue
 fun ByteArray.shouldContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderByteArray_infix")
+@IgnorableReturnValue
 infix fun ByteArray.shouldContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun ByteArray.shouldNotContainInOrder(vararg ts: Byte): ByteArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderByteArray_infix")
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotContainInOrder(expected: ByteArray): ByteArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // ShortArray
+@IgnorableReturnValue
 fun ShortArray.shouldContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderShortArray_infix")
+@IgnorableReturnValue
 infix fun ShortArray.shouldContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun ShortArray.shouldNotContainInOrder(vararg ts: Short): ShortArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderShortArray_infix")
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotContainInOrder(expected: ShortArray): ShortArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // CharArray
+@IgnorableReturnValue
 fun CharArray.shouldContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderCharArray_infix")
+@IgnorableReturnValue
 infix fun CharArray.shouldContainInOrder(expected: CharArray): CharArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun CharArray.shouldNotContainInOrder(vararg ts: Char): CharArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderCharArray_infix")
+@IgnorableReturnValue
 infix fun CharArray.shouldNotContainInOrder(expected: CharArray): CharArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // IntArray
+@IgnorableReturnValue
 fun IntArray.shouldContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderIntArray_infix")
+@IgnorableReturnValue
 infix fun IntArray.shouldContainInOrder(expected: IntArray): IntArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun IntArray.shouldNotContainInOrder(vararg ts: Int): IntArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderIntArray_infix")
+@IgnorableReturnValue
 infix fun IntArray.shouldNotContainInOrder(expected: IntArray): IntArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // LongArray
+@IgnorableReturnValue
 fun LongArray.shouldContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderLongArray_infix")
+@IgnorableReturnValue
 infix fun LongArray.shouldContainInOrder(expected: LongArray): LongArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun LongArray.shouldNotContainInOrder(vararg ts: Long): LongArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderLongArray_infix")
+@IgnorableReturnValue
 infix fun LongArray.shouldNotContainInOrder(expected: LongArray): LongArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // FloatArray
+@IgnorableReturnValue
 fun FloatArray.shouldContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderFloatArray_infix")
+@IgnorableReturnValue
 infix fun FloatArray.shouldContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun FloatArray.shouldNotContainInOrder(vararg ts: Float): FloatArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderFloatArray_infix")
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotContainInOrder(expected: FloatArray): FloatArray = apply { asList().shouldNotContainInOrder(expected.asList()) }
 
 // DoubleArray
+@IgnorableReturnValue
 fun DoubleArray.shouldContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldContainInOrder(ts.asList()) }
 @JvmName("shouldContainInOrderDoubleArray_infix")
+@IgnorableReturnValue
 infix fun DoubleArray.shouldContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldContainInOrder(expected.asList()) }
+@IgnorableReturnValue
 fun DoubleArray.shouldNotContainInOrder(vararg ts: Double): DoubleArray = apply { asList().shouldNotContainInOrder(ts.asList()) }
 @JvmName("shouldNotContainInOrderDoubleArray_infix")
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotContainInOrder(expected: DoubleArray): DoubleArray = apply { asList().shouldNotContainInOrder(expected.asList()) }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/larger.kt
@@ -22,6 +22,7 @@ import io.kotest.matchers.shouldNot
  *
  * @see ByteArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldBeLargerThan(other: ByteArray): ByteArray = apply {
    asList() shouldBeLargerThan other.asList()
 }
@@ -41,6 +42,7 @@ infix fun ByteArray.shouldBeLargerThan(other: ByteArray): ByteArray = apply {
  *
  * @see ByteArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotBeLargerThan(other: ByteArray): ByteArray = apply {
    asList() shouldNotBeLargerThan other.asList()
 }
@@ -60,6 +62,7 @@ infix fun ByteArray.shouldNotBeLargerThan(other: ByteArray): ByteArray = apply {
  *
  * @see IntArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun IntArray.shouldBeLargerThan(other: IntArray): IntArray = apply {
    asList() shouldBeLargerThan other.asList()
 }
@@ -79,6 +82,7 @@ infix fun IntArray.shouldBeLargerThan(other: IntArray): IntArray = apply {
  *
  * @see IntArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun IntArray.shouldNotBeLargerThan(other: IntArray): IntArray = apply {
    asList() shouldNotBeLargerThan other.asList()
 }
@@ -98,6 +102,7 @@ infix fun IntArray.shouldNotBeLargerThan(other: IntArray): IntArray = apply {
  *
  * @see ShortArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun ShortArray.shouldBeLargerThan(other: ShortArray): ShortArray = apply {
    asList() shouldBeLargerThan other.asList()
 }
@@ -117,6 +122,7 @@ infix fun ShortArray.shouldBeLargerThan(other: ShortArray): ShortArray = apply {
  *
  * @see ShortArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotBeLargerThan(other: ShortArray): ShortArray = apply {
    asList() shouldNotBeLargerThan other.asList()
 }
@@ -136,6 +142,7 @@ infix fun ShortArray.shouldNotBeLargerThan(other: ShortArray): ShortArray = appl
  *
  * @see LongArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun LongArray.shouldBeLargerThan(other: LongArray): LongArray = apply {
    asList() shouldBeLargerThan other.asList()
 }
@@ -155,6 +162,7 @@ infix fun LongArray.shouldBeLargerThan(other: LongArray): LongArray = apply {
  *
  * @see LongArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun LongArray.shouldNotBeLargerThan(other: LongArray): LongArray = apply {
    asList() shouldNotBeLargerThan other.asList()
 }
@@ -174,6 +182,7 @@ infix fun LongArray.shouldNotBeLargerThan(other: LongArray): LongArray = apply {
  *
  * @see FloatArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun FloatArray.shouldBeLargerThan(other: FloatArray): FloatArray = apply {
    this.asList() shouldBeLargerThan other.asList()
 }
@@ -193,6 +202,7 @@ infix fun FloatArray.shouldBeLargerThan(other: FloatArray): FloatArray = apply {
  *
  * @see FloatArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotBeLargerThan(other: FloatArray): FloatArray = apply {
    this.asList() shouldNotBeLargerThan other.asList()
 }
@@ -213,6 +223,7 @@ infix fun FloatArray.shouldNotBeLargerThan(other: FloatArray): FloatArray = appl
  *
  * @see DoubleArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun DoubleArray.shouldBeLargerThan(other: DoubleArray): DoubleArray = apply {
    this.asList() shouldBeLargerThan other.asList()
 }
@@ -232,6 +243,7 @@ infix fun DoubleArray.shouldBeLargerThan(other: DoubleArray): DoubleArray = appl
  *
  * @see DoubleArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotBeLargerThan(other: DoubleArray): DoubleArray = apply {
    this.asList() shouldNotBeLargerThan other.asList()
 }
@@ -251,6 +263,7 @@ infix fun DoubleArray.shouldNotBeLargerThan(other: DoubleArray): DoubleArray = a
  *
  * @see CharArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun CharArray.shouldBeLargerThan(other: CharArray): CharArray = apply {
    this.asList() shouldBeLargerThan other.asList()
 }
@@ -270,6 +283,7 @@ infix fun CharArray.shouldBeLargerThan(other: CharArray): CharArray = apply {
  *
  * @see CharArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun CharArray.shouldNotBeLargerThan(other: CharArray): CharArray = apply {
    this.asList() shouldNotBeLargerThan other.asList()
 }
@@ -289,6 +303,7 @@ infix fun CharArray.shouldNotBeLargerThan(other: CharArray): CharArray = apply {
  *
  * @see BooleanArray.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun BooleanArray.shouldBeLargerThan(other: BooleanArray): BooleanArray = apply {
    this.asList() shouldBeLargerThan other.asList()
 }
@@ -308,6 +323,7 @@ infix fun BooleanArray.shouldBeLargerThan(other: BooleanArray): BooleanArray = a
  *
  * @see BooleanArray.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotBeLargerThan(other: BooleanArray): BooleanArray = apply {
    this.asList() shouldNotBeLargerThan other.asList()
 }
@@ -329,6 +345,7 @@ infix fun BooleanArray.shouldNotBeLargerThan(other: BooleanArray): BooleanArray 
  *
  * @see Iterable.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun <T, U, I : Iterable<T>> I.shouldBeLargerThan(other: Iterable<U>): I = apply {
    toList() should beLargerThan(other)
 }
@@ -348,6 +365,7 @@ infix fun <T, U, I : Iterable<T>> I.shouldBeLargerThan(other: Iterable<U>): I = 
  *
  * @see Iterable.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun <T, U, I : Iterable<T>> I.shouldNotBeLargerThan(other: Iterable<U>): I = apply {
    toList() shouldNot beLargerThan(other)
 }
@@ -367,6 +385,7 @@ infix fun <T, U, I : Iterable<T>> I.shouldNotBeLargerThan(other: Iterable<U>): I
  *
  * @see Array.shouldNotBeLargerThan
  */
+@IgnorableReturnValue
 infix fun <T, U> Array<T>.shouldBeLargerThan(other: Array<U>): Array<T> = apply {
    asList().shouldBeLargerThan(other.asList())
 }
@@ -386,6 +405,7 @@ infix fun <T, U> Array<T>.shouldBeLargerThan(other: Array<U>): Array<T> = apply 
  *
  * @see Array.shouldBeLargerThan
  */
+@IgnorableReturnValue
 infix fun <T, U> Array<T>.shouldNotBeLargerThan(other: Array<U>): Array<T> = apply {
    asList().shouldNotBeLargerThan(other.asList())
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/matchers.kt
@@ -6,12 +6,18 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldHaveElementAt(index: Int, element: T) = toList().shouldHaveElementAt(index, element)
+@IgnorableReturnValue
 fun <T> Array<T>.shouldHaveElementAt(index: Int, element: T) = asList().shouldHaveElementAt(index, element)
+@IgnorableReturnValue
 fun <T> List<T>.shouldHaveElementAt(index: Int, element: T) = this should haveElementAt(index, element)
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldNotHaveElementAt(index: Int, element: T) = toList().shouldNotHaveElementAt(index, element)
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotHaveElementAt(index: Int, element: T) = asList().shouldNotHaveElementAt(index, element)
+@IgnorableReturnValue
 fun <T> List<T>.shouldNotHaveElementAt(index: Int, element: T) = this shouldNot haveElementAt(index, element)
 
 fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L> {
@@ -46,8 +52,11 @@ fun <T, L : List<T>> haveElementAt(index: Int, element: T) = object : Matcher<L>
    }
 }
 
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldExist(p: (T) -> Boolean) = toList().shouldExist(p)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldExist(p: (T) -> Boolean) = asList().shouldExist(p)
+@IgnorableReturnValue
 infix fun <T> Collection<T>.shouldExist(p: (T) -> Boolean) = this should exist(p)
 fun <T> exist(p: (T) -> Boolean) = object : Matcher<Collection<T>> {
    override fun test(value: Collection<T>): MatcherResult {
@@ -62,76 +71,137 @@ fun <T> exist(p: (T) -> Boolean) = object : Matcher<Collection<T>> {
    }
 }
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldMatchInOrder(vararg assertions: (T) -> Unit) = toList().shouldMatchInOrder(assertions.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldMatchInOrder(vararg assertions: (T) -> Unit) = asList().shouldMatchInOrder(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldMatchInOrder(vararg assertions: (T) -> Unit) = this.shouldMatchInOrder(assertions.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldMatchInOrder(assertions: List<(T) -> Unit>) = toList().shouldMatchInOrder(assertions)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldMatchInOrder(assertions: List<(T) -> Unit>) = asList().shouldMatchInOrder(assertions)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldMatchInOrder(assertions: List<(T) -> Unit>) = this should matchInOrder(assertions.toList(), allowGaps = false)
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldNotMatchInOrder(vararg assertions: (T) -> Unit) = toList().shouldNotMatchInOrder(assertions.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotMatchInOrder(vararg assertions: (T) -> Unit) = asList().shouldNotMatchInOrder(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldNotMatchInOrder(vararg assertions: (T) -> Unit) = this.shouldNotMatchInOrder(assertions.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotMatchInOrder(assertions: List<(T) -> Unit>) = toList().shouldNotMatchInOrder(assertions)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotMatchInOrder(assertions: List<(T) -> Unit>) = asList().shouldNotMatchInOrder(assertions)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotMatchInOrder(assertions: List<(T) -> Unit>) = this shouldNot matchInOrder(assertions.toList(), allowGaps = false)
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldMatchInOrderSubset(vararg assertions: (T) -> Unit) = toList().shouldMatchInOrderSubset(assertions.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldMatchInOrderSubset(vararg assertions: (T) -> Unit) = asList().shouldMatchInOrderSubset(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldMatchInOrderSubset(vararg assertions: (T) -> Unit) = this.shouldMatchInOrderSubset(assertions.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldMatchInOrderSubset(assertions: List<(T) -> Unit>) = toList().shouldMatchInOrderSubset(assertions)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldMatchInOrderSubset(assertions: List<(T) -> Unit>) = asList().shouldMatchInOrderSubset(assertions)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldMatchInOrderSubset(assertions: List<(T) -> Unit>) = this should matchInOrder(assertions.toList(), allowGaps = true)
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldNotMatchInOrderSubset(vararg assertions: (T) -> Unit) = toList().shouldNotMatchInOrderSubset(assertions.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotMatchInOrderSubset(vararg assertions: (T) -> Unit) = asList().shouldNotMatchInOrderSubset(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldNotMatchInOrderSubset(vararg assertions: (T) -> Unit) = this.shouldNotMatchInOrderSubset(assertions.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotMatchInOrderSubset(assertions: List<(T) -> Unit>) = toList().shouldNotMatchInOrderSubset(assertions)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotMatchInOrderSubset(assertions: List<(T) -> Unit>) = asList().shouldNotMatchInOrderSubset(assertions)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotMatchInOrderSubset(assertions: List<(T) -> Unit>) = this shouldNot matchInOrder(assertions.toList(), allowGaps = true)
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldMatchEach(vararg assertions: (T) -> Unit) = toList().shouldMatchEach(assertions.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldMatchEach(vararg assertions: (T) -> Unit) = asList().shouldMatchEach(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldMatchEach(vararg assertions: (T) -> Unit) = this.shouldMatchEach(assertions.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldMatchEach(assertions: List<(T) -> Unit>) = toList().shouldMatchEach(assertions)
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldMatchEach(expected: Iterable<T>, asserter: (T, T) -> Unit) = toList().shouldMatchEach(expected.toList(), asserter)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldMatchEach(assertions: List<(T) -> Unit>) = asList().shouldMatchEach(assertions)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldMatchEach(assertions: List<(T) -> Unit>) = this should matchEach(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldMatchEach(expected: List<T>, asserter: (T, T) -> Unit) = this should matchEach(expected, asserter)
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldNotMatchEach(vararg assertions: (T) -> Unit) = toList().shouldNotMatchEach(assertions.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotMatchEach(vararg assertions: (T) -> Unit) = asList().shouldNotMatchEach(assertions.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldNotMatchEach(vararg assertions: (T) -> Unit) = this.shouldNotMatchEach(assertions.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotMatchEach(assertions: List<(T) -> Unit>) = toList().shouldNotMatchEach(assertions)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotMatchEach(assertions: List<(T) -> Unit>) = asList().shouldNotMatchEach(assertions)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotMatchEach(assertions: List<(T) -> Unit>) = this shouldNot matchEach(assertions.toList())
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldExistInOrder(vararg ps: (T) -> Boolean) = toList().shouldExistInOrder(ps.toList())
+@IgnorableReturnValue
 fun <T> Array<T>.shouldExistInOrder(vararg ps: (T) -> Boolean) = asList().shouldExistInOrder(ps.toList())
+@IgnorableReturnValue
 fun <T> List<T>.shouldExistInOrder(vararg ps: (T) -> Boolean) = this.shouldExistInOrder(ps.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldExistInOrder(expected: List<(T) -> Boolean>) = toList().shouldExistInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldExistInOrder(expected: List<(T) -> Boolean>) = asList().shouldExistInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldExistInOrder(expected: List<(T) -> Boolean>) = this should existInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotExistInOrder(expected: Iterable<(T) -> Boolean>) =
    toList().shouldNotExistInOrder(expected.toList())
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotExistInOrder(expected: Array<(T) -> Boolean>) =
    asList().shouldNotExistInOrder(expected.asList())
 
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotExistInOrder(expected: List<(T) -> Boolean>) =
    toList().shouldNotExistInOrder(expected)
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotExistInOrder(expected: List<(T) -> Boolean>) = asList().shouldNotExistInOrder(expected)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotExistInOrder(expected: List<(T) -> Boolean>) = this shouldNot existInOrder(expected)
 
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldContainAnyOf(vararg ts: T) = toList().shouldContainAnyOf(*ts)
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainAnyOf(vararg ts: T) = asList().shouldContainAnyOf(*ts)
+@IgnorableReturnValue
 fun <T> Collection<T>.shouldContainAnyOf(vararg ts: T) = this should containAnyOf(ts.asList())
+@IgnorableReturnValue
 fun <T> Iterable<T>.shouldNotContainAnyOf(vararg ts: T) = toList().shouldNotContainAnyOf(*ts)
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainAnyOf(vararg ts: T) = asList().shouldNotContainAnyOf(*ts)
+@IgnorableReturnValue
 fun <T> Collection<T>.shouldNotContainAnyOf(vararg ts: T) = this shouldNot containAnyOf(ts.asList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldContainAnyOf(ts: Collection<T>) = toList().shouldContainAnyOf(ts)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldContainAnyOf(ts: Collection<T>) = asList().shouldContainAnyOf(ts)
+@IgnorableReturnValue
 infix fun <T> Collection<T>.shouldContainAnyOf(ts: Collection<T>) = this should containAnyOf(ts)
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotContainAnyOf(ts: Collection<T>) = toList().shouldNotContainAnyOf(ts)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotContainAnyOf(ts: Collection<T>) = asList().shouldNotContainAnyOf(ts)
+@IgnorableReturnValue
 infix fun <T> Collection<T>.shouldNotContainAnyOf(ts: Collection<T>) = this shouldNot containAnyOf(ts)
 
 fun <T> containAnyOf(ts: Collection<T>) = object : Matcher<Collection<T>> {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/nulls.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/nulls.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldNot
  *
  * @return the same iterable for further assertions
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldContainOnlyNulls(): I = apply { toList() should containOnlyNulls() }
 
 /**
@@ -37,6 +38,7 @@ fun <T, I : Iterable<T>> I.shouldContainOnlyNulls(): I = apply { toList() should
  *
  * @return the same array for further assertions
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainOnlyNulls(): Array<T> = apply { asList().shouldContainOnlyNulls() }
 
 /**
@@ -54,6 +56,7 @@ fun <T> Array<T>.shouldContainOnlyNulls(): Array<T> = apply { asList().shouldCon
  *
  * @return the same iterable for further assertions
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotContainOnlyNulls(): I = apply { toList() shouldNot containOnlyNulls() }
 
 /**
@@ -71,6 +74,7 @@ fun <T, I : Iterable<T>> I.shouldNotContainOnlyNulls(): I = apply { toList() sho
  *
  * @return the same array for further assertions
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainOnlyNulls(): Array<T> = apply { asList().shouldNotContainOnlyNulls() }
 
 /**
@@ -117,6 +121,7 @@ fun <T> containOnlyNulls() = object : Matcher<Collection<T>> {
  *
  * @return the same iterable for further assertions
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldContainNull(): I = apply { toList() should containNull() }
 
 /**
@@ -134,6 +139,7 @@ fun <T, I : Iterable<T>> I.shouldContainNull(): I = apply { toList() should cont
  *
  * @return the same array for further assertions
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainNull(): Array<T> = apply { asList().shouldContainNull() }
 
 
@@ -152,6 +158,7 @@ fun <T> Array<T>.shouldContainNull(): Array<T> = apply { asList().shouldContainN
  *
  * @return the same iterable for further assertions
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotContainNull(): I = apply { toList() shouldNot containNull() }
 
 /**
@@ -169,6 +176,7 @@ fun <T, I : Iterable<T>> I.shouldNotContainNull(): I = apply { toList() shouldNo
  *
  * @return the same array for further assertions
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainNull(): Array<T> = apply { asList().shouldNotContainNull() }
 
 /**
@@ -215,6 +223,7 @@ fun <T> containNull() = object : Matcher<Collection<T>> {
  *
  * @return the same iterable for further assertions
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldContainNoNulls(): I = apply { toList() should containNoNulls() }
 
 /**
@@ -232,6 +241,7 @@ fun <T, I : Iterable<T>> I.shouldContainNoNulls(): I = apply { toList() should c
  *
  * @return the same array for further assertions
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldContainNoNulls(): Array<T> = apply { asList().shouldContainNoNulls() }
 
 
@@ -250,6 +260,7 @@ fun <T> Array<T>.shouldContainNoNulls(): Array<T> = apply { asList().shouldConta
  *
  * @return the same iterable for further assertions
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotContainNoNulls(): I = apply { toList() shouldNot containNoNulls() }
 
 /**
@@ -267,6 +278,7 @@ fun <T, I : Iterable<T>> I.shouldNotContainNoNulls(): I = apply { toList() shoul
  *
  * @return the same array for further assertions
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotContainNoNulls(): Array<T> = apply { asList().shouldNotContainNoNulls() }
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/oneof.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/oneof.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.shouldNot
  * @see [shouldNotBeOneOf]
  * @see [beOneOf]
  */
+@IgnorableReturnValue
 infix fun <T> T.shouldBeOneOf(collection: Collection<T>): T {
    this should beOneOf(collection)
    return this
@@ -35,6 +36,7 @@ infix fun <T> T.shouldBeOneOf(collection: Collection<T>): T {
  * @see [shouldBeOneOf]
  * @see [beOneOf]
  */
+@IgnorableReturnValue
 infix fun <T> T.shouldNotBeOneOf(collection: Collection<T>): T {
    this shouldNot beOneOf(collection)
    return this
@@ -51,6 +53,7 @@ infix fun <T> T.shouldNotBeOneOf(collection: Collection<T>): T {
  * @see [shouldNotBeOneOf]
  * @see [beOneOf]
  */
+@IgnorableReturnValue
 fun <T> T.shouldBeOneOf(vararg any: T): T {
    this should beOneOf(any.toList())
    return this
@@ -68,6 +71,7 @@ fun <T> T.shouldBeOneOf(vararg any: T): T {
  * @see [shouldNotBeOneOf]
  * @see [beOneOf]
  */
+@IgnorableReturnValue
 fun <T> T.shouldNotBeOneOf(vararg any: T): T {
    this shouldNot beOneOf(any.toList())
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/singleElement.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/singleElement.kt
@@ -7,45 +7,54 @@ import io.kotest.matchers.MatcherResultBuilder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldHaveSingleElement(t: T): I {
    toList().shouldHaveSingleElement(t)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldHaveSingleElement(t: T): Array<T> {
    asList().shouldHaveSingleElement(t)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldHaveSingleElement(p: (T) -> Boolean): I {
    toList().shouldHaveSingleElement(p)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldHaveSingleElement(p: (T) -> Boolean): Array<T> {
    asList().shouldHaveSingleElement(p)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldHaveSingleElement(t: T): C {
    this should singleElement(t)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldHaveSingleElement(p: (T) -> Boolean): C {
    this should singleElement(p)
    return this
 }
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotHaveSingleElement(t: T): I {
    toList().shouldNotHaveSingleElement(t)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotHaveSingleElement(t: T): Array<T> {
    asList().shouldNotHaveSingleElement(t)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldNotHaveSingleElement(t: T): C {
    this shouldNot singleElement(t)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/singleton.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/singleton.kt
@@ -15,16 +15,19 @@ package io.kotest.matchers.collections
  * @see [shouldNotBeSingleton]
  * @see [shouldHaveSingleElement]
  */
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C.shouldBeSingleton(): C {
    this shouldHaveSize 1
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldBeSingleton(): I {
    toList().shouldBeSingleton()
    return this
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldBeSingleton(): Array<T> {
    asList().shouldBeSingleton()
    return this
@@ -47,17 +50,20 @@ fun <T> Array<T>.shouldBeSingleton(): Array<T> {
  * @see [shouldBeSingleton]
  * @see [shouldNotHaveSingleElement]
  */
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C.shouldNotBeSingleton(): C {
    this shouldNotHaveSize 1
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotBeSingleton(): I {
    toList().shouldNotBeSingleton()
    return this
 
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotBeSingleton(): Array<T> {
    asList().shouldNotBeSingleton()
    return this
@@ -78,13 +84,16 @@ fun <T> Array<T>.shouldNotBeSingleton(): Array<T> {
  *
  * @see [shouldBeSingleton]
  */
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C.shouldBeSingle(): T {
    this shouldHaveSize 1
    return this.single()
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldBeSingle(): T = toList().shouldBeSingle()
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldBeSingle(): T = asList().shouldBeSingle()
 
 
@@ -103,16 +112,19 @@ fun <T> Array<T>.shouldBeSingle(): T = asList().shouldBeSingle()
  * @see [shouldBeSingle]
  * @see [shouldNotBeSingleton]
  */
+@IgnorableReturnValue
 fun <T, C : Collection<T>> C.shouldNotBeSingle(): C {
    this shouldNotHaveSize 1
    return this
 }
 
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotBeSingle(): I {
    toList().shouldNotBeSingle()
    return this
 }
 
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotBeSingle(): Array<T> {
    asList().shouldNotBeSingle()
    return this
@@ -122,6 +134,7 @@ fun <T> Array<T>.shouldNotBeSingle(): Array<T> {
 /**
  * Verifies this collection contains only one element and executes the given lambda against that element.
  */
+@IgnorableReturnValue
 inline fun <T, C : Collection<T>> C.shouldBeSingleton(fn: (T) -> Unit): C {
    this.shouldBeSingleton()
    fn(this.first())
@@ -131,6 +144,7 @@ inline fun <T, C : Collection<T>> C.shouldBeSingleton(fn: (T) -> Unit): C {
 /**
  * Verifies this collection contains only one element and executes the given lambda against that element.
  */
+@IgnorableReturnValue
 inline fun <T, I : Iterable<T>> I.shouldBeSingleton(fn: (T) -> Unit): I {
    toList().shouldBeSingleton(fn)
    return this
@@ -139,6 +153,7 @@ inline fun <T, I : Iterable<T>> I.shouldBeSingleton(fn: (T) -> Unit): I {
 /**
  * Verifies this collection contains only one element and executes the given lambda against that element.
  */
+@IgnorableReturnValue
 inline fun <T> Array<T>.shouldBeSingleton(fn: (T) -> Unit): Array<T> {
    asList().shouldBeSingleton(fn)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/size.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/size.kt
@@ -8,176 +8,211 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldHave
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldHaveSize(size: Int): I {
    toList().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldHaveSize(size: Int): Array<T> {
    asList().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun BooleanArray.shouldHaveSize(size: Int): BooleanArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ByteArray.shouldHaveSize(size: Int): ByteArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun CharArray.shouldHaveSize(size: Int): CharArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ShortArray.shouldHaveSize(size: Int): ShortArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun IntArray.shouldHaveSize(size: Int): IntArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun LongArray.shouldHaveSize(size: Int): LongArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun FloatArray.shouldHaveSize(size: Int): FloatArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun DoubleArray.shouldHaveSize(size: Int): DoubleArray {
    toTypedArray().shouldHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldHaveSize(size: Int): C {
    this should haveSize(size = size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotHaveSize(size: Int): I {
    toList().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotHaveSize(size: Int): Array<T> {
    asList().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotHaveSize(size: Int): BooleanArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotHaveSize(size: Int): ByteArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun CharArray.shouldNotHaveSize(size: Int): CharArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotHaveSize(size: Int): ShortArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun IntArray.shouldNotHaveSize(size: Int): IntArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun LongArray.shouldNotHaveSize(size: Int): LongArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotHaveSize(size: Int): FloatArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotHaveSize(size: Int): DoubleArray {
    toTypedArray().shouldNotHaveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldNotHaveSize(size: Int): C {
    this shouldNot haveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, U, I : Iterable<T>> I.shouldBeSameSizeAs(other: Collection<U>): I {
    toList().shouldBeSameSizeAs(other)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, U> Array<T>.shouldBeSameSizeAs(other: Collection<U>): Array<T> {
    asList().shouldBeSameSizeAs(other)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, U, I : Iterable<T>> I.shouldBeSameSizeAs(other: Iterable<U>): I {
    toList().shouldBeSameSizeAs(other.toList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, U> Array<T>.shouldBeSameSizeAs(other: Array<U>): Array<T> {
    asList().shouldBeSameSizeAs(other.asList())
    return this
 }
 
+@IgnorableReturnValue
 infix fun BooleanArray.shouldBeSameSizeAs(other: BooleanArray): BooleanArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun ByteArray.shouldBeSameSizeAs(other: ByteArray): ByteArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun CharArray.shouldBeSameSizeAs(other: CharArray): CharArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun ShortArray.shouldBeSameSizeAs(other: ShortArray): ShortArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun IntArray.shouldBeSameSizeAs(other: IntArray): IntArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun LongArray.shouldBeSameSizeAs(other: LongArray): LongArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun FloatArray.shouldBeSameSizeAs(other: FloatArray): FloatArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun DoubleArray.shouldBeSameSizeAs(other: DoubleArray): DoubleArray {
    toTypedArray().shouldBeSameSizeAs(other.toTypedArray())
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, U, C : Collection<T>> C.shouldBeSameSizeAs(other: Collection<U>): C {
    this should beSameSizeAs(other)
    return this
@@ -191,56 +226,67 @@ fun <T, U> beSameSizeAs(other: Collection<U>) = object : Matcher<Collection<T>> 
       .build()
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldHaveAtLeastSize(n: Int): I {
    toList().shouldHaveAtLeastSize(n)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldHaveAtLeastSize(n: Int): Array<T> {
    asList().shouldHaveAtLeastSize(n)
    return this
 }
 
+@IgnorableReturnValue
 infix fun BooleanArray.shouldHaveAtLeastSize(size: Int): BooleanArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ByteArray.shouldHaveAtLeastSize(size: Int): ByteArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun CharArray.shouldHaveAtLeastSize(size: Int): CharArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ShortArray.shouldHaveAtLeastSize(size: Int): ShortArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun IntArray.shouldHaveAtLeastSize(size: Int): IntArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun LongArray.shouldHaveAtLeastSize(size: Int): LongArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun FloatArray.shouldHaveAtLeastSize(size: Int): FloatArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun DoubleArray.shouldHaveAtLeastSize(size: Int): DoubleArray {
    toTypedArray().shouldHaveAtLeastSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldHaveAtLeastSize(n: Int): C {
    this shouldHave atLeastSize(n)
    return this
@@ -254,56 +300,67 @@ fun <T> atLeastSize(expected: Int) = object : Matcher<Collection<T>> {
       .build()
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldHaveAtMostSize(n: Int): I {
    toList().shouldHaveAtMostSize(n)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldHaveAtMostSize(n: Int): Array<T> {
    asList().shouldHaveAtMostSize(n)
    return this
 }
 
+@IgnorableReturnValue
 infix fun BooleanArray.shouldHaveAtMostSize(size: Int): BooleanArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ByteArray.shouldHaveAtMostSize(size: Int): ByteArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun CharArray.shouldHaveAtMostSize(size: Int): CharArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun ShortArray.shouldHaveAtMostSize(size: Int): ShortArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun IntArray.shouldHaveAtMostSize(size: Int): IntArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun LongArray.shouldHaveAtMostSize(size: Int): LongArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun FloatArray.shouldHaveAtMostSize(size: Int): FloatArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun DoubleArray.shouldHaveAtMostSize(size: Int): DoubleArray {
    toTypedArray().shouldHaveAtMostSize(size)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Collection<T>> C.shouldHaveAtMostSize(n: Int): C {
    this shouldHave atMostSize(n)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/smaller.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/smaller.kt
@@ -24,6 +24,7 @@ import io.kotest.matchers.shouldNot
  *
  * @see ByteArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldBeSmallerThan(other: ByteArray): ByteArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -45,6 +46,7 @@ infix fun ByteArray.shouldBeSmallerThan(other: ByteArray): ByteArray = apply {
  *
  * @see ByteArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotBeSmallerThan(other: ByteArray): ByteArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -66,6 +68,7 @@ infix fun ByteArray.shouldNotBeSmallerThan(other: ByteArray): ByteArray = apply 
  *
  * @see IntArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun IntArray.shouldBeSmallerThan(other: IntArray): IntArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -87,6 +90,7 @@ infix fun IntArray.shouldBeSmallerThan(other: IntArray): IntArray = apply {
  *
  * @see IntArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun IntArray.shouldNotBeSmallerThan(other: IntArray): IntArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -108,6 +112,7 @@ infix fun IntArray.shouldNotBeSmallerThan(other: IntArray): IntArray = apply {
  *
  * @see ShortArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun ShortArray.shouldBeSmallerThan(other: ShortArray): ShortArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -129,6 +134,7 @@ infix fun ShortArray.shouldBeSmallerThan(other: ShortArray): ShortArray = apply 
  *
  * @see ShortArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotBeSmallerThan(other: ShortArray): ShortArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -150,6 +156,7 @@ infix fun ShortArray.shouldNotBeSmallerThan(other: ShortArray): ShortArray = app
  *
  * @see LongArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun LongArray.shouldBeSmallerThan(other: LongArray): LongArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -172,6 +179,7 @@ infix fun LongArray.shouldBeSmallerThan(other: LongArray): LongArray = apply {
  * @see LongArray.shouldBeSmallerThan
  */
 
+@IgnorableReturnValue
 infix fun LongArray.shouldNotBeSmallerThan(other: LongArray): LongArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -193,6 +201,7 @@ infix fun LongArray.shouldNotBeSmallerThan(other: LongArray): LongArray = apply 
  *
  * @see FloatArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun FloatArray.shouldBeSmallerThan(other: FloatArray): FloatArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -214,6 +223,7 @@ infix fun FloatArray.shouldBeSmallerThan(other: FloatArray): FloatArray = apply 
  *
  * @see FloatArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotBeSmallerThan(other: FloatArray): FloatArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -235,6 +245,7 @@ infix fun FloatArray.shouldNotBeSmallerThan(other: FloatArray): FloatArray = app
  *
  * @see DoubleArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun DoubleArray.shouldBeSmallerThan(other: DoubleArray): DoubleArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -256,6 +267,7 @@ infix fun DoubleArray.shouldBeSmallerThan(other: DoubleArray): DoubleArray = app
  *
  * @see DoubleArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotBeSmallerThan(other: DoubleArray): DoubleArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -277,6 +289,7 @@ infix fun DoubleArray.shouldNotBeSmallerThan(other: DoubleArray): DoubleArray = 
  *
  * @see CharArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun CharArray.shouldBeSmallerThan(other: CharArray): CharArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -298,6 +311,7 @@ infix fun CharArray.shouldBeSmallerThan(other: CharArray): CharArray = apply {
  *
  * @see CharArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun CharArray.shouldNotBeSmallerThan(other: CharArray): CharArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -319,6 +333,7 @@ infix fun CharArray.shouldNotBeSmallerThan(other: CharArray): CharArray = apply 
  *
  * @see BooleanArray.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun BooleanArray.shouldBeSmallerThan(other: BooleanArray): BooleanArray = apply {
    this.asList() shouldBeSmallerThan other.asList()
 }
@@ -340,6 +355,7 @@ infix fun BooleanArray.shouldBeSmallerThan(other: BooleanArray): BooleanArray = 
  *
  * @see BooleanArray.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotBeSmallerThan(other: BooleanArray): BooleanArray = apply {
    this.asList() shouldNotBeSmallerThan other.asList()
 }
@@ -364,6 +380,7 @@ infix fun BooleanArray.shouldNotBeSmallerThan(other: BooleanArray): BooleanArray
  *
  * @see Iterable.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun <T, U, I : Iterable<T>> I.shouldBeSmallerThan(other: Iterable<U>): I = apply {
    toList() should beSmallerThan(other)
 }
@@ -386,6 +403,7 @@ infix fun <T, U, I : Iterable<T>> I.shouldBeSmallerThan(other: Iterable<U>): I =
  *
  * @see Array.shouldNotBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun <T, U> Array<T>.shouldBeSmallerThan(other: Array<U>): Array<T> = apply {
    asList() should beSmallerThan(other.asList())
 }
@@ -408,6 +426,7 @@ infix fun <T, U> Array<T>.shouldBeSmallerThan(other: Array<U>): Array<T> = apply
  *
  * @see Iterable.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun <T, U, I : Iterable<T>> I.shouldNotBeSmallerThan(other: Iterable<U>): I = apply {
    toList() shouldNot beSmallerThan(other)
 }
@@ -429,6 +448,7 @@ infix fun <T, U, I : Iterable<T>> I.shouldNotBeSmallerThan(other: Iterable<U>): 
  *
  * @see Array.shouldBeSmallerThan
  */
+@IgnorableReturnValue
 infix fun <T, U> Array<T>.shouldNotBeSmallerThan(other: Array<U>): Array<T> = apply {
    asList() shouldNot beSmallerThan(other.asList())
 }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sorted.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sorted.kt
@@ -7,21 +7,25 @@ import io.kotest.matchers.shouldNot
 
 // SHOULD BE SORTED: empty, transform, comparator
 // Array ================================================================================================
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldBeSorted(): Array<T> {
    asList().shouldBeSorted()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, E : Comparable<E>> Array<T>.shouldBeSortedBy(transform: (T) -> E): Array<T> {
    asList().shouldBeSortedBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldBeSortedWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldBeSortedWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldBeSortedWith(cmp: (T, T) -> Int): Array<T> {
    asList().shouldBeSortedWith(cmp)
    return this
@@ -29,21 +33,25 @@ infix fun <T> Array<T>.shouldBeSortedWith(cmp: (T, T) -> Int): Array<T> {
 
 // List ================================================================================================
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldBeSorted(): List<T> {
    this should beSorted()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, E : Comparable<E>> List<T>.shouldBeSortedBy(transform: (T) -> E): List<T> {
    this should beSortedBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldBeSortedWith(comparator: Comparator<in T>): List<T> {
    this should beSortedWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldBeSortedWith(cmp: (T, T) -> Int): List<T> {
    this should beSortedWith(cmp)
    return this
@@ -51,21 +59,25 @@ infix fun <T> List<T>.shouldBeSortedWith(cmp: (T, T) -> Int): List<T> {
 
 // Iterable ==========================================================================================
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeSorted(): I {
    toList().shouldBeSorted()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>, E : Comparable<E>> I.shouldBeSortedBy(transform: (T) -> E): I {
    toList().shouldBeSortedBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldBeSortedWith(comparator: Comparator<in T>): I {
    toList().shouldBeSortedWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldBeSortedWith(cmp: (T, T) -> Int): I {
    toList().shouldBeSortedWith(cmp)
    return this
@@ -75,21 +87,25 @@ infix fun <T, I : Iterable<T>> I.shouldBeSortedWith(cmp: (T, T) -> Int): I {
 // SHOULD BE SORTED: empty, transform, comparator
 // Array =============================================================================================
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldNotBeSorted(): Array<T> {
    asList().shouldNotBeSorted()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, E : Comparable<E>> Array<T>.shouldNotBeSortedBy(transform: (T) -> E): Array<T> {
    asList() shouldNotBeSortedBy transform
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotBeSortedWith(comparator: Comparator<in T>): Array<T> {
    asList().shouldNotBeSortedWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotBeSortedWith(cmp: (T, T) -> Int): Array<T> {
    asList().shouldNotBeSortedWith(cmp)
    return this
@@ -97,21 +113,25 @@ infix fun <T> Array<T>.shouldNotBeSortedWith(cmp: (T, T) -> Int): Array<T> {
 
 // List ===============================================================================================
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldNotBeSorted(): List<T> {
    this shouldNot beSorted()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, E : Comparable<E>> List<T>.shouldNotBeSortedBy(transform: (T) -> E): List<T> {
    this shouldNot beSortedBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotBeSortedWith(comparator: Comparator<in T>): List<T> {
    this shouldNot beSortedWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotBeSortedWith(cmp: (T, T) -> Int): List<T> {
    this shouldNot beSortedWith(cmp)
    return this
@@ -119,21 +139,25 @@ infix fun <T> List<T>.shouldNotBeSortedWith(cmp: (T, T) -> Int): List<T> {
 
 // Iterable ===============================================================================================
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldNotBeSorted(): I {
    toList().shouldNotBeSorted()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>, E : Comparable<E>> I.shouldNotBeSortedBy(transform: (T) -> E): I {
    toList().shouldNotBeSortedBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotBeSortedWith(comparator: Comparator<in T>): I {
    toList().shouldNotBeSortedWith(comparator)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>> I.shouldNotBeSortedWith(cmp: (T, T) -> Int): I {
    toList().shouldNotBeSortedWith(cmp)
    return this
@@ -141,28 +165,44 @@ infix fun <T, I : Iterable<T>> I.shouldNotBeSortedWith(cmp: (T, T) -> Int): I {
 
 // Primitive Arrays ==================================================================================
 
+@IgnorableReturnValue
 fun BooleanArray.shouldBeSorted(): BooleanArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun BooleanArray.shouldNotBeSorted(): BooleanArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun ByteArray.shouldBeSorted(): ByteArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun ByteArray.shouldNotBeSorted(): ByteArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun ShortArray.shouldBeSorted(): ShortArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun ShortArray.shouldNotBeSorted(): ShortArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun CharArray.shouldBeSorted(): CharArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun CharArray.shouldNotBeSorted(): CharArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun IntArray.shouldBeSorted(): IntArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun IntArray.shouldNotBeSorted(): IntArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun LongArray.shouldBeSorted(): LongArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun LongArray.shouldNotBeSorted(): LongArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun FloatArray.shouldBeSorted(): FloatArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun FloatArray.shouldNotBeSorted(): FloatArray = apply { asList().shouldNotBeSorted() }
 
+@IgnorableReturnValue
 fun DoubleArray.shouldBeSorted(): DoubleArray = apply { asList().shouldBeSorted() }
+@IgnorableReturnValue
 fun DoubleArray.shouldNotBeSorted(): DoubleArray = apply { asList().shouldNotBeSorted() }
 
 fun <T> beSortedWith(comparator: Comparator<in T>): Matcher<List<T>> = sortedWith(comparator)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sortedDesc.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/sortedDesc.kt
@@ -5,31 +5,37 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Array<T>.shouldBeSortedDescending(): Array<T> {
    asList().shouldBeSortedDescending()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, E : Comparable<E>> Array<T>.shouldBeSortedDescendingBy(transform: (T) -> E): Array<T> {
    asList().shouldBeSortedDescendingBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> List<T>.shouldBeSortedDescending(): List<T> {
    this should beSortedDescending()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, E : Comparable<E>> List<T>.shouldBeSortedDescendingBy(transform: (T) -> E): List<T> {
    this should beSortedDescendingBy(transform)
    return this
 }
 
+@IgnorableReturnValue
 fun <T : Comparable<T>, I : Iterable<T>> I.shouldBeSortedDescending(): I {
    toList().shouldBeSortedDescending()
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T, I : Iterable<T>, E : Comparable<E>> I.shouldBeSortedDescendingBy(transform: (T) -> E): I {
    toList().shouldBeSortedDescendingBy(transform)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/startwith.kt
@@ -8,26 +8,42 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldStartWith(element: T) = toList().shouldStartWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldStartWith(slice: Iterable<T>) = toList().shouldStartWith(slice.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldStartWith(slice: Array<T>) = toList().shouldStartWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldStartWith(element: T) = asList().shouldStartWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldStartWith(slice: Collection<T>) = asList().shouldStartWith(slice)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldStartWith(slice: Array<T>) = asList().shouldStartWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldStartWith(element: T) = this should startWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldStartWith(slice: Collection<T>) = this should startWith(slice)
 
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotStartWith(element: T) = toList().shouldNotStartWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotStartWith(slice: Iterable<T>) = toList().shouldNotStartWith(slice.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotStartWith(slice: Array<T>) = toList().shouldNotStartWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotStartWith(element: T) = asList().shouldNotStartWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotStartWith(slice: Collection<T>) = asList().shouldNotStartWith(slice)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotStartWith(slice: Array<T>) = asList().shouldNotStartWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotStartWith(element: T) = this shouldNot startWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotStartWith(slice: Collection<T>) = this shouldNot startWith(slice)
 
 fun <T> startWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
@@ -143,27 +159,44 @@ private data class SliceComparison<T>(
    }
 }
 
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldEndWith(element: T) = toList().shouldEndWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldEndWith(slice: Iterable<T>) = toList().shouldEndWith(slice.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldEndWith(slice: Array<T>) = toList().shouldEndWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldEndWith(element: T) = asList().shouldEndWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldEndWith(slice: Collection<T>) = asList().shouldEndWith(slice)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldEndWith(slice: Array<T>) = asList().shouldEndWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldEndWith(element: T) = this.shouldEndWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldEndWith(slice: Collection<T>) = this should endWith(slice)
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldEndWith(slice: Array<T>) = this.shouldEndWith(slice.toList())
 
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotEndWith(element: T) = toList().shouldNotEndWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotEndWith(slice: Iterable<T>) = toList().shouldNotEndWith(slice.toList())
+@IgnorableReturnValue
 infix fun <T> Iterable<T>.shouldNotEndWith(slice: Array<T>) = toList().shouldNotEndWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotEndWith(element: T) = asList().shouldNotEndWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotEndWith(slice: Collection<T>) = asList().shouldNotEndWith(slice)
+@IgnorableReturnValue
 infix fun <T> Array<T>.shouldNotEndWith(slice: Array<T>) = asList().shouldNotEndWith(slice.asList())
 
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotEndWith(element: T) = this shouldNot endWith(listOf(element))
+@IgnorableReturnValue
 infix fun <T> List<T>.shouldNotEndWith(slice: Collection<T>) = this shouldNot endWith(slice)
 
 fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
@@ -182,43 +215,75 @@ fun <T> endWith(expectedSlice: Collection<T>) = object : Matcher<List<T>> {
 
 // Primitive array overloads for shouldStartWith / shouldNotStartWith
 
+@IgnorableReturnValue
 infix fun BooleanArray.shouldStartWith(slice: BooleanArray): BooleanArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotStartWith(slice: BooleanArray): BooleanArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun BooleanArray.shouldEndWith(slice: BooleanArray): BooleanArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun BooleanArray.shouldNotEndWith(slice: BooleanArray): BooleanArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun ByteArray.shouldStartWith(slice: ByteArray): ByteArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotStartWith(slice: ByteArray): ByteArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun ByteArray.shouldEndWith(slice: ByteArray): ByteArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotEndWith(slice: ByteArray): ByteArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun ShortArray.shouldStartWith(slice: ShortArray): ShortArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotStartWith(slice: ShortArray): ShortArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun ShortArray.shouldEndWith(slice: ShortArray): ShortArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun ShortArray.shouldNotEndWith(slice: ShortArray): ShortArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun CharArray.shouldStartWith(slice: CharArray): CharArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun CharArray.shouldNotStartWith(slice: CharArray): CharArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun CharArray.shouldEndWith(slice: CharArray): CharArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun CharArray.shouldNotEndWith(slice: CharArray): CharArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun IntArray.shouldStartWith(slice: IntArray): IntArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun IntArray.shouldNotStartWith(slice: IntArray): IntArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun IntArray.shouldEndWith(slice: IntArray): IntArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun IntArray.shouldNotEndWith(slice: IntArray): IntArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun LongArray.shouldStartWith(slice: LongArray): LongArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun LongArray.shouldNotStartWith(slice: LongArray): LongArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun LongArray.shouldEndWith(slice: LongArray): LongArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun LongArray.shouldNotEndWith(slice: LongArray): LongArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun FloatArray.shouldStartWith(slice: FloatArray): FloatArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotStartWith(slice: FloatArray): FloatArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun FloatArray.shouldEndWith(slice: FloatArray): FloatArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun FloatArray.shouldNotEndWith(slice: FloatArray): FloatArray = apply { asList().shouldNotEndWith(slice.asList()) }
 
+@IgnorableReturnValue
 infix fun DoubleArray.shouldStartWith(slice: DoubleArray): DoubleArray = apply { asList().shouldStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotStartWith(slice: DoubleArray): DoubleArray = apply { asList().shouldNotStartWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun DoubleArray.shouldEndWith(slice: DoubleArray): DoubleArray = apply { asList().shouldEndWith(slice.asList()) }
+@IgnorableReturnValue
 infix fun DoubleArray.shouldNotEndWith(slice: DoubleArray): DoubleArray = apply { asList().shouldNotEndWith(slice.asList()) }
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/unique.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/unique.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldNot
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun BooleanArray.shouldBeUnique(): BooleanArray = apply { asList() should beUniqueByEquals("BooleanArray") }
 
 /**
@@ -19,6 +20,7 @@ fun BooleanArray.shouldBeUnique(): BooleanArray = apply { asList() should beUniq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun BooleanArray.shouldNotBeUnique(): BooleanArray = apply { asList() shouldNot beUniqueByEquals("BooleanArray") }
 
 /**
@@ -27,6 +29,7 @@ fun BooleanArray.shouldNotBeUnique(): BooleanArray = apply { asList() shouldNot 
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun ByteArray.shouldBeUnique(): ByteArray = apply { asList() should beUniqueByEquals("ByteArray") }
 
 /**
@@ -35,6 +38,7 @@ fun ByteArray.shouldBeUnique(): ByteArray = apply { asList() should beUniqueByEq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun ByteArray.shouldNotBeUnique(): ByteArray = apply { asList() shouldNot beUniqueByEquals("ByteArray") }
 
 /**
@@ -43,6 +47,7 @@ fun ByteArray.shouldNotBeUnique(): ByteArray = apply { asList() shouldNot beUniq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun ShortArray.shouldBeUnique(): ShortArray = apply { asList() should beUniqueByEquals("ShortArray") }
 
 /**
@@ -51,6 +56,7 @@ fun ShortArray.shouldBeUnique(): ShortArray = apply { asList() should beUniqueBy
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun ShortArray.shouldNotBeUnique(): ShortArray = apply { asList() shouldNot beUniqueByEquals("ShortArray") }
 
 /**
@@ -59,6 +65,7 @@ fun ShortArray.shouldNotBeUnique(): ShortArray = apply { asList() shouldNot beUn
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun CharArray.shouldBeUnique(): CharArray = apply { asList() should beUniqueByEquals("CharArray") }
 
 /**
@@ -67,6 +74,7 @@ fun CharArray.shouldBeUnique(): CharArray = apply { asList() should beUniqueByEq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun CharArray.shouldNotBeUnique(): CharArray = apply { asList() shouldNot beUniqueByEquals("CharArray") }
 
 /**
@@ -75,6 +83,7 @@ fun CharArray.shouldNotBeUnique(): CharArray = apply { asList() shouldNot beUniq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun IntArray.shouldBeUnique(): IntArray = apply { asList() should beUniqueByEquals("IntArray") }
 
 /**
@@ -83,6 +92,7 @@ fun IntArray.shouldBeUnique(): IntArray = apply { asList() should beUniqueByEqua
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun IntArray.shouldNotBeUnique(): IntArray = apply { asList() shouldNot beUniqueByEquals("IntArray") }
 
 /**
@@ -91,6 +101,7 @@ fun IntArray.shouldNotBeUnique(): IntArray = apply { asList() shouldNot beUnique
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun LongArray.shouldBeUnique(): LongArray = apply { asList() should beUniqueByEquals("LongArray") }
 
 /**
@@ -99,6 +110,7 @@ fun LongArray.shouldBeUnique(): LongArray = apply { asList() should beUniqueByEq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun LongArray.shouldNotBeUnique(): LongArray = apply { asList() shouldNot beUniqueByEquals("LongArray") }
 
 /**
@@ -107,6 +119,7 @@ fun LongArray.shouldNotBeUnique(): LongArray = apply { asList() shouldNot beUniq
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun FloatArray.shouldBeUnique(): FloatArray = apply { asList() should beUniqueByEquals("FloatArray") }
 
 /**
@@ -115,6 +128,7 @@ fun FloatArray.shouldBeUnique(): FloatArray = apply { asList() should beUniqueBy
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun FloatArray.shouldNotBeUnique(): FloatArray = apply { asList() shouldNot beUniqueByEquals("FloatArray") }
 
 /**
@@ -123,6 +137,7 @@ fun FloatArray.shouldNotBeUnique(): FloatArray = apply { asList() shouldNot beUn
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun DoubleArray.shouldBeUnique(): DoubleArray = apply { asList() should beUniqueByEquals("DoubleArray") }
 
 /**
@@ -131,6 +146,7 @@ fun DoubleArray.shouldBeUnique(): DoubleArray = apply { asList() should beUnique
  *
  * @return the input instance is returned for chaining
  */
+@IgnorableReturnValue
 fun DoubleArray.shouldNotBeUnique(): DoubleArray = apply { asList() shouldNot beUniqueByEquals("DoubleArray") }
 
 /**
@@ -150,6 +166,7 @@ fun DoubleArray.shouldNotBeUnique(): DoubleArray = apply { asList() shouldNot be
  *
  * @return the input instance is returned for chaining.
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldBeUnique(): Array<T> = apply { asList() should beUniqueByEquals("Array") }
 
 /**
@@ -170,6 +187,7 @@ fun <T> Array<T>.shouldBeUnique(): Array<T> = apply { asList() should beUniqueBy
  * @param comparator the [Comparator] used to compare elements for equality.
  * @return the input instance is returned for chaining.
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldBeUnique(comparator: Comparator<T>): Array<T> = apply { asList() should beUniqueByCompare("Array", comparator) }
 
 /**
@@ -189,6 +207,7 @@ fun <T> Array<T>.shouldBeUnique(comparator: Comparator<T>): Array<T> = apply { a
  *
  * @return the input instance is returned for chaining.
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotBeUnique(): Array<T> = apply { asList() shouldNot beUniqueByEquals("Array") }
 
 /**
@@ -209,6 +228,7 @@ fun <T> Array<T>.shouldNotBeUnique(): Array<T> = apply { asList() shouldNot beUn
  * @param comparator the [Comparator] used to compare elements for equality.
  * @return the input instance is returned for chaining.
  */
+@IgnorableReturnValue
 fun <T> Array<T>.shouldNotBeUnique(comparator: Comparator<T>): Array<T> = apply { asList() shouldNot beUniqueByCompare("Array", comparator) }
 
 
@@ -230,6 +250,7 @@ fun <T> Array<T>.shouldNotBeUnique(comparator: Comparator<T>): Array<T> = apply 
  *
  * @return the input instance is returned for chaining, maintaining the input type.
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldBeUnique(): I = apply { this should beUniqueByEquals(null) }
 
 
@@ -251,6 +272,7 @@ fun <T, I : Iterable<T>> I.shouldBeUnique(): I = apply { this should beUniqueByE
  * @param comparator the [Comparator] used to compare elements for equality.
  * @return the input instance is returned for chaining, maintaining the input type.
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldBeUnique(comparator: Comparator<T>): I = apply { this should beUniqueByCompare(null, comparator) }
 
 /**
@@ -270,6 +292,7 @@ fun <T, I : Iterable<T>> I.shouldBeUnique(comparator: Comparator<T>): I = apply 
  *
  * @return the input instance is returned for chaining, maintaining the input type.
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotBeUnique(): I = apply { this shouldNot beUniqueByEquals(null) }
 
 /**
@@ -290,6 +313,7 @@ fun <T, I : Iterable<T>> I.shouldNotBeUnique(): I = apply { this shouldNot beUni
  * @param comparator the [Comparator] used to compare elements for equality.
  * @return the input instance is returned for chaining, maintaining the input type.
  */
+@IgnorableReturnValue
 fun <T, I : Iterable<T>> I.shouldNotBeUnique(comparator: Comparator<T>): I = apply { this shouldNot beUniqueByCompare(null, comparator) }
 
 fun <T> beUnique(): Matcher<Iterable<T>> = beUniqueByEquals(null)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/comparables/ComparableMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/comparables/ComparableMatchers.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldNotBe
  * @see [shouldNotBeLessThan]
  * @see [shouldBeLessThanOrEqualTo]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeLessThan(other: T): T {
    this shouldBe lt(other)
    return this
@@ -35,6 +36,7 @@ infix fun <T : Comparable<T>> T.shouldBeLessThan(other: T): T {
  * @see [shouldBeLessThan]
  * @see [shouldNotBeLessThanOrEqualTo]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeLessThan(other: T): T {
    this shouldNotBe lt(other)
    return this
@@ -62,6 +64,7 @@ fun <T : Comparable<T>> beLessThan(x: T) = object : Matcher<Comparable<T>> {
  * @see [shouldNotBeLessThanOrEqualTo]
  * @see [shouldBeLessThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeLessThanOrEqualTo(other: T): T {
    this shouldBe lte(other)
    return this
@@ -80,6 +83,7 @@ infix fun <T : Comparable<T>> T.shouldBeLessThanOrEqualTo(other: T): T {
  * @see [shouldNotBeLessThanOrEqualTo]
  * @see [shouldBeLessThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeAtMost(other: T): T {
    this shouldBe lte(other)
    return this
@@ -98,6 +102,7 @@ infix fun <T : Comparable<T>> T.shouldBeAtMost(other: T): T {
  * @see [shouldBeLessThanOrEqualTo]
  * @see [shouldNotBeLessThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeLessThanOrEqualTo(other: T): T {
    this shouldNotBe lte(other)
    return this
@@ -116,6 +121,7 @@ infix fun <T : Comparable<T>> T.shouldNotBeLessThanOrEqualTo(other: T): T {
  * @see [shouldBeLessThanOrEqualTo]
  * @see [shouldNotBeLessThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeAtMost(other: T): T {
    this shouldNotBe lte(other)
    return this
@@ -141,6 +147,7 @@ fun <T : Comparable<T>> beLessThanOrEqualTo(x: T) = object : Matcher<Comparable<
  * @see [shouldNotBeGreaterThan]
  * @see [shouldBeGreaterThanOrEqualTo]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeGreaterThan(other: T): T {
    this shouldBe gt(other)
    return this
@@ -157,6 +164,7 @@ infix fun <T : Comparable<T>> T.shouldBeGreaterThan(other: T): T {
  * @see [shouldBeGreaterThan]
  * @see [shouldNotBeGreaterThanOrEqualTo]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeGreaterThan(other: T) = this shouldNotBe gt(other)
 fun <T : Comparable<T>> gt(x: T) = beGreaterThan(x)
 fun <T : Comparable<T>> beGreaterThan(x: T) = object : Matcher<Comparable<T>> {
@@ -180,6 +188,7 @@ fun <T : Comparable<T>> beGreaterThan(x: T) = object : Matcher<Comparable<T>> {
  * @see [shouldNotBeGreaterThanOrEqualTo]
  * @see [shouldBeGreaterThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeGreaterThanOrEqualTo(other: T): T {
    this shouldBe gte(other)
    return this
@@ -198,6 +207,7 @@ infix fun <T : Comparable<T>> T.shouldBeGreaterThanOrEqualTo(other: T): T {
  * @see [shouldNotBeGreaterThanOrEqualTo]
  * @see [shouldBeGreaterThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeAtLeast(other: T): T {
    this shouldBe gte(other)
    return this
@@ -216,6 +226,7 @@ infix fun <T : Comparable<T>> T.shouldBeAtLeast(other: T): T {
  * @see [shouldBeGreaterThanOrEqualTo]
  * @see [shouldNotBeGreaterThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeGreaterThanOrEqualTo(other: T): T {
    this shouldNotBe gte(other)
    return this
@@ -234,6 +245,7 @@ infix fun <T : Comparable<T>> T.shouldNotBeGreaterThanOrEqualTo(other: T): T {
  * @see [shouldBeGreaterThanOrEqualTo]
  * @see [shouldNotBeGreaterThan]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeAtLeast(other: T): T {
    this shouldNotBe gte(other)
    return this
@@ -257,6 +269,7 @@ fun <T : Comparable<T>> beGreaterThanOrEqualTo(x: T) = object : Matcher<Comparab
  * This will pass if the value is equal to [other] (compareTo returns 0).
  *
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeEqualComparingTo(other: T): T {
    this should beEqualComparingTo(other)
    return this
@@ -271,6 +284,7 @@ infix fun <T : Comparable<T>> T.shouldBeEqualComparingTo(other: T): T {
  * This will pass if the value is NOT equal to [other] (compareTo doesn't return 0).
  *
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeEqualComparingTo(other: T): T {
    this shouldNot beEqualComparingTo(other)
    return this
@@ -294,6 +308,7 @@ fun <T : Comparable<T>> beEqualComparingTo(other: T) = object : Matcher<T> {
  * This will pass if the value is equal to [other] (compare returns 0).
  *
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> T.shouldBeEqualComparingTo(other: T, comparator: Comparator<T>): T {
    this should compareTo(other, comparator)
    return this
@@ -307,6 +322,7 @@ fun <T : Comparable<T>> T.shouldBeEqualComparingTo(other: T, comparator: Compara
  * This will pass if the value is NOT equal to [other] (compare doesn't return 0).
  *
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> T.shouldNotBeEqualComparingTo(other: T, comparator: Comparator<T>): T {
    this shouldNot compareTo(other, comparator)
    return this
@@ -327,6 +343,7 @@ fun <T> compareTo(other: T, comparator: Comparator<T>) = object : Matcher<T> {
  *
  * This assertion always fails if the supplied `lower > upper`.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> T.shouldBeBetween(lower: T, upper: T): T {
    this should beBetween(lower, upper)
    return this
@@ -337,6 +354,7 @@ fun <T : Comparable<T>> T.shouldBeBetween(lower: T, upper: T): T {
  *
  * This assertion always succeeds if the supplied `lower > upper`.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> T.shouldNotBeBetween(lower: T, upper: T): T {
    this shouldNot beBetween(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/concurrent/suspension/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/concurrent/suspension/concurrent.kt
@@ -24,6 +24,7 @@ import kotlin.time.measureTimedValue
  * }
  *
  * */
+@IgnorableReturnValue
 suspend fun <A> shouldCompleteWithin(
    duration: Duration,
    operation: suspend () -> A,
@@ -55,6 +56,7 @@ suspend fun <A> shouldCompleteWithin(
  *   (2+2) shouldBe 4
  * }
  */
+@IgnorableReturnValue
 suspend fun <A> shouldCompleteBetween(
    durationRange: ClosedRange<Duration>,
    operation: suspend () -> A,
@@ -91,6 +93,7 @@ suspend fun <A> shouldCompleteBetween(
  *   (2+2) shouldBe 4
  * }
  */
+@IgnorableReturnValue
 suspend fun shouldTimeout(
    duration: Duration,
    operation: suspend () -> Unit,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Between.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Between.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldNotBe
  * 0.5.shouldBeBetween(0.2, 0.3, 0.1)   // Assertion fails
  * ```
  */
+@IgnorableReturnValue
 fun Double.shouldBeBetween(a: Double, b: Double, tolerance: Double): Double {
    this shouldBe between(a, b, tolerance)
    return this
@@ -43,6 +44,7 @@ fun Double.shouldBeBetween(a: Double, b: Double, tolerance: Double): Double {
  * 0.5.shouldNotBeBetween(0.2, 0.3, 0.1)   // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun Double.shouldNotBeBetween(a: Double, b: Double, tolerance: Double): Double {
    this shouldNotBe between(a, b, tolerance)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Exactly.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Exactly.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.shouldNotBe
  * This matcher considers NaN to be equal to NaN.
  * To disable this behavior, set the system property `kotest.assertions.nan.equality.disable` to true.
  */
+@IgnorableReturnValue
 infix fun Double.shouldBeExactly(other: Double): Double {
    if (AssertionsConfig.disableNaNEquality) {
       this shouldBe exactly(other)
@@ -45,6 +46,7 @@ infix fun Double.shouldBeExactly(other: Double): Double {
  * This matcher considers NaN to be equal to NaN.
  * To disable this behavior, set the system property `kotest.assertions.nan.equality.disable` to true.
  */
+@IgnorableReturnValue
 infix fun Double.shouldNotBeExactly(other: Double): Double {
    if (AssertionsConfig.disableNaNEquality) {
       this shouldNotBe exactly(other)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/GreaterThan.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/GreaterThan.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.shouldNotBe
  * @see [Double.shouldBeGreaterThanOrEqual]
  * @see [Double.shouldNotBeLessThan]
  */
+@IgnorableReturnValue
 infix fun Double.shouldBeGreaterThan(x: Double): Double {
    this shouldBe gt(x)
    return this
@@ -39,6 +40,7 @@ infix fun Double.shouldBeGreaterThan(x: Double): Double {
  * @see [Double.shouldBeLessThan]
  * @see [Double.shouldNotBeGreaterThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldNotBeGreaterThan(x: Double): Double {
    this shouldNotBe gt(x)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/GreaterThanOrEqual.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/GreaterThanOrEqual.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.shouldNotBe
  * @see [Double.shouldBeGreaterThan]
  * @see [Double.shouldNotBeLessThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldBeGreaterThanOrEqual(x: Double): Double {
    this shouldBe gte(x)
    return this
@@ -42,6 +43,7 @@ infix fun Double.shouldBeGreaterThanOrEqual(x: Double): Double {
  * @see [Double.shouldBeGreaterThan]
  * @see [Double.shouldNotBeLessThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldBeAtLeast(x: Double): Double = shouldBeGreaterThanOrEqual(x)
 
 /**
@@ -58,6 +60,7 @@ infix fun Double.shouldBeAtLeast(x: Double): Double = shouldBeGreaterThanOrEqual
  * @see [Double.shouldNotBeGreaterThan]
  * @see [Double.shouldBeLessThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldNotBeGreaterThanOrEqual(x: Double): Double {
    this shouldNotBe gte(x)
    return this
@@ -77,6 +80,7 @@ infix fun Double.shouldNotBeGreaterThanOrEqual(x: Double): Double {
  * @see [Double.shouldNotBeAtLeast]
  * @see [Double.shouldBeLessThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldNotBeAtLeast(x: Double): Double {
    this shouldNotBe gte(x)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Infinity.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Infinity.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.shouldNot
  *
  * @see [bePositiveInfinity]
  */
+@IgnorableReturnValue
 fun Double.shouldBePositiveInfinity(): Double {
    this should bePositiveInfinity()
    return this
@@ -34,6 +35,7 @@ fun Double.shouldBePositiveInfinity(): Double {
  *
  * @see [bePositiveInfinity]
  */
+@IgnorableReturnValue
 fun Double.shouldNotBePositiveInfinity(): Double {
    this shouldNot bePositiveInfinity()
    return this
@@ -69,6 +71,7 @@ fun bePositiveInfinity() = object : Matcher<Double> {
  *
  * @see [beNegativeInfinity]
  */
+@IgnorableReturnValue
 fun Double.shouldBeNegativeInfinity(): Double {
    this should beNegativeInfinity()
    return this
@@ -86,6 +89,7 @@ fun Double.shouldBeNegativeInfinity(): Double {
  *
  * @see [beNegativeInfinity]
  */
+@IgnorableReturnValue
 fun Double.shouldNotBeNegativeInfinity(): Double {
    this shouldNot beNegativeInfinity()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/LessThan.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/LessThan.kt
@@ -20,6 +20,7 @@ import io.kotest.matchers.shouldNotBe
  * @see [Double.shouldNotBeGreaterThan]
  * @see [Double.shouldBeLessThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldBeLessThan(x: Double): Double {
    this shouldBe lt(x)
    return this
@@ -39,6 +40,7 @@ infix fun Double.shouldBeLessThan(x: Double): Double {
  * @see [Double.shouldBeGreaterThan]
  * @see [Double.shouldNotBeLessThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldNotBeLessThan(x: Double): Double {
    this shouldNotBe lt(x)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/LessThanOrEqual.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/LessThanOrEqual.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.shouldNotBe
  * @see [Double.shouldBeLessThan]
  * @see [Double.shouldNotBeGreaterThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldBeLessThanOrEqual(x: Double): Double {
    this shouldBe lte(x)
    return this
@@ -40,6 +41,7 @@ infix fun Double.shouldBeLessThanOrEqual(x: Double): Double {
  * @see [Double.shouldNotBeLessThan]
  * @see [Double.shouldBeGreaterThanOrEqual]
  */
+@IgnorableReturnValue
 infix fun Double.shouldNotBeLessThanOrEqual(x: Double): Double {
    this shouldNotBe lte(x)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Multiple.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Multiple.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.should
 /**
  * Beware, has no tolerance handling so will fail for numbers where the orders of magnitude vary greatly.
  */
+@IgnorableReturnValue
 infix fun Double?.shouldBeMultipleOf(other: Double): Double? {
    this should beMultipleOf(other)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/NaN.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/NaN.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.shouldNot
  * ```
  * @see [beNaN]
  */
+@IgnorableReturnValue
 fun Double.shouldBeNaN(): Double {
    this should beNaN()
    return this
@@ -36,6 +37,7 @@ fun Double.shouldBeNaN(): Double {
  * ```
  * @see [beNaN]
  */
+@IgnorableReturnValue
 fun Double.shouldNotBeNaN(): Double {
    this shouldNot beNaN()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Negative.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Negative.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldNotBe
  *
  * @see [Double.shouldNotBePositive]
  */
+@IgnorableReturnValue
 fun Double.shouldBeNegative(): Double {
    this shouldBe negative()
    return this
@@ -38,6 +39,7 @@ fun Double.shouldBeNegative(): Double {
  *
  * @see [Double.shouldBePositive]
  */
+@IgnorableReturnValue
 fun Double.shouldNotBeNegative(): Double {
    this shouldNotBe negative()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Positive.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Positive.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldNotBe
  *
  * @see [Double.shouldNotBeNegative]
  */
+@IgnorableReturnValue
 fun Double.shouldBePositive(): Double {
    this shouldBe positive()
    return this
@@ -38,6 +39,7 @@ fun Double.shouldBePositive(): Double {
  *
  * @see [Double.shouldBeNegative]
  */
+@IgnorableReturnValue
 fun Double.shouldNotBePositive(): Double {
    this shouldNotBe positive()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Tolerance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Tolerance.kt
@@ -87,6 +87,7 @@ class ToleranceMatcher(private val expected: Double?, private val tolerance: Dou
  * 30.0.shouldBeWithinPercentageOf(100.0, 10.0)  // Fail
  *
  */
+@IgnorableReturnValue
 fun Double.shouldBeWithinPercentageOf(other: Double, percentage: Double): Double {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this should beWithinPercentageOf(other, percentage)
@@ -101,6 +102,7 @@ fun Double.shouldBeWithinPercentageOf(other: Double, percentage: Double): Double
  * 30.0.shouldNotBeWithinPercentageOf(100.0, 10.0)  // Passes
  *
  */
+@IgnorableReturnValue
 fun Double.shouldNotBeWithinPercentageOf(other: Double, percentage: Double): Double {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this shouldNot beWithinPercentageOf(other, percentage)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Zero.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/doubles/Zero.kt
@@ -13,6 +13,7 @@ package io.kotest.matchers.doubles
  * -0.1 shouldBeZero()   // Assertion fails
  * ```
  */
+@IgnorableReturnValue
 fun Double.shouldBeZero(): Double {
    this shouldBeExactly 0.0
    return this
@@ -31,6 +32,7 @@ fun Double.shouldBeZero(): Double {
  * 0.0 shouldNotBeZero()   // Assertion fails
  * ```
  */
+@IgnorableReturnValue
 fun Double.shouldNotBeZero(): Double {
    this shouldNotBeExactly 0.0
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/shouldEqual.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/equals/shouldEqual.kt
@@ -8,11 +8,13 @@ import io.kotest.matchers.MatcherResultBuilder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <A : Any> A.shouldBeEqual(expected: A): A {
    this should beEqual(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <A : Any> A.shouldNotBeEqual(expected: A): A {
    this shouldNot beEqual(expected)
    return this
@@ -29,6 +31,7 @@ infix fun <A : Any> A.shouldNotBeEqual(expected: A): A {
  * 1 shouldEqual "1"     // compile error - Int vs String
  * ```
  */
+@IgnorableReturnValue
 infix fun <@kotlin.internal.OnlyInputTypes T> T.shouldEqual(expected: T): T {
    this should beEqual(expected)
    return this
@@ -45,6 +48,7 @@ infix fun <@kotlin.internal.OnlyInputTypes T> T.shouldEqual(expected: T): T {
  * 1 shouldNotEqual "1"     // compile error - Int vs String
  * ```
  */
+@IgnorableReturnValue
 infix fun <@kotlin.internal.OnlyInputTypes T> T.shouldNotEqual(expected: T): T {
    this shouldNot beEqual(expected)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Between.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Between.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldNotBe
  * 0.5.shouldBeBetween(0.2, 0.3, 0.1)   // Assertion fails
  * ```
  */
+@IgnorableReturnValue
 fun Float.shouldBeBetween(a: Float, b: Float, tolerance: Float): Float {
    this shouldBe between(a, b, tolerance)
    return this
@@ -43,6 +44,7 @@ fun Float.shouldBeBetween(a: Float, b: Float, tolerance: Float): Float {
  * 0.5.shouldNotBeBetween(0.2, 0.3, 0.1)   // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun Float.shouldNotBeBetween(a: Float, b: Float, tolerance: Float): Float {
    this shouldNotBe between(a, b, tolerance)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Infinity.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Infinity.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.shouldNot
  *
  * @see [bePositiveInfinity]
  */
+@IgnorableReturnValue
 fun Float.shouldBePositiveInfinity(): Float {
    this should bePositiveInfinity()
    return this
@@ -34,6 +35,7 @@ fun Float.shouldBePositiveInfinity(): Float {
  *
  * @see [bePositiveInfinity]
  */
+@IgnorableReturnValue
 fun Float.shouldNotBePositiveInfinity(): Float {
    this shouldNot bePositiveInfinity()
    return this
@@ -68,6 +70,7 @@ fun bePositiveInfinity() = object : Matcher<Float> {
  *
  * @see [beNegativeInfinity]
  */
+@IgnorableReturnValue
 fun Float.shouldBeNegativeInfinity(): Float {
    this should beNegativeInfinity()
    return this
@@ -85,6 +88,7 @@ fun Float.shouldBeNegativeInfinity(): Float {
  *
  * @see [beNegativeInfinity]
  */
+@IgnorableReturnValue
 fun Float.shouldNotBeNegativeInfinity(): Float {
    this shouldNot beNegativeInfinity()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/NaN.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/NaN.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.shouldNot
  * ```
  * @see [beNaN]
  */
+@IgnorableReturnValue
 fun Float.shouldBeNaN(): Float {
    this should beNaN()
    return this
@@ -36,6 +37,7 @@ fun Float.shouldBeNaN(): Float {
  * ```
  * @see [beNaN]
  */
+@IgnorableReturnValue
 fun Float.shouldNotBeNaN(): Float {
    this shouldNot beNaN()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Negative.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Negative.kt
@@ -18,6 +18,7 @@ import io.kotest.matchers.shouldNotBe
  *
  * @see [Float.shouldNotBePositive]
  */
+@IgnorableReturnValue
 fun Float.shouldBeNegative(): Float {
    this shouldBe negative()
    return this
@@ -37,6 +38,7 @@ fun Float.shouldBeNegative(): Float {
  *
  * @see [Float.shouldBePositive]
  */
+@IgnorableReturnValue
 fun Float.shouldNotBeNegative(): Float {
    this shouldNotBe negative()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Positive.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/Positive.kt
@@ -19,6 +19,7 @@ import io.kotest.matchers.shouldNotBe
  *
  * @see [Float.shouldNotBeNegative]
  */
+@IgnorableReturnValue
 fun Float.shouldBePositive(): Float {
    this shouldBe positive()
    return this
@@ -38,6 +39,7 @@ fun Float.shouldBePositive(): Float {
  *
  * @see [Float.shouldBeNegative]
  */
+@IgnorableReturnValue
 fun Float.shouldNotBePositive(): Float {
    this shouldNotBe positive()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/floats/matchers.kt
@@ -63,43 +63,52 @@ fun beGreaterThanOrEqualTo(x: Float) = object : Matcher<Float> {
          { "$value should not be >= $x" })
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldBeLessThan(x: Float): Float {
    this shouldBe lt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldNotBeLessThan(x: Float): Float {
    this shouldNotBe lt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldBeLessThanOrEqual(x: Float): Float {
    this shouldBe lte(x)
    return this
 }
+@IgnorableReturnValue
 infix fun Float.shouldNotBeLessThanOrEqual(x: Float): Float {
    this shouldNotBe lte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldBeGreaterThan(x: Float): Float {
    this shouldBe gt(x)
    return this
 }
+@IgnorableReturnValue
 infix fun Float.shouldNotBeGreaterThan(x: Float): Float {
    this shouldNotBe gt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldBeGreaterThanOrEqual(x: Float): Float {
    this shouldBe gte(x)
    return this
 }
+@IgnorableReturnValue
 infix fun Float.shouldNotBeGreaterThanOrEqual(x: Float): Float {
    this shouldNotBe gte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldBeExactly(x: Float): Float {
    if (AssertionsConfig.disableNaNEquality) {
       this shouldBe exactly(x)
@@ -109,6 +118,7 @@ infix fun Float.shouldBeExactly(x: Float): Float {
    return this
 }
 
+@IgnorableReturnValue
 infix fun Float.shouldNotBeExactly(x: Float): Float {
    if (AssertionsConfig.disableNaNEquality) {
       this shouldNotBe exactly(x)
@@ -118,10 +128,12 @@ infix fun Float.shouldNotBeExactly(x: Float): Float {
    return this
 }
 
+@IgnorableReturnValue
 fun Float.shouldBeZero(): Float {
    this shouldBeExactly 0f
    return this
 }
+@IgnorableReturnValue
 fun Float.shouldNotBeZero(): Float {
    this shouldNotBeExactly 0f
    return this
@@ -136,6 +148,7 @@ fun Float.shouldNotBeZero(): Float {
  * 30.0.shouldBeWithinPercentageOf(100.0, 10.0)  // Fail
  *
  */
+@IgnorableReturnValue
 fun Float.shouldBeWithinPercentageOf(other: Float, percentage: Double): Float {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this should beWithinPercentageOf(other, percentage)
@@ -150,6 +163,7 @@ fun Float.shouldBeWithinPercentageOf(other: Float, percentage: Double): Float {
  * 30.0.shouldNotBeWithinPercentageOf(100.0, 10.0)  // Passes
  *
  */
+@IgnorableReturnValue
 fun Float.shouldNotBeWithinPercentageOf(other: Float, percentage: Double): Float {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this shouldNot beWithinPercentageOf(other, percentage)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/IntMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/IntMatchers.kt
@@ -15,6 +15,7 @@ import kotlin.math.absoluteValue
    "Int-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Int import `io.kotest.matchers.ints.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(a, b)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun Int.shouldBeBetween(a: Int, b: Int) = this shouldBe between(a, b)
 
 /**
@@ -24,6 +25,7 @@ fun Int.shouldBeBetween(a: Int, b: Int) = this shouldBe between(a, b)
    "Int-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Int import `io.kotest.matchers.ints.shouldNotBeBetween` manually.",
    ReplaceWith("shouldNotBeBetween(a, b)", "io.kotest.matchers.comparables.shouldNotBeBetween")
 )
+@IgnorableReturnValue
 fun Int.shouldNotBeBetween(a: Int, b: Int) = this shouldNot between(a, b)
 
 /**
@@ -83,6 +85,7 @@ fun beGreaterThanOrEqualTo(x: Int) = object : Matcher<Int> {
 /**
  * Match that verifies a given integer is within the given [IntRange].
  */
+@IgnorableReturnValue
 infix fun Int.shouldBeInRange(range: IntRange): Int {
    this should beInRange(range)
    return this
@@ -91,6 +94,7 @@ infix fun Int.shouldBeInRange(range: IntRange): Int {
 /**
  * Match that verifies a given integer is not within the given [IntRange].
  */
+@IgnorableReturnValue
 infix fun Int.shouldNotBeInRange(range: IntRange): Int {
    this shouldNot beInRange(range)
    return this
@@ -124,6 +128,7 @@ fun exactly(x: Int) = object : Matcher<Int> {
  * 30.shouldBeWithinPercentageOf(100, 10.0)  // Fail
  *
  */
+@IgnorableReturnValue
 fun Int.shouldBeWithinPercentageOf(other: Int, percentage: Double): Int {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this should beWithinPercentageOf(other, percentage)
@@ -138,6 +143,7 @@ fun Int.shouldBeWithinPercentageOf(other: Int, percentage: Double): Int {
  * 30.shouldNotBeWithinPercentageOf(100, 10.0)  // Passes
  *
  */
+@IgnorableReturnValue
 fun Int.shouldNotBeWithinPercentageOf(other: Int, percentage: Double): Int {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this shouldNot beWithinPercentageOf(other, percentage)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/int.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/int.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 
+@IgnorableReturnValue
 fun Int.shouldBePositive(): Int {
    this shouldBe positive()
    return this
@@ -23,6 +24,7 @@ fun positive() = object : Matcher<Int> {
       { "$value should not be > 0" })
 }
 
+@IgnorableReturnValue
 fun Int.shouldBeNonNegative(): Int {
    this shouldBe nonNegative()
    return this
@@ -36,6 +38,7 @@ fun nonNegative() = object : Matcher<Int> {
          { "$value should not be >= 0" })
 }
 
+@IgnorableReturnValue
 fun Int.shouldBeNegative(): Int {
    this shouldBe negative()
    return this
@@ -48,6 +51,7 @@ fun negative() = object : Matcher<Int> {
       { "$value should not be < 0" })
 }
 
+@IgnorableReturnValue
 fun Int.shouldBeNonPositive(): Int {
    this shouldBe nonPositive()
    return this
@@ -61,11 +65,13 @@ fun nonPositive() = object : Matcher<Int> {
          { "$value should not be <= 0" })
 }
 
+@IgnorableReturnValue
 fun Int.shouldBeEven(): Int {
    this should beEven()
    return this
 }
 
+@IgnorableReturnValue
 fun Int.shouldNotBeEven(): Int {
    this shouldNot beEven()
    return this
@@ -79,11 +85,13 @@ fun beEven() = object : Matcher<Int> {
          { "$value should be odd" })
 }
 
+@IgnorableReturnValue
 fun Int.shouldBeOdd(): Int {
    this should beOdd()
    return this
 }
 
+@IgnorableReturnValue
 fun Int.shouldNotBeOdd(): Int {
    this shouldNot beOdd()
    return this
@@ -97,66 +105,82 @@ fun beOdd() = object : Matcher<Int> {
          { "$value should be even" })
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeLessThan(x: Int): Int {
    this shouldBe lt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldNotBeLessThan(x: Int): Int {
    this shouldNotBe lt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeLessThanOrEqual(x: Int): Int {
    this shouldBe lte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeAtMost(x: Int): Int = this.shouldBeLessThanOrEqual(x)
+@IgnorableReturnValue
 infix fun Int.shouldNotBeAtMost(x: Int): Int = this.shouldBeGreaterThan(x)
+@IgnorableReturnValue
 infix fun Int.shouldBeAtLeast(x: Int): Int = this.shouldBeGreaterThanOrEqual(x)
+@IgnorableReturnValue
 infix fun Int.shouldNotBeAtLeast(x: Int): Int = this.shouldBeLessThan(x)
 
+@IgnorableReturnValue
 infix fun Int.shouldNotBeLessThanOrEqual(x: Int): Int {
    this shouldNotBe lte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeGreaterThan(x: Int): Int {
    this shouldBe gt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldNotBeGreaterThan(x: Int): Int {
    this shouldNotBe gt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeGreaterThanOrEqual(x: Int): Int {
    this shouldBe gte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldNotBeGreaterThanOrEqual(x: Int): Int {
    this shouldNotBe gte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldBeExactly(x: Int): Int {
    this shouldBe exactly(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Int.shouldNotBeExactly(x: Int): Int {
    this shouldNotBe exactly(x)
    return this
 }
 
+@IgnorableReturnValue
 fun Int.shouldBeZero(): Int {
    this shouldBeExactly 0
    return this
 }
 
+@IgnorableReturnValue
 fun Int.shouldNotBeZero(): Int {
    this shouldNotBeExactly 0
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/uint.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ints/uint.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
    "UInt-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the UInt import `io.kotest.matchers.ints.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(lower, upper)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun UInt.shouldBeBetween(lower: UInt, upper: UInt): UInt {
    this shouldBe between(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/iterator/IteratorMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/iterator/IteratorMatchers.kt
@@ -5,10 +5,14 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <T> Iterator<T>.shouldBeEmpty() = this should beEmpty()
+@IgnorableReturnValue
 fun <T> Iterator<T>.shouldNotHaveNext() = this.shouldBeEmpty()
 
+@IgnorableReturnValue
 fun <T> Iterator<T>.shouldHaveNext() = this.shouldNotBeEmpty()
+@IgnorableReturnValue
 fun <T> Iterator<T>.shouldNotBeEmpty() = this shouldNot beEmpty()
 
 fun <T> beEmpty(): Matcher<Iterator<T>> = object : Matcher<Iterator<T>> {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/LongMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/LongMatchers.kt
@@ -42,7 +42,9 @@ fun beGreaterThanOrEqualTo(x: Long) = object : Matcher<Long> {
          { "$value should not be >= $x" })
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeInRange(range: LongRange) = this should beInRange(range)
+@IgnorableReturnValue
 infix fun Long.shouldNotBeInRange(range: LongRange) = this shouldNot beInRange(range)
 fun beInRange(range: LongRange) = object : Matcher<Long> {
    override fun test(value: Long): MatcherResult =
@@ -68,6 +70,7 @@ fun exactly(x: Long) = object : Matcher<Long> {
  * 30.shouldBeWithinPercentageOf(100, 10.0)  // Fail
  *
  */
+@IgnorableReturnValue
 fun Long.shouldBeWithinPercentageOf(other: Long, percentage: Double) {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this should beWithinPercentageOf(other, percentage)
@@ -81,6 +84,7 @@ fun Long.shouldBeWithinPercentageOf(other: Long, percentage: Double) {
  * 30.shouldNotBeWithinPercentageOf(100, 10.0)  // Passes
  *
  */
+@IgnorableReturnValue
 fun Long.shouldNotBeWithinPercentageOf(other: Long, percentage: Double) {
    require(percentage > 0.0) { "Percentage must be > 0.0" }
    this shouldNot beWithinPercentageOf(other, percentage)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/between.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/between.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNot
    "Long-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Long import `io.kotest.matchers.longs.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(a, b)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun Long.shouldBeBetween(a: Long, b: Long): Long {
    this shouldBe between(a, b)
    return this
@@ -24,6 +25,7 @@ fun Long.shouldBeBetween(a: Long, b: Long): Long {
    "Long-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Long import `io.kotest.matchers.longs.shouldNotBeBetween` manually.",
    ReplaceWith("shouldNotBeBetween(a, b)", "io.kotest.matchers.comparables.shouldNotBeBetween")
 )
+@IgnorableReturnValue
 fun Long.shouldNotBeBetween(a: Long, b: Long): Long {
    this shouldNot between(a, b)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/long.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/long.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 
+@IgnorableReturnValue
 fun Long.shouldBePositive(): Long {
    this shouldBe positiveL()
    return this
@@ -24,6 +25,7 @@ fun positiveL() = object : Matcher<Long> {
          { "$value should not be > 0" })
 }
 
+@IgnorableReturnValue
 fun Long.shouldBeNonNegative(): Long {
    this shouldBe nonNegativeL()
    return this
@@ -37,6 +39,7 @@ fun nonNegativeL() = object : Matcher<Long> {
          { "$value should not be >= 0" })
 }
 
+@IgnorableReturnValue
 fun Long.shouldBeNegative(): Long {
    this shouldBe negativeL()
    return this
@@ -50,6 +53,7 @@ fun negativeL() = object : Matcher<Long> {
          { "$value should not be < 0" })
 }
 
+@IgnorableReturnValue
 fun Long.shouldBeNonPositive(): Long {
    this shouldBe nonPositiveL()
    return this
@@ -63,11 +67,13 @@ fun nonPositiveL() = object : Matcher<Long> {
          { "$value should not be <= 0" })
 }
 
+@IgnorableReturnValue
 fun Long.shouldBeEven(): Long {
    this should lbeEven()
    return this
 }
 
+@IgnorableReturnValue
 fun Long.shouldNotBeEven(): Long {
    this shouldNot lbeEven()
    return this
@@ -81,11 +87,13 @@ fun lbeEven() = object : Matcher<Long> {
          { "$value should be odd" })
 }
 
+@IgnorableReturnValue
 fun Long.shouldBeOdd(): Long {
    this should lbeOdd()
    return this
 }
 
+@IgnorableReturnValue
 fun Long.shouldNotBeOdd(): Long {
    this shouldNot lbeOdd()
    return this
@@ -99,66 +107,82 @@ fun lbeOdd() = object : Matcher<Long> {
          { "$value should be even" })
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeLessThan(x: Long): Long {
    this shouldBe lt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldNotBeLessThan(x: Long): Long {
    this shouldNotBe lt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeLessThanOrEqual(x: Long): Long {
    this shouldBe lte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldNotBeLessThanOrEqual(x: Long): Long {
    this shouldNotBe lte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeGreaterThan(x: Long): Long {
    this shouldBe gt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldNotBeGreaterThan(x: Long): Long {
    this shouldNotBe gt(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeGreaterThanOrEqual(x: Long): Long {
    this shouldBe gte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldNotBeGreaterThanOrEqual(x: Long): Long {
    this shouldNotBe gte(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldBeAtMost(x: Long): Long = this.shouldBeLessThanOrEqual(x)
+@IgnorableReturnValue
 infix fun Long.shouldNotBeAtMost(x: Long): Long = this.shouldBeGreaterThan(x)
+@IgnorableReturnValue
 infix fun Long.shouldBeAtLeast(x: Long): Long = this.shouldBeGreaterThanOrEqual(x)
+@IgnorableReturnValue
 infix fun Long.shouldNotBeAtLeast(x: Long): Long = this.shouldBeLessThan(x)
 
+@IgnorableReturnValue
 infix fun Long.shouldBeExactly(x: Long): Long {
    this shouldBe exactly(x)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Long.shouldNotBeExactly(x: Long): Long {
    this shouldNotBe exactly(x)
    return this
 }
 
+@IgnorableReturnValue
 fun Long.shouldBeZero(): Long {
    this shouldBeExactly 0L
    return this
 }
 
+@IgnorableReturnValue
 fun Long.shouldNotBeZero(): Long {
    this shouldNotBeExactly 0L
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/multipleOf.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/multipleOf.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 
+@IgnorableReturnValue
 infix fun Long?.shouldBeMultipleOf(other: Long): Long? {
    this should beMultipleOf(other)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/ulong.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/longs/ulong.kt
@@ -11,6 +11,7 @@ import io.kotest.matchers.shouldBe
    "ULong-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the ULong import `io.kotest.matchers.longs.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(lower, upper)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun ULong.shouldBeBetween(lower: ULong, upper: ULong): ULong {
    this shouldBe between(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/maps/matchers.kt
@@ -5,130 +5,159 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldContain(key: K, value: V): Map<K, V> {
    this should mapcontain(key, value)
    return this
 }
 
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotContain(key: K, value: V): Map<K, V> {
    this shouldNot mapcontain(key, value)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldContain(entry: Pair<K, V>): Map<K, V> {
    this should mapcontain(entry.first, entry.second)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldNotContain(entry: Pair<K, V>): Map<K, V> {
    this shouldNot mapcontain(entry.first, entry.second)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldContainExactly(expected: Map<K, V>): Map<K, V> {
    this should containExactly(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldNotContainExactly(expected: Map<K, V>): Map<K, V> {
    this shouldNot containExactly(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldContainAll(expected: Map<K, V>): Map<K, V> {
    this should containAll(expected)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldNotContainAll(expected: Map<K, V>): Map<K, V> {
    this shouldNot containAll(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V : Any> Map<K, V>.shouldHaveKey(key: K): Map<K, V> {
    this should haveKey(key)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V : Any> Map<K, V>.shouldContainKey(key: K): Map<K, V> {
    this should haveKey(key)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V : Any> Map<K, V>.shouldNotHaveKey(key: K): Map<K, V> {
    this shouldNot haveKey(key)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V : Any> Map<K, V>.shouldNotContainKey(key: K): Map<K, V> {
    this shouldNot haveKey(key)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldContainValue(value: V): Map<K, V> {
    this should haveValue<V>(value)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldNotContainValue(value: V): Map<K, V> {
    this shouldNot haveValue<V>(value)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldHaveSize(size: Int): Map<K, V> {
    this should haveSize(size)
    return this
 }
 
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldHaveKeys(vararg keys: K): Map<K, V> {
    this should haveKeys(*keys)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldContainKeys(vararg keys: K): Map<K, V> {
    this should haveKeys(*keys)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldContainAnyKeysOf(vararg keys: K): Map<K, V> {
    this should containAnyKeys(*keys)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotHaveKeys(vararg keys: K): Map<K, V> {
    this shouldNot haveKeys(*keys)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotContainKeys(vararg keys: K): Map<K, V> {
    this shouldNot haveKeys(*keys)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotContainAnyKeysOf(vararg keys: K): Map<K, V> {
    this shouldNot containAnyKeys(*keys)
    return this
 }
 
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldHaveValues(vararg values: V): Map<K, V> {
    this should haveValues(*values)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldContainValues(vararg values: V): Map<K, V> {
    this should haveValues(*values)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldContainAnyValuesOf(vararg values: V): Map<K, V> {
    this should containAnyValues(*values)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotHaveValues(vararg values: V): Map<K, V> {
    this shouldNot haveValues(*values)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotContainValues(vararg values: V): Map<K, V> {
    this shouldNot haveValues(*values)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotContainAnyValuesOf(vararg values: V): Map<K, V> {
    this shouldNot containAnyValues(*values)
    return this
 }
 
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldBeEmpty(): Map<K, V> {
    this should beEmpty()
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotBeEmpty(): Map<K, V> {
    this shouldNot beEmpty()
    return this
@@ -145,35 +174,43 @@ fun beEmpty() = object : Matcher<Map<*, *>> {
 }
 
 
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldMatchAll(vararg matchers: Pair<K, (V) -> Unit>): Map<K, V> {
    this should matchAll(*matchers)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldMatchAll(expected: Map<K, (V) -> Unit>): Map<K, V> {
    this should matchAll(expected)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotMatchAll(vararg matchers: Pair<K, (V) -> Unit>): Map<K, V> {
    this shouldNot matchAll(*matchers)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldNotMatchAll(expected: Map<K, (V) -> Unit>): Map<K, V> {
    this shouldNot matchAll(expected)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldMatchExactly(vararg matchers: Pair<K, (V) -> Unit>): Map<K, V> {
    this should matchExactly(*matchers)
    return this
 }
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldMatchExactly(expected: Map<K, (V) -> Unit>): Map<K, V> {
    this should matchExactly(expected)
    return this
 }
+@IgnorableReturnValue
 fun <K, V> Map<K, V>.shouldNotMatchExactly(vararg matchers: Pair<K, (V) -> Unit>): Map<K, V> {
    this shouldNot matchExactly(*matchers)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <K, V> Map<K, V>.shouldNotMatchExactly(expected: Map<K, (V) -> Unit>): Map<K, V> {
    this shouldNot matchExactly(expected)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/nulls/matchers.kt
@@ -23,6 +23,7 @@ import kotlin.contracts.contract
  *
  * ```
  */
+@IgnorableReturnValue
 fun Any?.shouldBeNull() {
   contract {
     returns() implies (this@shouldBeNull == null)
@@ -63,6 +64,7 @@ fun Any?.shouldBeNull() {
  *
  * ```
  */
+@IgnorableReturnValue
 fun <T> T?.shouldNotBeNull(): T {
    contract {
       returns() implies (this@shouldNotBeNull != null)
@@ -79,6 +81,7 @@ fun <T> T?.shouldNotBeNull(): T {
  *     length should beEven()
  * }
  */
+@IgnorableReturnValue
 inline infix fun <T : Any> T?.shouldNotBeNull(block: T.() -> Unit): T {
    contract {
       returns() implies (this@shouldNotBeNull != null)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/properties/properties.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/properties/properties.kt
@@ -18,6 +18,7 @@ import kotlin.reflect.KProperty0
  * Asserts that this property has a specific value. Unlike regular [shouldBe], the name of the property
  * will be automatically added to the error message
  */
+@IgnorableReturnValue
 infix fun <T> KProperty0<T>.shouldHaveValue(expected: T): KProperty0<T> {
    this should haveValue(expected)
    return this
@@ -27,6 +28,7 @@ infix fun <T> KProperty0<T>.shouldHaveValue(expected: T): KProperty0<T> {
  * Asserts that this property does not have a specific value. Unlike regular [shouldNotBe], the name of the
  * property will be automatically added to the error message
  */
+@IgnorableReturnValue
 infix fun <T> KProperty0<T>.shouldNotHaveValue(expected: T): KProperty0<T> {
    this shouldNot haveValue(expected)
    return this
@@ -52,6 +54,7 @@ fun <T> haveValue(expected: T) = object : Matcher<KProperty0<T>> {
  *
  * The name of the property will be automatically added to the error message should any failures occur within the block.
  */
+@IgnorableReturnValue
 inline infix fun <T> KProperty0<T>.shouldMatch(block: T.() -> Unit) {
    withClue(name) {
       block(get())

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bein.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bein.kt
@@ -18,11 +18,13 @@ import io.kotest.matchers.shouldNot
  * @see [shouldNotBeIn]
  * @see [beIn]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeIn(range: ClosedRange<T>): T {
    this should beIn(range)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldBeInOpenEndRange(range: OpenEndRange<T>): T {
    this should beInOpenEndRange(range)
    return this
@@ -39,11 +41,13 @@ infix fun <T : Comparable<T>> T.shouldBeInOpenEndRange(range: OpenEndRange<T>): 
  * @see [shouldNotBeIn]
  * @see [beIn]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeIn(range: ClosedRange<T>): T {
    this shouldNot beIn(range)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> T.shouldNotBeInOpenEndRange(range: OpenEndRange<T>): T {
    this shouldNot beInOpenEndRange(range)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bewithin.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/bewithin.kt
@@ -17,6 +17,7 @@ import io.kotest.matchers.shouldNot
  * @see [shouldBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldBeWithin(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should beWithin(Range.ofClosedRange(range))
    return this
@@ -33,6 +34,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldBeWithin(range: ClosedRange<T
  * @see [shouldBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 inline infix fun <reified T : Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: ClosedRange<T>): OpenEndRange<T> {
    when (T::class) {
       Int::class -> shouldBeWithinRangeOfInt(
@@ -59,6 +61,7 @@ inline infix fun <reified T : Comparable<T>> OpenEndRange<T>.shouldBeWithin(rang
  * @see [shouldBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldBeWithin(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should beWithin(Range.ofOpenEndRange(range))
    return this
@@ -73,6 +76,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldBeWithin(range: OpenEndRange<
  * @see [shouldBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) should beWithin(Range.ofOpenEndRange(range))
    return this
@@ -89,6 +93,7 @@ infix fun <T : Comparable<T>> OpenEndRange<T>.shouldBeWithin(range: OpenEndRange
  * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot beWithin(Range.ofClosedRange(range))
    return this
@@ -103,6 +108,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: ClosedRang
  * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot beWithin(Range.ofOpenEndRange(range))
    return this
@@ -119,6 +125,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotBeWithin(range: OpenEndRan
  * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 inline infix fun <reified T : Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(range: ClosedRange<T>): OpenEndRange<T> {
 
    when (T::class) {
@@ -146,6 +153,7 @@ inline infix fun <reified T : Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(r
  * @see [shouldNotBeWithin]
  * @see [beWithin]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotBeWithin(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) shouldNot beWithin(Range.ofOpenEndRange(range))
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/intersect.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/intersect.kt
@@ -16,6 +16,7 @@ import io.kotest.matchers.shouldNot
  * @see [shouldIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldIntersect(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should intersect(Range.ofClosedRange(range))
    return this
@@ -31,6 +32,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldIntersect(range: ClosedRange<
  * @see [shouldIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> OpenEndRange<T>.shouldIntersect(range: ClosedRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) should intersect(Range.ofClosedRange(range))
    return this
@@ -44,6 +46,7 @@ infix fun <T : Comparable<T>> OpenEndRange<T>.shouldIntersect(range: ClosedRange
  * @see [shouldIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldIntersect(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) should intersect(Range.ofOpenEndRange(range))
    return this
@@ -57,6 +60,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldIntersect(range: OpenEndRange
  * @see [shouldIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> OpenEndRange<T>.shouldIntersect(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) should intersect(Range.ofOpenEndRange(range))
    return this
@@ -72,6 +76,7 @@ infix fun <T : Comparable<T>> OpenEndRange<T>.shouldIntersect(range: OpenEndRang
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: ClosedRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot intersect(Range.ofClosedRange(range))
    return this
@@ -85,6 +90,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: ClosedRan
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: OpenEndRange<T>): ClosedRange<T> {
    Range.ofClosedRange(this) shouldNot intersect(Range.ofOpenEndRange(range))
    return this
@@ -100,6 +106,7 @@ infix fun <T : Comparable<T>> ClosedRange<T>.shouldNotIntersect(range: OpenEndRa
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: ClosedRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) shouldNot intersect(Range.ofClosedRange(range))
    return this
@@ -113,6 +120,7 @@ infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: ClosedRa
  * @see [shouldNotIntersect]
  * @see [intersect]
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> OpenEndRange<T>.shouldNotIntersect(range: OpenEndRange<T>): OpenEndRange<T> {
    Range.ofOpenEndRange(this) shouldNot intersect(Range.ofOpenEndRange(range))
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/regex/RegexMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/regex/RegexMatchers.kt
@@ -12,6 +12,7 @@ import io.kotest.matchers.shouldNot
  * @see [beRegex]
  * */
 @Deprecated("Use `shouldEqualRegex` instead. Deprecated in 6.0", ReplaceWith("this shouldEqualRegex anotherRegex"))
+@IgnorableReturnValue
 infix fun Regex.shouldBeRegex(anotherRegex: Regex): Regex = shouldEqualRegex(anotherRegex)
 
 /**
@@ -20,6 +21,7 @@ infix fun Regex.shouldBeRegex(anotherRegex: Regex): Regex = shouldEqualRegex(ano
  * @see [shouldNotBeRegex]
  * @see [beRegex]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldEqualRegex(anotherRegex: Regex): Regex {
    this should beRegex(anotherRegex)
    return this
@@ -35,6 +37,7 @@ infix fun Regex.shouldEqualRegex(anotherRegex: Regex): Regex {
    "Use `shouldNotEqualRegex` instead. Deprecated in 6.0",
    ReplaceWith("this shouldNotEqualRegex anotherRegex")
 )
+@IgnorableReturnValue
 infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldNotEqualRegex(anotherRegex)
 
 /**
@@ -43,6 +46,7 @@ infix fun Regex.shouldNotBeRegex(anotherRegex: Regex): Regex = shouldNotEqualReg
  * @see [shouldBeRegex]
  * @see [beRegex]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldNotEqualRegex(anotherRegex: Regex): Regex {
    this shouldNot beRegex(anotherRegex)
    return this
@@ -64,6 +68,7 @@ fun areEqualRegexMatcher(regex: Regex) = object : Matcher<Regex> {
  * @see [shouldNotHavePattern]
  * @see [havePattern]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldHavePattern(regexPattern: String): Regex {
    this should havePattern(regexPattern)
    return this
@@ -74,6 +79,7 @@ infix fun Regex.shouldHavePattern(regexPattern: String): Regex {
  * @see [shouldHavePattern]
  * @see [havePattern]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldNotHavePattern(regexPattern: String): Regex {
    this shouldNot havePattern(regexPattern)
    return this
@@ -96,6 +102,7 @@ fun haveSamePatternMatcher(pattern: String) = object : Matcher<Regex> {
  * @see [shouldNotHaveExactRegexOptions]
  * @see [haveExactOptions]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldHaveExactRegexOptions(regexOptions: Set<RegexOption>): Regex {
    this should haveExactOptions(regexOptions)
    return this
@@ -106,6 +113,7 @@ infix fun Regex.shouldHaveExactRegexOptions(regexOptions: Set<RegexOption>): Reg
  * @see [shouldHaveExactRegexOptions]
  * @see [haveExactOptions]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldNotHaveExactRegexOptions(regexOptions: Set<RegexOption>): Regex {
    this shouldNot haveExactOptions(regexOptions)
    return this
@@ -128,6 +136,7 @@ fun haveSameRegexOptionsMatcher(options: Set<RegexOption>) = object : Matcher<Re
  * @see [shouldNotIncludeRegexOption]
  * @see [includeOption]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldIncludeRegexOption(regexOption: RegexOption): Regex {
    this should includeOption(regexOption)
    return this
@@ -138,6 +147,7 @@ infix fun Regex.shouldIncludeRegexOption(regexOption: RegexOption): Regex {
  * @see [shouldIncludeRegexOption]
  * @see [includeOption]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldNotIncludeRegexOption(regexOption: RegexOption): Regex {
    this shouldNot includeOption(regexOption)
    return this
@@ -160,6 +170,7 @@ fun haveRegexOptionMatcher(option: RegexOption) = object : Matcher<Regex> {
  * @see [shouldNotIncludeRegexOptions]
  * @see [includeOptions]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldIncludeRegexOptions(regexOptions: Set<RegexOption>): Regex {
    this should includeOptions(regexOptions)
    return this
@@ -170,6 +181,7 @@ infix fun Regex.shouldIncludeRegexOptions(regexOptions: Set<RegexOption>): Regex
  * @see [shouldIncludeRegexOptions]
  * @see [includeOptions]
  * */
+@IgnorableReturnValue
 infix fun Regex.shouldNotIncludeRegexOptions(regexOptions: Set<RegexOption>): Regex {
    this shouldNot includeOptions(regexOptions)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/regex/strings.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/regex/strings.kt
@@ -5,13 +5,19 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun Regex.shouldMatch(str: String) = this should matchString(str)
+@IgnorableReturnValue
 infix fun Regex.shouldNotMatch(str: String) = this shouldNot matchString(str)
 
+@IgnorableReturnValue
 fun Regex.shouldMatchAll(vararg strs: String) = this should matchAllStrings(*strs)
+@IgnorableReturnValue
 fun Regex.shouldNotMatchAll(vararg strs: String) = this shouldNot matchAllStrings(*strs)
 
+@IgnorableReturnValue
 fun Regex.shouldMatchAny(vararg strs: String) = this should matchAnyStrings(*strs)
+@IgnorableReturnValue
 fun Regex.shouldNotMatchAny(vararg strs: String) = this shouldNot matchAnyStrings(*strs)
 
 fun matchString(str: String) = object : Matcher<Regex> {

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/result/failures.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/result/failures.kt
@@ -16,6 +16,7 @@ import kotlin.reflect.KClass
  * @see shouldBeSuccess
  */
 @Deprecated("Use shouldBeSuccess instead. Deprecated since 6.0", ReplaceWith("shouldBeSuccess()"))
+@IgnorableReturnValue
 fun <T> Result<T>.shouldNotBeFailure(): T = shouldBeSuccess()
 
 /**
@@ -26,6 +27,7 @@ fun <T> Result<T>.shouldNotBeFailure(): T = shouldBeSuccess()
  * ~~~
  * @see shouldNotBeSuccess
  */
+@IgnorableReturnValue
 fun Result<*>.shouldBeFailure(): Throwable {
    this should FailureMatcher()
    return exceptionOrNull()!!
@@ -39,6 +41,7 @@ fun Result<*>.shouldBeFailure(): Throwable {
  * success("abc") shouldBeFailure MyException           // Assertion fails
  * ~~~
  */
+@IgnorableReturnValue
 infix fun Result<*>.shouldBeFailure(expected: Throwable): Throwable {
    this should FailureMatcher(expected)
    return exceptionOrNull()!!
@@ -52,6 +55,7 @@ infix fun Result<*>.shouldBeFailure(expected: Throwable): Throwable {
  * }
  * ~~~
  */
+@IgnorableReturnValue
 infix fun Result<*>.shouldBeFailure(block: ((Throwable) -> Unit)): Throwable {
    this should FailureMatcher()
    return exceptionOrNull()!!.also { block(it) }
@@ -66,6 +70,7 @@ infix fun Result<*>.shouldBeFailure(block: ((Throwable) -> Unit)): Throwable {
  * ~~~
  */
 @JvmName("shouldBeFailureT")
+@IgnorableReturnValue
 inline fun <reified T : Throwable> Result<*>.shouldBeFailure(block: ((T) -> Unit) = {}): T {
    this should FailureTypeMatcher(T::class)
    return (exceptionOrNull() as T).also(block)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/result/successes.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/result/successes.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.should
  * @see [shouldBeFailure]
  */
 @Deprecated("Use shouldBeFailure instead. Deprecated since 6.0. Will be removed in 6.3", ReplaceWith("shouldBeFailure()"))
+@IgnorableReturnValue
 fun <T> Result<T>.shouldNotBeSuccess(): Throwable = shouldBeFailure()
 
 /**
@@ -21,6 +22,7 @@ fun <T> Result<T>.shouldNotBeSuccess(): Throwable = shouldBeFailure()
  * success("abc").shouldBeSuccess()       // Assertion passes
  * failure(MyException).shouldBeSuccess() // Assertion fails
  */
+@IgnorableReturnValue
 fun <T> Result<T>.shouldBeSuccess(): T {
    this should beSuccess()
    return getOrThrow()
@@ -33,6 +35,7 @@ fun <T> Result<T>.shouldBeSuccess(): T {
  * success("abc") shouldBeSuccess "cba"       // Assertion fails
  * failure(MyException) shouldBeSuccess "abc" // Assertion fails
  */
+@IgnorableReturnValue
 infix fun <T> Result<T>.shouldBeSuccess(expected: T): T {
    this should beSuccess(expected)
    return getOrThrow()
@@ -50,6 +53,7 @@ infix fun <T> Result<T>.shouldBeSuccess(expected: T): T {
  * }
  *
  */
+@IgnorableReturnValue
 infix fun <T> Result<T>.shouldBeSuccess(block: ((T) -> Unit)): T {
    this should beSuccess()
    return getOrThrow().also { block(it) }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sequences/matchers.kt
@@ -31,7 +31,9 @@ For now, the documentation should mention that infinite sequences will cause the
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldContainOnlyNulls() = this should containOnlyNulls()
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotContainOnlyNulls() = this shouldNot containOnlyNulls()
 fun <T> containOnlyNulls() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
@@ -44,7 +46,9 @@ fun <T> containOnlyNulls() = object : Matcher<Sequence<T>> {
    }
 }
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldContainNull() = this should containNull()
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotContainNull() = this shouldNot containNull()
 fun <T> containNull() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
@@ -57,7 +61,9 @@ fun <T> containNull() = object : Matcher<Sequence<T>> {
    }
 }
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldHaveElementAt(index: Int, element: T) = this should haveElementAt(index, element)
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotHaveElementAt(index: Int, element: T) = this shouldNot haveElementAt(index, element)
 
 fun <T, S : Sequence<T>> haveElementAt(index: Int, element: T) = object : Matcher<S> {
@@ -84,8 +90,10 @@ fun <T, S : Sequence<T>> haveElementAt(index: Int, element: T) = object : Matche
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldContainNoNulls() = this should containNoNulls()
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotContainNoNulls() = this shouldNot containNoNulls()
 fun <T> containNoNulls() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>) =
@@ -96,7 +104,9 @@ fun <T> containNoNulls() = object : Matcher<Sequence<T>> {
       )
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Sequence<T>> C.shouldContain(t: T) = this should contain(t)
+@IgnorableReturnValue
 infix fun <T, C : Sequence<T>> C.shouldNotContain(t: T) = this shouldNot contain(t)
 fun <T, C : Sequence<T>> contain(t: T) = object : Matcher<C> {
    override fun test(value: C): MatcherResult {
@@ -109,10 +119,14 @@ fun <T, C : Sequence<T>> contain(t: T) = object : Matcher<C> {
    }
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Sequence<T>> C?.shouldNotContainExactly(expected: C) = this shouldNot containExactly(expected)
+@IgnorableReturnValue
 fun <T, C : Sequence<T>> C?.shouldNotContainExactly(vararg expected: T) = this shouldNot containExactly(*expected)
 
+@IgnorableReturnValue
 infix fun <T, C : Sequence<T>> C?.shouldContainExactly(expected: C) = this should containExactly(expected)
+@IgnorableReturnValue
 fun <T, C : Sequence<T>> C?.shouldContainExactly(vararg expected: T) = this should containExactly(*expected)
 
 fun <T> containExactly(vararg expected: T): Matcher<Sequence<T>?> = containExactly(expected.asSequence())
@@ -169,9 +183,11 @@ fun <T, C : Sequence<T>> containExactly(expected: C): Matcher<C?> = neverNullMat
       { "Sequence should not contain exactly ${consumedExpectedValues.printValues(expectedIterator.hasNext())}" })
 }
 
+@IgnorableReturnValue
 infix fun <T, C : Sequence<T>> C?.shouldNotContainAllInAnyOrder(expected: C) =
    this shouldNot containAllInAnyOrder(expected)
 
+@IgnorableReturnValue
 fun <T, C : Sequence<T>> C?.shouldNotContainAllInAnyOrder(vararg expected: T) =
    this shouldNot containAllInAnyOrder(*expected)
 
@@ -179,6 +195,7 @@ fun <T, C : Sequence<T>> C?.shouldNotContainAllInAnyOrder(vararg expected: T) =
  * Verifies that the given [Sequence] contains all the specified elements in any order.
  * The sequence may additionally contain other elements.
  */
+@IgnorableReturnValue
 infix fun <T, C : Sequence<T>> C?.shouldContainAllInAnyOrder(expected: C) =
    this should containAllInAnyOrder(expected)
 
@@ -186,6 +203,7 @@ infix fun <T, C : Sequence<T>> C?.shouldContainAllInAnyOrder(expected: C) =
  * Verifies that the given [Sequence] contains all the specified elements in any order.
  * The sequence may additionally contain other elements.
  */
+@IgnorableReturnValue
 fun <T, C : Sequence<T>> C?.shouldContainAllInAnyOrder(vararg expected: T) =
    this should containAllInAnyOrder(*expected)
 
@@ -209,6 +227,7 @@ fun <T, C : Sequence<T>> containAllInAnyOrder(expected: C): Matcher<C?> = neverN
 
 internal fun <T> List<T>.counted(): Map<T, Int> = this.groupingBy { it }.eachCount()
 
+@IgnorableReturnValue
 infix fun <T : Comparable<T>, C : Sequence<T>> C.shouldHaveUpperBound(t: T) = this should haveUpperBound(t)
 
 fun <T : Comparable<T>, C : Sequence<T>> haveUpperBound(t: T) = object : Matcher<C> {
@@ -231,6 +250,7 @@ fun <T : Comparable<T>, C : Sequence<T>> haveUpperBound(t: T) = object : Matcher
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 infix fun <T : Comparable<T>, C : Sequence<T>> C.shouldHaveLowerBound(t: T) = this should haveLowerBound(t)
 
 /**
@@ -259,15 +279,19 @@ fun <T : Comparable<T>, C : Sequence<T>> haveLowerBound(t: T) = object : Matcher
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldBeUnique() = this should beUnique()
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotBeUnique() = this shouldNot beUnique()
 fun <T> beUnique() = object : Matcher<Sequence<T>> {
    val delegate = beUniqueByEquals<T>("Sequence")
    override fun test(value: Sequence<T>): MatcherResult = delegate.test(value.asIterable())
 }
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldContainDuplicates() = this should containDuplicates()
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotContainDuplicates() = this shouldNot containDuplicates()
 fun <T> containDuplicates() = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>): MatcherResult {
@@ -281,8 +305,10 @@ fun <T> containDuplicates() = object : Matcher<Sequence<T>> {
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldBeSorted() = this should beSorted()
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldNotBeSorted() = this shouldNot beSorted()
 
 /**
@@ -316,8 +342,10 @@ fun <T : Comparable<T>> sorted(): Matcher<Sequence<T>> = object : Matcher<Sequen
    }
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldBeSortedWith(comparator: Comparator<in T>) = this should beSortedWith(comparator)
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldBeSortedWith(cmp: (T, T) -> Int) = this should beSortedWith(cmp)
 
 fun <T> beSortedWith(comparator: Comparator<in T>): Matcher<Sequence<T>> = sortedWith(comparator)
@@ -344,13 +372,17 @@ fun <T> sortedWith(cmp: (T, T) -> Int): Matcher<Sequence<T>> = object : Matcher<
    }
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotBeSortedWith(comparator: Comparator<in T>) = this shouldNot beSortedWith(comparator)
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotBeSortedWith(cmp: (T, T) -> Int) = this shouldNot beSortedWith(cmp)
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveSingleElement(t: T): Sequence<T> {
    this should singleElement(t)
    return this
 }
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotHaveSingleElement(t: T): Sequence<T> {
    this shouldNot singleElement(t)
    return this
@@ -394,12 +426,16 @@ fun <T> singleElement(expectedElement: T) = object : Matcher<Sequence<T>> {
 }
 
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveCount(count: Int) = this should haveCount(count)
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotHaveCount(count: Int) = this shouldNot haveCount(
    count
 )
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveSize(size: Int) = this should haveCount(size)
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotHaveSize(size: Int) = this shouldNot haveCount(size)
 
 //fun <T> haveSize(size: Int) = haveCount(size)
@@ -417,6 +453,7 @@ fun <T> haveCount(count: Int): Matcher<Sequence<T>> = object : Matcher<Sequence<
 }
 
 
+@IgnorableReturnValue
 infix fun <T, U> Sequence<T>.shouldBeLargerThan(other: Sequence<U>) = this should beLargerThan(other)
 
 fun <T, U> beLargerThan(other: Sequence<U>) = object : Matcher<Sequence<T>> {
@@ -431,6 +468,7 @@ fun <T, U> beLargerThan(other: Sequence<U>) = object : Matcher<Sequence<T>> {
    }
 }
 
+@IgnorableReturnValue
 infix fun <T, U> Sequence<T>.shouldBeSmallerThan(other: Sequence<U>) = this should beSmallerThan(other)
 
 fun <T, U> beSmallerThan(other: Sequence<U>) = object : Matcher<Sequence<T>> {
@@ -445,6 +483,7 @@ fun <T, U> beSmallerThan(other: Sequence<U>) = object : Matcher<Sequence<T>> {
    }
 }
 
+@IgnorableReturnValue
 infix fun <T, U> Sequence<T>.shouldBeSameCountAs(other: Sequence<U>) = this should beSameCountAs(
    other
 )
@@ -461,8 +500,10 @@ fun <T, U> beSameCountAs(other: Sequence<U>) = object : Matcher<Sequence<T>> {
    }
 }
 
+@IgnorableReturnValue
 infix fun <T, U> Sequence<T>.shouldBeSameSizeAs(other: Sequence<U>) = this.shouldBeSameCountAs(other)
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveAtLeastCount(n: Int) = this shouldHave atLeastCount(n)
 
 fun <T> atLeastCount(n: Int) = object : Matcher<Sequence<T>> {
@@ -473,8 +514,10 @@ fun <T> atLeastCount(n: Int) = object : Matcher<Sequence<T>> {
    )
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveAtLeastSize(n: Int) = this.shouldHaveAtLeastCount(n)
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveAtMostCount(n: Int) = this shouldHave atMostCount(n)
 fun <T> atMostCount(n: Int) = object : Matcher<Sequence<T>> {
    override fun test(value: Sequence<T>) = MatcherResult(
@@ -484,14 +527,18 @@ fun <T> atMostCount(n: Int) = object : Matcher<Sequence<T>> {
    )
 }
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldHaveAtMostSize(n: Int) = this shouldHave atMostCount(n)
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldContainInOrder(vararg ts: T) =
    this should containsInOrder(ts.asSequence())
 
+@IgnorableReturnValue
 infix fun <T : Comparable<T>> Sequence<T>.shouldContainInOrder(expected: Sequence<T>) =
    this should containsInOrder(expected)
 
+@IgnorableReturnValue
 fun <T : Comparable<T>> Sequence<T>.shouldNotContainInOrder(expected: Sequence<T>) =
    this shouldNot containsInOrder(expected)
 
@@ -517,7 +564,9 @@ fun <T> containsInOrder(subsequence: Sequence<T>): Matcher<Sequence<T>?> = never
    )
 }
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldBeEmpty() = this should beEmpty()
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotBeEmpty() = this shouldNot beEmpty()
 fun <T> beEmpty(): Matcher<Sequence<T>> = object : Matcher<Sequence<T>> {
    private val delegate = iterableBeEmpty<T>("Sequence")
@@ -526,12 +575,18 @@ fun <T> beEmpty(): Matcher<Sequence<T>> = object : Matcher<Sequence<T>> {
 }
 
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldContainAll(vararg ts: T) = this should containAll(ts.toList())
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldContainAll(ts: Collection<T>) = this should containAll(ts.toList())
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldContainAll(ts: Sequence<T>) = this should containAll(ts)
 
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldNotContainAll(vararg ts: T) = this shouldNot containAll(ts.asList())
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotContainAll(ts: Collection<T>) = this shouldNot containAll(ts.toList())
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldNotContainAll(ts: Sequence<T>) = this shouldNot containAll(ts)
 
 fun <T> containAll(ts: Sequence<T>): Matcher<Sequence<T>> = containAll(ts.toList())
@@ -556,8 +611,11 @@ fun <T> containAll(ts: List<T>): Matcher<Sequence<T>> = object : Matcher<Sequenc
  *
  * See a more detailed explanation of this logic concept in ["Vacuous truth"](https://en.wikipedia.org/wiki/Vacuous_truth) article.
  */
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldMatchEach(vararg assertions: (T) -> Unit) = toList().shouldMatchEach(assertions.toList())
 
+@IgnorableReturnValue
 infix fun <T> Sequence<T>.shouldMatchEach(assertions: List<(T) -> Unit>) = toList().shouldMatchEach(assertions)
+@IgnorableReturnValue
 fun <T> Sequence<T>.shouldMatchEach(expected: Sequence<T>, asserter: (T, T) -> Unit) =
    toList().shouldMatchEach(expected.toList(), asserter)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sets/intersections.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/sets/intersections.kt
@@ -6,11 +6,13 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <T> Set<T>.shouldIntersect(ts: Set<T>): Set<T> {
    this should intersectWith(ts)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> Set<T>.shouldNotIntersect(ts: Set<T>): Set<T> {
    this shouldNot intersectWith(ts)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/short/short.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/short/short.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldBe
    "Short-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the Short import `io.kotest.matchers.short.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(lower, upper)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun Short.shouldBeBetween(lower: Short, upper: Short): Short {
    this shouldBe between(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/short/ushort.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/short/ushort.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldBe
    "UShort-specific assertion is getting replaced with a new Comparable assertion of the same name.\nNote: If you perform the offered IDE autocorrection, you still need to remove the UShort import `io.kotest.matchers.short.shouldBeBetween` manually.",
    ReplaceWith("shouldBeBetween(lower, upper)", "io.kotest.matchers.comparables.shouldBeBetween")
 )
+@IgnorableReturnValue
 fun UShort.shouldBeBetween(lower: UShort, upper: UShort): UShort {
    this shouldBe between(lower, upper)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/should.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/should.kt
@@ -18,6 +18,7 @@ import io.kotest.assertions.withClue
  * @see [io.kotest.assertions.eq.Eq]
  */
 @Suppress("UNCHECKED_CAST")
+@IgnorableReturnValue
 infix fun <T> T.shouldBe(expected: T?): T {
    when (expected) {
       is Matcher<*> -> should(expected as Matcher<T>)
@@ -41,6 +42,7 @@ infix fun <T> T.shouldBe(expected: T?): T {
  * @see [io.kotest.assertions.eq.Eq]
  */
 @Suppress("UNCHECKED_CAST")
+@IgnorableReturnValue
 fun <T> T.shouldBe(expected: T?, msg: String): T {
    when (expected) {
       is Matcher<*> -> should(expected as Matcher<T>)
@@ -52,6 +54,7 @@ fun <T> T.shouldBe(expected: T?, msg: String): T {
 }
 
 @Suppress("UNCHECKED_CAST")
+@IgnorableReturnValue
 infix fun <T> T.shouldNotBe(expected: Any?): T {
    when (expected) {
       is Matcher<*> -> shouldNot(expected as Matcher<T>)
@@ -60,12 +63,16 @@ infix fun <T> T.shouldNotBe(expected: Any?): T {
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T> T.shouldHave(matcher: Matcher<T>) = should(matcher)
+@IgnorableReturnValue
 infix fun <T> T.should(matcher: Matcher<T>) {
    invokeMatcher(this, matcher)
 }
 
+@IgnorableReturnValue
 infix fun <T> T.shouldNotHave(matcher: Matcher<T>) = shouldNot(matcher)
+@IgnorableReturnValue
 infix fun <T> T.shouldNot(matcher: Matcher<T>) = should(matcher.invert())
 
 /**
@@ -82,6 +89,7 @@ infix fun <T> T.shouldNot(matcher: Matcher<T>) = should(matcher.invert())
  * ```
  * @return Unit
  */
+@IgnorableReturnValue
 inline infix fun <T> T.should(matcher: (T) -> Unit) = matcher(this)
 
 fun <T> be(expected: T): Matcher<T> = EqMatcher(expected)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/case.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/case.kt
@@ -7,11 +7,13 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldBeUpperCase(): A {
    this should beUpperCase()
    return this!!
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldNotBeUpperCase(): A {
    this shouldNot beUpperCase()
    return this!!
@@ -25,11 +27,13 @@ fun beUpperCase(): Matcher<CharSequence?> = neverNullMatcher { value ->
    )
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence?> A.shouldBeLowerCase(): A {
    this should beLowerCase()
    return this
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence?> A.shouldNotBeLowerCase(): A {
    this shouldNot beLowerCase()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/containExactCopies.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/containExactCopies.kt
@@ -22,6 +22,7 @@ import io.kotest.matchers.shouldNot
  * "Mayday".shouldContainExactCopies("ay", copies = 3, allowOverlaps = false)
  * "121212".shouldContainExactCopies("1212", copies = 2, allowOverlaps = false)
  */
+@IgnorableReturnValue
 fun String.shouldContainExactCopies(
    element: String,
    copies: Int,
@@ -48,6 +49,7 @@ fun String.shouldContainExactCopies(
  * "121212".shouldNotContainExactCopies("1212", copies = 2, allowOverlaps = true)
  *
  */
+@IgnorableReturnValue
 fun String.shouldNotContainExactCopies(
    element: String,
    copies: Int,

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/containInOrderWithoutOverlaps.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/containInOrderWithoutOverlaps.kt
@@ -21,11 +21,13 @@ import io.kotest.matchers.shouldNot
  * "sourdough bread".shouldContainInOrderWithoutOverlaps("bread", "read")
  * "superstar".shouldContainInOrderWithoutOverlaps("supers", "star")
  */
+@IgnorableReturnValue
 fun String.shouldContainInOrderWithoutOverlaps(vararg substrings: String): String {
    this should containInOrderWithoutOverlaps(*substrings)
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotContainInOrderWithoutOverlaps(vararg substrings: String): String {
    this shouldNot containInOrderWithoutOverlaps(*substrings)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/end.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/end.kt
@@ -8,11 +8,13 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldEndWith(suffix: CharSequence): A {
    this should endWith(suffix)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotEndWith(suffix: CharSequence): A {
    this shouldNot endWith(suffix)
    return this!!
@@ -34,6 +36,7 @@ fun endWith(suffix: CharSequence): Matcher<CharSequence?> = neverNullMatcher { v
    )
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence?> A.shouldEndWith(regex: Regex): A {
    this should endWith(regex)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/lengths.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/lengths.kt
@@ -7,11 +7,13 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldHaveMaxLength(length: Int): A {
    this should haveMaxLength(length)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotHaveMaxLength(length: Int): A {
    this shouldNot haveMaxLength(length)
    return this!!
@@ -24,11 +26,13 @@ fun haveMaxLength(length: Int): Matcher<CharSequence?> = neverNullMatcher { valu
       { "${value.print().value} should have minimum length of ${length + 1}" })
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldHaveMinLength(length: Int): A {
    this should haveMinLength(length)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotHaveMinLength(length: Int): A {
    this shouldNot haveMinLength(length)
    return this!!
@@ -44,6 +48,7 @@ fun haveMinLength(length: Int): Matcher<CharSequence?> = neverNullMatcher { valu
 /**
  * Match that verifies a given [CharSequence] has a length within the given [IntRange].
  */
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldHaveLengthBetween(range: IntRange): A {
    this should haveLengthBetween(range.first, range.last)
    return this!!
@@ -51,11 +56,13 @@ fun <A : CharSequence> A?.shouldHaveLengthBetween(range: IntRange): A {
 /**
  * Match that verifies a given [CharSequence] has a length between [min, max] (inclusive, inclusive).
  */
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldHaveLengthBetween(min: Int, max: Int): A {
    this should haveLengthBetween(min, max)
    return this!!
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldNotHaveLengthBetween(range: IntRange): A {
    this shouldNot haveLengthBetween(range.first, range.last)
    return this!!
@@ -64,6 +71,7 @@ fun <A : CharSequence> A?.shouldNotHaveLengthBetween(range: IntRange): A {
 /**
  * Match that verifies a given [CharSequence] does not have a length between [min, max] (inclusive, inclusive).
  */
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldNotHaveLengthBetween(min: Int, max: Int): A {
    this shouldNot haveLengthBetween(min, max)
    return this!!
@@ -82,11 +90,13 @@ fun haveLengthBetween(min: Int, max: Int): Matcher<CharSequence?> {
    }
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldHaveLengthIn(range: IntRange): A {
    this should haveLengthIn(range)
    return this!!
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldNotHaveLengthIn(range: IntRange): A {
    this shouldNot haveLengthIn(range)
    return this!!
@@ -102,22 +112,26 @@ fun haveLengthIn(range: IntRange): Matcher<CharSequence?> {
 }
 
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldHaveLength(length: Int): A {
    this should haveLength(length)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotHaveLength(length: Int): A {
    this shouldNot haveLength(length)
    return this!!
 }
 
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldHaveSameLengthAs(other: String): A {
    this should haveSameLengthAs(other)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotHaveSameLengthAs(other: String): A {
    this shouldNot haveSameLengthAs(other)
    return this!!

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/lines.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/lines.kt
@@ -7,21 +7,25 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldBeSingleLine(): A {
    this should haveLineCount(1)
    return this!!
 }
 
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldNotBeSingleLine(): A {
    this shouldNot haveLineCount(1)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldHaveLineCount(count: Int): A {
    this should haveLineCount(count)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotHaveLineCount(count: Int): A {
    this shouldNot haveLineCount(count)
    return this!!

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/match.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/match.kt
@@ -7,21 +7,25 @@ import io.kotest.matchers.neverNullMatcher
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldMatch(regex: String): A {
    this should match(regex)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldMatch(regex: Regex): A {
    this should match(regex)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotMatch(regex: String): A {
    this shouldNot match(regex)
    return this!!
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence> A?.shouldNotMatch(regex: Regex): A {
    this shouldNot match(regex)
    return this!!

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/matchers.kt
@@ -15,11 +15,13 @@ import io.kotest.matchers.string.UUIDVersion.ANY
 import kotlin.contracts.contract
 import kotlin.text.RegexOption.IGNORE_CASE
 
+@IgnorableReturnValue
 fun String?.shouldContainOnlyDigits(): String? {
    this should containOnlyDigits()
    return this
 }
 
+@IgnorableReturnValue
 fun String?.shouldNotContainOnlyDigits(): String? {
    this shouldNot containOnlyDigits()
    return this
@@ -33,11 +35,13 @@ fun containOnlyDigits() = neverNullMatcher<String> { value ->
       { "${value.print().value} should not contain only digits" })
 }
 
+@IgnorableReturnValue
 fun String?.shouldContainADigit(): String? {
    this should containADigit()
    return this
 }
 
+@IgnorableReturnValue
 fun String?.shouldNotContainADigit(): String? {
    this shouldNot containADigit()
    return this
@@ -54,11 +58,13 @@ fun containADigit() = neverNullMatcher<String> { value ->
       { "${value.print().value} should not contain any digits$possibleFirstDigitMessage" })
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldContainOnlyOnce(substr: String): String? {
    this should containOnlyOnce(substr)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldNotContainOnlyOnce(substr: String): String? {
    this shouldNot containOnlyOnce(substr)
    return this
@@ -79,11 +85,13 @@ fun containOnlyOnce(substring: String) = neverNullMatcher<String> { value ->
       { "${value.print().value} should not contain the substring ${substring.print().value} exactly once" })
 }
 
+@IgnorableReturnValue
 fun String?.shouldBeEmpty(): String? {
    this should beEmpty()
    return this
 }
 
+@IgnorableReturnValue
 fun String?.shouldNotBeEmpty(): String? {
    this shouldNot beEmpty()
    return this
@@ -96,11 +104,13 @@ fun beEmpty() = neverNullMatcher<String> { value ->
       { "${value.print().value} should not be empty" })
 }
 
+@IgnorableReturnValue
 fun String?.shouldBeBlank(): String? {
    this should beBlank()
    return this
 }
 
+@IgnorableReturnValue
 fun String?.shouldNotBeBlank(): String? {
    this shouldNot beBlank()
    return this
@@ -115,11 +125,13 @@ fun beBlank() = neverNullMatcher<String> { value ->
    )
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldContainIgnoringCase(substr: String): String? {
    this should containIgnoringCase(substr)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldNotContainIgnoringCase(substr: String): String? {
    this shouldNot containIgnoringCase(substr)
    return this
@@ -134,11 +146,13 @@ fun containIgnoringCase(substr: String) = neverNullMatcher<String> { value ->
    )
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldContain(regex: Regex): String? {
    this should contain(regex)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldNotContain(regex: Regex): String? {
    this shouldNot contain(regex)
    return this
@@ -171,11 +185,13 @@ fun contain(regex: Regex) = neverNullMatcher<String> { value ->
  * "are you ready".shouldContainInOrder("read", "ready")
  *
  */
+@IgnorableReturnValue
 fun String?.shouldContainInOrder(vararg substrings: String): String? {
    this should containInOrder(*substrings)
    return this
 }
 
+@IgnorableReturnValue
 fun String?.shouldNotContainInOrder(vararg substrings: String): String? {
    this shouldNot containInOrder(*substrings)
    return this
@@ -290,11 +306,13 @@ internal sealed interface ContainInOrderOutcome {
    }
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldContain(substr: String): String? {
    this should contain(substr)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldNotContain(substr: String): String? {
    this shouldNot contain(substr)
    return this
@@ -302,11 +320,13 @@ infix fun String?.shouldNotContain(substr: String): String? {
 
 fun contain(substr: String) = include(substr)
 
+@IgnorableReturnValue
 infix fun String?.shouldInclude(substr: String): String? {
    this should include(substr)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String?.shouldNotInclude(substr: String): String? {
    this shouldNot include(substr)
    return this
@@ -342,6 +362,7 @@ fun include(substr: String) = neverNullMatcher<String> { value ->
  * @see [shouldNotBeEqualIgnoringCase]
  * @see [beEqualIgnoringCase]
  */
+@IgnorableReturnValue
 infix fun String?.shouldBeEqualIgnoringCase(other: String): String? {
    this should beEqualIgnoringCase(other)
    return this
@@ -364,6 +385,7 @@ infix fun String?.shouldBeEqualIgnoringCase(other: String): String? {
  * @see [shouldBeEqualIgnoringCase]
  * @see [beEqualIgnoringCase]
  */
+@IgnorableReturnValue
 infix fun String?.shouldNotBeEqualIgnoringCase(other: String): String? {
    this shouldNot beEqualIgnoringCase(other)
    return this
@@ -422,6 +444,7 @@ enum class UUIDVersion(
  *
  * See [RFC4122](https://tools.ietf.org/html/rfc4122)
  */
+@IgnorableReturnValue
 fun String.shouldBeUUID(
    version: UUIDVersion = ANY,
    considerNilValid: Boolean = true
@@ -448,6 +471,7 @@ fun String.shouldBeUUID(
  *
  * See [RFC4122](https://tools.ietf.org/html/rfc4122)
  */
+@IgnorableReturnValue
 fun String.shouldNotBeUUID(
    version: UUIDVersion = ANY,
    considerNilValid: Boolean = true
@@ -482,6 +506,7 @@ fun beUUID(
    private fun String.isNilUUID() = this == "00000000-0000-0000-0000-000000000000"
 }
 
+@IgnorableReturnValue
 fun String?.shouldBeInteger(radix: Int = 10): Int {
    contract {
       returns() implies (this@shouldBeInteger != null)

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/start.kt
@@ -9,11 +9,13 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.math.min
 
+@IgnorableReturnValue
 infix fun <A : CharSequence?> A.shouldStartWith(prefix: CharSequence): A {
    this should startWith(prefix)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence?> A.shouldNotStartWith(prefix: CharSequence): A {
    this shouldNot startWith(prefix)
    return this
@@ -47,6 +49,7 @@ fun startWith(prefix: CharSequence): Matcher<CharSequence?> = neverNullMatcher {
    )
 }
 
+@IgnorableReturnValue
 infix fun <A : CharSequence?> A.shouldStartWith(regex: Regex): A {
    this should startWith(regex)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/tf.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/tf.kt
@@ -21,6 +21,7 @@ import io.kotest.matchers.should
  *
  * ```
  */
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldBeTruthy(): A {
    this should beTruthy()
    return this!!
@@ -42,6 +43,7 @@ fun <A : CharSequence> A?.shouldBeTruthy(): A {
  *
  * ```
  */
+@IgnorableReturnValue
 fun <A : CharSequence> A?.shouldBeFalsy(): A {
    this should beFalsy()
    return this!!

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/throwable/matchers.kt
@@ -8,11 +8,13 @@ import io.kotest.matchers.MatcherResultBuilder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 infix fun Throwable.shouldHaveMessage(message: String): Throwable {
    this should haveMessage(message)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldNotHaveMessage(message: String): Throwable {
    this shouldNot haveMessage(message)
    return this
@@ -29,11 +31,13 @@ fun haveMessage(message: String) = object : Matcher<Throwable> {
       .build()
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldHaveMessage(message: Regex): Throwable {
    this should haveMessage(message)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldNotHaveMessage(message: Regex): Throwable {
    this shouldNot haveMessage(message)
    return this
@@ -47,12 +51,14 @@ fun haveMessage(regex: Regex) = object : Matcher<Throwable> {
 }
 
 
+@IgnorableReturnValue
 fun Throwable.shouldHaveCause(block: (Throwable) -> Unit = {}): Throwable {
    this should haveCause()
    block.invoke(cause!!)
    return this
 }
 
+@IgnorableReturnValue
 fun Throwable.shouldNotHaveCause(): Throwable {
    this shouldNot haveCause()
    return this
@@ -62,11 +68,13 @@ fun haveCause() = object : Matcher<Throwable> {
    override fun test(value: Throwable) = resultForThrowable(value.cause)
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldHaveStackTraceContaining(substr: String): Throwable {
    this should haveStackTraceContaining(substr)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldNotHaveStackTraceContaining(substr: String): Throwable {
    this shouldNot haveStackTraceContaining(substr)
    return this
@@ -83,11 +91,13 @@ fun haveStackTraceContaining(substr: String) = object : Matcher<Throwable> {
       { "Throwable stacktrace should not contain substring: ${substr.print().value}" })
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldHaveStackTraceContaining(regex: Regex): Throwable {
    this should haveStackTraceContaining(regex)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Throwable.shouldNotHaveStackTraceContaining(regex: Regex): Throwable {
    this shouldNot haveStackTraceContaining(regex)
    return this
@@ -104,11 +114,13 @@ fun haveStackTraceContaining(regex: Regex) = object : Matcher<Throwable> {
       { "Throwable stacktrace should not contain regex: ${regex.print().value}" })
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Throwable> Throwable.shouldHaveCauseInstanceOf(): Throwable {
    this should haveCauseInstanceOf<T>()
    return this
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Throwable> Throwable.shouldNotHaveCauseInstanceOf(): Throwable {
    this shouldNot haveCauseInstanceOf<T>()
    return this
@@ -124,11 +136,13 @@ inline fun <reified T : Throwable> haveCauseInstanceOf() = object : Matcher<Thro
    }
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Throwable> Throwable.shouldHaveCauseOfType(): Throwable {
    this should haveCauseOfType<T>()
    return this
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Throwable> Throwable.shouldNotHaveCauseOfType(): Throwable {
    this shouldNot haveCauseOfType<T>()
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/time/duration.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/time/duration.kt
@@ -8,11 +8,13 @@ import io.kotest.matchers.shouldNot
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 
+@IgnorableReturnValue
 infix fun Duration.shouldHaveSeconds(seconds: Long): Duration {
    this should haveSeconds(seconds)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Duration.shouldNotHaveSeconds(seconds: Long): Duration {
    this shouldNot haveSeconds(seconds)
    return this
@@ -27,11 +29,13 @@ fun haveSeconds(seconds: Long) = neverNullMatcher<Duration> { value ->
 }
 
 
+@IgnorableReturnValue
 infix fun Duration.shouldHaveMillis(millis: Long): Duration {
    this should haveMillis(millis)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Duration.shouldNotHaveMillis(millis: Long): Duration {
    this shouldNot haveMillis(millis)
    return this
@@ -45,8 +49,10 @@ fun haveMillis(millis: Long) = neverNullMatcher<Duration> { value ->
    )
 }
 
+@IgnorableReturnValue
 infix fun Duration.shouldHaveMinutes(minutes: Long) = this should haveMinutes(minutes)
 
+@IgnorableReturnValue
 infix fun Duration.shouldNotHaveMinutes(minutes: Long) = this shouldNot haveMinutes(minutes)
 
 fun haveMinutes(minutes: Long) = neverNullMatcher<Duration> { value ->
@@ -58,8 +64,10 @@ fun haveMinutes(minutes: Long) = neverNullMatcher<Duration> { value ->
 }
 
 
+@IgnorableReturnValue
 infix fun Duration.shouldHaveHours(hours: Long) = this should haveHours(hours)
 
+@IgnorableReturnValue
 infix fun Duration.shouldNotHaveHours(hours: Long) = this shouldNot haveHours(hours)
 
 

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/tuples/pairs.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/tuples/pairs.kt
@@ -5,11 +5,13 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <A> Pair<A, *>.shouldHaveFirst(a: A): Pair<A, *> {
    this should haveFirst(a)
    return this
 }
 
+@IgnorableReturnValue
 fun <A> Pair<A, *>.shouldNotHaveFirst(a: A): Pair<A, *> {
    this shouldNot haveFirst(a)
    return this
@@ -26,11 +28,13 @@ fun <A> haveFirst(a: A) = object : Matcher<Pair<A, *>> {
    }
 }
 
+@IgnorableReturnValue
 fun <B> Pair<*, B>.shouldHaveSecond(b: B): Pair<*, B> {
    this should haveSecond(b)
    return this
 }
 
+@IgnorableReturnValue
 fun <B> Pair<*, B>.shouldNotHaveSecond(b: B): Pair<*, B> {
    this shouldNot haveSecond(b)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/tuples/triples.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/tuples/triples.kt
@@ -5,11 +5,13 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun <A> Triple<A, *, *>.shouldHaveFirst(a: A): Triple<A, *, *> {
    this should haveTripleFirst(a)
    return this
 }
 
+@IgnorableReturnValue
 fun <A> Triple<A, *, *>.shouldNotHaveFirst(a: A): Triple<A, *, *> {
    this shouldNot haveTripleFirst(a)
    return this
@@ -26,11 +28,13 @@ fun <A> haveTripleFirst(a: A) = object : Matcher<Triple<A, *, *>> {
    }
 }
 
+@IgnorableReturnValue
 fun <B> Triple<*, B, *>.shouldHaveSecond(b: B): Triple<*, B, *> {
    this should haveTripleSecond(b)
    return this
 }
 
+@IgnorableReturnValue
 fun <B> Triple<*, B, *>.shouldNotHaveSecond(b: B): Triple<*, B, *> {
    this shouldNot haveTripleSecond(b)
    return this
@@ -48,11 +52,13 @@ fun <B> haveTripleSecond(b: B) = object : Matcher<Triple<*, B, *>> {
 }
 
 
+@IgnorableReturnValue
 fun <C> Triple<*, *, C>.shouldHaveThird(c: C): Triple<*, *, C> {
    this should haveTripleThird(c)
    return this
 }
 
+@IgnorableReturnValue
 fun <C> Triple<*, *, C>.shouldNotHaveThird(c: C): Triple<*, *, C> {
    this shouldNot haveTripleThird(c)
    return this

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/types/hash.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/types/hash.kt
@@ -22,6 +22,7 @@ import io.kotest.matchers.shouldNot
  *
  * @see [Any.shouldNotHaveSameHashCodeAs]
  */
+@IgnorableReturnValue
 infix fun Any.shouldHaveSameHashCodeAs(other: Any) = this should haveSameHashCodeAs(other)
 
 /**
@@ -39,6 +40,7 @@ infix fun Any.shouldHaveSameHashCodeAs(other: Any) = this should haveSameHashCod
  *
  * @see [Any.shouldHaveSameHashCodeAs]
  */
+@IgnorableReturnValue
 infix fun Any.shouldNotHaveSameHashCodeAs(other: Any) = this shouldNot haveSameHashCodeAs(other)
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/types/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/types/matchers.kt
@@ -33,6 +33,7 @@ import kotlin.contracts.contract
  * @param block Lambda that receives typecasted instance as argument for further assertions.
  * @return The typecasted instance
  */
+@IgnorableReturnValue
 inline fun <reified T : Any> Any?.shouldBeInstanceOf(block: (T) -> Unit = { }): T {
    val matcher = beInstanceOf<T>()
    this shouldBe matcher
@@ -66,6 +67,7 @@ inline fun <reified T : Any> Any?.shouldBeInstanceOf(block: (T) -> Unit = { }): 
  *
  * @return The typecasted instance
  */
+@IgnorableReturnValue
 inline fun <reified T : Any> Any?.shouldBeInstanceOf(): T {
    contract {
       returns() implies (this@shouldBeInstanceOf is T)
@@ -90,6 +92,7 @@ inline fun <reified T : Any> Any?.shouldBeInstanceOf(): T {
  * list.shouldNotBeInstanceOf<LinkedList<Int>>
  * ```
  */
+@IgnorableReturnValue
 inline fun <reified T : Any> Any?.shouldNotBeInstanceOf() {
    val matcher = beInstanceOf<T>()
    this shouldNotBe matcher
@@ -122,6 +125,7 @@ inline fun <reified T : Any> Any?.shouldNotBeInstanceOf() {
  * @param block Lambda that receives typecasted instance  as argument for further assertions.
  * @return The typecasted instance
  */
+@IgnorableReturnValue
 inline fun <reified T : Any> Any?.shouldBeTypeOf(block: (T) -> Unit = { }): T {
    val matcher = beOfType<T>()
    this shouldBe matcher
@@ -129,6 +133,7 @@ inline fun <reified T : Any> Any?.shouldBeTypeOf(block: (T) -> Unit = { }): T {
    return this
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Any> Any?.shouldBeTypeOf(): T {
    contract {
       returns() implies (this@shouldBeTypeOf is T)
@@ -153,10 +158,13 @@ inline fun <reified T : Any> Any?.shouldBeTypeOf(): T {
  * list.shouldNotBeTypeOf<LinkedList<Int>>
  * ```
  */
+@IgnorableReturnValue
 inline fun <reified T : Any> Any?.shouldNotBeTypeOf() {
    val matcher = beOfType<T>()
    this shouldNotBe matcher
 }
 
+@IgnorableReturnValue
 infix fun Any?.shouldBeSameInstanceAs(ref: Any?) = this should beTheSameInstanceAs(ref)
+@IgnorableReturnValue
 infix fun Any?.shouldNotBeSameInstanceAs(ref: Any?) = this shouldNotBe beTheSameInstanceAs(ref)

--- a/kotest-assertions/kotest-assertions-core/src/jsMain/kotlin/io/kotest/matchers/date/date.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jsMain/kotlin/io/kotest/matchers/date/date.kt
@@ -28,6 +28,7 @@ import kotlin.js.Date
  *     firstTime shouldHaveSameHoursAs secondTime   //  Assertion fails, 23 != 16
 ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveSameHoursAs(other: Date) = this should haveSameHours(other)
 
 /**
@@ -51,6 +52,7 @@ infix fun Date.shouldHaveSameHoursAs(other: Date) = this should haveSameHours(ot
  *     firstTime shouldNotHaveSameHoursAs secondTime   //  Assertion fails, 23 == 23
 ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldNotHaveSameHoursAs(other: Date) = this shouldNot haveSameHours(other)
 
 /**
@@ -108,6 +110,7 @@ fun haveSameHours(other: Date): Matcher<Date> = object : Matcher<Date> {
  *
  * @see Date.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun Date.shouldBeBefore(other: Date) = this should before(other)
 
 /**
@@ -134,6 +137,7 @@ infix fun Date.shouldBeBefore(other: Date) = this should before(other)
  *
  * @see Date.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun Date.shouldNotBeBefore(other: Date) = this shouldNot before(other)
 
 /**
@@ -192,6 +196,7 @@ fun before(date: Date): Matcher<Date> = object : Matcher<Date> {
  *
  * @see Date.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun Date.shouldBeAfter(other: Date) = this should after(other)
 
 /**
@@ -217,6 +222,7 @@ infix fun Date.shouldBeAfter(other: Date) = this should after(other)
  *
  * @see Date.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun Date.shouldNotBeAfter(other: Date) = this shouldNot after(other)
 
 /**
@@ -260,6 +266,7 @@ fun after(other: Date): Matcher<Date> = object : Matcher<Date> {
  *    date.shouldHaveDayOfWeek(2019) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveYear(year: Int) = this.getFullYear() shouldBe year
 
 
@@ -272,6 +279,7 @@ infix fun Date.shouldHaveYear(year: Int) = this.getFullYear() shouldBe year
  *    date.shouldHaveDayOfWeek(5) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveDayOfWeek(day: Int) = this.getDay() shouldBe day
 
 /**
@@ -283,6 +291,7 @@ infix fun Date.shouldHaveDayOfWeek(day: Int) = this.getDay() shouldBe day
  *    date.shouldHaveDayOfWeek(5) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveDayOfMonth(day: Int) = this.getDate() shouldBe day
 
 /**
@@ -294,6 +303,7 @@ infix fun Date.shouldHaveDayOfMonth(day: Int) = this.getDate() shouldBe day
  *    date.shouldHaveMonth(2) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveMonth(month: Int) = this.getMonth() shouldBe month
 
 /**
@@ -305,6 +315,7 @@ infix fun Date.shouldHaveMonth(month: Int) = this.getMonth() shouldBe month
  *    date.shouldHaveHour(12) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveHour(hour: Int) = this.getHours() shouldBe hour
 
 /**
@@ -316,6 +327,7 @@ infix fun Date.shouldHaveHour(hour: Int) = this.getHours() shouldBe hour
  *    date.shouldHaveMinute(10) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveMinute(minute: Int) = this.getMinutes() shouldBe minute
 
 /**
@@ -327,4 +339,5 @@ infix fun Date.shouldHaveMinute(minute: Int) = this.getMinutes() shouldBe minute
  *    date.shouldHaveSecond(11) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun Date.shouldHaveSecond(second: Int) = this.getSeconds() shouldBe second

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/assertions/async/timeout.jvm.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/assertions/async/timeout.jvm.kt
@@ -15,6 +15,7 @@ import kotlin.time.toKotlinDuration
       "kotlin.time.toKotlinDuration",
    ),
 )
+@IgnorableReturnValue
 suspend fun <A> shouldTimeout(duration: Duration, thunk: suspend () -> A): Unit =
    shouldTimeout(duration.toKotlinDuration()) { thunk() }
 
@@ -28,6 +29,7 @@ suspend fun <A> shouldTimeout(duration: Duration, thunk: suspend () -> A): Unit 
       "java.time.Duration"
    ),
 )
+@IgnorableReturnValue
 suspend fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: suspend () -> A) {
    @Suppress("DEPRECATION")
    shouldTimeout(Duration.of(timeout, unit.ChronoUnit())) { thunk() }

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/atomic/AtomicBooleanMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/atomic/AtomicBooleanMatchers.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @see [AtomicBoolean.shouldNotBeFalse]
  * @see [AtomicBoolean.shouldBeFalse]
  */
+@IgnorableReturnValue
 fun AtomicBoolean.shouldBeTrue() = get() shouldBe true
 
 /**
@@ -38,6 +39,7 @@ fun AtomicBoolean.shouldBeTrue() = get() shouldBe true
  * @see [AtomicBoolean.shouldBeFalse]
  * @see [AtomicBoolean.shouldNotBeFalse]
  */
+@IgnorableReturnValue
 fun AtomicBoolean.shouldNotBeTrue() = get() shouldNotBe true
 
 /**
@@ -56,6 +58,7 @@ fun AtomicBoolean.shouldNotBeTrue() = get() shouldNotBe true
  * @see [AtomicBoolean.shouldNotBeTrue]
  * @see [AtomicBoolean.shouldBeTrue]
  */
+@IgnorableReturnValue
 fun AtomicBoolean.shouldBeFalse() = get() shouldBe false
 
 /**
@@ -74,4 +77,5 @@ fun AtomicBoolean.shouldBeFalse() = get() shouldBe false
  * @see [AtomicBoolean.shouldBeTrue]
  * @see [AtomicBoolean.shouldNotBeTrue]
  */
+@IgnorableReturnValue
 fun AtomicBoolean.shouldNotBeFalse() = get() shouldNotBe false

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/BigDecimalTolerance.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/BigDecimalTolerance.kt
@@ -75,6 +75,7 @@ class ToleranceMatcher(private val expected: BigDecimal?, private val tolerance:
  * BigDecimal("30.0").shouldBeWithinPercentageOf(BigDecimal("100.0:), 10.0)  // Fail
  *
  */
+@IgnorableReturnValue
 fun BigDecimal.shouldBeWithinPercentageOf(other: BigDecimal, percentage: BigDecimal) {
    require(percentage > BigDecimal.ZERO) { "Percentage must be > 0.0" }
    this should beWithinPercentageOf(other, percentage)
@@ -88,6 +89,7 @@ fun BigDecimal.shouldBeWithinPercentageOf(other: BigDecimal, percentage: BigDeci
  * BigDecimal("30.0").shouldNotBeWithinPercentageOf(BigDecimal("100.0"), 10.0)  // Passes
  *
  */
+@IgnorableReturnValue
 fun BigDecimal.shouldNotBeWithinPercentageOf(other: BigDecimal, percentage: BigDecimal) {
    require(percentage > BigDecimal.ZERO) { "Percentage must be > 0, was: $percentage" }
    this shouldNot beWithinPercentageOf(other, percentage)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/bigdecimal/matchers.kt
@@ -12,58 +12,84 @@ import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import java.math.BigDecimal
 
+@IgnorableReturnValue
 fun BigDecimal.shouldBeZero() = this shouldBe BigDecimal.ZERO
+@IgnorableReturnValue
 fun BigDecimal.shouldBePositive() = this shouldBe gt(BigDecimal.ZERO)
+@IgnorableReturnValue
 fun BigDecimal.shouldBeNegative() = this shouldBe lt(BigDecimal.ZERO)
+@IgnorableReturnValue
 fun BigDecimal.shouldNotBePositive() = this shouldNotBe gt(BigDecimal.ZERO)
+@IgnorableReturnValue
 fun BigDecimal.shouldNotBeNegative() = this shouldNotBe lt(BigDecimal.ZERO)
 
+@IgnorableReturnValue
 infix fun BigDecimal.shouldHavePrecision(precision: Int) = this.precision() shouldBe precision
 
+@IgnorableReturnValue
 infix fun BigDecimal.shouldHaveScale(scale: Int) = this.scale() shouldBe scale
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotHaveScale(scale: Int) = this.scale() shouldNotBe scale
 
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeLessThan(other: BigDecimal) = this shouldBe lt(other)
 @Deprecated(
    "use Kotest's shouldBeLessThanOrEqual",
    ReplaceWith("shouldBeLessThanOrEqual", "io.kotest.matchers.bigdecimal")
 )
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeLessThanOrEquals(other: BigDecimal) = this.shouldBeLessThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeAtMost(other: BigDecimal) = this.shouldBeLessThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeLessThanOrEqual(other: BigDecimal) = this shouldBe lte(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeLessThan(other: BigDecimal) = this shouldNotBe lt(other)
 @Deprecated(
    "use Kotest's shouldNotBeLessThanOrEqual",
    ReplaceWith("shouldNotBeLessThanOrEqual", "io.kotest.matchers.bigdecimal")
 )
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeLessThanOrEquals(other: BigDecimal) = this.shouldNotBeLessThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeAtMost(other: BigDecimal) = this.shouldNotBeLessThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeLessThanOrEqual(other: BigDecimal) = this shouldNotBe lte(other)
 
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeGreaterThan(other: BigDecimal) = this shouldBe gt(other)
 @Deprecated(
    "use Kotest's shouldBeGreaterThanOrEqual",
    ReplaceWith("shouldBeGreaterThanOrEqual", "io.kotest.matchers.bigdecimal")
 )
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeGreaterThanOrEquals(other: BigDecimal) = this.shouldBeGreaterThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeAtLeast(other: BigDecimal) = this.shouldBeGreaterThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeGreaterThanOrEqual(other: BigDecimal) = this shouldBe gte(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeGreaterThan(other: BigDecimal) = this shouldNotBe gt(other)
 @Deprecated(
    "use Kotest's shouldNotBeGreaterThanOrEqual",
    ReplaceWith("shouldNotBeGreaterThanOrEqual", "io.kotest.matchers.bigdecimal")
 )
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeGreaterThanOrEquals(other: BigDecimal) = this.shouldNotBeGreaterThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeAtLeast(other: BigDecimal) = this.shouldNotBeGreaterThanOrEqual(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeGreaterThanOrEqual(other: BigDecimal) = this shouldNotBe gte(other)
 
 @Deprecated("use <T: Comparable<T>> shouldBeIn",
    ReplaceWith("this shouldBeIn (range)", "io.kotest.matchers.ranges.shouldBeIn")
 )
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeInRange(range: ClosedRange<BigDecimal>) = this should beInClosedRange(range)
 @Deprecated("use <T: Comparable<T>> shouldNotBeIn",
    ReplaceWith("this shouldNotBeIn (range)", "io.kotest.matchers.ranges.shouldNotBeIn")
 )
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeInRange(range: ClosedRange<BigDecimal>) = this shouldNot beInClosedRange(range)
 fun beInClosedRange(range: ClosedRange<BigDecimal>) = object : Matcher<BigDecimal> {
    override fun test(value: BigDecimal) = MatcherResult(
@@ -73,7 +99,9 @@ fun beInClosedRange(range: ClosedRange<BigDecimal>) = object : Matcher<BigDecima
    )
 }
 
+@IgnorableReturnValue
 infix fun BigDecimal.shouldBeEqualIgnoringScale(other: BigDecimal) = this should beEqualIgnoringScale(other)
+@IgnorableReturnValue
 infix fun BigDecimal.shouldNotBeEqualIgnoringScale(other: BigDecimal) = this shouldNot beEqualIgnoringScale(other)
 
 fun beEqualIgnoringScale(other: BigDecimal) = object : Matcher<BigDecimal> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/channels/ChannelMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/channels/ChannelMatchers.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.delay
  * Opposite of [Channel.shouldBeOpen].
  */
 @DelicateCoroutinesApi
+@IgnorableReturnValue
 fun <T> Channel<T>.shouldBeClosed() = this should beClosed()
 
 @DelicateCoroutinesApi
@@ -32,6 +33,7 @@ fun <T> beClosed() = object : Matcher<Channel<T>> {
  * Opposite of [Channel.shouldBeClosed].
  */
 @DelicateCoroutinesApi
+@IgnorableReturnValue
 fun <T> Channel<T>.shouldBeOpen() = this shouldNot beClosed()
 
 /**
@@ -39,6 +41,7 @@ fun <T> Channel<T>.shouldBeOpen() = this shouldNot beClosed()
  *
  */
 @ExperimentalCoroutinesApi
+@IgnorableReturnValue
 fun <T> Channel<T>.shouldBeEmpty() = this should beEmpty()
 
 @ExperimentalCoroutinesApi
@@ -54,6 +57,7 @@ fun <T> beEmpty() = object : Matcher<Channel<T>> {
  * Asserts that this [Channel] should receive [n] elements, then is closed.
  */
 @DelicateCoroutinesApi
+@IgnorableReturnValue
 suspend fun <T> Channel<T>.shouldHaveSize(n: Int) {
    repeat(n) {
       this@shouldHaveSize.receive()
@@ -64,6 +68,7 @@ suspend fun <T> Channel<T>.shouldHaveSize(n: Int) {
 /**
  * Asserts that this [Channel] should receive at least [n] elements.
  */
+@IgnorableReturnValue
 suspend fun <T> Channel<T>.shouldReceiveAtLeast(n: Int) {
    repeat(n) { this@shouldReceiveAtLeast.receive() }
 }
@@ -72,6 +77,7 @@ suspend fun <T> Channel<T>.shouldReceiveAtLeast(n: Int) {
  * Asserts that this [Channel] should receive at most [n] elements, then is closed.
  */
 @DelicateCoroutinesApi
+@IgnorableReturnValue
 suspend fun <T> Channel<T>.shouldReceiveAtMost(n: Int) {
    var count = 0
    for (value in this@shouldReceiveAtMost) {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/collections/containAllIgnoringFields.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/collections/containAllIgnoringFields.kt
@@ -15,6 +15,7 @@ import io.kotest.assertions.AssertionsConfig.maxCollectionPrintSize as printSize
  * @param field ignored field in comparison
  * @param other other ignored fields in comparison
  */
+@IgnorableReturnValue
 fun <T : Any> Iterable<T>.shouldContainAllIgnoringFields(
    ts: Collection<T>,
    field: KProperty<*>,
@@ -28,6 +29,7 @@ fun <T : Any> Iterable<T>.shouldContainAllIgnoringFields(
  * @param field ignored field in comparison
  * @param other other ignored fields in comparison
  */
+@IgnorableReturnValue
 fun <T : Any> Array<T>.shouldContainAllIgnoringFields(
    ts: Collection<T>,
    field: KProperty<*>,
@@ -41,6 +43,7 @@ fun <T : Any> Array<T>.shouldContainAllIgnoringFields(
  * @param field ignored field in comparison
  * @param other other ignored fields in comparison
  */
+@IgnorableReturnValue
 fun <T : Any> Collection<T>.shouldContainAllIgnoringFields(
    ts: Collection<T>,
    field: KProperty<*>,

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/concurrent.kt
@@ -7,10 +7,12 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration
 
+@IgnorableReturnValue
 fun <A> shouldCompleteWithin(duration: Duration, thunk: () -> A): A {
    return shouldCompleteWithin(duration.inWholeMilliseconds, TimeUnit.MILLISECONDS, thunk)
 }
 
+@IgnorableReturnValue
 fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A): A {
 
    val ref = AtomicReference<A>(null)
@@ -37,10 +39,12 @@ fun <A> shouldCompleteWithin(timeout: Long, unit: TimeUnit, thunk: () -> A): A {
    return ref.get()
 }
 
+@IgnorableReturnValue
 fun <A> shouldTimeout(duration: Duration, thunk: () -> A) {
    return shouldTimeout(duration.inWholeMilliseconds, TimeUnit.MILLISECONDS, thunk)
 }
 
+@IgnorableReturnValue
 fun <A> shouldTimeout(timeout: Long, unit: TimeUnit, thunk: () -> A) {
 
    val latch = CountDownLatch(1)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/threads.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/concurrent/threads.kt
@@ -5,7 +5,9 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 
+@IgnorableReturnValue
 fun Thread.shouldBeBlocked() = this should beBlocked()
+@IgnorableReturnValue
 fun Thread.shouldNotBeBlocked() = this shouldNot beBlocked()
 fun beBlocked() = object : Matcher<Thread> {
    override fun test(value: Thread) = MatcherResult(
@@ -16,7 +18,9 @@ fun beBlocked() = object : Matcher<Thread> {
       })
 }
 
+@IgnorableReturnValue
 fun Thread.shouldBeTerminated() = this should beTerminated()
+@IgnorableReturnValue
 fun Thread.shouldNotBeTerminated() = this shouldNot beTerminated()
 fun beTerminated() = object : Matcher<Thread> {
    override fun test(value: Thread) = MatcherResult(
@@ -27,7 +31,9 @@ fun beTerminated() = object : Matcher<Thread> {
       })
 }
 
+@IgnorableReturnValue
 fun Thread.shouldBeAlive() = this should beAlive()
+@IgnorableReturnValue
 fun Thread.shouldNotBeAlive() = this shouldNot beAlive()
 fun beAlive() = object : Matcher<Thread> {
    override fun test(value: Thread) = MatcherResult(
@@ -38,7 +44,9 @@ fun beAlive() = object : Matcher<Thread> {
       })
 }
 
+@IgnorableReturnValue
 fun Thread.shouldBeDaemon() = this should beDaemon()
+@IgnorableReturnValue
 fun Thread.shouldNotBeDaemon() = this shouldNot beDaemon()
 fun beDaemon() = object : Matcher<Thread> {
    override fun test(value: Thread) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/instant.kt
@@ -55,42 +55,49 @@ fun closeTo(anotherInstant: Instant, duration: Duration) = object : Matcher<Inst
  * Assert that [Instant] is before [anotherInstant].
  * @see [shouldNotBeBefore]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldBeBefore(anotherInstant: Instant) = this shouldBe before(anotherInstant)
 
 /**
  * Assert that [Instant] is not before [anotherInstant].
  * @see [shouldBeBefore]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldNotBeBefore(anotherInstant: Instant) = this shouldNotBe before(anotherInstant)
 
 /**
  * Assert that [Instant] is after [anotherInstant].
  * @see [shouldNotBeAfter]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldBeAfter(anotherInstant: Instant) = this shouldBe after(anotherInstant)
 
 /**
  * Assert that [Instant] is not after [anotherInstant].
  * @see [shouldNotBeAfter]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldNotBeAfter(anotherInstant: Instant) = this shouldNot after(anotherInstant)
 
 /**
  * Assert that [Instant] is between [fromInstant] and [toInstant].
  * @see [shouldNotBeBetween]
  * */
+@IgnorableReturnValue
 fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldBe between(fromInstant, toInstant)
 
 /**
  * Assert that [Instant] is not between [fromInstant] and [toInstant].
  * @see [shouldNotBeBetween]
  * */
+@IgnorableReturnValue
 fun Instant.shouldNotBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldNotBe between(fromInstant, toInstant)
 
 /**
  * Assert that [Instant] is close to [anotherInstant] in range by [duration].
  * @see [shouldBeCloseTo]
  * */
+@IgnorableReturnValue
 fun Instant.shouldBeCloseTo(anotherInstant: Instant, duration: Duration) =
    this shouldBe closeTo(anotherInstant, duration)
 
@@ -98,6 +105,7 @@ fun Instant.shouldBeCloseTo(anotherInstant: Instant, duration: Duration) =
  * Assert that [Instant] is not close to [anotherInstant] in range by [duration].
  * @see [shouldNotBeCloseTo]
  * */
+@IgnorableReturnValue
 fun Instant.shouldNotBeCloseTo(anotherInstant: Instant, duration: Duration) =
    this shouldNotBe closeTo(anotherInstant, duration)
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localdatetime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localdatetime.kt
@@ -73,6 +73,7 @@ fun beToday() = object : Matcher<LocalDate> {
  *      LocalDateTime.now().shouldBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldBeToday() = this should beInToday()
 
 /**
@@ -82,6 +83,7 @@ fun LocalDateTime.shouldBeToday() = this should beInToday()
  *      LocalDate.now().shouldBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDate.shouldBeToday() = this should beToday()
 
 /**
@@ -91,6 +93,7 @@ fun LocalDate.shouldBeToday() = this should beToday()
  *      LocalDateTime.of(2009, Month.APRIL, 2,2,2).shouldNotBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldNotBeToday() = this shouldNot beInToday()
 
 /**
@@ -100,6 +103,7 @@ fun LocalDateTime.shouldNotBeToday() = this shouldNot beInToday()
  *      LocalDate.of(2009, Month.APRIL, 2).shouldNotBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDate.shouldNotBeToday() = this shouldNot beToday()
 
 infix fun LocalDateTime.plusOrMinus(tolerance: Duration): LocalDateTimeToleranceMatcher =

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localtime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/localtime.kt
@@ -30,6 +30,7 @@ import kotlin.time.Duration
  *     firstTime shouldHaveSameHoursAs secondTime   //  Assertion fails, 23 != 16
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldHaveSameHoursAs(time: LocalTime) = this should haveSameHours(time)
 
 /**
@@ -53,6 +54,7 @@ infix fun LocalTime.shouldHaveSameHoursAs(time: LocalTime) = this should haveSam
  *     firstTime shouldNotHaveSameHoursAs secondTime   //  Assertion fails, 23 == 23
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldNotHaveSameHoursAs(time: LocalTime) = this shouldNot haveSameHours(time)
 
 /**
@@ -107,6 +109,7 @@ fun haveSameHours(time: LocalTime): Matcher<LocalTime> = object : Matcher<LocalT
  *     firstTime shouldHaveSameMinutesAs secondTime   //  Assertion fails, 59 != 1
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldHaveSameMinutesAs(time: LocalTime) = this should haveSameMinutes(time)
 
 /**
@@ -130,6 +133,7 @@ infix fun LocalTime.shouldHaveSameMinutesAs(time: LocalTime) = this should haveS
  *     firstTime shouldNotHaveSameMinutesAs secondTime   //  Assertion fails, 59 == 59
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldNotHaveSameMinutesAs(time: LocalTime) = this shouldNot haveSameMinutes(time)
 
 /**
@@ -183,6 +187,7 @@ fun haveSameMinutes(time: LocalTime): Matcher<LocalTime> = object : Matcher<Loca
  *     firstTime shouldHaveSameSecondsAs secondTime   //  Assertion fails, 30 != 25
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldHaveSameSecondsAs(time: LocalTime) = this should haveSameSeconds(time)
 
 /**
@@ -206,6 +211,7 @@ infix fun LocalTime.shouldHaveSameSecondsAs(time: LocalTime) = this should haveS
  *     firstTime shouldNotHaveSameSecondsAs secondTime   //  Assertion fails, 30 == 30
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldNotHaveSameSecondsAs(time: LocalTime) = this shouldNot haveSameSeconds(time)
 
 /**
@@ -259,6 +265,7 @@ fun haveSameSeconds(time: LocalTime): Matcher<LocalTime> = object : Matcher<Loca
  *     firstTime shouldHaveSameNanosAs nanoTime   //  Assertion fails, 1000 != 3333
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldHaveSameNanosAs(time: LocalTime) = this should haveSameNanos(time)
 
 /**
@@ -282,6 +289,7 @@ infix fun LocalTime.shouldHaveSameNanosAs(time: LocalTime) = this should haveSam
  *     firstTime shouldNotHaveSameNanosAs secondTime   //  Assertion fails, 1000 == 1000
 ```
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldNotHaveSameNanosAs(time: LocalTime) = this shouldNot haveSameNanos(time)
 
 /**
@@ -338,6 +346,7 @@ fun haveSameNanos(time: LocalTime): Matcher<LocalTime> = object : Matcher<LocalT
  *
  * @see LocalTime.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldBeBefore(time: LocalTime) = this should before(time)
 
 /**
@@ -363,6 +372,7 @@ infix fun LocalTime.shouldBeBefore(time: LocalTime) = this should before(time)
  *
  * @see LocalTime.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldNotBeBefore(time: LocalTime) = this shouldNot before(time)
 
 /**
@@ -419,6 +429,7 @@ fun before(time: LocalTime): Matcher<LocalTime> = object : Matcher<LocalTime> {
  *
  * @see LocalTime.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldBeAfter(time: LocalTime) = this should after(time)
 
 /**
@@ -444,6 +455,7 @@ infix fun LocalTime.shouldBeAfter(time: LocalTime) = this should after(time)
  *
  * @see LocalTime.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalTime.shouldNotBeAfter(time: LocalTime) = this shouldNot after(time)
 
 /**
@@ -501,6 +513,7 @@ fun after(time: LocalTime): Matcher<LocalTime> = object : Matcher<LocalTime> {
  *
  * @see LocalTime.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun LocalTime.shouldBeBetween(a: LocalTime, b: LocalTime) = this shouldBe between(a, b)
 
 /**
@@ -527,6 +540,7 @@ fun LocalTime.shouldBeBetween(a: LocalTime, b: LocalTime) = this shouldBe betwee
  *
  * @see LocalTime.shouldBeBetween
  */
+@IgnorableReturnValue
 fun LocalTime.shouldNotBeBetween(a: LocalTime, b: LocalTime) = this shouldNotBe between(a, b)
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/matchers.kt
@@ -37,6 +37,7 @@ import java.time.temporal.TemporalAmount
  *     firstDate shouldHaveSameYearAs secondDate   //  Assertion fails, 2018 != 1998
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldHaveSameYearAs(date: LocalDate) = this should haveSameYear(date)
 
 /**
@@ -60,6 +61,7 @@ infix fun LocalDate.shouldHaveSameYearAs(date: LocalDate) = this should haveSame
  *    firstDate shouldNotHaveSameYearAs  secondDate   //  Assertion fails, 1998 == 1998, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotHaveSameYearAs(date: LocalDate) = this shouldNot haveSameYear(date)
 
 /**
@@ -115,6 +117,7 @@ fun haveSameYear(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDa
  *    firstDate shouldHaveSameYearAs secondDate   //  Assertion fails, 2018 != 1998
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSameYearAs(date: LocalDateTime) = this should haveSameYear(date)
 
 /**
@@ -138,6 +141,7 @@ infix fun LocalDateTime.shouldHaveSameYearAs(date: LocalDateTime) = this should 
  *    firstDate shouldNotHaveSameYearAs  secondDate   //  Assertion fails, 1998 == 1998, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotHaveSameYearAs(date: LocalDateTime) = this shouldNot haveSameYear(date)
 
 /**
@@ -194,6 +198,7 @@ fun haveSameYear(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher
  *    firstDate shouldHaveSameYearAs secondDate   //  Assertion fails, 2018 != 1998
  * ```
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldHaveSameYearAs(date: ZonedDateTime) = this should haveSameYear(date)
 
 /**
@@ -218,6 +223,7 @@ infix fun ZonedDateTime.shouldHaveSameYearAs(date: ZonedDateTime) = this should 
  *     firstDate shouldNotHaveSameYearAs  secondDate   //  Assertion fails, 1998 == 1998, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldNotHaveSameYearAs(date: ZonedDateTime) = this shouldNot haveSameYear(date)
 
 /**
@@ -276,6 +282,7 @@ fun haveSameYear(date: ZonedDateTime): Matcher<ZonedDateTime> = object : Matcher
 
  * ```
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldHaveSameYearAs(date: OffsetDateTime) = this should haveSameYear(date)
 
 /**
@@ -301,6 +308,7 @@ infix fun OffsetDateTime.shouldHaveSameYearAs(date: OffsetDateTime) = this shoul
  *
  * ```
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldNotHaveSameYearAs(date: OffsetDateTime) = this shouldNot haveSameYear(date)
 
 /**
@@ -357,6 +365,7 @@ fun haveSameYear(date: OffsetDateTime): Matcher<OffsetDateTime> = object : Match
  *    firstDate shouldNot haveSameYear(secondDate)    //  Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldHaveSameMonthAs(date: LocalDate) = this should haveSameMonth(date)
 
 /**
@@ -380,6 +389,7 @@ infix fun LocalDate.shouldHaveSameMonthAs(date: LocalDate) = this should haveSam
  *    firstDate shouldHaveSameMonthAs secondDate   //  Assertion fails, 2 != 3
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotHaveSameMonthAs(date: LocalDate) = this shouldNot haveSameMonth(date)
 
 /**
@@ -435,6 +445,7 @@ fun haveSameMonth(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalD
  *    firstDate shouldNot haveSameMonth(secondDate)    //  Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSameMonthAs(date: LocalDateTime) = this should haveSameMonth(date)
 
 /**
@@ -458,6 +469,7 @@ infix fun LocalDateTime.shouldHaveSameMonthAs(date: LocalDateTime) = this should
  *    firstDate shouldHaveSameMonthAs secondDate   //  Assertion fails, 2 != 3
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotHaveSameMonthAs(date: LocalDateTime) = this shouldNot haveSameMonth(date)
 
 /**
@@ -514,6 +526,7 @@ fun haveSameMonth(date: LocalDateTime): Matcher<LocalDateTime> = object : Matche
  *    firstDate shouldNot haveSameMonth(secondDate)    //  Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldHaveSameMonthAs(date: ZonedDateTime) = this should haveSameMonth(date)
 
 /**
@@ -538,6 +551,7 @@ infix fun ZonedDateTime.shouldHaveSameMonthAs(date: ZonedDateTime) = this should
  *    firstDate shouldHaveSameMonthAs secondDate   //  Assertion fails, 2 != 3
  * ```
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldNotHaveSameMonthAs(date: ZonedDateTime) = this shouldNot haveSameMonth(date)
 
 /**
@@ -595,6 +609,7 @@ fun haveSameMonth(date: ZonedDateTime): Matcher<ZonedDateTime> = object : Matche
  *    firstDate shouldHaveSameMonthAs secondDate   //  Assertion fails, 2 != 3
  * ```
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldHaveSameMonthAs(date: OffsetDateTime) = this should haveSameMonth(date)
 
 /**
@@ -619,6 +634,7 @@ infix fun OffsetDateTime.shouldHaveSameMonthAs(date: OffsetDateTime) = this shou
  *    firstDate shouldNotHaveSameMonthAs  secondDate   //  Assertion fails, 2 == 2, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldNotHaveSameMonthAs(date: OffsetDateTime) = this shouldNot haveSameMonth(date)
 
 /**
@@ -675,6 +691,7 @@ fun haveSameMonth(date: OffsetDateTime): Matcher<OffsetDateTime> = object : Matc
  *    firstDate shouldHaveSameDayAs secondDate   //  Assertion fails, 9 != 10
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldHaveSameDayAs(date: LocalDate) = this should haveSameDay(date)
 
 /**
@@ -698,6 +715,7 @@ infix fun LocalDate.shouldHaveSameDayAs(date: LocalDate) = this should haveSameD
  *    firstDate shouldNotHaveSameDayAs  secondDate   //  Assertion fails, 9 == 9, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotHaveSameDayAs(date: LocalDate) = this shouldNot haveSameDay(date)
 
 /**
@@ -753,6 +771,7 @@ fun haveSameDay(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDat
  *    firstDate shouldHaveSameDayAs secondDate   //  Assertion fails, 9 != 10
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSameDayAs(date: LocalDateTime) = this should haveSameDay(date)
 
 /**
@@ -776,6 +795,7 @@ infix fun LocalDateTime.shouldHaveSameDayAs(date: LocalDateTime) = this should h
  *    firstDate shouldNotHaveSameDayAs  secondDate   // Assertion fails, 9 == 9, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotHaveSameDayAs(date: LocalDateTime) = this shouldNot haveSameDay(date)
 
 /**
@@ -832,6 +852,7 @@ fun haveSameDay(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher<
  *    firstDate shouldHaveSameDayAs secondDate   // Assertion fails, 9 != 10
  * ```
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldHaveSameDayAs(date: ZonedDateTime) = this should haveSameDay(date)
 
 /**
@@ -856,6 +877,7 @@ infix fun ZonedDateTime.shouldHaveSameDayAs(date: ZonedDateTime) = this should h
  *    firstDate shouldNotHaveSameDayAs  secondDate   // Assertion fails, 9 == 9, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldNotHaveSameDayAs(date: ZonedDateTime) = this shouldNot haveSameDay(date)
 
 /**
@@ -913,6 +935,7 @@ fun haveSameDay(date: ZonedDateTime): Matcher<ZonedDateTime> = object : Matcher<
  *    firstDate shouldHaveSameDayAs secondDate   // Assertion fails, 9 != 12
  * ```
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldHaveSameDayAs(date: OffsetDateTime) = this should haveSameDay(date)
 
 /**
@@ -937,6 +960,7 @@ infix fun OffsetDateTime.shouldHaveSameDayAs(date: OffsetDateTime) = this should
  *    firstDate shouldNotHaveSameDayAs  secondDate   // Assertion fails, 9 == 9, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldNotHaveSameDayAs(date: OffsetDateTime) = this shouldNot haveSameDay(date)
 
 /**
@@ -995,6 +1019,7 @@ fun haveSameDay(date: OffsetDateTime): Matcher<OffsetDateTime> = object : Matche
  *
  * @see LocalDate.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldBeBefore(date: LocalDate) = this should before(date)
 
 /**
@@ -1021,6 +1046,7 @@ infix fun LocalDate.shouldBeBefore(date: LocalDate) = this should before(date)
  *
  * @see LocalDate.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotBeBefore(date: LocalDate) = this shouldNot before(date)
 
 /**
@@ -1076,6 +1102,7 @@ fun before(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDate> {
  *
  * @see LocalDateTime.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldBeBefore(date: LocalDateTime) = this should before(date)
 
 /**
@@ -1101,6 +1128,7 @@ infix fun LocalDateTime.shouldBeBefore(date: LocalDateTime) = this should before
  *
  * @see LocalDateTime.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotBeBefore(date: LocalDateTime) = this shouldNot before(date)
 
 /**
@@ -1157,6 +1185,7 @@ fun before(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher<Local
  *
  * @see ZonedDateTime.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldBeBefore(date: ZonedDateTime) = this should before(date)
 
 /**
@@ -1183,6 +1212,7 @@ infix fun ZonedDateTime.shouldBeBefore(date: ZonedDateTime) = this should before
  *
  * @see ZonedDateTime.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldNotBeBefore(date: ZonedDateTime) = this shouldNot before(date)
 
 /**
@@ -1240,6 +1270,7 @@ fun before(date: ZonedDateTime): Matcher<ZonedDateTime> = object : Matcher<Zoned
  *
  * @see OffsetDateTime.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldBeBefore(date: OffsetDateTime) = this should before(date)
 
 /**
@@ -1266,6 +1297,7 @@ infix fun OffsetDateTime.shouldBeBefore(date: OffsetDateTime) = this should befo
  *
  * @see OffsetDateTime.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldNotBeBefore(date: OffsetDateTime) = this shouldNot before(date)
 
 /**
@@ -1322,6 +1354,7 @@ fun before(date: OffsetDateTime): Matcher<OffsetDateTime> = object : Matcher<Off
  *
  * @see LocalDate.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldBeAfter(date: LocalDate) = this should after(date)
 
 /**
@@ -1347,6 +1380,7 @@ infix fun LocalDate.shouldBeAfter(date: LocalDate) = this should after(date)
  *
  * @see LocalDate.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotBeAfter(date: LocalDate) = this shouldNot after(date)
 
 /**
@@ -1402,6 +1436,7 @@ fun after(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDate> {
  *
  * @see LocalDateTime.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldBeAfter(date: LocalDateTime) = this should after(date)
 
 /**
@@ -1427,6 +1462,7 @@ infix fun LocalDateTime.shouldBeAfter(date: LocalDateTime) = this should after(d
  *
  * @see LocalDateTime.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotBeAfter(date: LocalDateTime) = this shouldNot after(date)
 
 /**
@@ -1483,6 +1519,7 @@ fun after(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher<LocalD
  *
  * @see ZonedDateTime.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldBeAfter(date: ZonedDateTime) = this should after(date)
 
 /**
@@ -1509,6 +1546,7 @@ infix fun ZonedDateTime.shouldBeAfter(date: ZonedDateTime) = this should after(d
  *
  * @see ZonedDateTime.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldNotBeAfter(date: ZonedDateTime) = this shouldNot after(date)
 
 /**
@@ -1566,6 +1604,7 @@ fun after(date: ZonedDateTime): Matcher<ZonedDateTime> = object : Matcher<ZonedD
  *
  * @see OffsetDateTime.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldBeAfter(date: OffsetDateTime) = this should after(date)
 
 /**
@@ -1592,6 +1631,7 @@ infix fun OffsetDateTime.shouldBeAfter(date: OffsetDateTime) = this should after
  *
  * @see OffsetDateTime.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldNotBeAfter(date: OffsetDateTime) = this shouldNot after(date)
 
 /**
@@ -1646,6 +1686,7 @@ fun after(date: OffsetDateTime): Matcher<OffsetDateTime> = object : Matcher<Offs
  *     firstDate.shouldBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is not within 3 days of secondDate
  * ```
  */
+@IgnorableReturnValue
 fun LocalDate.shouldBeWithin(period: Period, date: LocalDate) = this should within(period, date)
 
 /**
@@ -1669,6 +1710,7 @@ fun LocalDate.shouldBeWithin(period: Period, date: LocalDate) = this should with
  *     firstDate.shouldNotBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is within 3 days of secondDate, and we expected not to
  * ```
  */
+@IgnorableReturnValue
 fun LocalDate.shouldNotBeWithin(period: Period, date: LocalDate) = this shouldNot within(period, date)
 
 /**
@@ -1728,6 +1770,7 @@ fun within(period: Period, date: LocalDate): Matcher<LocalDate> = object : Match
  *     firstDate.shouldBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is not within 3 days of secondDate
  * ```
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldBeWithin(temporalAmount: TemporalAmount, date: LocalDateTime) = this should within(temporalAmount, date)
 
 /**
@@ -1751,6 +1794,7 @@ fun LocalDateTime.shouldBeWithin(temporalAmount: TemporalAmount, date: LocalDate
  *     firstDate.shouldNotBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is within 3 days of secondDate, and we expected not to
  * ```
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldNotBeWithin(temporalAmount: TemporalAmount, date: LocalDateTime) = this shouldNot within(temporalAmount, date)
 
 /**
@@ -1813,6 +1857,7 @@ fun within(temporalAmount: TemporalAmount, date: LocalDateTime): Matcher<LocalDa
  *     firstDate.shouldBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is not within 3 days of secondDate
  * ```
  */
+@IgnorableReturnValue
 fun ZonedDateTime.shouldBeWithin(temporalAmount: TemporalAmount, date: ZonedDateTime) = this should within(temporalAmount, date)
 
 /**
@@ -1837,6 +1882,7 @@ fun ZonedDateTime.shouldBeWithin(temporalAmount: TemporalAmount, date: ZonedDate
  *     firstDate.shouldNotBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is within 3 days of secondDate, and we expected not to
  * ```
  */
+@IgnorableReturnValue
 fun ZonedDateTime.shouldNotBeWithin(temporalAmount: TemporalAmount, date: ZonedDateTime) = this shouldNot within(temporalAmount, date)
 
 /**
@@ -1899,6 +1945,7 @@ fun within(temporalAmount: TemporalAmount, date: ZonedDateTime): Matcher<ZonedDa
  *     firstDate.shouldBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is not within 3 days of secondDate
  * ```
  */
+@IgnorableReturnValue
 fun OffsetDateTime.shouldBeWithin(temporalAmount: TemporalAmount, date: OffsetDateTime) = this should within(temporalAmount, date)
 
 /**
@@ -1923,6 +1970,7 @@ fun OffsetDateTime.shouldBeWithin(temporalAmount: TemporalAmount, date: OffsetDa
  *     firstDate.shouldNotBeWithin(Period.ofDays(3), secondDate)   // Assertion fails, firstDate is within 3 days of secondDate, and we expected not to
  * ```
  */
+@IgnorableReturnValue
 fun OffsetDateTime.shouldNotBeWithin(temporalAmount: TemporalAmount, date: OffsetDateTime) = this shouldNot within(temporalAmount, date)
 
 /**
@@ -1987,6 +2035,7 @@ fun within(temporalAmount: TemporalAmount, date: OffsetDateTime): Matcher<Offset
  *
  * @see LocalDate.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun LocalDate.shouldBeBetween(a: LocalDate, b: LocalDate) = this shouldBe between(a, b)
 
 /**
@@ -2013,6 +2062,7 @@ fun LocalDate.shouldBeBetween(a: LocalDate, b: LocalDate) = this shouldBe betwee
  *
  * @see LocalDate.shouldBeBetween
  */
+@IgnorableReturnValue
 fun LocalDate.shouldNotBeBetween(a: LocalDate, b: LocalDate) = this shouldNotBe between(a, b)
 
 /**
@@ -2075,6 +2125,7 @@ fun between(a: LocalDate, b: LocalDate): Matcher<LocalDate> = object : Matcher<L
  *
  * @see LocalDateTime.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldBeBetween(a: LocalDateTime, b: LocalDateTime) = this shouldBe between(a, b)
 
 /**
@@ -2101,6 +2152,7 @@ fun LocalDateTime.shouldBeBetween(a: LocalDateTime, b: LocalDateTime) = this sho
  *
  * @see LocalDateTime.shouldBeBetween
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldNotBeBetween(a: LocalDateTime, b: LocalDateTime) = this shouldNotBe between(a, b)
 
 /**
@@ -2163,6 +2215,7 @@ fun between(a: LocalDateTime, b: LocalDateTime): Matcher<LocalDateTime> = object
  *
  * @see ZonedDateTime.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun ZonedDateTime.shouldBeBetween(a: ZonedDateTime, b: ZonedDateTime) = this shouldBe between(a, b)
 
 /**
@@ -2189,6 +2242,7 @@ fun ZonedDateTime.shouldBeBetween(a: ZonedDateTime, b: ZonedDateTime) = this sho
  *
  * @see ZonedDateTime.shouldBeBetween
  */
+@IgnorableReturnValue
 fun ZonedDateTime.shouldNotBeBetween(a: ZonedDateTime, b: ZonedDateTime) = this shouldNotBe between(a, b)
 
 /**
@@ -2252,6 +2306,7 @@ fun between(a: ZonedDateTime, b: ZonedDateTime): Matcher<ZonedDateTime> = object
  *
  * @see OffsetDateTime.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun OffsetDateTime.shouldBeBetween(a: OffsetDateTime, b: OffsetDateTime) = this shouldBe between(a, b)
 
 /**
@@ -2278,6 +2333,7 @@ fun OffsetDateTime.shouldBeBetween(a: OffsetDateTime, b: OffsetDateTime) = this 
  *
  * @see OffsetDateTime.shouldBeBetween
  */
+@IgnorableReturnValue
 fun OffsetDateTime.shouldNotBeBetween(a: OffsetDateTime, b: OffsetDateTime) = this shouldNotBe between(a, b)
 
 /**
@@ -2326,6 +2382,7 @@ fun between(a: OffsetDateTime, b: OffsetDateTime): Matcher<OffsetDateTime> = obj
  *    date.shouldHaveDayOfMonth(15) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfMonth(day: Int) = this.dayOfMonth shouldBe day
 
 /**
@@ -2337,6 +2394,7 @@ infix fun LocalDateTime.shouldHaveDayOfMonth(day: Int) = this.dayOfMonth shouldB
  *    date.shouldHaveDayOfYear(46) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfYear(day: Int) = this.dayOfYear shouldBe day
 
 /**
@@ -2349,7 +2407,9 @@ infix fun LocalDateTime.shouldHaveDayOfYear(day: Int) = this.dayOfYear shouldBe 
  *    date.shouldHaveDayOfWeek(5) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfWeek(day: Int) = this.dayOfWeek.value shouldBe day
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfWeek(day: DayOfWeek) = this.dayOfWeek shouldBe day
 
 /**
@@ -2362,7 +2422,9 @@ infix fun LocalDateTime.shouldHaveDayOfWeek(day: DayOfWeek) = this.dayOfWeek sho
  *    date.shouldHaveMonth(FEBRUARY) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveMonth(month: Int) = this.month.value shouldBe month
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveMonth(month: Month) = this.month shouldBe month
 
 /**
@@ -2374,6 +2436,7 @@ infix fun LocalDateTime.shouldHaveMonth(month: Month) = this.month shouldBe mont
  *    date.shouldHaveHour(12) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveHour(hour: Int) = this.hour shouldBe hour
 
 /**
@@ -2385,6 +2448,7 @@ infix fun LocalDateTime.shouldHaveHour(hour: Int) = this.hour shouldBe hour
  *    date.shouldHaveMinute(10) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveMinute(minute: Int) = this.minute shouldBe minute
 
 /**
@@ -2396,6 +2460,7 @@ infix fun LocalDateTime.shouldHaveMinute(minute: Int) = this.minute shouldBe min
  *    date.shouldHaveSecond(11) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSecond(second: Int) = this.second shouldBe second
 
 /**
@@ -2407,6 +2472,7 @@ infix fun LocalDateTime.shouldHaveSecond(second: Int) = this.second shouldBe sec
  *    date.shouldHaveNano(10) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveNano(nano: Int) = this.nano shouldBe nano
 
 /**
@@ -2429,6 +2495,7 @@ infix fun LocalDateTime.shouldHaveNano(nano: Int) = this.nano shouldBe nano
  *
  * @see ZonedDateTime.shouldNotHaveSameInstantAs
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldHaveSameInstantAs(other: ZonedDateTime) = this should haveSameInstantAs(other)
 
 /**
@@ -2451,6 +2518,7 @@ infix fun ZonedDateTime.shouldHaveSameInstantAs(other: ZonedDateTime) = this sho
  *
  * @see ZonedDateTime.shouldHaveSameInstantAs
  */
+@IgnorableReturnValue
 infix fun ZonedDateTime.shouldNotHaveSameInstantAs(other: ZonedDateTime) = this shouldNot haveSameInstantAs(other)
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/offsetdatetime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/offsetdatetime.kt
@@ -26,6 +26,7 @@ fun beInTodayODT() = object : Matcher<OffsetDateTime> {
  *      OffsetDateTime.now().shouldBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun OffsetDateTime.shouldBeToday() = this should beInTodayODT()
 
 
@@ -36,6 +37,7 @@ fun OffsetDateTime.shouldBeToday() = this should beInTodayODT()
  *      OffsetDateTime.of(2009, Month.APRIL, 2,2,2).shouldNotBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun OffsetDateTime.shouldNotBeToday() = this shouldNot beInTodayODT()
 
 /**
@@ -58,6 +60,7 @@ fun OffsetDateTime.shouldNotBeToday() = this shouldNot beInTodayODT()
  *
  * @see OffsetDateTime.shouldNotHaveSameInstantAs
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldHaveSameInstantAs(other: OffsetDateTime) = this should haveSameInstantAs(other)
 
 /**
@@ -80,6 +83,7 @@ infix fun OffsetDateTime.shouldHaveSameInstantAs(other: OffsetDateTime) = this s
  *
  * @see OffsetDateTime.shouldHaveSameInstantAs
  */
+@IgnorableReturnValue
 infix fun OffsetDateTime.shouldNotHaveSameInstantAs(other: OffsetDateTime) = this shouldNot haveSameInstantAs(other)
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/timestamp.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/timestamp.kt
@@ -40,34 +40,40 @@ fun beBetween(fromTimestamp: Timestamp, toTimestamp: Timestamp) = object : Match
  * Assert that [Timestamp] is after [anotherTimestamp].
  * @see [shouldNotBeAfter]
  * */
+@IgnorableReturnValue
 infix fun Timestamp.shouldBeAfter(anotherTimestamp: Timestamp) = this should beAfter(anotherTimestamp)
 
 /**
  * Assert that [Timestamp] is not after [anotherTimestamp].
  * @see [shouldBeAfter]
  * */
+@IgnorableReturnValue
 infix fun Timestamp.shouldNotBeAfter(anotherTimestamp: Timestamp) = this shouldNot beAfter(anotherTimestamp)
 
 /**
  * Assert that [Timestamp] is before [anotherTimestamp].
  * @see [shouldNotBeBefore]
  * */
+@IgnorableReturnValue
 infix fun Timestamp.shouldBeBefore(anotherTimestamp: Timestamp) = this should beBefore(anotherTimestamp)
 
 /**
  * Assert that [Timestamp] is not before [anotherTimestamp].
  * @see [shouldBeBefore]
  * */
+@IgnorableReturnValue
 infix fun Timestamp.shouldNotBeBefore(anotherTimestamp: Timestamp) = this shouldNot beBefore(anotherTimestamp)
 
 /**
  * Assert that [Timestamp] is between [fromTimestamp] and [toTimestamp].
  * @see [shouldNotBeBetween]
  * */
+@IgnorableReturnValue
 fun Timestamp.shouldBeBetween(fromTimestamp: Timestamp, toTimestamp: Timestamp) = this should beBetween(fromTimestamp, toTimestamp)
 
 /**
  * Assert that [Timestamp] is not between [fromTimestamp] and [toTimestamp].
  * @see [shouldNotBeBetween]
  * */
+@IgnorableReturnValue
 fun Timestamp.shouldNotBeBetween(fromTimestamp: Timestamp, toTimestamp: Timestamp) = this shouldNot beBetween(fromTimestamp, toTimestamp)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/zoneddatetime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/zoneddatetime.kt
@@ -26,6 +26,7 @@ fun beInTodayZDT() = object : Matcher<ZonedDateTime> {
  *      ZonedDateTime.of(2009, Month.APRIL, 2,2,2).shouldNotBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun ZonedDateTime.shouldNotBeToday() = this shouldNot beInTodayZDT()
 
 /**
@@ -35,6 +36,7 @@ fun ZonedDateTime.shouldNotBeToday() = this shouldNot beInTodayZDT()
  *      ZonedDateTime.now().shouldBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun ZonedDateTime.shouldBeToday() = this should beInTodayZDT()
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/equalToComparingFields.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/equalToComparingFields.kt
@@ -8,12 +8,14 @@ import io.kotest.matchers.shouldNot
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 
+@IgnorableReturnValue
 infix fun <T : Any> T.shouldBeEqualUsingFields(other: T): T {
    val config = FieldEqualityConfig()
    this should beEqualUsingFields(other, config)
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T : Any> T.shouldNotBeEqualUsingFields(other: T): T {
    val config = FieldEqualityConfig()
    this shouldNot beEqualUsingFields(other, config)
@@ -60,6 +62,7 @@ infix fun <T : Any> T.shouldNotBeEqualUsingFields(other: T): T {
  *  }
  *  ```
  * */
+@IgnorableReturnValue
 infix fun <T : Any> T.shouldBeEqualUsingFields(block: FieldEqualityConfig.() -> T): T {
    val config = FieldEqualityConfig()
    val other = block.invoke(config)
@@ -67,6 +70,7 @@ infix fun <T : Any> T.shouldBeEqualUsingFields(block: FieldEqualityConfig.() -> 
    return this
 }
 
+@IgnorableReturnValue
 infix fun <T : Any> T.shouldNotBeEqualUsingFields(block: FieldEqualityConfig.() -> T): T {
    val config = FieldEqualityConfig()
    val other = block.invoke(config)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/equality/reflection.kt
@@ -39,6 +39,7 @@ import kotlin.reflect.jvm.isAccessible
  * or if [other] is not an instance of the same class as receiver [T]
  *
  */
+@IgnorableReturnValue
 fun <T : Any> T.shouldBeEqualToUsingFields(other: T, vararg properties: KProperty<*>) {
    require(this::class.isInstance(other)){"other is not an instance of declaring class"}
    this should beEqualToUsingFields(other, *properties)
@@ -67,6 +68,7 @@ fun <T : Any> T.shouldBeEqualToUsingFields(other: T, vararg properties: KPropert
  * Note: Throws [IllegalArgumentException] if [properties] contains any non-public property
  *
  */
+@IgnorableReturnValue
 fun <T : Any, V: Any> T.shouldBeEqualToDifferentTypeUsingFields(other: V, vararg properties: KProperty1<T, *>) {
    this should beEqualToUsingFields(other, *properties)
 }
@@ -97,6 +99,7 @@ fun <T : Any, V: Any> T.shouldBeEqualToDifferentTypeUsingFields(other: V, vararg
  * @see [shouldNotBeEqualToIgnoringFields]
  *
  */
+@IgnorableReturnValue
 fun <T : Any> T.shouldNotBeEqualToUsingFields(other: T, vararg properties: KProperty<*>) {
    this shouldNot beEqualToUsingFields(other, *properties)
 }
@@ -169,6 +172,7 @@ fun <T : Any, V: Any> beEqualToUsingFields(other: V, vararg fields: KProperty<*>
  * ```
  *
  */
+@IgnorableReturnValue
 fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, property: KProperty<*>, vararg others: KProperty<*>) {
    require(this::class.isInstance(other)){"other is not an instance of declaring class"}
    this should beEqualToIgnoringFields(other = other, ignorePrivateFields = true, property = property, others = others)
@@ -197,6 +201,7 @@ fun <T : Any> T.shouldBeEqualToIgnoringFields(other: T, property: KProperty<*>, 
  * Note: Throws [IllegalArgumentException] if [properties] contains any non-public property
  *
  */
+@IgnorableReturnValue
 fun <T : Any, V: Any> T.shouldBeEqualToDifferentTypeIgnoringFields(other: V, property: KProperty1<T, *>, vararg others: KProperty1<T, *>) {
    this should beEqualToIgnoringFields(other = other, ignorePrivateFields = true, property = property, others = others)
 }
@@ -226,6 +231,7 @@ fun <T : Any, V: Any> T.shouldBeEqualToDifferentTypeIgnoringFields(other: V, pro
  *
  */
 
+@IgnorableReturnValue
 fun <T : Any> T.shouldBeEqualToIgnoringFields(
    other: T,
    ignorePrivateFields: Boolean,
@@ -260,6 +266,7 @@ fun <T : Any> T.shouldBeEqualToIgnoringFields(
  * ```
  *
  */
+@IgnorableReturnValue
 fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, property: KProperty<*>, vararg others: KProperty<*>) =
    this shouldNot beEqualToIgnoringFields(
       other = other,
@@ -291,6 +298,7 @@ fun <T : Any> T.shouldNotBeEqualToIgnoringFields(other: T, property: KProperty<*
  * ```
  *
  */
+@IgnorableReturnValue
 fun <T : Any> T.shouldNotBeEqualToIgnoringFields(
    other: T,
    ignorePrivateFields: Boolean,
@@ -394,6 +402,7 @@ fun <T : Any> beEqualToIgnoringFields(
  *  ))
  *  ```
  * */
+@IgnorableReturnValue
 fun <T : Any> T.shouldBeEqualToComparingFields(
    other: T,
    fieldsEqualityCheckConfig: FieldsEqualityCheckConfig = FieldsEqualityCheckConfig()
@@ -401,14 +410,17 @@ fun <T : Any> T.shouldBeEqualToComparingFields(
    this should beEqualComparingFields(other, fieldsEqualityCheckConfig)
 }
 
+@IgnorableReturnValue
 infix fun <T : Any> T.shouldBeEqualToComparingFields(other: T) {
    shouldBeEqualToComparingFields(other, FieldsEqualityCheckConfig())
 }
 
+@IgnorableReturnValue
 infix fun <T : Any> T.shouldNotBeEqualToComparingFields(other: T) {
    this shouldNot beEqualComparingFields(other, FieldsEqualityCheckConfig())
 }
 
+@IgnorableReturnValue
 fun <T : Any> T.shouldNotBeEqualToComparingFields(
    other: T,
    fieldsEqualityCheckConfig: FieldsEqualityCheckConfig

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/content.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/content.kt
@@ -9,6 +9,7 @@ import java.io.FileInputStream
 import java.io.InputStreamReader
 import java.nio.charset.Charset
 
+@IgnorableReturnValue
 fun File.shouldHaveSameContentAs(other: File, charset: Charset = Charset.forName("utf8")) =
    this should object : Matcher<File> {
       override fun test(value: File): MatcherResult {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/matchers.kt
@@ -16,7 +16,9 @@ private fun File.safeList(): List<String> = this.list()?.toList() ?: emptyList()
 private fun File.safeListFiles(): List<File> = this.listFiles()?.toList() ?: emptyList()
 private fun File.safeListFiles(filter: FileFilter): List<File> = this.listFiles(filter)?.toList() ?: emptyList()
 
+@IgnorableReturnValue
 fun File.shouldBeEmptyDirectory() = this should beEmptyDirectory()
+@IgnorableReturnValue
 fun File.shouldNotBeEmptyDirectory() = this shouldNot beEmptyDirectory()
 fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult {
@@ -42,7 +44,9 @@ fun beEmptyDirectory(): Matcher<File> = object : Matcher<File> {
    }
 }
 
+@IgnorableReturnValue
 infix fun File.shouldContainNFiles(n: Int) = this shouldBe containNFiles(n)
+@IgnorableReturnValue
 infix fun File.shouldNotContainNFiles(n: Int) = this shouldNotBe containNFiles(n)
 fun containNFiles(n: Int): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult = MatcherResult(
@@ -52,7 +56,9 @@ fun containNFiles(n: Int): Matcher<File> = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 fun File.shouldBeEmpty() = this shouldBe emptyFile()
+@IgnorableReturnValue
 fun File.shouldNotBeEmpty() = this shouldNotBe emptyFile()
 fun emptyFile(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -63,7 +69,9 @@ fun emptyFile(): Matcher<File> = object : Matcher<File> {
       )
 }
 
+@IgnorableReturnValue
 fun File.shouldExist() = this should exist()
+@IgnorableReturnValue
 fun File.shouldNotExist() = this shouldNot exist()
 fun exist() = object : Matcher<File> {
    override fun test(value: File) =
@@ -74,7 +82,9 @@ fun exist() = object : Matcher<File> {
       )
 }
 
+@IgnorableReturnValue
 infix fun File.shouldContainFile(name: String) = this should containFile(name)
+@IgnorableReturnValue
 infix fun File.shouldNotContainFile(name: String) = this shouldNot containFile(name)
 fun containFile(name: String) = object : Matcher<File> {
    override fun test(value: File): MatcherResult {
@@ -88,10 +98,14 @@ fun containFile(name: String) = object : Matcher<File> {
    }
 }
 
+@IgnorableReturnValue
 fun File.shouldBeSymbolicLink() = this.toPath() should beSymbolicLink()
+@IgnorableReturnValue
 fun File.shouldNotBeSymbolicLink() = this.toPath() shouldNot beSymbolicLink()
 
+@IgnorableReturnValue
 infix fun File.shouldHaveParent(name: String) = this should haveParent(name)
+@IgnorableReturnValue
 infix fun File.shouldNotHaveParent(name: String) = this shouldNot haveParent(name)
 fun haveParent(name: String) = object : Matcher<File> {
    private fun isParentEqualExpected(parent: File?): Boolean =
@@ -104,7 +118,9 @@ fun haveParent(name: String) = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 fun File.shouldBeADirectory() = this should aDirectory()
+@IgnorableReturnValue
 fun File.shouldNotBeADirectory() = this shouldNot aDirectory()
 fun aDirectory(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult = MatcherResult(
@@ -114,7 +130,9 @@ fun aDirectory(): Matcher<File> = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 fun File.shouldBeAFile() = this should aFile()
+@IgnorableReturnValue
 fun File.shouldNotBeAFile() = this shouldNot aFile()
 fun aFile(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -124,9 +142,13 @@ fun aFile(): Matcher<File> = object : Matcher<File> {
          { "File $value should not be a file" })
 }
 
+@IgnorableReturnValue
 infix fun File.shouldBeSmaller(other: Path) = this should beSmaller(other.toFile())
+@IgnorableReturnValue
 infix fun File.shouldBeSmaller(other: File) = this should beSmaller(other)
+@IgnorableReturnValue
 infix fun File.shouldNotBeSmaller(other: Path) = this shouldNot beSmaller(other.toFile())
+@IgnorableReturnValue
 infix fun File.shouldNotBeSmaller(other: File) = this shouldNot beSmaller(other)
 
 fun beSmaller(other: File): Matcher<File> = object : Matcher<File> {
@@ -141,9 +163,13 @@ fun beSmaller(other: File): Matcher<File> = object : Matcher<File> {
    }
 }
 
+@IgnorableReturnValue
 infix fun File.shouldBeLarger(other: Path) = this should beLarger(other.toFile())
+@IgnorableReturnValue
 infix fun File.shouldBeLarger(other: File) = this should beLarger(other)
+@IgnorableReturnValue
 infix fun File.shouldNotBeLarger(other: Path) = this shouldNot beLarger(other.toFile())
+@IgnorableReturnValue
 infix fun File.shouldNotBeLarger(other: File) = this shouldNot beLarger(other)
 
 fun beLarger(other: File): Matcher<File> = object : Matcher<File> {
@@ -158,7 +184,9 @@ fun beLarger(other: File): Matcher<File> = object : Matcher<File> {
    }
 }
 
+@IgnorableReturnValue
 fun File.shouldBeCanonical() = this should beCanonicalPath()
+@IgnorableReturnValue
 fun File.shouldNotBeCanonical() = this shouldNot beCanonicalPath()
 fun beCanonicalPath(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult = MatcherResult(
@@ -168,7 +196,9 @@ fun beCanonicalPath(): Matcher<File> = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 fun File.shouldBeAbsolute() = this should beAbsolute()
+@IgnorableReturnValue
 fun File.shouldNotBeAbsolute() = this shouldNot beAbsolute()
 fun beAbsolute(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -178,7 +208,9 @@ fun beAbsolute(): Matcher<File> = object : Matcher<File> {
          { "File $value should not be absolute" })
 }
 
+@IgnorableReturnValue
 fun File.shouldBeRelative() = this should beRelative()
+@IgnorableReturnValue
 fun File.shouldNotBeRelative() = this shouldNot beRelative()
 fun beRelative(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -188,7 +220,9 @@ fun beRelative(): Matcher<File> = object : Matcher<File> {
          { "File $value should not be relative" })
 }
 
+@IgnorableReturnValue
 infix fun File.shouldHaveFileSize(size: Long) = this should haveFileSize(size)
+@IgnorableReturnValue
 infix fun File.shouldNotHaveFileSize(size: Long) = this shouldNot haveFileSize(size)
 fun haveFileSize(size: Long): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult = MatcherResult(
@@ -198,7 +232,9 @@ fun haveFileSize(size: Long): Matcher<File> = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 fun File.shouldBeWriteable() = this should beWriteable()
+@IgnorableReturnValue
 fun File.shouldNotBeWriteable() = this shouldNot beWriteable()
 fun beWriteable(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -208,7 +244,9 @@ fun beWriteable(): Matcher<File> = object : Matcher<File> {
          { "File $value should not be writeable" })
 }
 
+@IgnorableReturnValue
 fun File.shouldBeExecutable() = this should beExecutable()
+@IgnorableReturnValue
 fun File.shouldNotBeExecutable() = this shouldNot beExecutable()
 fun beExecutable(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult = MatcherResult(
@@ -218,7 +256,9 @@ fun beExecutable(): Matcher<File> = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 fun File.shouldBeHidden() = this should beHidden()
+@IgnorableReturnValue
 fun File.shouldNotBeHidden() = this shouldNot beHidden()
 fun beHidden(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -228,7 +268,9 @@ fun beHidden(): Matcher<File> = object : Matcher<File> {
          { "File $value should not be hidden" })
 }
 
+@IgnorableReturnValue
 fun File.shouldBeReadable() = this should beReadable()
+@IgnorableReturnValue
 fun File.shouldNotBeReadable() = this shouldNot beReadable()
 fun beReadable(): Matcher<File> = object : Matcher<File> {
    override fun test(value: File): MatcherResult =
@@ -238,16 +280,24 @@ fun beReadable(): Matcher<File> = object : Matcher<File> {
          { "File $value should not be readable" })
 }
 
+@IgnorableReturnValue
 infix fun File.shouldStartWithPath(path: Path) = this should startWithPath(path)
+@IgnorableReturnValue
 infix fun File.shouldNotStartWithPath(path: Path) = this shouldNot startWithPath(path)
 
+@IgnorableReturnValue
 infix fun File.shouldStartWithPath(prefix: String) = this should startWithPath(prefix)
+@IgnorableReturnValue
 infix fun File.shouldNotStartWithPath(prefix: String) = this shouldNot startWithPath(prefix)
 
+@IgnorableReturnValue
 infix fun File.shouldStartWithPath(file: File) = this should startWithPath(file)
+@IgnorableReturnValue
 infix fun File.shouldNotStartWithPath(file: File) = this shouldNot startWithPath(file)
 
+@IgnorableReturnValue
 infix fun Path.shouldStartWithPath(path: Path) = this.toFile() should startWithPath(path)
+@IgnorableReturnValue
 infix fun Path.shouldNotStartWithPath(path: Path) = this.toFile() shouldNot startWithPath(path)
 
 fun startWithPath(path: Path) = startWithPath(path.toFile())
@@ -260,10 +310,12 @@ fun startWithPath(prefix: String) = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 infix fun File.shouldHaveSameStructureAs(file: File) {
    this.shouldHaveSameStructureAs(file) { _, _ -> false }
 }
 
+@IgnorableReturnValue
 fun File.shouldHaveSameStructureAs(
    file: File,
    compare: (expect: File, actual: File) -> Boolean,
@@ -290,6 +342,7 @@ fun File.shouldHaveSameStructureAs(
    }
 }
 
+@IgnorableReturnValue
 fun File.shouldHaveSameStructureAs(
    file: File,
    filterLhs: (File) -> Boolean = { false },
@@ -300,10 +353,12 @@ fun File.shouldHaveSameStructureAs(
    }
 }
 
+@IgnorableReturnValue
 infix fun File.shouldHaveSameStructureAndContentAs(file: File) {
    this.shouldHaveSameStructureAndContentAs(file) { _, _ -> false }
 }
 
+@IgnorableReturnValue
 fun File.shouldHaveSameStructureAndContentAs(
    file: File,
    compare: (expect: File, actual: File) -> Boolean,
@@ -331,6 +386,7 @@ fun File.shouldHaveSameStructureAndContentAs(
    }
 }
 
+@IgnorableReturnValue
 fun File.shouldHaveSameStructureAndContentAs(
    file: File,
    filterLhs: (File) -> Boolean = { false },

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/names.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/file/names.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.io.File
 
+@IgnorableReturnValue
 fun File.shouldHaveExtension(vararg exts: String) = this should haveExtension(*exts)
+@IgnorableReturnValue
 fun File.shouldNotHaveExtension(vararg exts: String) = this shouldNot haveExtension(*exts)
 fun haveExtension(vararg exts: String) = object : Matcher<File> {
    override fun test(value: File) = MatcherResult(
@@ -16,7 +18,9 @@ fun haveExtension(vararg exts: String) = object : Matcher<File> {
    )
 }
 
+@IgnorableReturnValue
 infix fun File.shouldHavePath(name: String) = this should havePath(name)
+@IgnorableReturnValue
 infix fun File.shouldNotHavePath(name: String) = this shouldNot havePath(name)
 fun havePath(name: String) = object : Matcher<File> {
    override fun test(value: File) =
@@ -27,7 +31,9 @@ fun havePath(name: String) = object : Matcher<File> {
       )
 }
 
+@IgnorableReturnValue
 infix fun File.shouldHaveName(name: String) = this should haveName(name)
+@IgnorableReturnValue
 infix fun File.shouldNotHaveName(name: String) = this shouldNot haveName(name)
 fun haveName(name: String) = object : Matcher<File> {
    override fun test(value: File) =
@@ -39,7 +45,9 @@ fun haveName(name: String) = object : Matcher<File> {
 }
 
 
+@IgnorableReturnValue
 infix fun File.shouldHaveNameWithoutExtension(name: String) = this should haveNameWithoutExtension(name)
+@IgnorableReturnValue
 infix fun File.shouldNotHaveNameWithoutExtension(name: String) = this shouldNot haveNameWithoutExtension(name)
 fun haveNameWithoutExtension(name: String) = object : Matcher<File> {
    override fun test(value: File): MatcherResult {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/future/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/future/matchers.kt
@@ -8,7 +8,9 @@ import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import java.util.concurrent.CompletableFuture
 
+@IgnorableReturnValue
 fun <T> CompletableFuture<T>.shouldBeCompletedExceptionally() = this shouldBe completedExceptionally<T>()
+@IgnorableReturnValue
 fun <T> CompletableFuture<T>.shouldNotBeCompletedExceptionally() = this shouldNotBe completedExceptionally<T>()
 fun <T> completedExceptionally() = object : Matcher<CompletableFuture<T>> {
    override fun test(value: CompletableFuture<T>): MatcherResult =
@@ -24,7 +26,9 @@ internal fun errorMessageForFailedFuture(failedFuture: CompletableFuture<*>): St
    return "Future should not be completed exceptionally, but it failed with ${exception.cause}"
 }
 
+@IgnorableReturnValue
 fun <T> CompletableFuture<T>.shouldBeCompleted() = this shouldBe completed<T>()
+@IgnorableReturnValue
 fun <T> CompletableFuture<T>.shouldNotBeCompleted() = this shouldNotBe completed<T>()
 fun <T> completed() = object : Matcher<CompletableFuture<T>> {
    override fun test(value: CompletableFuture<T>): MatcherResult =
@@ -36,7 +40,9 @@ fun <T> completed() = object : Matcher<CompletableFuture<T>> {
          })
 }
 
+@IgnorableReturnValue
 fun <T> CompletableFuture<T>.shouldBeCancelled() = this shouldBe cancelled<T>()
+@IgnorableReturnValue
 fun <T> CompletableFuture<T>.shouldNotBeCancelled() = this shouldNotBe cancelled<T>()
 fun <T> cancelled() = object : Matcher<CompletableFuture<T>> {
    override fun test(value: CompletableFuture<T>): MatcherResult =
@@ -48,9 +54,11 @@ fun <T> cancelled() = object : Matcher<CompletableFuture<T>> {
          })
 }
 
+@IgnorableReturnValue
 infix fun CompletableFuture<*>.shouldCompleteExceptionallyWith(throwable: Throwable) =
    this should completeExceptionallyWith(throwable)
 
+@IgnorableReturnValue
 infix fun CompletableFuture<*>.shouldNotCompleteExceptionallyWith(throwable: Throwable) =
    this shouldNot completeExceptionallyWith(throwable)
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/optional/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/optional/matchers.kt
@@ -15,6 +15,7 @@ import java.util.Optional
  * Optional.of("A").shouldBeEmpty() // Assertion fails
  * ```
  */
+@IgnorableReturnValue
 fun <T> Optional<T>.shouldBeEmpty() = this should beEmpty()
 
 /**
@@ -26,6 +27,7 @@ fun <T> Optional<T>.shouldBeEmpty() = this should beEmpty()
  * Optional.empty().shouldNotBeEmpty() // Assertion fails
  * ```
  */
+@IgnorableReturnValue
 fun <T> Optional<T>.shouldNotBeEmpty() = this shouldNot beEmpty()
 
 /**
@@ -51,6 +53,7 @@ fun <T> beEmpty() = object : Matcher<Optional<T>> {
  *
  * ```
  */
+@IgnorableReturnValue
 infix fun <T> Optional<T>.shouldBePresent(block: T.(value: T) -> Unit): T {
     shouldBePresent()
     get().block(get())
@@ -77,6 +80,7 @@ infix fun <T> Optional<T>.shouldBePresent(block: T.(value: T) -> Unit): T {
  * ```
  *
  */
+@IgnorableReturnValue
 fun <T> Optional<T>.shouldBePresent(): T {
     this should bePresent()
     return get()
@@ -85,6 +89,7 @@ fun <T> Optional<T>.shouldBePresent(): T {
 /**
  * Verifies that this Optional contains no value
  */
+@IgnorableReturnValue
 fun <T> Optional<T>.shouldNotBePresent() = this shouldNot bePresent()
 
 /**

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/canonical.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/canonical.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.nio.file.Path
 
+@IgnorableReturnValue
 fun Path.shouldBeCanonical() = this should beCanonicalPath()
+@IgnorableReturnValue
 fun Path.shouldNotBeCanonical() = this shouldNot beCanonicalPath()
 fun beCanonicalPath(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/contents.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/contents.kt
@@ -8,7 +8,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.name
 
+@IgnorableReturnValue
 fun Path.shouldContainFiles(vararg files: String) = this should containFiles(files.asList())
+@IgnorableReturnValue
 fun Path.shouldNotContainFiles(vararg files: String) = this shouldNot containFiles(files.asList())
 
 fun containFiles(names: List<String>) = object : Matcher<Path> {
@@ -33,7 +35,9 @@ fun containFiles(names: List<String>) = object : Matcher<Path> {
    }
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldContainFile(name: String) = this should containFile(name)
+@IgnorableReturnValue
 infix fun Path.shouldNotContainFile(name: String) = this shouldNot containFile(name)
 
 fun containFile(name: String) = object : Matcher<Path> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/empty.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/empty.kt
@@ -10,7 +10,9 @@ import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 
+@IgnorableReturnValue
 fun Path.shouldBeEmptyDirectory() = this should beEmptyDirectory()
+@IgnorableReturnValue
 fun Path.shouldNotBeEmptyDirectory() = this shouldNot beEmptyDirectory()
 
 fun beEmptyDirectory(): Matcher<Path> = object : Matcher<Path> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/names.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/names.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.nio.file.Path
 
+@IgnorableReturnValue
 fun Path.shouldHaveExtension(vararg exts: String) = this should haveExtension(*exts)
+@IgnorableReturnValue
 fun Path.shouldNotHaveExtension(vararg exts: String) = this shouldNot haveExtension(*exts)
 fun haveExtension(vararg exts: String) = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult {
@@ -21,7 +23,9 @@ fun haveExtension(vararg exts: String) = object : Matcher<Path> {
 }
 
 
+@IgnorableReturnValue
 infix fun Path.shouldHaveNameWithoutExtension(name: String) = this should haveNameWithoutExtension(name)
+@IgnorableReturnValue
 infix fun Path.shouldNotHaveNameWithoutExtension(name: String) = this shouldNot haveNameWithoutExtension(name)
 fun haveNameWithoutExtension(name: String) = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/nfiles.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/nfiles.kt
@@ -8,7 +8,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.isDirectory
 
+@IgnorableReturnValue
 infix fun Path.shouldContainNFiles(n: Int) = this should containNFiles(n)
+@IgnorableReturnValue
 infix fun Path.shouldNotContainNFiles(n: Int) = this shouldNot containNFiles(n)
 
 fun containNFiles(n: Int): Matcher<Path> = object : Matcher<Path> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/paths.kt
@@ -12,13 +12,19 @@ import kotlin.io.path.isRegularFile
 import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.name
 
+@IgnorableReturnValue
 infix fun Path.shouldStartWithPath(file: File) = this should startWithPath(file)
+@IgnorableReturnValue
 infix fun Path.shouldNotStartWithPath(file: File) = this shouldNot startWithPath(file)
 
+@IgnorableReturnValue
 infix fun Path.shouldStartWithPath(prefix: String) = this should startWithPath(prefix)
+@IgnorableReturnValue
 infix fun Path.shouldNotStartWithPath(prefix: String) = this shouldNot startWithPath(prefix)
 
+@IgnorableReturnValue
 infix fun Path.shouldStartWithPath(path: Path) = this should startWithPath(path)
+@IgnorableReturnValue
 infix fun Path.shouldNotStartWithPath(path: Path) = this shouldNot startWithPath(path)
 
 fun startWithPath(path: Path) = startWithPath(path.toString())
@@ -30,7 +36,9 @@ fun startWithPath(prefix: String) = object : Matcher<Path> {
       { "Path $value should not start with $prefix" })
 }
 
+@IgnorableReturnValue
 fun Path.shouldExist() = this should exist()
+@IgnorableReturnValue
 fun Path.shouldNotExist() = this shouldNot exist()
 fun exist() = object : Matcher<Path> {
    override fun test(value: Path) =
@@ -40,7 +48,9 @@ fun exist() = object : Matcher<Path> {
          { "Path $value should not exist" })
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldHaveFileSize(size: Long) = this should haveFileSize(size)
+@IgnorableReturnValue
 infix fun Path.shouldNotHaveFileSize(size: Long) = this shouldNot haveFileSize(size)
 fun haveFileSize(size: Long): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult = MatcherResult(
@@ -50,7 +60,9 @@ fun haveFileSize(size: Long): Matcher<Path> = object : Matcher<Path> {
 }
 
 
+@IgnorableReturnValue
 fun Path.shouldBeADirectory() = this should aDirectory()
+@IgnorableReturnValue
 fun Path.shouldNotBeADirectory() = this shouldNot aDirectory()
 fun aDirectory(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult = MatcherResult(
@@ -59,7 +71,9 @@ fun aDirectory(): Matcher<Path> = object : Matcher<Path> {
       { "File $value should not be a directory" })
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeAFile() = this should aFile()
+@IgnorableReturnValue
 fun Path.shouldNotBeAFile() = this shouldNot aFile()
 fun aFile(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult = MatcherResult(
@@ -68,7 +82,9 @@ fun aFile(): Matcher<Path> = object : Matcher<Path> {
       { "Path $value should not be a regular file" })
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeAbsolute() = this should beAbsolute()
+@IgnorableReturnValue
 fun Path.shouldNotBeAbsolute() = this shouldNot beAbsolute()
 fun beAbsolute(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult =
@@ -78,7 +94,9 @@ fun beAbsolute(): Matcher<Path> = object : Matcher<Path> {
          { "Path $value should not be absolute" })
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeRelative() = this should beRelative()
+@IgnorableReturnValue
 fun Path.shouldNotBeRelative() = this shouldNot beRelative()
 fun beRelative(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult =
@@ -88,7 +106,9 @@ fun beRelative(): Matcher<Path> = object : Matcher<Path> {
          { "Path $value should not be relative" })
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeReadable() = this should beReadable()
+@IgnorableReturnValue
 fun Path.shouldNotBeReadable() = this shouldNot beReadable()
 fun beReadable(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult =
@@ -99,7 +119,9 @@ fun beReadable(): Matcher<Path> = object : Matcher<Path> {
       )
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeWriteable() = this should beWriteable()
+@IgnorableReturnValue
 fun Path.shouldNotBeWriteable() = this shouldNot beWriteable()
 fun beWriteable(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult =
@@ -110,7 +132,9 @@ fun beWriteable(): Matcher<Path> = object : Matcher<Path> {
       )
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeExecutable() = this should beExecutable()
+@IgnorableReturnValue
 fun Path.shouldNotBeExecutable() = this shouldNot beExecutable()
 fun beExecutable(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult = MatcherResult(
@@ -120,7 +144,9 @@ fun beExecutable(): Matcher<Path> = object : Matcher<Path> {
    )
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeHidden() = this should beHidden()
+@IgnorableReturnValue
 fun Path.shouldNotBeHidden() = this shouldNot beHidden()
 fun beHidden(): Matcher<Path> = object : Matcher<Path> {
    override fun test(value: Path): MatcherResult =
@@ -130,7 +156,9 @@ fun beHidden(): Matcher<Path> = object : Matcher<Path> {
          { "Path $value should not be hidden" })
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldContainFileDeep(name: String) = this should containFileDeep(name)
+@IgnorableReturnValue
 infix fun Path.shouldNotContainFileDeep(name: String) = this shouldNot containFileDeep(name)
 fun containFileDeep(name: String): Matcher<Path> = object : Matcher<Path> {
 
@@ -147,7 +175,9 @@ fun containFileDeep(name: String): Matcher<Path> = object : Matcher<Path> {
    )
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldHaveParent(name: String) = this should haveParent(name)
+@IgnorableReturnValue
 infix fun Path.shouldNotHaveParent(name: String) = this shouldNot haveParent(name)
 fun haveParent(name: String) = object : Matcher<Path> {
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/sizes.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/sizes.kt
@@ -8,9 +8,13 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 
+@IgnorableReturnValue
 infix fun Path.shouldBeLarger(other: Path) = this should beLarger(other)
+@IgnorableReturnValue
 infix fun Path.shouldBeLarger(other: File) = this should beLarger(other.toPath())
+@IgnorableReturnValue
 infix fun Path.shouldNotBeLarger(other: Path) = this shouldNot beLarger(other)
+@IgnorableReturnValue
 infix fun Path.shouldNotBeLarger(other: File) = this shouldNot beLarger(other.toPath())
 
 fun beLarger(other: Path): Matcher<Path> = object : Matcher<Path> {
@@ -24,9 +28,13 @@ fun beLarger(other: Path): Matcher<Path> = object : Matcher<Path> {
    }
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldBeSmaller(other: Path) = this should beSmaller(other)
+@IgnorableReturnValue
 infix fun Path.shouldBeSmaller(other: File) = this should beSmaller(other.toPath())
+@IgnorableReturnValue
 infix fun Path.shouldNotBeSmaller(other: Path) = this shouldNot beSmaller(other)
+@IgnorableReturnValue
 infix fun Path.shouldNotBeSmaller(other: File) = this shouldNot beSmaller(other.toPath())
 
 fun beSmaller(other: Path): Matcher<Path> = object : Matcher<Path> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/symbolic.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/paths/symbolic.kt
@@ -7,7 +7,9 @@ import io.kotest.matchers.shouldNot
 import java.nio.file.Files
 import java.nio.file.Path
 
+@IgnorableReturnValue
 fun Path.shouldBeSymbolicLink() = this should beSymbolicLink()
+@IgnorableReturnValue
 fun Path.shouldNotBeSymbolicLink() = this shouldNot beSymbolicLink()
 fun beSymbolicLink() = object : Matcher<Path> {
    override fun test(value: Path) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/property/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/property/matchers.kt
@@ -34,8 +34,13 @@ fun beNamed(expectedName: String) = Matcher<KProperty<*>> {
    )
 }
 
+@IgnorableReturnValue
 fun KProperty<*>.shouldBeNullable() = this should beNullable()
+@IgnorableReturnValue
 fun KProperty<*>.shouldBeNotNullable() = this should beNullable().invert()
+@IgnorableReturnValue
 fun KProperty<*>.shouldBeMutable() = this should beMutable()
+@IgnorableReturnValue
 fun KProperty<*>.shouldBeImmutable() = this should beImmutable()
+@IgnorableReturnValue
 infix fun KProperty<*>.shouldBeNamed(expectedName: String) = this should beNamed(expectedName)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/callableMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/callableMatchers.kt
@@ -11,7 +11,9 @@ import kotlin.reflect.KVisibility
 import kotlin.reflect.full.isSupertypeOf
 import kotlin.reflect.full.starProjectedType
 
+@IgnorableReturnValue
 infix fun KCallable<*>.shouldHaveVisibility(visibility: KVisibility) = this should haveCallableVisibility(visibility)
+@IgnorableReturnValue
 infix fun KCallable<*>.shouldNotHaveVisibility(visibility: KVisibility) = this shouldNot haveCallableVisibility(visibility)
 fun haveCallableVisibility(expected: KVisibility) = object : Matcher<KCallable<*>> {
    override fun test(value: KCallable<*>) = MatcherResult(
@@ -22,7 +24,9 @@ fun haveCallableVisibility(expected: KVisibility) = object : Matcher<KCallable<*
       })
 }
 
+@IgnorableReturnValue
 fun KCallable<*>.shouldBeFinal() = this should beFinal()
+@IgnorableReturnValue
 fun KCallable<*>.shouldNotBeFinal() = this shouldNot beFinal()
 fun beFinal() = object : Matcher<KCallable<*>> {
    override fun test(value: KCallable<*>) = MatcherResult(
@@ -33,7 +37,9 @@ fun beFinal() = object : Matcher<KCallable<*>> {
       })
 }
 
+@IgnorableReturnValue
 fun KCallable<*>.shouldBeOpen() = this should beOpen()
+@IgnorableReturnValue
 fun KCallable<*>.shouldNotBeOpen() = this shouldNot beOpen()
 fun beOpen() = object : Matcher<KCallable<*>> {
    override fun test(value: KCallable<*>) = MatcherResult(
@@ -44,7 +50,9 @@ fun beOpen() = object : Matcher<KCallable<*>> {
       })
 }
 
+@IgnorableReturnValue
 fun KCallable<*>.shouldBeAbstract() = this should beAbstract()
+@IgnorableReturnValue
 fun KCallable<*>.shouldNotBeAbstract() = this shouldNot beAbstract()
 fun beAbstract() = object : Matcher<KCallable<*>> {
    override fun test(value: KCallable<*>) = MatcherResult(
@@ -55,7 +63,9 @@ fun beAbstract() = object : Matcher<KCallable<*>> {
       })
 }
 
+@IgnorableReturnValue
 fun KCallable<*>.shouldBeSuspendable() = this should beSuspendable()
+@IgnorableReturnValue
 fun KCallable<*>.shouldNotBeSuspendable() = this shouldNot beSuspendable()
 fun beSuspendable() = object : Matcher<KCallable<*>> {
    override fun test(value: KCallable<*>) = MatcherResult(
@@ -66,11 +76,14 @@ fun beSuspendable() = object : Matcher<KCallable<*>> {
       })
 }
 
+@IgnorableReturnValue
 fun KCallable<*>.shouldAcceptParameters(parameters: List<KClass<*>>, block: (List<KParameter>) -> Unit) {
   this should acceptParametersOfType(parameters)
   block(this.parameters)
 }
+@IgnorableReturnValue
 infix fun KCallable<*>.shouldAcceptParameters(parameters: List<KClass<*>>) = this should acceptParametersOfType(parameters)
+@IgnorableReturnValue
 infix fun KCallable<*>.shouldNotAcceptParameters(parameters: List<KClass<*>>) = this shouldNot acceptParametersOfType(parameters)
 fun acceptParametersOfType(parameters: List<KClass<*>>) = object : Matcher<KCallable<*>> {
    private fun validate(index: Int, acc: Boolean, parameter: KParameter): Boolean {
@@ -85,11 +98,14 @@ fun acceptParametersOfType(parameters: List<KClass<*>>) = object : Matcher<KCall
       })
 }
 
+@IgnorableReturnValue
 fun KCallable<*>.shouldHaveParametersWithName(parameters: List<String>, block: (List<KParameter>) -> Unit) {
   this should haveParametersWithName(parameters)
   block(this.parameters)
 }
+@IgnorableReturnValue
 infix fun KCallable<*>.shouldHaveParametersWithName(parameters: List<String>) = this should haveParametersWithName(parameters)
+@IgnorableReturnValue
 infix fun KCallable<*>.shouldNotHaveParametersWithName(parameters: List<String>) = this shouldNot haveParametersWithName(parameters)
 fun haveParametersWithName(parameters: List<String>) = object : Matcher<KCallable<*>> {
    private fun validate(index: Int, acc: Boolean, parameter: KParameter): Boolean {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/classMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/classMatchers.kt
@@ -13,9 +13,13 @@ import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.full.isSuperclassOf
 import kotlin.reflect.full.primaryConstructor
 
+@IgnorableReturnValue
 fun KClass<*>.shouldHaveAnnotations() = this should haveClassAnnotations()
+@IgnorableReturnValue
 fun KClass<*>.shouldNotHaveAnnotations() = this shouldNot haveClassAnnotations()
+@IgnorableReturnValue
 infix fun KClass<*>.shouldHaveAnnotations(count: Int) = this should haveClassAnnotations(count)
+@IgnorableReturnValue
 infix fun KClass<*>.shouldNotHaveAnnotations(count: Int) = this shouldNot haveClassAnnotations(count)
 
 fun haveClassAnnotations(count: Int = -1) = object : Matcher<KClass<*>> {
@@ -34,11 +38,13 @@ fun haveClassAnnotations(count: Int = -1) = object : Matcher<KClass<*>> {
   }
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Annotation> KClass<*>.shouldBeAnnotatedWith(block: (T) -> Unit = {}) {
   this should beClassAnnotatedWith<T>()
   findAnnotation<T>()?.let(block)
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Annotation> KClass<*>.shouldNotBeAnnotatedWith() = this shouldNot beClassAnnotatedWith<T>()
 inline fun <reified T : Annotation> beClassAnnotatedWith() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -48,12 +54,15 @@ inline fun <reified T : Annotation> beClassAnnotatedWith() = object : Matcher<KC
    )
 }
 
+@IgnorableReturnValue
 fun KClass<*>.shouldHaveFunction(name: String, block: (KFunction<*>) -> Unit) {
   this should haveFunction(name)
   findFunction(name)?.let(block)
 }
 
+@IgnorableReturnValue
 infix fun KClass<*>.shouldHaveFunction(name: String) = this should haveFunction(name)
+@IgnorableReturnValue
 infix fun KClass<*>.shouldNotHaveFunction(name: String) = this shouldNot haveFunction(name)
 fun haveFunction(name: String) = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -63,11 +72,14 @@ fun haveFunction(name: String) = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 fun KClass<*>.shouldHaveMemberProperty(name: String, block: (KProperty<*>) -> Unit) {
   this should haveMemberProperty(name)
   findMemberProperty(name)?.let(block)
 }
+@IgnorableReturnValue
 infix fun KClass<*>.shouldHaveMemberProperty(name: String) = this should haveMemberProperty(name)
+@IgnorableReturnValue
 infix fun KClass<*>.shouldNotHaveMemberProperty(name: String) = this shouldNot haveMemberProperty(name)
 fun haveMemberProperty(name: String) = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -77,7 +89,9 @@ fun haveMemberProperty(name: String) = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 inline fun <reified T> KClass<*>.shouldBeSubtypeOf() = this should beSubtypeOf<T>()
+@IgnorableReturnValue
 inline fun <reified T> KClass<*>.shouldNotBeSubtypeOf() = this shouldNot beSubtypeOf<T>()
 inline fun <reified T> beSubtypeOf() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -87,7 +101,9 @@ inline fun <reified T> beSubtypeOf() = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 inline fun <reified T> KClass<*>.shouldBeSupertypeOf() = this should beSuperTypeOf<T>()
+@IgnorableReturnValue
 inline fun <reified T> KClass<*>.shouldNotBeSupertypeOf() = this shouldNot beSuperTypeOf<T>()
 inline fun <reified T> beSuperTypeOf() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -97,7 +113,9 @@ inline fun <reified T> beSuperTypeOf() = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 fun KClass<*>.shouldBeData() = this should beData()
+@IgnorableReturnValue
 fun KClass<*>.shouldNotBeData() = this shouldNot beData()
 fun beData() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -107,7 +125,9 @@ fun beData() = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 fun KClass<*>.shouldBeSealed() = this should beSealed()
+@IgnorableReturnValue
 fun KClass<*>.shouldNotBeSealed() = this shouldNot beSealed()
 fun beSealed() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -117,7 +137,9 @@ fun beSealed() = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 fun KClass<*>.shouldBeCompanion() = this should beCompanion()
+@IgnorableReturnValue
 fun KClass<*>.shouldNotBeCompanion() = this shouldNot beCompanion()
 fun beCompanion() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -127,7 +149,9 @@ fun beCompanion() = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 fun KClass<*>.shouldHavePrimaryConstructor() = this should havePrimaryConstructor()
+@IgnorableReturnValue
 fun KClass<*>.shouldNotHavePrimaryConstructor() = this shouldNot havePrimaryConstructor()
 fun havePrimaryConstructor() = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(
@@ -137,7 +161,9 @@ fun havePrimaryConstructor() = object : Matcher<KClass<*>> {
    )
 }
 
+@IgnorableReturnValue
 infix fun KClass<*>.shouldHaveVisibility(expected: KVisibility) = this should haveClassVisibility(expected)
+@IgnorableReturnValue
 infix fun KClass<*>.shouldNotHaveVisibility(expected: KVisibility) = this shouldNot haveClassVisibility(expected)
 fun haveClassVisibility(expected: KVisibility) = object : Matcher<KClass<*>> {
    override fun test(value: KClass<*>) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/functionMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/functionMatchers.kt
@@ -7,9 +7,13 @@ import io.kotest.matchers.shouldNot
 import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 
+@IgnorableReturnValue
 fun KFunction<*>.shouldHaveAnnotations() = this should haveFunctionAnnotations()
+@IgnorableReturnValue
 fun KFunction<*>.shouldNotHaveAnnotations() = this shouldNot haveFunctionAnnotations()
+@IgnorableReturnValue
 infix fun KFunction<*>.shouldHaveAnnotations(count: Int) = this should haveFunctionAnnotations(count)
+@IgnorableReturnValue
 infix fun KFunction<*>.shouldNotHaveAnnotations(count: Int) = this shouldNot haveFunctionAnnotations(count)
 fun haveFunctionAnnotations(count: Int = -1) = object : Matcher<KFunction<*>> {
   override fun test(value: KFunction<*>) = if (count < 0) {
@@ -29,11 +33,13 @@ fun haveFunctionAnnotations(count: Int = -1) = object : Matcher<KFunction<*>> {
   }
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Annotation> KFunction<*>.shouldBeAnnotatedWith(block: (T) -> Unit = {}) {
   this should beAnnotatedWith<T>()
   findAnnotation<T>()?.let(block)
 }
 
+@IgnorableReturnValue
 inline fun <reified T : Annotation> KFunction<*>.shouldNotBeAnnotatedWith() = this shouldNot beAnnotatedWith<T>()
 inline fun <reified T : Annotation> beAnnotatedWith() = object : Matcher<KFunction<*>> {
    override fun test(value: KFunction<*>) = MatcherResult(
@@ -44,10 +50,14 @@ inline fun <reified T : Annotation> beAnnotatedWith() = object : Matcher<KFuncti
       })
 }
 
+@IgnorableReturnValue
 inline fun <reified T> KFunction<*>.shouldHaveReturnType() = this.returnType.shouldBeOfType<T>()
+@IgnorableReturnValue
 inline fun <reified T> KFunction<*>.shouldNotHaveReturnType() = this.returnType.shouldNotBeOfType<T>()
 
+@IgnorableReturnValue
 fun KFunction<*>.shouldBeInline() = this should beInline()
+@IgnorableReturnValue
 fun KFunction<*>.shouldNotBeInline() = this shouldNot beInline()
 fun beInline() = object : Matcher<KFunction<*>> {
    override fun test(value: KFunction<*>) = MatcherResult(
@@ -58,7 +68,9 @@ fun beInline() = object : Matcher<KFunction<*>> {
       })
 }
 
+@IgnorableReturnValue
 fun KFunction<*>.shouldBeInfix() = this should beInfix()
+@IgnorableReturnValue
 fun KFunction<*>.shouldNotBeInfix() = this shouldNot beInfix()
 fun beInfix() = object : Matcher<KFunction<*>> {
    override fun test(value: KFunction<*>) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/propertyMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/propertyMatchers.kt
@@ -6,10 +6,14 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlin.reflect.KProperty
 
+@IgnorableReturnValue
 inline fun <reified T> KProperty<*>.shouldBeOfType() = this.returnType.shouldBeOfType<T>()
+@IgnorableReturnValue
 inline fun <reified T> KProperty<*>.shouldNotBeOfType() = this.returnType.shouldNotBeOfType<T>()
 
+@IgnorableReturnValue
 fun KProperty<*>.shouldBeConst() = this should beConst()
+@IgnorableReturnValue
 fun KProperty<*>.shouldNotBeConst() = this shouldNot beConst()
 fun beConst() = object : Matcher<KProperty<*>> {
    override fun test(value: KProperty<*>) = MatcherResult(
@@ -20,7 +24,9 @@ fun beConst() = object : Matcher<KProperty<*>> {
       })
 }
 
+@IgnorableReturnValue
 fun KProperty<*>.shouldBeLateInit() = this should beLateInit()
+@IgnorableReturnValue
 fun KProperty<*>.shouldNotBeLateInit() = this shouldNot beLateInit()
 fun beLateInit() = object : Matcher<KProperty<*>> {
    override fun test(value: KProperty<*>) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/typeMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/reflection/typeMatchers.kt
@@ -8,7 +8,9 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.isSubtypeOf
 import kotlin.reflect.full.starProjectedType
 
+@IgnorableReturnValue
 inline fun <reified T> KType.shouldBeOfType() = this should beOfType<T>()
+@IgnorableReturnValue
 inline fun <reified T> KType.shouldNotBeOfType() = this shouldNot beOfType<T>()
 inline fun <reified T> beOfType() = object : Matcher<KType> {
    override fun test(value: KType) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/byteArrayMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/byteArrayMatchers.kt
@@ -13,6 +13,7 @@ import kotlin.io.path.writeBytes
 /**
  * Will match when given ByteArray and resource value are equal
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldMatchResource(
    path: String
 ): ByteArray {
@@ -23,6 +24,7 @@ infix fun ByteArray.shouldMatchResource(
 /**
  * Will match when given ByteArray and resource value differ
  */
+@IgnorableReturnValue
 infix fun ByteArray.shouldNotMatchResource(
    path: String
 ): ByteArray {
@@ -33,6 +35,7 @@ infix fun ByteArray.shouldNotMatchResource(
 /**
  * Will match if the given ByteArray and the resource value matches using matcher provided by [matcherProvider]
  */
+@IgnorableReturnValue
 fun ByteArray.shouldMatchResource(
    path: String,
    matcherProvider: (ByteArray) -> Matcher<ByteArray>
@@ -44,6 +47,7 @@ fun ByteArray.shouldMatchResource(
 /**
  * Will match if the given ByteArray and the resource value **not** matches using matcher provided by [matcherProvider]
  */
+@IgnorableReturnValue
 fun ByteArray.shouldNotMatchResource(
    path: String,
    matcherProvider: (ByteArray) -> Matcher<ByteArray>

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/stringMatchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/resource/stringMatchers.kt
@@ -18,6 +18,7 @@ import kotlin.io.path.writeText
  *
  * This will ignore differences in "\r", "\n" and "\r\n", so it is not dependent on the system line separator.
  */
+@IgnorableReturnValue
 infix fun String.shouldMatchResource(
    path: String
 ): String {
@@ -30,6 +31,7 @@ infix fun String.shouldMatchResource(
  *
  * This will ignore differences in "\r", "\n" and "\r\n", so it is not dependent on the system line separator.
  */
+@IgnorableReturnValue
 infix fun String.shouldNotMatchResource(
    path: String
 ): String {
@@ -43,6 +45,7 @@ infix fun String.shouldNotMatchResource(
  * @param ignoreLineSeparators if true, will ignore differences in "\r", "\n" and "\r\n", so it is not dependent on the system line separator.
  * @param trim if true, will trim the expected and actual values before comparing them.
  */
+@IgnorableReturnValue
 fun String.shouldMatchResource(
    path: String,
    matcherProvider: (String) -> Matcher<String> = ::be,
@@ -61,6 +64,7 @@ fun String.shouldMatchResource(
 /**
  * Will match if the given String and the resource value **not** matches using matcher provided by [matcherProvider]
  */
+@IgnorableReturnValue
 fun String.shouldNotMatchResource(
    path: String,
    matcherProvider: (String) -> Matcher<String> = ::be,

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/sql/resultset.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/sql/resultset.kt
@@ -6,10 +6,12 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.sql.ResultSet
 
+@IgnorableReturnValue
 infix fun ResultSet.shouldHaveRows(rowCount: Int) = this should haveRowCount(
    rowCount
 )
 
+@IgnorableReturnValue
 infix fun ResultSet.shouldNotHaveRows(rowCount: Int) = this shouldNot haveRowCount(
    rowCount
 )
@@ -23,10 +25,12 @@ fun haveRowCount(rowCount: Int) = object : Matcher<ResultSet> {
       )
 }
 
+@IgnorableReturnValue
 infix fun ResultSet.shouldHaveColumns(columnCount: Int) = this should haveColumnCount(
    columnCount
 )
 
+@IgnorableReturnValue
 infix fun ResultSet.shouldNotHaveColumns(columnCount: Int) = this shouldNot haveColumnCount(
    columnCount
 )
@@ -40,10 +44,12 @@ fun haveColumnCount(columnCount: Int) = object : Matcher<ResultSet> {
       )
 }
 
+@IgnorableReturnValue
 infix fun ResultSet.shouldContainColumn(columnName: String) = this should containColumn(
    columnName
 )
 
+@IgnorableReturnValue
 infix fun ResultSet.shouldNotContainColumn(columnName: String) = this shouldNot containColumn(
    columnName
 )
@@ -61,6 +67,7 @@ fun containColumn(columnName: String) = object : Matcher<ResultSet> {
 }
 
 @Suppress("UNCHECKED_CAST")
+@IgnorableReturnValue
 fun <T> ResultSet.shouldHaveColumn(columnName: String, next: (List<T>) -> Unit) {
    this shouldContainColumn columnName
    val data = mutableListOf<T>()
@@ -70,6 +77,7 @@ fun <T> ResultSet.shouldHaveColumn(columnName: String, next: (List<T>) -> Unit) 
    next(data)
 }
 
+@IgnorableReturnValue
 fun ResultSet.shouldHaveRow(rowNum: Int, next: (List<Any>) -> Unit) {
    val metaData = this.metaData
    val colCount = metaData.columnCount

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/stats/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/stats/matchers.kt
@@ -33,6 +33,7 @@ import kotlin.math.sqrt
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldHaveMean(value: BigDecimal, precision: Int = 4) = this should haveMean<T>(value, precision)
 
 /**
@@ -59,6 +60,7 @@ fun <T : Number> Collection<T>.shouldHaveMean(value: BigDecimal, precision: Int 
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldHaveMean(value: Double, precision: Int = 4) = this should haveMean<T>(value, precision)
 
 /**
@@ -85,6 +87,7 @@ fun <T : Number> Collection<T>.shouldHaveMean(value: Double, precision: Int = 4)
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldNotHaveMean(value: BigDecimal, precision: Int = 4) = this shouldNot haveMean<T>(value, precision)
 
 /**
@@ -109,6 +112,7 @@ fun <T : Number> Collection<T>.shouldNotHaveMean(value: BigDecimal, precision: I
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldNotHaveMean(value: Double, precision: Int = 4) = this shouldNot haveMean<T>(value, precision)
 
 /**
@@ -135,6 +139,7 @@ fun <T : Number> Collection<T>.shouldNotHaveMean(value: Double, precision: Int =
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldHaveVariance(value: BigDecimal, precision: Int = 4) = this should haveVariance<T>(value, precision)
 
 /**
@@ -159,6 +164,7 @@ fun <T : Number> Collection<T>.shouldHaveVariance(value: BigDecimal, precision: 
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldHaveVariance(value: Double, precision: Int = 4) = this should haveVariance<T>(value, precision)
 
 /**
@@ -183,6 +189,7 @@ fun <T : Number> Collection<T>.shouldHaveVariance(value: Double, precision: Int 
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldNotHaveVariance(value: BigDecimal, precision: Int = 4) = this shouldNot haveVariance<T>(value, precision)
 
 /**
@@ -207,6 +214,7 @@ fun <T : Number> Collection<T>.shouldNotHaveVariance(value: BigDecimal, precisio
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldNotHaveVariance(value: Double, precision: Int = 4) = this shouldNot haveVariance<T>(value, precision)
 
 /**
@@ -231,6 +239,7 @@ fun <T : Number> Collection<T>.shouldNotHaveVariance(value: Double, precision: I
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldHaveStandardDeviation(value: BigDecimal, precision: Int = 4) = this should haveStandardDeviation<T>(value, precision)
 
 /**
@@ -255,6 +264,7 @@ fun <T : Number> Collection<T>.shouldHaveStandardDeviation(value: BigDecimal, pr
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldHaveStandardDeviation(value: Double, precision: Int = 4) = this should haveStandardDeviation<T>(value, precision)
 
 /**
@@ -279,6 +289,7 @@ fun <T : Number> Collection<T>.shouldHaveStandardDeviation(value: Double, precis
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldNotHaveStandardDeviation(value: BigDecimal, precision: Int = 4) = this shouldNot haveStandardDeviation<T>(value, precision)
 
 /**
@@ -303,6 +314,7 @@ fun <T : Number> Collection<T>.shouldNotHaveStandardDeviation(value: BigDecimal,
  * @param precision - precision, by default - 4 digits after decimal point
  *
  */
+@IgnorableReturnValue
 fun <T : Number> Collection<T>.shouldNotHaveStandardDeviation(value: Double, precision: Int = 4) = this shouldNot haveStandardDeviation<T>(value, precision)
 
 private val defaultMathContext = MathContext(64, RoundingMode.HALF_UP)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/string/digest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/string/digest.kt
@@ -5,7 +5,9 @@ import io.kotest.matchers.*
 import java.math.BigInteger
 import java.security.MessageDigest
 
+@IgnorableReturnValue
 fun String?.shouldHaveDigest(algo: String, digest: String) = this should haveDigest(algo, digest)
+@IgnorableReturnValue
 fun String?.shouldNotHaveDigest(algo: String, digest: String) = this shouldNot haveDigest(algo, digest)
 fun haveDigest(algo: String, digest: String) : Matcher<String?> = neverNullMatcher { value ->
    val alg = MessageDigest.getInstance(algo)

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/types/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/types/matchers.kt
@@ -6,9 +6,11 @@ import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 
+@IgnorableReturnValue
 inline fun <A, reified T : Annotation> Class<A>.shouldHaveAnnotation() =
    this.shouldHaveAnnotation(T::class.java)
 
+@IgnorableReturnValue
 infix fun <A, T> Class<A>.shouldHaveAnnotation(annotationClass: Class<T>) =
    this should haveAnnotation(annotationClass)
 

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/uri/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/uri/matchers.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.net.URI
 
+@IgnorableReturnValue
 fun URI.shouldBeOpaque() = this should beOpaque()
+@IgnorableReturnValue
 fun URI.shouldNotBeOpaque() = this shouldNot beOpaque()
 fun beOpaque() = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -17,7 +19,9 @@ fun beOpaque() = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHaveScheme(scheme: String) = this should haveScheme(scheme)
+@IgnorableReturnValue
 infix fun URI.shouldNotHaveScheme(scheme: String) = this shouldNot haveScheme(scheme)
 fun haveScheme(scheme: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -28,7 +32,9 @@ fun haveScheme(scheme: String) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHavePort(port: Int) = this should havePort(port)
+@IgnorableReturnValue
 infix fun URI.shouldNotHavePort(port: Int) = this shouldNot havePort(port)
 fun havePort(port: Int) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -39,7 +45,9 @@ fun havePort(port: Int) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHaveHost(host: String) = this should haveHost(host)
+@IgnorableReturnValue
 infix fun URI.shouldNotHaveHost(host: String) = this shouldNot haveHost(host)
 fun haveHost(host: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -50,7 +58,9 @@ fun haveHost(host: String) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHaveQuery(q: String) = this should haveQuery(q)
+@IgnorableReturnValue
 infix fun URI.shouldNotHaveQuery(q: String) = this shouldNot haveQuery(q)
 fun haveQuery(q: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -61,7 +71,9 @@ fun haveQuery(q: String) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHaveAuthority(authority: String) = this should haveAuthority(authority)
+@IgnorableReturnValue
 infix fun URI.shouldNotHaveAuthority(authority: String) = this shouldNot haveAuthority(authority)
 fun haveAuthority(authority: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -72,7 +84,9 @@ fun haveAuthority(authority: String) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHavePath(path: String) = this should havePath(path)
+@IgnorableReturnValue
 infix fun URI.shouldNotHavePath(path: String) = this shouldNot havePath(path)
 fun havePath(path: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -83,7 +97,9 @@ fun havePath(path: String) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHaveParameter(key: String) = this should haveParameter(key)
+@IgnorableReturnValue
 infix fun URI.shouldNotHaveParameter(key: String) = this shouldNot haveParameter(key)
 fun haveParameter(key: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(
@@ -94,7 +110,9 @@ fun haveParameter(key: String) = object : Matcher<URI> {
       })
 }
 
+@IgnorableReturnValue
 infix fun URI.shouldHaveFragment(fragment: String) = this should haveFragment(fragment)
+@IgnorableReturnValue
 infix fun URI.shouldNotHaveFragment(fragment: String) = this shouldNot haveFragment(fragment)
 fun haveFragment(fragment: String) = object : Matcher<URI> {
    override fun test(value: URI) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/url/matchers.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/url/matchers.kt
@@ -6,7 +6,9 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import java.net.URL
 
+@IgnorableReturnValue
 fun URL.shouldBeOpaque() = this should beOpaque()
+@IgnorableReturnValue
 fun URL.shouldNotBeOpaque() = this shouldNot beOpaque()
 fun beOpaque() = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -16,7 +18,9 @@ fun beOpaque() = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHaveProtocol(protocol: String) = this should haveProtocol(protocol)
+@IgnorableReturnValue
 infix fun URL.shouldNotHaveProtocol(protocol: String) = this shouldNot haveProtocol(protocol)
 fun haveProtocol(protocol: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -26,7 +30,9 @@ fun haveProtocol(protocol: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHavePort(port: Int) = this should havePort(port)
+@IgnorableReturnValue
 infix fun URL.shouldNotHavePort(port: Int) = this shouldNot havePort(port)
 fun havePort(port: Int) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -36,7 +42,9 @@ fun havePort(port: Int) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHaveHost(host: String) = this should haveHost(host)
+@IgnorableReturnValue
 infix fun URL.shouldNotHaveHost(host: String) = this shouldNot haveHost(host)
 fun haveHost(host: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -46,7 +54,9 @@ fun haveHost(host: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHaveQuery(q: String) = this should haveQuery(q)
+@IgnorableReturnValue
 infix fun URL.shouldNotHaveQuery(q: String) = this shouldNot haveQuery(q)
 fun haveQuery(q: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -56,7 +66,9 @@ fun haveQuery(q: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHaveAuthority(authority: String) = this should haveAuthority(authority)
+@IgnorableReturnValue
 infix fun URL.shouldNotHaveAuthority(authority: String) = this shouldNot haveAuthority(authority)
 fun haveAuthority(authority: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -66,7 +78,9 @@ fun haveAuthority(authority: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHavePath(path: String) = this should havePath(path)
+@IgnorableReturnValue
 infix fun URL.shouldNotHavePath(path: String) = this shouldNot havePath(path)
 fun havePath(path: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -76,7 +90,9 @@ fun havePath(path: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHaveParameter(key: String) = this should haveParameter(key)
+@IgnorableReturnValue
 infix fun URL.shouldNotHaveParameter(key: String) = this shouldNot haveParameter(key)
 fun haveParameter(key: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(
@@ -86,7 +102,9 @@ fun haveParameter(key: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 fun URL.shouldHaveParameterValue(key: String, value: String) = this should haveParameterValue(key, value)
+@IgnorableReturnValue
 fun URL.shouldNotHaveParameterValue(key: String, value: String) = this shouldNot haveParameterValue(key, value)
 
 fun haveParameterValue(key: String, v: String) = object : Matcher<URL> {
@@ -97,7 +115,9 @@ fun haveParameterValue(key: String, v: String) = object : Matcher<URL> {
    )
 }
 
+@IgnorableReturnValue
 infix fun URL.shouldHaveRef(ref: String) = this should haveRef(ref)
+@IgnorableReturnValue
 infix fun URL.shouldNotHaveRef(ref: String) = this shouldNot haveRef(ref)
 fun haveRef(ref: String) = object : Matcher<URL> {
    override fun test(value: URL) = MatcherResult(

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/jsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/jsonMatchers.kt
@@ -88,31 +88,37 @@ fun beJsonType(kClass: KClass<*>, parser: Json): Matcher<String?> = object : Mat
    }
 }
 
+@IgnorableReturnValue
 fun String.shouldBeEmptyJsonArray(): String {
    this should matchJson("[]")
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldBeEmptyJsonObject(): String {
    this should matchJson("{}")
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldBeJsonArray(): String {
    this should beJsonArray()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldBeJsonArray(parser: Json): String {
    this should beJsonArray(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeJsonArray(): String {
    this shouldNot beJsonArray()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeJsonArray(parser: Json): String {
    this shouldNot beJsonArray(parser)
    return this
@@ -121,21 +127,25 @@ fun String.shouldNotBeJsonArray(parser: Json): String {
 fun beJsonArray(): Matcher<String?> = beJsonType(JsonArray::class)
 fun beJsonArray(parser: Json): Matcher<String?> = beJsonType(JsonArray::class, parser)
 
+@IgnorableReturnValue
 fun String.shouldBeJsonObject(): String {
    this should beJsonObject()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldBeJsonObject(parser: Json): String {
    this should beJsonObject(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeJsonObject(): String {
    this shouldNot beJsonObject()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeJsonObject(parser: Json): String {
    this shouldNot beJsonObject(parser)
    return this
@@ -144,21 +154,25 @@ fun String.shouldNotBeJsonObject(parser: Json): String {
 fun beJsonObject(): Matcher<String?> = beJsonType(JsonObject::class)
 fun beJsonObject(parser: Json): Matcher<String?> = beJsonType(JsonObject::class, parser)
 
+@IgnorableReturnValue
 fun String.shouldBeValidJson(): String {
    this should beValidJson()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldBeValidJson(parser: Json): String {
    this should beValidJson(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeValidJson(): String {
    this shouldNot beValidJson()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeValidJson(parser: Json): String {
    this shouldNot beValidJson(parser)
    return this

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/matchers.kt
@@ -85,6 +85,7 @@ data class JsonTree(val root: JsonNode, val raw: String)
  *
  * To more precisely control the comparison, use [shouldEqualJson] that accepts a [CompareJsonOptions].
  */
+@IgnorableReturnValue
 infix fun String.shouldEqualJson(@Language("json") expected: String): String {
    this should equalJson(expected, CompareJsonOptions())
    return this
@@ -94,6 +95,7 @@ infix fun String.shouldEqualJson(@Language("json") expected: String): String {
  * Verifies that the recevier matches the json string returned by the given block [configureAndProvideExpected].
  * The function allows configuration of [CompareJsonOptions] before returning the expected json.
  */
+@IgnorableReturnValue
 infix fun String.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): String {
    val options = CompareJsonOptions()
    val expected = options.configureAndProvideExpected()
@@ -101,11 +103,13 @@ infix fun String.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldEqualJson(@Language("json") expected: String, parser: Json): String {
    this should equalJson(expected, CompareJsonOptions(), parser)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String.shouldNotEqualJson(@Language("json") expected: String): String {
    this shouldNot equalJson(expected, CompareJsonOptions())
    return this
@@ -114,6 +118,7 @@ infix fun String.shouldNotEqualJson(@Language("json") expected: String): String 
 /**
  * Configures [CompareJsonOptions] with the given block, which should also return the expected value
  */
+@IgnorableReturnValue
 infix fun String.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): String {
    val options = CompareJsonOptions()
    val expected = options.configureAndProvideExpected()
@@ -121,11 +126,13 @@ infix fun String.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOpti
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotEqualJson(@Language("json") expected: String, parser: Json): String {
    this shouldNot equalJson(expected, CompareJsonOptions(), parser)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
@@ -133,6 +140,7 @@ infix fun String.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    }
 }
 
+@IgnorableReturnValue
 infix fun String.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected: String) {
    shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
@@ -141,6 +149,7 @@ infix fun String.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expecte
    }
 }
 
+@IgnorableReturnValue
 infix fun String.shouldNotEqualSpecifiedJson(@Language("json") expected: String) {
    shouldNotEqualJson {
       fieldComparison = FieldComparison.Lenient

--- a/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/commonMain/kotlin/io/kotest/assertions/json/schema/matchSchema.kt
@@ -13,10 +13,12 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun String?.shouldMatchSchema(schema: JsonSchema) =
    this should stringJsonMatcher(schema)
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun String?.shouldNotMatchSchema(schema: JsonSchema) =
    this shouldNot stringJsonMatcher(schema)
 
@@ -26,9 +28,11 @@ internal fun stringJsonMatcher(schema: JsonSchema): Matcher<String?> {
 }
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun JsonElement.shouldMatchSchema(schema: JsonSchema) = this should matchSchema(schema)
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun JsonElement.shouldNotMatchSchema(schema: JsonSchema) = this shouldNot matchSchema(schema)
 
 val parseToJson = object : Matcher<String?> {

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/jsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/jsonMatchers.kt
@@ -11,71 +11,85 @@ import io.kotest.assertions.json.paths.shouldNotBeValidJson
 import kotlinx.serialization.json.Json
 import java.io.File
 
+@IgnorableReturnValue
 fun File.shouldBeEmptyJsonArray(): File {
    this.toPath().shouldBeEmptyJsonArray()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeEmptyJsonObject(): File {
    this.toPath().shouldBeEmptyJsonObject()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeJsonArray(): File {
    this.toPath().shouldBeJsonArray()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeJsonArray(parser: Json): File {
    this.toPath().shouldBeJsonArray(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotBeJsonArray(): File {
    this.toPath().shouldNotBeJsonArray()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotBeJsonArray(parser: Json): File {
    this.toPath().shouldNotBeJsonArray(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeJsonObject(): File {
    this.toPath().shouldBeJsonObject()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeJsonObject(parser: Json): File {
    this.toPath().shouldBeJsonObject(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotBeJsonObject(): File {
    this.toPath().shouldNotBeJsonObject()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotBeJsonObject(parser: Json): File {
    this.toPath().shouldNotBeJsonObject(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeValidJson(): File {
    this.toPath().shouldBeValidJson()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldBeValidJson(parser: Json): File {
    this.toPath().shouldBeValidJson(parser)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotBeValidJson(): File {
    this.toPath().shouldNotBeValidJson()
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotBeValidJson(parser: Json): File {
    this.toPath().shouldNotBeValidJson(parser)
    return this

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/matchSchema.kt
@@ -7,12 +7,14 @@ import io.kotest.common.ExperimentalKotest
 import java.io.File
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun File.shouldMatchSchema(schema: JsonSchema): File {
    this.toPath().shouldMatchSchema(schema)
    return this
 }
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun File.shouldNotMatchSchema(schema: JsonSchema): File {
    this.toPath().shouldNotMatchSchema(schema)
    return this

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/file/matchers.kt
@@ -10,44 +10,53 @@ import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
 import java.io.File
 
+@IgnorableReturnValue
 infix fun File.shouldEqualJson(@Language("json") expected: String): File {
    this.toPath().shouldEqualJson(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun File.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): File {
    this.toPath().shouldEqualJson(configureAndProvideExpected)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldEqualJson(@Language("json") expected: String, parser: Json): File {
    this.toPath().shouldEqualJson(expected, parser)
    return this
 }
 
+@IgnorableReturnValue
 infix fun File.shouldNotEqualJson(@Language("json") expected: String): File {
    this.toPath().shouldNotEqualJson(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun File.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): File {
    this.toPath().shouldNotEqualJson(configureAndProvideExpected)
    return this
 }
 
+@IgnorableReturnValue
 fun File.shouldNotEqualJson(@Language("json") expected: String, parser: Json): File {
    this.toPath().shouldNotEqualJson(expected, parser)
    return this
 }
 
+@IgnorableReturnValue
 infix fun File.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    this.toPath().shouldEqualSpecifiedJson(expected)
 }
 
+@IgnorableReturnValue
 infix fun File.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected: String) {
    this.toPath().shouldEqualSpecifiedJsonIgnoringOrder(expected)
 }
 
+@IgnorableReturnValue
 infix fun File.shouldNotEqualSpecifiedJson(@Language("json") expected: String) {
    this.toPath().shouldNotEqualSpecifiedJson(expected)
 }

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keys.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldNot
 import org.intellij.lang.annotations.Language
 import kotlin.contracts.contract
 
+@IgnorableReturnValue
 infix fun String?.shouldContainJsonKey(@Language("JSONPath") path: String) {
    contract {
       returns() implies (this@shouldContainJsonKey != null)
@@ -15,6 +16,7 @@ infix fun String?.shouldContainJsonKey(@Language("JSONPath") path: String) {
    this should containJsonKey(path)
 }
 
+@IgnorableReturnValue
 infix fun String.shouldNotContainJsonKey(@Language("JSONPath") path: String) =
    this shouldNot containJsonKey(path)
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/keyvalues.kt
@@ -15,6 +15,7 @@ import io.kotest.matchers.shouldNot
 import org.intellij.lang.annotations.Language
 import kotlin.contracts.contract
 
+@IgnorableReturnValue
 inline fun <reified T> String?.shouldContainJsonKeyValue(@Language("JSONPath") path: String, value: T) {
    contract {
       returns() implies (this@shouldContainJsonKeyValue != null)
@@ -23,6 +24,7 @@ inline fun <reified T> String?.shouldContainJsonKeyValue(@Language("JSONPath") p
    this should containJsonKeyValue(path, value)
 }
 
+@IgnorableReturnValue
 inline fun <reified T> String.shouldNotContainJsonKeyValue(@Language("JSONPath") path: String, value: T) =
    this shouldNot containJsonKeyValue(path, value)
 

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/jsonMatchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/jsonMatchers.kt
@@ -12,71 +12,85 @@ import kotlinx.serialization.json.Json
 import java.nio.file.Path
 import kotlin.io.path.readText
 
+@IgnorableReturnValue
 fun Path.shouldBeEmptyJsonArray(): Path {
    this should (exist() and aFile() and matchJson("[]").contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeEmptyJsonObject(): Path {
    this should (exist() and aFile() and matchJson("{}").contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeJsonArray(): Path {
    this should (exist() and aFile() and beJsonArray().contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeJsonArray(parser: Json): Path {
    this should (exist() and aFile() and beJsonArray(parser).contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotBeJsonArray(): Path {
    this should (exist() and aFile() and beJsonArray().contramap<Path> { it.readText() }.invert())
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotBeJsonArray(parser: Json): Path {
    this should (exist() and aFile() and beJsonArray(parser).contramap<Path> { it.readText() }.invert())
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeJsonObject(): Path {
    this should (exist() and aFile() and beJsonObject().contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeJsonObject(parser: Json): Path {
    this should (exist() and aFile() and beJsonObject(parser).contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotBeJsonObject(): Path {
    this should (exist() and aFile() and beJsonObject().contramap<Path> { it.readText() }.invert())
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotBeJsonObject(parser: Json): Path {
    this should (exist() and aFile() and beJsonObject(parser).contramap<Path> { it.readText() }.invert())
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeValidJson(): Path {
    this should (exist() and aFile() and beValidJson().contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldBeValidJson(parser: Json): Path {
    this should (exist() and aFile() and beValidJson(parser).contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotBeValidJson(): Path {
    this should (exist() and aFile() and beValidJson().contramap<Path> { it.readText() }.invert())
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotBeValidJson(parser: Json): Path {
    this should (exist() and aFile() and beValidJson(parser).contramap<Path> { it.readText() }.invert())
    return this

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchSchema.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchSchema.kt
@@ -11,12 +11,14 @@ import java.nio.file.Path
 import kotlin.io.path.readText
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun Path.shouldMatchSchema(schema: JsonSchema): Path {
    this should (exist() and aFile() and stringJsonMatcher(schema).contramap { it.readText() })
    return this
 }
 
 @ExperimentalKotest
+@IgnorableReturnValue
 infix fun Path.shouldNotMatchSchema(schema: JsonSchema): Path {
    this should (exist() and aFile() and stringJsonMatcher(schema).contramap<Path> { it.readText() }.invert())
    return this

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/paths/matchers.kt
@@ -14,11 +14,13 @@ import org.intellij.lang.annotations.Language
 import java.nio.file.Path
 import kotlin.io.path.readText
 
+@IgnorableReturnValue
 infix fun Path.shouldEqualJson(@Language("json") expected: String): Path {
    this should (exist() and aFile() and equalJson(expected, CompareJsonOptions()).contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): Path {
    val options = CompareJsonOptions()
    val expected = configureAndProvideExpected(options)
@@ -26,16 +28,19 @@ infix fun Path.shouldEqualJson(configureAndProvideExpected: CompareJsonOptions.(
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldEqualJson(@Language("json") expected: String, parser: Json): Path {
    this should (exist() and aFile() and equalJson(expected, CompareJsonOptions(), parser).contramap { it.readText() })
    return this
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldNotEqualJson(@Language("json") expected: String): Path {
    this.readText() shouldNot equalJson(expected, CompareJsonOptions())
    return this
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOptions.() -> String): Path {
    val options = CompareJsonOptions()
    val expected = configureAndProvideExpected(options)
@@ -44,11 +49,13 @@ infix fun Path.shouldNotEqualJson(configureAndProvideExpected: CompareJsonOption
    return this
 }
 
+@IgnorableReturnValue
 fun Path.shouldNotEqualJson(@Language("json") expected: String, parser: Json): Path {
    this.readText() shouldNot equalJson(expected, CompareJsonOptions(), parser)
    return this
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    this.shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
@@ -56,6 +63,7 @@ infix fun Path.shouldEqualSpecifiedJson(@Language("json") expected: String) {
    }
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected: String) {
    this.shouldEqualJson {
       fieldComparison = FieldComparison.Lenient
@@ -64,6 +72,7 @@ infix fun Path.shouldEqualSpecifiedJsonIgnoringOrder(@Language("json") expected:
    }
 }
 
+@IgnorableReturnValue
 infix fun Path.shouldNotEqualSpecifiedJson(@Language("json") expected: String) {
    this.shouldNotEqualJson {
       fieldComparison = FieldComparison.Lenient

--- a/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
+++ b/kotest-assertions/kotest-assertions-json/src/jvmMain/kotlin/io/kotest/assertions/json/resources.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
 import kotlin.contracts.contract
 
+@IgnorableReturnValue
 infix fun String?.shouldMatchJsonResource(@Language("file-reference") resource: String) {
    contract {
       returns() implies (this@shouldMatchJsonResource != null)
@@ -18,6 +19,7 @@ infix fun String?.shouldMatchJsonResource(@Language("file-reference") resource: 
    this should matchJsonResource(resource)
 }
 
+@IgnorableReturnValue
 fun String?.shouldMatchJsonResource(@Language("file-reference") resource: String, parser: Json) {
    contract {
       returns() implies (this@shouldMatchJsonResource != null)
@@ -26,9 +28,11 @@ fun String?.shouldMatchJsonResource(@Language("file-reference") resource: String
    this should matchJsonResource(resource, parser)
 }
 
+@IgnorableReturnValue
 infix fun String.shouldNotMatchJsonResource(@Language("file-reference") resource: String) =
    this shouldNot matchJsonResource(resource)
 
+@IgnorableReturnValue
 fun String.shouldNotMatchJsonResource(@Language("file-reference") resource: String, parser: Json) =
    this shouldNot matchJsonResource(resource, parser)
 

--- a/kotest-assertions/kotest-assertions-konform/src/commonMain/kotlin/io/kotest/assertions/konform/matchers.kt
+++ b/kotest-assertions/kotest-assertions-konform/src/commonMain/kotlin/io/kotest/assertions/konform/matchers.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 
+@IgnorableReturnValue
 infix fun <T> Validation<T>.shouldBeValid(value: T) = this should beValid(value)
 
 fun <A> beValid(a: A) = object : Matcher<Validation<A>> {
@@ -21,6 +22,7 @@ fun <A> beValid(a: A) = object : Matcher<Validation<A>> {
    }
 }
 
+@IgnorableReturnValue
 infix fun <T> Validation<T>.shouldBeInvalid(value: T) = this should beInvalid(value)
 
 fun <A> beInvalid(a: A) = object : Matcher<Validation<A>> {
@@ -33,11 +35,13 @@ fun <A> beInvalid(a: A) = object : Matcher<Validation<A>> {
    }
 }
 
+@IgnorableReturnValue
 inline fun <T> Validation<T>.shouldBeInvalid(value: T, fn: (Invalid) -> Unit) {
    this.shouldBeInvalid(value)
    fn(this(value) as Invalid)
 }
 
+@IgnorableReturnValue
 fun Invalid.shouldContainError(field: Any, error: String) {
    val list = this[field]
    list.let {
@@ -46,6 +50,7 @@ fun Invalid.shouldContainError(field: Any, error: String) {
    }
 }
 
+@IgnorableReturnValue
 fun Invalid.shouldContainError(propertyPaths: Collection<Any>, error: String) {
    val list = this.get(*propertyPaths.toTypedArray())
    list.let {

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/datetime.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/datetime.kt
@@ -34,6 +34,7 @@ import kotlinx.datetime.number
  *     firstDate shouldHaveSameYearAs secondDate   //  Assertion fails, 2018 != 1998
 ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldHaveSameYearAs(date: LocalDate) = this should haveSameYear(date)
 
 /**
@@ -57,6 +58,7 @@ infix fun LocalDate.shouldHaveSameYearAs(date: LocalDate) = this should haveSame
  *    firstDate shouldNotHaveSameYearAs  secondDate   //  Assertion fails, 1998 == 1998, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotHaveSameYearAs(date: LocalDate) = this shouldNot haveSameYear(date)
 
 /**
@@ -111,6 +113,7 @@ fun haveSameYear(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDa
  *    firstDate shouldHaveSameYearAs secondDate   //  Assertion fails, 2018 != 1998
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSameYearAs(date: LocalDateTime) = this should haveSameYear(date)
 
 /**
@@ -134,6 +137,7 @@ infix fun LocalDateTime.shouldHaveSameYearAs(date: LocalDateTime) = this should 
  *    firstDate shouldNotHaveSameYearAs  secondDate   //  Assertion fails, 1998 == 1998, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotHaveSameYearAs(date: LocalDateTime) = this shouldNot haveSameYear(date)
 
 /**
@@ -188,6 +192,7 @@ fun haveSameYear(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher
  *    firstDate shouldNot haveSameYear(secondDate)    //  Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldHaveSameMonthAs(date: LocalDate) = this should haveSameMonth(date)
 
 /**
@@ -211,6 +216,7 @@ infix fun LocalDate.shouldHaveSameMonthAs(date: LocalDate) = this should haveSam
  *    firstDate shouldHaveSameMonthAs secondDate   //  Assertion fails, 2 != 3
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotHaveSameMonthAs(date: LocalDate) = this shouldNot haveSameMonth(date)
 
 /**
@@ -265,6 +271,7 @@ fun haveSameMonth(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalD
  *    firstDate shouldNot haveSameMonth(secondDate)    //  Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSameMonthAs(date: LocalDateTime) = this should haveSameMonth(date)
 
 /**
@@ -288,6 +295,7 @@ infix fun LocalDateTime.shouldHaveSameMonthAs(date: LocalDateTime) = this should
  *    firstDate shouldHaveSameMonthAs secondDate   //  Assertion fails, 2 != 3
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotHaveSameMonthAs(date: LocalDateTime) = this shouldNot haveSameMonth(date)
 
 /**
@@ -342,6 +350,7 @@ fun haveSameMonth(date: LocalDateTime): Matcher<LocalDateTime> = object : Matche
  *    firstDate shouldHaveSameDayAs secondDate   //  Assertion fails, 9 != 10
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldHaveSameDayAs(date: LocalDate) = this should haveSameDay(date)
 
 /**
@@ -365,6 +374,7 @@ infix fun LocalDate.shouldHaveSameDayAs(date: LocalDate) = this should haveSameD
  *    firstDate shouldNotHaveSameDayAs  secondDate   //  Assertion fails, 9 == 9, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotHaveSameDayAs(date: LocalDate) = this shouldNot haveSameDay(date)
 
 /**
@@ -419,6 +429,7 @@ fun haveSameDay(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDat
  *    firstDate shouldHaveSameDayAs secondDate   //  Assertion fails, 9 != 10
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSameDayAs(date: LocalDateTime) = this should haveSameDay(date)
 
 /**
@@ -442,6 +453,7 @@ infix fun LocalDateTime.shouldHaveSameDayAs(date: LocalDateTime) = this should h
  *    firstDate shouldNotHaveSameDayAs  secondDate   // Assertion fails, 9 == 9, and we expected a difference
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotHaveSameDayAs(date: LocalDateTime) = this shouldNot haveSameDay(date)
 
 /**
@@ -498,6 +510,7 @@ fun haveSameDay(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher<
  *
  * @see LocalDate.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldBeBefore(date: LocalDate) = this should before(date)
 
 /**
@@ -524,6 +537,7 @@ infix fun LocalDate.shouldBeBefore(date: LocalDate) = this should before(date)
  *
  * @see LocalDate.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotBeBefore(date: LocalDate) = this shouldNot before(date)
 
 /**
@@ -576,6 +590,7 @@ fun before(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDate> {
  *
  * @see LocalDateTime.shouldNotBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldBeBefore(date: LocalDateTime) = this should before(date)
 
 /**
@@ -601,6 +616,7 @@ infix fun LocalDateTime.shouldBeBefore(date: LocalDateTime) = this should before
  *
  * @see LocalDateTime.shouldBeAfter
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotBeBefore(date: LocalDateTime) = this shouldNot before(date)
 
 /**
@@ -653,6 +669,7 @@ fun before(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher<Local
  *
  * @see LocalDate.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldBeAfter(date: LocalDate) = this should after(date)
 
 /**
@@ -678,6 +695,7 @@ infix fun LocalDate.shouldBeAfter(date: LocalDate) = this should after(date)
  *
  * @see LocalDate.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDate.shouldNotBeAfter(date: LocalDate) = this shouldNot after(date)
 
 /**
@@ -730,6 +748,7 @@ fun after(date: LocalDate): Matcher<LocalDate> = object : Matcher<LocalDate> {
  *
  * @see LocalDateTime.shouldNotBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldBeAfter(date: LocalDateTime) = this should after(date)
 
 /**
@@ -755,6 +774,7 @@ infix fun LocalDateTime.shouldBeAfter(date: LocalDateTime) = this should after(d
  *
  * @see LocalDateTime.shouldBeBefore
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldNotBeAfter(date: LocalDateTime) = this shouldNot after(date)
 
 /**
@@ -811,6 +831,7 @@ fun after(date: LocalDateTime): Matcher<LocalDateTime> = object : Matcher<LocalD
  *
  * @see LocalDate.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun LocalDate.shouldBeBetween(a: LocalDate, b: LocalDate) = this shouldBe between(a, b)
 
 /**
@@ -837,6 +858,7 @@ fun LocalDate.shouldBeBetween(a: LocalDate, b: LocalDate) = this shouldBe betwee
  *
  * @see LocalDate.shouldBeBetween
  */
+@IgnorableReturnValue
 fun LocalDate.shouldNotBeBetween(a: LocalDate, b: LocalDate) = this shouldNotBe between(a, b)
 
 /**
@@ -898,6 +920,7 @@ fun between(a: LocalDate, b: LocalDate): Matcher<LocalDate> = object : Matcher<L
  *
  * @see LocalDateTime.shouldNotBeBetween
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldBeBetween(a: LocalDateTime, b: LocalDateTime) = this shouldBe between(a, b)
 
 /**
@@ -924,6 +947,7 @@ fun LocalDateTime.shouldBeBetween(a: LocalDateTime, b: LocalDateTime) = this sho
  *
  * @see LocalDateTime.shouldBeBetween
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldNotBeBetween(a: LocalDateTime, b: LocalDateTime) = this shouldNotBe between(a, b)
 
 /**
@@ -970,6 +994,7 @@ fun between(a: LocalDateTime, b: LocalDateTime): Matcher<LocalDateTime> = object
  *    date.shouldHaveDayOfMonth(15) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfMonth(day: Int) = this.dayOfMonth shouldBe day
 
 /**
@@ -981,6 +1006,7 @@ infix fun LocalDateTime.shouldHaveDayOfMonth(day: Int) = this.dayOfMonth shouldB
  *    date.shouldHaveDayOfYear(46) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfYear(day: Int) = this.dayOfYear shouldBe day
 
 /**
@@ -993,7 +1019,9 @@ infix fun LocalDateTime.shouldHaveDayOfYear(day: Int) = this.dayOfYear shouldBe 
  *    date.shouldHaveDayOfWeek(5) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfWeek(day: Int) = this.dayOfWeek.isoDayNumber shouldBe day
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveDayOfWeek(day: DayOfWeek) = this.dayOfWeek shouldBe day
 
 /**
@@ -1006,7 +1034,9 @@ infix fun LocalDateTime.shouldHaveDayOfWeek(day: DayOfWeek) = this.dayOfWeek sho
  *    date.shouldHaveMonth(FEBRUARY) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveMonth(month: Int) = this.month.number shouldBe month
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveMonth(month: Month) = this.month shouldBe month
 
 /**
@@ -1018,6 +1048,7 @@ infix fun LocalDateTime.shouldHaveMonth(month: Month) = this.month shouldBe mont
  *    date.shouldHaveHour(12) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveHour(hour: Int) = this.hour shouldBe hour
 
 /**
@@ -1029,6 +1060,7 @@ infix fun LocalDateTime.shouldHaveHour(hour: Int) = this.hour shouldBe hour
  *    date.shouldHaveMinute(10) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveMinute(minute: Int) = this.minute shouldBe minute
 
 /**
@@ -1040,6 +1072,7 @@ infix fun LocalDateTime.shouldHaveMinute(minute: Int) = this.minute shouldBe min
  *    date.shouldHaveSecond(11) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveSecond(second: Int) = this.second shouldBe second
 
 /**
@@ -1051,4 +1084,5 @@ infix fun LocalDateTime.shouldHaveSecond(second: Int) = this.second shouldBe sec
  *    date.shouldHaveNano(10) // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 infix fun LocalDateTime.shouldHaveNano(nano: Int) = this.nanosecond shouldBe nano

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/instant.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/instant.kt
@@ -11,12 +11,14 @@ import kotlinx.datetime.Instant
  * Assert that [Instant] is before [anotherInstant].
  * @see [shouldNotBeBefore]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldBeBefore(anotherInstant: Instant) = this shouldBe before(anotherInstant)
 
 /**
  * Assert that [Instant] is not before [anotherInstant].
  * @see [shouldBeBefore]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldNotBeBefore(anotherInstant: Instant) = this shouldNotBe before(anotherInstant)
 
 fun before(anotherInstant: Instant) = object : Matcher<Instant> {
@@ -33,12 +35,14 @@ fun before(anotherInstant: Instant) = object : Matcher<Instant> {
  * Assert that [Instant] is after [anotherInstant].
  * @see [shouldNotBeAfter]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldBeAfter(anotherInstant: Instant) = this shouldBe after(anotherInstant)
 
 /**
  * Assert that [Instant] is not after [anotherInstant].
  * @see [shouldNotBeAfter]
  * */
+@IgnorableReturnValue
 infix fun Instant.shouldNotBeAfter(anotherInstant: Instant) = this shouldNot after(anotherInstant)
 
 fun after(anotherInstant: Instant) = object : Matcher<Instant> {
@@ -55,12 +59,14 @@ fun after(anotherInstant: Instant) = object : Matcher<Instant> {
  * Assert that [Instant] is between [fromInstant] and [toInstant].
  * @see [shouldNotBeBetween]
  * */
+@IgnorableReturnValue
 fun Instant.shouldBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldBe between(fromInstant, toInstant)
 
 /**
  * Assert that [Instant] is between [fromInstant] and [toInstant].
  * @see [shouldBeBetween]
  * */
+@IgnorableReturnValue
 fun Instant.shouldNotBeBetween(fromInstant: Instant, toInstant: Instant) = this shouldNotBe between(fromInstant, toInstant)
 
 fun between(fromInstant: Instant, toInstant: Instant) = object : Matcher<Instant> {

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/today.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/today.kt
@@ -69,6 +69,7 @@ fun beToday(timezone: TimeZone = TimeZone.UTC) = object : Matcher<LocalDate> {
  *      Clock.System().todayIn(TimeZone.UTC).shouldBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldBeToday(timezone: TimeZone = TimeZone.UTC) = this should beInToday(timezone)
 
 /**
@@ -78,6 +79,7 @@ fun LocalDateTime.shouldBeToday(timezone: TimeZone = TimeZone.UTC) = this should
  *      Clock.System().todayIn(TimeZone.UTC).date.shouldBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDate.shouldBeToday(timezone: TimeZone = TimeZone.UTC) = this should beToday(timezone)
 
 /**
@@ -87,6 +89,7 @@ fun LocalDate.shouldBeToday(timezone: TimeZone = TimeZone.UTC) = this should beT
  *      LocalDateTime(2009, Month.APRIL, 2,2,2).shouldNotBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDateTime.shouldNotBeToday(timezone: TimeZone = TimeZone.UTC) = this shouldNot beInToday(timezone)
 
 /**
@@ -96,6 +99,7 @@ fun LocalDateTime.shouldNotBeToday(timezone: TimeZone = TimeZone.UTC) = this sho
  *      LocalDate(2009, Month.APRIL, 2).shouldNotBeToday() // Assertion passes
  * ```
  */
+@IgnorableReturnValue
 fun LocalDate.shouldNotBeToday(timezone: TimeZone = TimeZone.UTC) = this shouldNot beToday(timezone)
 
 

--- a/kotest-assertions/kotest-assertions-ktor/src/commonMain/kotlin/io/kotest/assertions/ktor/client/headers.kt
+++ b/kotest-assertions/kotest-assertions-ktor/src/commonMain/kotlin/io/kotest/assertions/ktor/client/headers.kt
@@ -10,91 +10,109 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpProtocolVersion
 import io.ktor.http.contentType
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveETag(etag: String): HttpResponse {
    this should haveHeader(HttpHeaders.ETag, etag)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldHaveETag(): HttpResponse {
    this should haveHeader(HttpHeaders.ETag)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveETag(etag: String): HttpResponse {
    this shouldNot haveHeader(HttpHeaders.ETag, etag)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldNotHaveETag(): HttpResponse {
    this shouldNot haveHeader(HttpHeaders.ETag)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveCacheControl(cacheControl: String): HttpResponse {
    this should haveHeader(HttpHeaders.CacheControl, cacheControl)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldHaveCacheControl(): HttpResponse {
    this should haveHeader(HttpHeaders.CacheControl)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveCacheControl(cacheControl: String): HttpResponse {
    this shouldNot haveHeader(HttpHeaders.CacheControl, cacheControl)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldNotHaveCacheControl(): HttpResponse {
    this shouldNot haveHeader(HttpHeaders.CacheControl)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveContentEncoding(encoding: String): HttpResponse {
    this should haveHeader(HttpHeaders.ContentEncoding, encoding)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldHaveContentEncoding(): HttpResponse {
    this should haveHeader(HttpHeaders.ContentEncoding)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveContentEncoding(encoding: String): HttpResponse {
    this shouldNot haveHeader(HttpHeaders.ContentEncoding, encoding)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldNotHaveContentEncoding(): HttpResponse {
    this shouldNot haveHeader(HttpHeaders.ContentEncoding)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveHeader(name: String): HttpResponse {
    this should haveHeader(name)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldHaveHeader(name: String, value: String): HttpResponse {
    this should haveHeader(name, value)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveHeader(name: String): HttpResponse {
    this shouldNot haveHeader(name)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldNotHaveHeader(name: String, value: String): HttpResponse {
    this shouldNot haveHeader(name, value)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveVersion(version: HttpProtocolVersion): HttpResponse {
    this should haveVersion(version)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveVersion(version: HttpProtocolVersion): HttpResponse {
    this shouldNot haveVersion(version)
    return this
@@ -110,11 +128,13 @@ fun haveVersion(version: HttpProtocolVersion) = object : Matcher<HttpResponse> {
    }
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveContentType(contentType: ContentType): HttpResponse {
    this should haveContentType(contentType)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveContentType(contentType: ContentType): HttpResponse {
    this shouldNot haveContentType(contentType)
    return this
@@ -130,11 +150,13 @@ fun haveContentType(contentType: ContentType) = object : Matcher<HttpResponse> {
    }
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveContentTypeMatching(contentType: ContentType): HttpResponse {
    this should haveContentTypeMatching(contentType)
    return this
 }
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveContentTypeMatching(contentType: ContentType): HttpResponse {
    this shouldNot haveContentTypeMatching(contentType)
    return this

--- a/kotest-assertions/kotest-assertions-ktor/src/commonMain/kotlin/io/kotest/assertions/ktor/client/shouldHaveStatus.kt
+++ b/kotest-assertions/kotest-assertions-ktor/src/commonMain/kotlin/io/kotest/assertions/ktor/client/shouldHaveStatus.kt
@@ -7,9 +7,13 @@ import io.kotest.matchers.shouldNot
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
 
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveStatus(httpStatusCode: HttpStatusCode) = shouldHaveStatus(httpStatusCode.value)
+@IgnorableReturnValue
 infix fun HttpResponse.shouldHaveStatus(code: Int) = this should haveStatus(code)
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveStatus(httpStatusCode: HttpStatusCode) = shouldNotHaveStatus(httpStatusCode.value)
+@IgnorableReturnValue
 infix fun HttpResponse.shouldNotHaveStatus(code: Int) = this shouldNot haveStatus(code)
 fun haveStatus(expected: Int) = object : Matcher<HttpResponse> {
    override fun test(value: HttpResponse): MatcherResult {
@@ -21,21 +25,25 @@ fun haveStatus(expected: Int) = object : Matcher<HttpResponse> {
    }
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldBeOK(): HttpResponse {
    this.shouldHaveStatus(HttpStatusCode.OK)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldBeInternalServerError(): HttpResponse {
    this.shouldHaveStatus(HttpStatusCode.InternalServerError)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldBeBadRequest(): HttpResponse {
    this.shouldHaveStatus(HttpStatusCode.BadRequest)
    return this
 }
 
+@IgnorableReturnValue
 fun HttpResponse.shouldBeNotFound(): HttpResponse {
    this.shouldHaveStatus(HttpStatusCode.NotFound)
    return this

--- a/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/assertSoftly.kt
+++ b/kotest-assertions/kotest-assertions-shared/src/commonMain/kotlin/io/kotest/assertions/assertSoftly.kt
@@ -1,5 +1,6 @@
 package io.kotest.assertions
 
+@IgnorableReturnValue
 inline fun <T> assertSoftly(assertions: () -> T): T {
    // Handle the edge case of nested calls to this function by only calling throwCollectedErrors in the
    // outermost verifyAll block

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll1.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll1.kt
@@ -9,12 +9,14 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A> forAll(vararg rows: Row1<A>, testfn: (A) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
    table(headers(paramA), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A> forNone(vararg rows: Row1<A>, testfn: (A) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll10.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll10.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J> forAll(
    vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
    testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit
@@ -27,6 +28,7 @@ fun <A, B, C, D, E, F, G, H, I, J> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J> forNone(
    vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
    testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll11.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll11.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    vararg rows: Row11<A, B, C, D, E, F, G, H, I, J, K>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K) -> Unit
@@ -28,6 +29,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    vararg rows: Row11<A, B, C, D, E, F, G, H, I, J, K>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll12.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll12.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    vararg rows: Row12<A, B, C, D, E, F, G, H, I, J, K, L>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
@@ -29,6 +30,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    vararg rows: Row12<A, B, C, D, E, F, G, H, I, J, K, L>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll13.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll13.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(
    vararg rows: Row13<A, B, C, D, E, F, G, H, I, J, K, L, M>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit
@@ -30,6 +31,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forNone(
    vararg rows: Row13<A, B, C, D, E, F, G, H, I, J, K, L, M>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll14.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll14.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(
    vararg rows: Row14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit
@@ -31,6 +32,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forNone(
    vararg rows: Row14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll15.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll15.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(
    vararg rows: Row15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit
@@ -32,6 +33,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forNone(
    vararg rows: Row15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll16.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll16.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(
    vararg rows: Row16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit
@@ -33,6 +34,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forNone(
    vararg rows: Row16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll17.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll17.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(
    vararg rows: Row17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit
@@ -34,6 +35,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP, paramQ), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forNone(
    vararg rows: Row17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll18.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll18.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(
    vararg rows: Row18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit
@@ -35,6 +36,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP, paramQ, paramR), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forNone(
    vararg rows: Row18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll19.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll19.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(
    vararg rows: Row19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit
@@ -36,6 +37,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP, paramQ, paramR, paramS), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forNone(
    vararg rows: Row19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll2.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll2.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B> forAll(vararg rows: Row2<A, B>, testfn: (A, B) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -16,6 +17,7 @@ fun <A, B> forAll(vararg rows: Row2<A, B>, testfn: (A, B) -> Unit) {
    table(headers(paramA, paramB), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B> forNone(vararg rows: Row2<A, B>, testfn: (A, B) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll20.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll20.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(
    vararg rows: Row20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit
@@ -37,6 +38,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP, paramQ, paramR, paramS, paramT), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forNone(
    vararg rows: Row20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll21.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll21.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forAll(
    vararg rows: Row21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit
@@ -38,6 +39,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP, paramQ, paramR, paramS, paramT, paramU), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forNone(
    vararg rows: Row21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll22.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll22.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forAll(
    vararg rows: Row22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit
@@ -39,6 +40,7 @@ fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI, paramJ, paramK, paramL, paramM, paramN, paramO, paramP, paramQ, paramR, paramS, paramT, paramU, paramV), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forNone(
    vararg rows: Row22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>,
    testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll3.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll3.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C> forAll(vararg rows: Row3<A, B, C>, testfn: (A, B, C) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -17,6 +18,7 @@ fun <A, B, C> forAll(vararg rows: Row3<A, B, C>, testfn: (A, B, C) -> Unit) {
    table(headers(paramA, paramB, paramC), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C> forNone(vararg rows: Row3<A, B, C>, testfn: (A, B, C) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll4.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll4.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D> forAll(vararg rows: Row4<A, B, C, D>, testfn: (A, B, C, D) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -18,6 +19,7 @@ fun <A, B, C, D> forAll(vararg rows: Row4<A, B, C, D>, testfn: (A, B, C, D) -> U
    table(headers(paramA, paramB, paramC, paramD), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D> forNone(vararg rows: Row4<A, B, C, D>, testfn: (A, B, C, D) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll5.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll5.kt
@@ -7,6 +7,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E> forAll(vararg rows: Row5<A, B, C, D, E>, testfn: (A, B, C, D, E) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -17,6 +18,7 @@ fun <A, B, C, D, E> forAll(vararg rows: Row5<A, B, C, D, E>, testfn: (A, B, C, D
    table(headers(paramA, paramB, paramC, paramD, paramE), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E> forNone(vararg rows: Row5<A, B, C, D, E>, testfn: (A, B, C, D, E) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll6.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll6.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F> forAll(vararg rows: Row6<A, B, C, D, E, F>, testfn: (A, B, C, D, E, F) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -20,6 +21,7 @@ fun <A, B, C, D, E, F> forAll(vararg rows: Row6<A, B, C, D, E, F>, testfn: (A, B
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F> forNone(
    vararg rows: Row6<A, B, C, D, E, F>,
    testfn: (A, B, C, D, E, F) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll7.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll7.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G> forAll(
    vararg rows: Row7<A, B, C, D, E, F, G>,
    testfn: (A, B, C, D, E, F, G) -> Unit
@@ -24,6 +25,7 @@ fun <A, B, C, D, E, F, G> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G> forNone(
    vararg rows: Row7<A, B, C, D, E, F, G>,
    testfn: (A, B, C, D, E, F, G) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll8.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll8.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H> forAll(
    vararg rows: Row8<A, B, C, D, E, F, G, H>,
    testfn: (A, B, C, D, E, F, G, H) -> Unit
@@ -25,6 +26,7 @@ fun <A, B, C, D, E, F, G, H> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H> forNone(
    vararg rows: Row8<A, B, C, D, E, F, G, H>,
    testfn: (A, B, C, D, E, F, G, H) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll9.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/blocking/forAll9.kt
@@ -9,6 +9,7 @@ import io.kotest.data.headers
 import io.kotest.data.paramNames
 import io.kotest.data.table
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I> forAll(
    vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
    testfn: (A, B, C, D, E, F, G, H, I) -> Unit
@@ -26,6 +27,7 @@ fun <A, B, C, D, E, F, G, H, I> forAll(
    table(headers(paramA, paramB, paramC, paramD, paramE, paramF, paramG, paramH, paramI), *rows).forAll(testfn)
 }
 
+@IgnorableReturnValue
 fun <A, B, C, D, E, F, G, H, I> forNone(
    vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
    testfn: (A, B, C, D, E, F, G, H, I) -> Unit

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll1.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll1.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A> forAll(vararg rows: Row1<A>, testfn: suspend (A) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -11,8 +12,10 @@ suspend fun <A> forAll(vararg rows: Row1<A>, testfn: suspend (A) -> Unit) {
 }
 
 @JvmName("forall1")
+@IgnorableReturnValue
 inline fun <A> forAll(table: Table1<A>, testfn: (A) -> Unit) = table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A> Table1<A>.forAll(fn: (A) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -25,6 +28,7 @@ inline fun <A> Table1<A>.forAll(fn: (A) -> Unit) {
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A> forNone(vararg rows: Row1<A>, testfn: suspend (A) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -32,8 +36,10 @@ suspend fun <A> forNone(vararg rows: Row1<A>, testfn: suspend (A) -> Unit) {
 }
 
 @JvmName("fornone1")
+@IgnorableReturnValue
 inline fun <A> forNone(table: Table1<A>, testfn: (A) -> Unit) = table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A> Table1<A>.forNone(fn: (A) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll10.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll10.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J) -> Unit
@@ -28,9 +29,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
 }
 
 @JvmName("forall10")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J> forAll(table: Table10<A, B, C, D, E, F, G, H, I, J>, testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J> Table10<A, B, C, D, E, F, G, H, I, J>.forAll(fn: (A, B, C, D, E, F, G, H, I, J) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -43,6 +46,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J> Table10<A, B, C, D, E, F, G, H, I, J>.
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    vararg rows: Row10<A, B, C, D, E, F, G, H, I, J>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J) -> Unit
@@ -67,9 +71,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
 }
 
 @JvmName("fornone10")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J> forNone(table: Table10<A, B, C, D, E, F, G, H, I, J>, testfn: (A, B, C, D, E, F, G, H, I, J) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J> Table10<A, B, C, D, E, F, G, H, I, J>.forNone(fn: (A, B, C, D, E, F, G, H, I, J) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll11.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll11.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    vararg rows: Row11<A, B, C, D, E, F, G, H, I, J, K>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K) -> Unit
@@ -29,9 +30,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
 }
 
 @JvmName("forall11")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K> forAll(table: Table11<A, B, C, D, E, F, G, H, I, J, K>, testfn: (A, B, C, D, E, F, G, H, I, J, K) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K> Table11<A, B, C, D, E, F, G, H, I, J, K>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -44,6 +47,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K> Table11<A, B, C, D, E, F, G, H, I, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    vararg rows: Row11<A, B, C, D, E, F, G, H, I, J, K>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K) -> Unit
@@ -69,9 +73,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
 }
 
 @JvmName("fornone11")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K> forNone(table: Table11<A, B, C, D, E, F, G, H, I, J, K>, testfn: (A, B, C, D, E, F, G, H, I, J, K) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K> Table11<A, B, C, D, E, F, G, H, I, J, K>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll12.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll12.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    vararg rows: Row12<A, B, C, D, E, F, G, H, I, J, K, L>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
@@ -30,9 +31,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
 }
 
 @JvmName("forall12")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(table: Table12<A, B, C, D, E, F, G, H, I, J, K, L>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Table12<A, B, C, D, E, F, G, H, I, J, K, L>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -45,6 +48,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Table12<A, B, C, D, E, F, G, H, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    vararg rows: Row12<A, B, C, D, E, F, G, H, I, J, K, L>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
@@ -71,9 +75,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
 }
 
 @JvmName("fornone12")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(table: Table12<A, B, C, D, E, F, G, H, I, J, K, L>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L> Table12<A, B, C, D, E, F, G, H, I, J, K, L>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll13.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll13.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(
    vararg rows: Row13<A, B, C, D, E, F, G, H, I, J, K, L, M>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit
@@ -31,9 +32,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(
 }
 
 @JvmName("forall13")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(table: Table13<A, B, C, D, E, F, G, H, I, J, K, L, M>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M> Table13<A, B, C, D, E, F, G, H, I, J, K, L, M>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -46,6 +49,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M> Table13<A, B, C, D, E, F, G, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forNone(
    vararg rows: Row13<A, B, C, D, E, F, G, H, I, J, K, L, M>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit
@@ -73,9 +77,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forNone(
 }
 
 @JvmName("fornone13")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forNone(table: Table13<A, B, C, D, E, F, G, H, I, J, K, L, M>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M> Table13<A, B, C, D, E, F, G, H, I, J, K, L, M>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll14.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll14.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(
    vararg rows: Row14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit
@@ -32,9 +33,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(
 }
 
 @JvmName("forall14")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(table: Table14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> Table14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -47,6 +50,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> Table14<A, B, C, D, E, F, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forNone(
    vararg rows: Row14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit
@@ -75,9 +79,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forNone(
 }
 
 @JvmName("fornone14")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forNone(table: Table14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> Table14<A, B, C, D, E, F, G, H, I, J, K, L, M, N>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll15.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll15.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(
    vararg rows: Row15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit
@@ -33,9 +34,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(
 }
 
 @JvmName("forall15")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(table: Table15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> Table15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -48,6 +51,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> Table15<A, B, C, D, E, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forNone(
    vararg rows: Row15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit
@@ -77,9 +81,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forNone(
 }
 
 @JvmName("fornone15")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forNone(table: Table15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> Table15<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll16.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll16.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(
    vararg rows: Row16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit
@@ -34,9 +35,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(
 }
 
 @JvmName("forall16")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(table: Table16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> Table16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -49,6 +52,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> Table16<A, B, C, D, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forNone(
    vararg rows: Row16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit
@@ -79,9 +83,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forNone(
 }
 
 @JvmName("fornone16")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forNone(table: Table16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> Table16<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll17.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll17.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(
    vararg rows: Row17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit
@@ -35,9 +36,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(
 }
 
 @JvmName("forall17")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(table: Table17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> Table17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -50,6 +53,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> Table17<A, B, C, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forNone(
    vararg rows: Row17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit
@@ -81,9 +85,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forNone(
 }
 
 @JvmName("fornone17")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forNone(table: Table17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> Table17<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll18.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll18.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(
    vararg rows: Row18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit
@@ -36,9 +37,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(
 }
 
 @JvmName("forall18")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(table: Table18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> Table18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -51,6 +54,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> Table18<A, B, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forNone(
    vararg rows: Row18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit
@@ -83,9 +87,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forNone(
 }
 
 @JvmName("fornone18")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forNone(table: Table18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> Table18<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll19.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll19.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(
    vararg rows: Row19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit
@@ -37,9 +38,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(
 }
 
 @JvmName("forall19")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(table: Table19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> Table19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -52,6 +55,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> Table19<A, 
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forNone(
    vararg rows: Row19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit
@@ -85,9 +89,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forNone(
 }
 
 @JvmName("fornone19")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forNone(table: Table19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> Table19<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll2.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll2.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B> forAll(vararg rows: Row2<A, B>, testfn: suspend (A, B) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -12,8 +13,10 @@ suspend fun <A, B> forAll(vararg rows: Row2<A, B>, testfn: suspend (A, B) -> Uni
 }
 
 @JvmName("forall2")
+@IgnorableReturnValue
 inline fun <A, B> forAll(table: Table2<A, B>, testfn: (A, B) -> Unit) = table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B> Table2<A, B>.forAll(fn: (A, B) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -26,6 +29,7 @@ inline fun <A, B> Table2<A, B>.forAll(fn: (A, B) -> Unit) {
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B> forNone(vararg rows: Row2<A, B>, testfn: suspend (A, B) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -34,8 +38,10 @@ suspend fun <A, B> forNone(vararg rows: Row2<A, B>, testfn: suspend (A, B) -> Un
 }
 
 @JvmName("fornone2")
+@IgnorableReturnValue
 inline fun <A, B> forNone(table: Table2<A, B>, testfn: (A, B) -> Unit) = table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B> Table2<A, B>.forNone(fn: (A, B) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll20.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll20.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(
    vararg rows: Row20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit
@@ -38,9 +39,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(
 }
 
 @JvmName("forall20")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(table: Table20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> Table20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -53,6 +56,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> Table20<
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forNone(
    vararg rows: Row20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit
@@ -87,9 +91,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forNone
 }
 
 @JvmName("fornone20")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forNone(table: Table20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> Table20<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll21.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll21.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forAll(
    vararg rows: Row21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit
@@ -39,9 +40,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forA
 }
 
 @JvmName("forall21")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forAll(table: Table21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> Table21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -54,6 +57,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> Table
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forNone(
    vararg rows: Row21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit
@@ -89,9 +93,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forN
 }
 
 @JvmName("fornone21")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forNone(table: Table21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> Table21<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll22.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll22.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forAll(
    vararg rows: Row22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit
@@ -40,9 +41,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> f
 }
 
 @JvmName("forall22")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forAll(table: Table22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> Table22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>.forAll(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -55,6 +58,7 @@ inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> Ta
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forNone(
    vararg rows: Row22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>,
    testfn: suspend (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit
@@ -91,9 +95,11 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> f
 }
 
 @JvmName("fornone22")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forNone(table: Table22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>, testfn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> Table22<A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V>.forNone(fn: (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll3.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll3.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forAll(vararg rows: Row3<A, B, C>, testfn: suspend (A, B, C) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -13,8 +14,10 @@ suspend fun <A, B, C> forAll(vararg rows: Row3<A, B, C>, testfn: suspend (A, B, 
 }
 
 @JvmName("forall3")
+@IgnorableReturnValue
 inline fun <A, B, C> forAll(table: Table3<A, B, C>, testfn: (A, B, C) -> Unit) = table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C> Table3<A, B, C>.forAll(fn: (A, B, C) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -27,6 +30,7 @@ inline fun <A, B, C> Table3<A, B, C>.forAll(fn: (A, B, C) -> Unit) {
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forNone(vararg rows: Row3<A, B, C>, testfn: suspend (A, B, C) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -36,8 +40,10 @@ suspend fun <A, B, C> forNone(vararg rows: Row3<A, B, C>, testfn: suspend (A, B,
 }
 
 @JvmName("fornone3")
+@IgnorableReturnValue
 inline fun <A, B, C> forNone(table: Table3<A, B, C>, testfn: (A, B, C) -> Unit) = table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C> Table3<A, B, C>.forNone(fn: (A, B, C) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll4.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll4.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forAll(vararg rows: Row4<A, B, C, D>, testfn: suspend (A, B, C, D) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -14,8 +15,10 @@ suspend fun <A, B, C, D> forAll(vararg rows: Row4<A, B, C, D>, testfn: suspend (
 }
 
 @JvmName("forall4")
+@IgnorableReturnValue
 inline fun <A, B, C, D> forAll(table: Table4<A, B, C, D>, testfn: (A, B, C, D) -> Unit) = table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D> Table4<A, B, C, D>.forAll(fn: (A, B, C, D) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -28,6 +31,7 @@ inline fun <A, B, C, D> Table4<A, B, C, D>.forAll(fn: (A, B, C, D) -> Unit) {
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forNone(vararg rows: Row4<A, B, C, D>, testfn: suspend (A, B, C, D) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -38,8 +42,10 @@ suspend fun <A, B, C, D> forNone(vararg rows: Row4<A, B, C, D>, testfn: suspend 
 }
 
 @JvmName("fornone4")
+@IgnorableReturnValue
 inline fun <A, B, C, D> forNone(table: Table4<A, B, C, D>, testfn: (A, B, C, D) -> Unit) = table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D> Table4<A, B, C, D>.forNone(fn: (A, B, C, D) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll5.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll5.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forAll(vararg rows: Row5<A, B, C, D, E>, testfn: suspend (A, B, C, D, E) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -15,8 +16,10 @@ suspend fun <A, B, C, D, E> forAll(vararg rows: Row5<A, B, C, D, E>, testfn: sus
 }
 
 @JvmName("forall5")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E> forAll(table: Table5<A, B, C, D, E>, testfn: (A, B, C, D, E) -> Unit) = table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E> Table5<A, B, C, D, E>.forAll(fn: (A, B, C, D, E) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -29,6 +32,7 @@ inline fun <A, B, C, D, E> Table5<A, B, C, D, E>.forAll(fn: (A, B, C, D, E) -> U
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forNone(vararg rows: Row5<A, B, C, D, E>, testfn: suspend (A, B, C, D, E) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -40,9 +44,11 @@ suspend fun <A, B, C, D, E> forNone(vararg rows: Row5<A, B, C, D, E>, testfn: su
 }
 
 @JvmName("fornone5")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E> forNone(table: Table5<A, B, C, D, E>, testfn: (A, B, C, D, E) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E> Table5<A, B, C, D, E>.forNone(fn: (A, B, C, D, E) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll6.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll6.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forAll(vararg rows: Row6<A, B, C, D, E, F>, testfn: suspend (A, B, C, D, E, F) -> Unit) {
    val params = paramNames(testfn)
    val paramA = params.getOrElse(0) { "a" }
@@ -18,9 +19,11 @@ suspend fun <A, B, C, D, E, F> forAll(vararg rows: Row6<A, B, C, D, E, F>, testf
 }
 
 @JvmName("forall6")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F> forAll(table: Table6<A, B, C, D, E, F>, testfn: (A, B, C, D, E, F) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F> Table6<A, B, C, D, E, F>.forAll(fn: (A, B, C, D, E, F) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -33,6 +36,7 @@ inline fun <A, B, C, D, E, F> Table6<A, B, C, D, E, F>.forAll(fn: (A, B, C, D, E
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forNone(
    vararg rows: Row6<A, B, C, D, E, F>,
    testfn: suspend (A, B, C, D, E, F) -> Unit
@@ -50,9 +54,11 @@ suspend fun <A, B, C, D, E, F> forNone(
 }
 
 @JvmName("fornone6")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F> forNone(table: Table6<A, B, C, D, E, F>, testfn: (A, B, C, D, E, F) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F> Table6<A, B, C, D, E, F>.forNone(fn: (A, B, C, D, E, F) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll7.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll7.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forAll(
    vararg rows: Row7<A, B, C, D, E, F, G>,
    testfn: suspend (A, B, C, D, E, F, G) -> Unit
@@ -22,9 +23,11 @@ suspend fun <A, B, C, D, E, F, G> forAll(
 }
 
 @JvmName("forall7")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G> forAll(table: Table7<A, B, C, D, E, F, G>, testfn: (A, B, C, D, E, F, G) -> Unit) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G> Table7<A, B, C, D, E, F, G>.forAll(fn: (A, B, C, D, E, F, G) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -37,6 +40,7 @@ inline fun <A, B, C, D, E, F, G> Table7<A, B, C, D, E, F, G>.forAll(fn: (A, B, C
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forNone(
    vararg rows: Row7<A, B, C, D, E, F, G>,
    testfn: suspend (A, B, C, D, E, F, G) -> Unit
@@ -55,9 +59,11 @@ suspend fun <A, B, C, D, E, F, G> forNone(
 }
 
 @JvmName("fornone7")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G> forNone(table: Table7<A, B, C, D, E, F, G>, testfn: (A, B, C, D, E, F, G) -> Unit) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G> Table7<A, B, C, D, E, F, G>.forNone(fn: (A, B, C, D, E, F, G) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll8.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll8.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    vararg rows: Row8<A, B, C, D, E, F, G, H>,
    testfn: suspend (A, B, C, D, E, F, G, H) -> Unit
@@ -26,12 +27,14 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
 }
 
 @JvmName("forall8")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H> forAll(
    table: Table8<A, B, C, D, E, F, G, H>,
    testfn: (A, B, C, D, E, F, G, H) -> Unit
 ) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H> Table8<A, B, C, D, E, F, G, H>.forAll(fn: (A, B, C, D, E, F, G, H) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -44,6 +47,7 @@ inline fun <A, B, C, D, E, F, G, H> Table8<A, B, C, D, E, F, G, H>.forAll(fn: (A
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    vararg rows: Row8<A, B, C, D, E, F, G, H>,
    testfn: suspend (A, B, C, D, E, F, G, H) -> Unit
@@ -66,12 +70,14 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
 }
 
 @JvmName("fornone8")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H> forNone(
    table: Table8<A, B, C, D, E, F, G, H>,
    testfn: (A, B, C, D, E, F, G, H) -> Unit
 ) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H> Table8<A, B, C, D, E, F, G, H>.forNone(fn: (A, B, C, D, E, F, G, H) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll9.kt
+++ b/kotest-assertions/kotest-assertions-table/src/commonMain/kotlin/io/kotest/data/forAll9.kt
@@ -4,6 +4,7 @@ package io.kotest.data
 
 import kotlin.jvm.JvmName
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
    testfn: suspend (A, B, C, D, E, F, G, H, I) -> Unit
@@ -27,12 +28,14 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
 }
 
 @JvmName("forall9")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I> forAll(
    table: Table9<A, B, C, D, E, F, G, H, I>,
    testfn: (A, B, C, D, E, F, G, H, I) -> Unit
 ) =
    table.forAll(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I> Table9<A, B, C, D, E, F, G, H, I>.forAll(fn: (A, B, C, D, E, F, G, H, I) -> Unit) {
    val collector = ErrorCollector()
    for (row in rows) {
@@ -45,6 +48,7 @@ inline fun <A, B, C, D, E, F, G, H, I> Table9<A, B, C, D, E, F, G, H, I>.forAll(
    collector.assertAll()
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    vararg rows: Row9<A, B, C, D, E, F, G, H, I>,
    testfn: suspend (A, B, C, D, E, F, G, H, I) -> Unit
@@ -68,12 +72,14 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
 }
 
 @JvmName("fornone9")
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I> forNone(
    table: Table9<A, B, C, D, E, F, G, H, I>,
    testfn: (A, B, C, D, E, F, G, H, I) -> Unit
 ) =
    table.forNone(testfn)
 
+@IgnorableReturnValue
 inline fun <A, B, C, D, E, F, G, H, I> Table9<A, B, C, D, E, F, G, H, I>.forNone(fn: (A, B, C, D, E, F, G, H, I) -> Unit) {
    for (row in rows) {
       try {

--- a/kotest-assertions/kotest-assertions-yaml/src/commonMain/kotlin/io/kotest/assertions/yaml/YamlMatchers.kt
+++ b/kotest-assertions/kotest-assertions-yaml/src/commonMain/kotlin/io/kotest/assertions/yaml/YamlMatchers.kt
@@ -11,11 +11,13 @@ import io.kotest.matchers.shouldNot
 
 private val yaml = Yaml.default
 
+@IgnorableReturnValue
 fun String.shouldBeValidYaml(): String {
    this should beValidYaml()
    return this
 }
 
+@IgnorableReturnValue
 fun String.shouldNotBeValidYaml(): String {
    this shouldNot beValidYaml()
    return this
@@ -40,11 +42,13 @@ fun beValidYaml() = object : Matcher<String?> {
    }
 }
 
+@IgnorableReturnValue
 infix fun String.shouldEqualYaml(expected: String): String {
    this should equalYaml(expected)
    return this
 }
 
+@IgnorableReturnValue
 infix fun String.shouldNotEqualYaml(expected: String): String {
    this shouldNot equalYaml(expected)
    return this

--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt
@@ -22,6 +22,7 @@ import java.lang.reflect.Field
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
  * already changed, the result is inconsistent, as the System Environment Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withEnvironment(key: String, value: String?, mode: OverrideMode = SetOrError, block: () -> T): T {
    return withEnvironment(key to value, mode, block)
 }
@@ -41,6 +42,7 @@ inline fun <T> withEnvironment(key: String, value: String?, mode: OverrideMode =
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
  * already changed, the result is inconsistent, as the System Environment Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withEnvironment(environment: Pair<String, String?>, mode: OverrideMode = SetOrError, block: () -> T): T {
    return withEnvironment(mapOf(environment), mode, block)
 }
@@ -60,6 +62,7 @@ inline fun <T> withEnvironment(environment: Pair<String, String?>, mode: Overrid
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the environment while it was
  * already changed, the result is inconsistent, as the System Environment Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withEnvironment(environment: Map<String, String?>, mode: OverrideMode = SetOrError, block: () -> T): T {
    val isWindows = "windows" in System.getProperty("os.name").orEmpty().lowercase()
    val originalEnvironment = if (isWindows) {

--- a/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemPropertiesExtensions.kt
+++ b/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemPropertiesExtensions.kt
@@ -21,6 +21,7 @@ import java.util.Properties
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the properties while it was
  * already changed, the result is inconsistent, as the System Properties Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withSystemProperty(key: String, value: String?, mode: OverrideMode = SetOrError, block: () -> T): T {
    return withSystemProperties(key to value, mode, block)
 }
@@ -39,6 +40,7 @@ inline fun <T> withSystemProperty(key: String, value: String?, mode: OverrideMod
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the properties while it was
  * already changed, the result is inconsistent, as the System Properties Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withSystemProperties(pair: Pair<String, String?>, mode: OverrideMode = SetOrError, block: () -> T): T {
    return withSystemProperties(mapOf(pair), mode, block)
 }
@@ -57,6 +59,7 @@ inline fun <T> withSystemProperties(pair: Pair<String, String?>, mode: OverrideM
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the properties while it was
  * already changed, the result is inconsistent, as the System Properties Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withSystemProperties(props: Properties, mode: OverrideMode = SetOrError, block: () -> T): T {
    val map = props.toStringStringMap()
    return withSystemProperties(map, mode, block)
@@ -76,6 +79,7 @@ inline fun <T> withSystemProperties(props: Properties, mode: OverrideMode = SetO
  * **ATTENTION**: This code is susceptible to race conditions. If you attempt to change the properties while it was
  * already changed, the result is inconsistent, as the System Properties Map is a single map.
  */
+@IgnorableReturnValue
 inline fun <T> withSystemProperties(props: Map<String, String?>, mode: OverrideMode = SetOrError, block: () -> T): T {
    val previous =
       Properties().apply { putAll(System.getProperties()) }.toStringStringMap()  // Safe copying to ensure immutability

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/TestConfiguration.kt
@@ -87,12 +87,14 @@ abstract class TestConfiguration : Extendable() {
    /**
     * Registers an [AutoCloseable] to be closed when the spec is completed.
     */
+   @IgnorableReturnValue
    fun <T : AutoCloseable> autoClose(closeable: T): T =
       autoClose(lazy(LazyThreadSafetyMode.NONE) { closeable }).value
 
    /**
     * Registers a lazy [AutoCloseable] to be closed when the spec is completed.
     */
+   @IgnorableReturnValue
    fun <T : AutoCloseable> autoClose(closeable: Lazy<T>): Lazy<T> {
       _parentConfiguration?.autoClose(closeable)
       _autoCloseables = listOf(closeable) + _autoCloseables
@@ -269,6 +271,7 @@ abstract class TestConfiguration : Extendable() {
    /**
     * Register an extension callback
     */
+   @IgnorableReturnValue
    fun extension(f: TestCaseExtensionFn) {
       this@TestConfiguration.extension(object : TestCaseExtension {
          override suspend fun intercept(testCase: TestCase, execute: suspend (TestCase) -> TestResult): TestResult =
@@ -305,6 +308,7 @@ abstract class TestConfiguration : Extendable() {
     * Register a single [Extension] of type T return that listener.
     */
    @Deprecated("Use extension instead", ReplaceWith("extension"))
+   @IgnorableReturnValue
    fun <T : Extension> register(extension: T): T {
       extensions(listOf(extension))
       return extension

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/MountableExtension.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/extensions/MountableExtension.kt
@@ -61,6 +61,7 @@ interface LazyMaterialized<MATERIALIZED> {
 }
 
 // cannot be suspending as it is used in constructors
+@IgnorableReturnValue
 fun <CONFIG, MATERIALIZED> Spec.install(
    ext: MountableExtension<CONFIG, MATERIALIZED>,
    configure: CONFIG.() -> Unit = {}
@@ -70,6 +71,7 @@ fun <CONFIG, MATERIALIZED> Spec.install(
 }
 
 // cannot be suspending as it is used in constructors
+@IgnorableReturnValue
 fun <CONFIG, MATERIALIZED> Spec.install(
    ext: LazyMountableExtension<CONFIG, MATERIALIZED>,
    configure: CONFIG.() -> Unit = {},

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/Extendable.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/Extendable.kt
@@ -26,6 +26,7 @@ abstract class Extendable {
    /**
     * Register a single [Extension] of type T and return that extension.
     */
+   @IgnorableReturnValue
    fun <T : Extension> extension(extension: T): T {
       extensions(extension)
       return extension

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
@@ -9,6 +9,7 @@ object TestDslState {
    private val started = mutableSetOf<String>()
    private val mutex = Semaphore(1)
 
+   @IgnorableReturnValue
    suspend fun startTest(name: TestName) = mutex.withPermit {
       started.add(name.name)
    }

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/spec/style/scopes/state.kt
@@ -9,9 +9,8 @@ object TestDslState {
    private val started = mutableSetOf<String>()
    private val mutex = Semaphore(1)
 
-   @IgnorableReturnValue
    suspend fun startTest(name: TestName) = mutex.withPermit {
-      started.add(name.name)
+      started += name.name
    }
 
    suspend fun clear(name: TestName) = mutex.withPermit {

--- a/kotest-property/kotest-property-arrow/src/commonMain/kotlin/io/kotest/property/arrow/laws/Util.kt
+++ b/kotest-property/kotest-property-arrow/src/commonMain/kotlin/io/kotest/property/arrow/laws/Util.kt
@@ -2,6 +2,7 @@ package io.kotest.property.arrow.laws
 
 import io.kotest.matchers.shouldBe as coreShouldBe
 
+@IgnorableReturnValue
 internal infix fun <A> A.shouldBe(a: A): A {
   this coreShouldBe a
   return this

--- a/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/dsl.kt
+++ b/kotest-property/kotest-property-permutations/src/commonMain/kotlin/io/kotest/permutations/dsl.kt
@@ -20,6 +20,7 @@ fun permconfig(configure: PermutationConfiguration.() -> Unit): PermutationConfi
  * Once the [configure] callback has completed, the permutations are executed.
  */
 @ExperimentalKotest
+@IgnorableReturnValue
 suspend fun permutations(
    configure: suspend PermutationConfiguration.() -> Unit,
 ): PermutationResult {
@@ -33,6 +34,7 @@ suspend fun permutations(
  * Once the [configure] callback has completed, the permutations are executed.
  */
 @ExperimentalKotest
+@IgnorableReturnValue
 suspend fun permutations(
    default: PermutationConfiguration,
    configure: suspend PermutationConfiguration.() -> Unit,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest10.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest10.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -21,6 +22,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -36,6 +38,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -51,6 +54,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -67,6 +71,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, config.copy(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
 ) = proptest(
@@ -84,6 +89,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
@@ -102,6 +108,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Unit
@@ -120,6 +127,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -139,6 +147,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -153,6 +162,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -168,6 +178,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, config) { a, b, c, d, E, F, G, H, I, J -> property(a, b, c, d, E, F, G, H, I, J) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -183,6 +194,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -199,10 +211,12 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
@@ -220,17 +234,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I, J -> property(a, b, c, d, e, F, G, H, I, J) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -245,6 +262,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -263,6 +281,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    property(a, b, c, d, E, F, G, H, I, J) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -278,6 +297,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -294,10 +314,12 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
@@ -315,11 +337,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, E, F, G, H, I, J -> property(a, b, c, d, E, F, G, H, I, J) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest11.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest11.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -22,6 +23,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -38,6 +40,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -54,6 +57,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -71,6 +75,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
 ) = proptest(
@@ -89,6 +94,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
@@ -108,6 +114,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Unit
@@ -127,6 +134,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -147,6 +155,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -162,6 +171,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -178,6 +188,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, config) { a, b, c, d, E, F, G, H, I, J, K -> property(a, b, c, d, E, F, G, H, I, J, K) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -194,6 +205,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -211,10 +223,12 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
@@ -233,17 +247,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I, J, K -> property(a, b, c, d, e, F, G, H, I, J, K) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -259,6 +276,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -278,6 +296,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    property(a, b, c, d, E, F, G, H, I, J, K) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -294,6 +313,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -311,10 +331,12 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
@@ -333,11 +355,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, E, F, G, H, I, J, K -> property(a, b, c, d, E, F, G, H, I, J, K) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest12.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest12.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -23,6 +24,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -40,6 +42,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -57,6 +60,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -75,6 +79,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
 ) = proptest(
@@ -94,6 +99,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
@@ -114,6 +120,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Unit
@@ -134,6 +141,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -155,6 +163,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -171,6 +180,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -188,6 +198,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, config) { a, b, c, d, E, F, G, H, I, J, K, L -> property(a, b, c, d, E, F, G, H, I, J, K, L) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -205,6 +216,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -223,10 +235,12 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
@@ -246,17 +260,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g, h, i, j, k, l -> property(a, b, c, d, e, f, g, h, i, j, k, l) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -273,6 +290,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -293,6 +311,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    property(a, b, c, d, e, f, g, h, i, j, k, l) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -310,6 +329,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -328,10 +348,12 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
@@ -351,11 +373,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g, h, i, j, k, l -> property(a, b, c, d, e, f, g, h, i, j, k, l) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I, reified J, reified K, reified L> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest13.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest13.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -24,6 +25,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -42,6 +44,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, config) { a, b, c, d, e, f, g, h, i, j, k, l, m -> property(a, b, c, d, e, f, g, h, i, j, k, l, m) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest14.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest14.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -25,6 +26,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN,  config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -44,6 +46,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n -> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest15.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest15.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -26,6 +27,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -46,6 +48,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o -> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest16.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest16.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -27,6 +28,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -48,6 +50,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p -> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest17.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest17.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -28,6 +29,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -50,6 +52,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q -> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest18.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest18.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -29,6 +30,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -52,6 +54,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r -> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest19.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest19.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -30,6 +31,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -54,6 +56,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s -> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest20.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest20.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -31,6 +32,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> checkAl
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, genT, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -56,6 +58,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, genT, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t-> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest21.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest21.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -32,6 +33,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> chec
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, genT, genU, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -58,6 +60,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forA
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, genT, genU, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u-> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest22.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest22.kt
@@ -6,6 +6,7 @@ import io.kotest.common.ExperimentalKotest
 import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -33,6 +34,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> c
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, genT, genU, genV, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -60,6 +62,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> f
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, genJ, genK, genL, genM, genN, genO, genP, genQ, genR, genS, genT, genU, genV, config) { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v-> property(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest6.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -17,6 +18,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ): PropertyContext = proptest<A, B, C, D, E, F>(genA, genB, genC, genD, genE, genF, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -28,6 +30,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -39,6 +42,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -51,6 +55,7 @@ suspend fun <A, B, C, D, E, F> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
 ) = proptest(
@@ -64,6 +69,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
@@ -78,6 +84,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F) -> Unit
@@ -92,6 +99,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -107,6 +115,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -117,6 +126,7 @@ suspend fun <A, B, C, D, E, F> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forAll<A, B, C, D, E, F>(PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -128,6 +138,7 @@ suspend fun <A, B, C, D, E, F> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = proptest<A, B, C, D, E, F>(genA, genB, genC, genD, genE, genF, config) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -139,6 +150,7 @@ suspend fun <A, B, C, D, E, F> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forAll<A, B, C, D, E, F>(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -151,10 +163,12 @@ suspend fun <A, B, C, D, E, F> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forAll<A, B, C, D, E, F>(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
 ): PropertyContext = forAll<A, B, C, D, E, F>(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
@@ -168,17 +182,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forAll<A, B, C, D, E, F>(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forAll<A, B, C, D, E, F>(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -189,6 +206,7 @@ suspend fun <A, B, C, D, E, F> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forNone<A, B, C, D, E, F>(PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -203,6 +221,7 @@ suspend fun <A, B, C, D, E, F> forNone(
    property(a, b, c, d, e, f) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -214,6 +233,7 @@ suspend fun <A, B, C, D, E, F> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forNone<A, B, C, D, E, F>(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -226,10 +246,12 @@ suspend fun <A, B, C, D, E, F> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forNone<A, B, C, D, E, F>(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
 ): PropertyContext = forNone<A, B, C, D, E, F>(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
@@ -243,11 +265,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f -> property(a, b, c, d, e, f) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F) -> Boolean
 ) = forNone<A, B, C, D, E, F>(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest7.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest7.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -18,6 +19,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -30,6 +32,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -42,6 +45,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -55,6 +59,7 @@ suspend fun <A, B, C, D, E, F, G> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
 ) = proptest(
@@ -69,6 +74,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
@@ -84,6 +90,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Unit
@@ -99,6 +106,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -115,6 +123,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F,G> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -126,6 +135,7 @@ suspend fun <A, B, C, D, E, F,G> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -138,6 +148,7 @@ suspend fun <A, B, C, D, E, F, G> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, config) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -150,6 +161,7 @@ suspend fun <A, B, C, D, E, F, G> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -163,10 +175,12 @@ suspend fun <A, B, C, D, E, F, G> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
@@ -181,17 +195,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -203,6 +220,7 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -218,6 +236,7 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    property(a, b, c, d, e, f, g) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -230,6 +249,7 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -243,10 +263,12 @@ suspend fun <A, B, C, D, E, F, G> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
@@ -261,11 +283,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g -> property(a, b, c, d, e, f, g) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest8.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest8.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -19,6 +20,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -32,6 +34,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -45,6 +48,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -59,6 +63,7 @@ suspend fun <A, B, C, D, E, F, G, H> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
 ) = proptest(
@@ -74,6 +79,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
@@ -90,6 +96,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Unit
@@ -106,6 +113,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -123,6 +131,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -135,6 +144,7 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -148,6 +158,7 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, config) { a, b, c, d, E, F, G, H -> property(a, b, c, d, E, F, G, H) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -161,6 +172,7 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -175,10 +187,12 @@ suspend fun <A, B, C, D, E, F, G, H> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
@@ -194,17 +208,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, f, g, h -> property(a, b, c, d, e, f, g, h) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -217,6 +234,7 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -233,6 +251,7 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    property(a, b, c, d, E, F, G, h) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -246,6 +265,7 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -260,10 +280,12 @@ suspend fun <A, B, C, D, E, F, G, H> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
@@ -279,11 +301,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, E, F, G, H -> property(a, b, c, d, E, F, G, H) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest9.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/PropertyTest9.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -20,6 +21,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI,  PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -34,6 +36,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -48,6 +51,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -63,6 +67,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
 ) = proptest(
@@ -79,6 +84,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
@@ -96,6 +102,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Unit
@@ -113,6 +120,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -131,6 +139,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -144,6 +153,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -158,6 +168,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = proptest(genA, genB, genC, genD, genE, genF, genG, genH, genI, config) { a, b, c, d, E, F, G, H, I -> property(a, b, c, d, E, F, G, H, I) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -172,6 +183,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -187,10 +199,12 @@ suspend fun <A, B, C, D, E, F, G, H, I> forAll(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
@@ -207,17 +221,20 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, e, F, G, H, I -> property(a, b, c, d, e, F, G, H, I) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -231,6 +248,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -248,6 +266,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    property(a, b, c, d, E, F, G, H, I) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -262,6 +281,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -277,10 +297,12 @@ suspend fun <A, B, C, D, E, F, G, H, I> forNone(
    property: suspend PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, genD, genE, genF, genG, genH, genI, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
@@ -297,11 +319,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E, reifi
    config
 ) { a, b, c, d, E, F, G, H, I -> property(a, b, c, d, E, F, G, H, I) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E, F, G, H, I) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E, reified F, reified G, reified H, reified I> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/coverage.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/coverage.kt
@@ -18,6 +18,7 @@ import io.kotest.assertions.AssertionErrorBuilder
  */
 @Suppress("DEPRECATION")
 @Deprecated("Use labels. See https://kotest.io/docs/proptest/property-test-statistics.html")
+@IgnorableReturnValue
 suspend fun checkCoverage(label: String, percentage: Double, f: suspend () -> PropertyContext): PropertyContext {
    val context = f()
    val labelled = context.classifications()[label] ?: 0
@@ -42,6 +43,7 @@ suspend fun checkCoverage(label: String, percentage: Double, f: suspend () -> Pr
  */
 @Suppress("DEPRECATION")
 @Deprecated("Use labels. See https://kotest.io/docs/proptest/property-test-statistics.html")
+@IgnorableReturnValue
 suspend fun checkCoverage(vararg pairs: Pair<String, Double>, f: suspend () -> PropertyContext): PropertyContext {
    val context = f()
    val attempts = context.attempts()

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/collections.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/collections.kt
@@ -20,6 +20,7 @@ fun <A> Exhaustive.Companion.collection(collection: Collection<A>): Exhaustive<A
 *    listOf(1, 2, 3)
 * )
 */
+@IgnorableReturnValue
 fun <A> Exhaustive.Companion.permutations(list: List<A>, length: Int = list.size): Exhaustive<List<A>> {
    require(length in 0..list.size) { "length must be between 0 and the list size (${list.size}), but was $length." }
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/collections.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/exhaustive/collections.kt
@@ -20,7 +20,6 @@ fun <A> Exhaustive.Companion.collection(collection: Collection<A>): Exhaustive<A
 *    listOf(1, 2, 3)
 * )
 */
-@IgnorableReturnValue
 fun <A> Exhaustive.Companion.permutations(list: List<A>, length: Int = list.size): Exhaustive<List<A>> {
    require(length in 0..list.size) { "length must be between 0 and the list size (${list.size}), but was $length." }
 

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/internal/proptest.kt
@@ -11,6 +11,7 @@ import io.kotest.property.RandomSource
 import io.kotest.property.arbitrary.removeEdgecases
 import io.kotest.property.seed.createRandom
 
+@IgnorableReturnValue
 suspend fun <A> proptest(
    genA: Gen<A>,
    config: PropTestConfig,
@@ -72,6 +73,7 @@ suspend fun <A> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -133,6 +135,7 @@ suspend fun <A, B> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -199,6 +202,7 @@ suspend fun <A, B, C> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -265,6 +269,7 @@ suspend fun <A, B, C, D> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -353,6 +358,7 @@ suspend fun <A, B, C, D, E> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -448,6 +454,7 @@ suspend fun <A, B, C, D, E, F> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -550,6 +557,7 @@ suspend fun <A, B, C, D, E, F, G> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -659,6 +667,7 @@ suspend fun <A, B, C, D, E, F, G, H> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -775,6 +784,7 @@ suspend fun <A, B, C, D, E, F, G, H, I> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -909,6 +919,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -1063,6 +1074,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -1226,6 +1238,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -1398,6 +1411,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -1579,6 +1593,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -1769,6 +1784,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -1985,6 +2001,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -2211,6 +2228,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -2466,6 +2484,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -2732,6 +2751,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S> proptest(
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -3009,6 +3029,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T> proptes
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> proptest(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -3297,6 +3318,7 @@ suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U> prop
    return context
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V> proptest(
    genA: Gen<A>,
    genB: Gen<B>,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest1.kt
@@ -9,17 +9,21 @@ import io.kotest.property.resolution.default
 import kotlin.jvm.JvmName
 
 @JvmName("checkAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.checkAll(property: suspend PropertyContext.(A) -> Unit) = checkAll(this, property)
 
+@IgnorableReturnValue
 suspend fun <A> checkAll(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext = proptest(genA, PropTestConfig(), property)
 
 @JvmName("checkAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.checkAll(iterations: Int, property: suspend PropertyContext.(A) -> Unit) =
    checkAll(iterations, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -27,9 +31,11 @@ suspend fun <A> checkAll(
 ): PropertyContext = proptest(genA, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
 @JvmName("checkAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.checkAll(config: PropTestConfig, property: suspend PropertyContext.(A) -> Unit) =
    checkAll(config, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -37,12 +43,14 @@ suspend fun <A> checkAll(
 ): PropertyContext = proptest(genA, config, property)
 
 @JvmName("checkAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.checkAll(
    iterations: Int,
    config: PropTestConfig,
    property: suspend PropertyContext.(A) -> Unit
 ) = checkAll(iterations, config, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -50,6 +58,7 @@ suspend fun <A> checkAll(
    property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext = proptest(genA, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> checkAll(
    noinline property: suspend PropertyContext.(A) -> Unit
 ): PropertyContext = proptest(
@@ -58,6 +67,7 @@ suspend inline fun <reified A> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A) -> Unit
@@ -67,6 +77,7 @@ suspend inline fun <reified A> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A) -> Unit
@@ -76,6 +87,7 @@ suspend inline fun <reified A> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -87,18 +99,22 @@ suspend inline fun <reified A> checkAll(
 )
 
 @JvmName("forAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forAll(property: suspend PropertyContext.(A) -> Boolean) =
    forAll(this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forAll(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
 ) = forAll(PropTestConfig(), genA, property)
 
 @JvmName("forAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forAll(iterations: Int, property: suspend PropertyContext.(A) -> Boolean) =
    forAll(iterations, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -106,9 +122,11 @@ suspend fun <A> forAll(
 ) = forAll(iterations, PropTestConfig(), genA, property)
 
 @JvmName("forAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forAll(config: PropTestConfig, property: suspend PropertyContext.(A) -> Boolean) =
    forAll(config, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -116,9 +134,11 @@ suspend fun <A> forAll(
 ) = proptest(genA, config) { a -> property(a) shouldBe true }
 
 @JvmName("forAllExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forAll(iterations: Int, config: PropTestConfig, property: suspend PropertyContext.(A) -> Boolean) =
    forAll(config.copy(iterations = iterations), this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -126,15 +146,18 @@ suspend fun <A> forAll(
    property: suspend PropertyContext.(A) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forAll(
    crossinline property: PropertyContext.(A) -> Boolean
 ) = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forAll(
    config: PropTestConfig,
    crossinline property: PropertyContext.(A) -> Boolean
@@ -143,6 +166,7 @@ suspend inline fun <reified A> forAll(
    config
 ) { a -> property(a) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -153,18 +177,22 @@ suspend inline fun <reified A> forAll(
 ) { a -> property(a) shouldBe true }
 
 @JvmName("forNoneExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forNone(property: suspend PropertyContext.(A) -> Boolean) =
    forNone(this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forNone(
    genA: Gen<A>,
    property: suspend PropertyContext.(A) -> Boolean
 ) = forNone(PropTestConfig(), genA, property)
 
 @JvmName("forNoneExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forNone(iterations: Int, property: suspend PropertyContext.(A) -> Boolean) =
    forAll(iterations, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -172,9 +200,11 @@ suspend fun <A> forNone(
 ) = forNone(iterations, PropTestConfig(), genA, property)
 
 @JvmName("forNoneExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forNone(config: PropTestConfig, property: suspend PropertyContext.(A) -> Boolean) =
    forNone(config, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forNone(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -185,6 +215,7 @@ suspend fun <A> forNone(
 ) { a -> property(a) shouldBe false }
 
 @JvmName("forNoneExt")
+@IgnorableReturnValue
 suspend fun <A> Gen<A>.forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -192,6 +223,7 @@ suspend fun <A> Gen<A>.forNone(
 ) =
    forNone(iterations, config, this, property)
 
+@IgnorableReturnValue
 suspend fun <A> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -199,15 +231,18 @@ suspend fun <A> forNone(
    property: suspend PropertyContext.(A) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forNone(
    crossinline property: PropertyContext.(A) -> Boolean
 ) = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forNone(
    config: PropTestConfig,
    crossinline property: PropertyContext.(A) -> Boolean
@@ -216,6 +251,7 @@ suspend inline fun <reified A> forNone(
    config
 ) { a -> property(a) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest2.kt
@@ -7,12 +7,14 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Unit
 ): PropertyContext = proptest(genA, genB, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend fun <A, B> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -20,6 +22,7 @@ suspend fun <A, B> checkAll(
    property: suspend PropertyContext.(A, B) -> Unit
 ): PropertyContext = proptest(genA, genB, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -27,6 +30,7 @@ suspend fun <A, B> checkAll(
    property: suspend PropertyContext.(A, B) -> Unit
 ): PropertyContext = proptest(genA, genB, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -35,6 +39,7 @@ suspend fun <A, B> checkAll(
    property: suspend PropertyContext.(A, B) -> Unit
 ): PropertyContext = proptest(genA, genB, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> checkAll(
    noinline property: suspend PropertyContext.(A, B) -> Unit
 ) = proptest(
@@ -44,6 +49,7 @@ suspend inline fun <reified A, reified B> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> PropTest.checkAll(
    noinline property: suspend PropertyContext.(A, B) -> Unit
 ) = proptest(
@@ -53,6 +59,7 @@ suspend inline fun <reified A, reified B> PropTest.checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B) -> Unit
@@ -63,6 +70,7 @@ suspend inline fun <reified A, reified B> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B) -> Unit
@@ -73,6 +81,7 @@ suspend inline fun <reified A, reified B> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -84,12 +93,14 @@ suspend inline fun <reified A, reified B> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = forAll(PropTestConfig(), genA, genB, property)
 
+@IgnorableReturnValue
 suspend fun <A, B> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -97,6 +108,7 @@ suspend fun <A, B> forAll(
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = proptest(genA, genB, config) { a, b -> property(a, b) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -104,6 +116,7 @@ suspend fun <A, B> forAll(
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, property)
 
+@IgnorableReturnValue
 suspend fun <A, B> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -112,10 +125,12 @@ suspend fun <A, B> forAll(
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forAll(
    crossinline property: PropertyContext.(A, B) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B) -> Boolean
@@ -125,23 +140,27 @@ suspend inline fun <reified A, reified B> forAll(
    config,
 ) { a, b -> property(a, b) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = forNone(PropTestConfig(), genA, genB, property)
 
+@IgnorableReturnValue
 suspend fun <A, B> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -149,6 +168,7 @@ suspend fun <A, B> forNone(
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = proptest(genA, genB, config) { a, b -> property(a, b) shouldBe false }
 
+@IgnorableReturnValue
 suspend fun <A, B> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -156,6 +176,7 @@ suspend fun <A, B> forNone(
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, property)
 
+@IgnorableReturnValue
 suspend fun <A, B> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -164,10 +185,12 @@ suspend fun <A, B> forNone(
    property: suspend PropertyContext.(A, B) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forNone(
    crossinline property: PropertyContext.(A, B) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B) -> Boolean
@@ -177,11 +200,13 @@ suspend inline fun <reified A, reified B> forNone(
    config
 ) { a, b -> property(a, b) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest3.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest3.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -20,6 +21,7 @@ suspend fun <A, B, C> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -29,6 +31,7 @@ suspend fun <A, B, C> checkAll(
 ): PropertyContext =
    proptest(genA, genB, genC, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -37,6 +40,7 @@ suspend fun <A, B, C> checkAll(
    property: suspend PropertyContext.(A, B, C) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -46,6 +50,7 @@ suspend fun <A, B, C> checkAll(
    property: suspend PropertyContext.(A, B, C) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> checkAll(
    noinline property: suspend PropertyContext.(A, B, C) -> Unit
 ) = proptest(
@@ -56,6 +61,7 @@ suspend inline fun <reified A, reified B, reified C> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C) -> Unit
@@ -67,6 +73,7 @@ suspend inline fun <reified A, reified B, reified C> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C) -> Unit
@@ -78,6 +85,7 @@ suspend inline fun <reified A, reified B, reified C> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -90,6 +98,7 @@ suspend inline fun <reified A, reified B, reified C> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -103,6 +112,7 @@ suspend fun <A, B, C> forAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -111,6 +121,7 @@ suspend fun <A, B, C> forAll(
    property: suspend PropertyContext.(A, B, C) -> Boolean
 ) = proptest(genA, genB, genC, config) { a, b, c -> property(a, b, c) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -119,6 +130,7 @@ suspend fun <A, B, C> forAll(
    property: suspend PropertyContext.(A, B, C) -> Boolean
 ) = forAll(iterations, PropTestConfig(), genA, genB, genC, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -128,10 +140,12 @@ suspend fun <A, B, C> forAll(
    property: suspend PropertyContext.(A, B, C) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forAll(
    crossinline property: PropertyContext.(A, B, C) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C) -> Boolean
@@ -142,17 +156,20 @@ suspend inline fun <reified A, reified B, reified C> forAll(
    config
 ) { a, b, c -> property(a, b, c) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -166,6 +183,7 @@ suspend fun <A, B, C> forNone(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -174,6 +192,7 @@ suspend fun <A, B, C> forNone(
    property: suspend PropertyContext.(A, B, C) -> Boolean
 ) = proptest(genA, genB, genC, config) { a, b, c -> property(a, b, c) shouldBe false }
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -182,6 +201,7 @@ suspend fun <A, B, C> forNone(
    property: suspend PropertyContext.(A, B, C) -> Boolean
 ) = forNone(iterations, PropTestConfig(), genA, genB, genC, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -191,10 +211,12 @@ suspend fun <A, B, C> forNone(
    property: suspend PropertyContext.(A, B, C) -> Boolean
 ) = forNone(config.copy(iterations = iterations), genA, genB, genC, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forNone(
    crossinline property: PropertyContext.(A, B, C) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C) -> Boolean
@@ -205,11 +227,13 @@ suspend inline fun <reified A, reified B, reified C> forNone(
    config
 ) { a, b, c -> property(a, b, c) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest4.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -22,6 +23,7 @@ suspend fun <A, B, C, D> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -32,6 +34,7 @@ suspend fun <A, B, C, D> checkAll(
 ): PropertyContext =
    proptest(genA, genB, genC, genD, config, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -41,6 +44,7 @@ suspend fun <A, B, C, D> checkAll(
    property: suspend PropertyContext.(A, B, C, D) -> Unit
 ): PropertyContext = checkAll(PropTestConfig(constraints = Constraints.iterations(iterations)), genA, genB, genC, genD, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -51,6 +55,7 @@ suspend fun <A, B, C, D> checkAll(
    property: suspend PropertyContext.(A, B, C, D) -> Unit
 ): PropertyContext = checkAll(config.copy(iterations = iterations), genA, genB, genC, genD, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
 ) = proptest(
@@ -62,6 +67,7 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
@@ -74,6 +80,7 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D) -> Unit
@@ -86,6 +93,7 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -99,6 +107,7 @@ suspend inline fun <reified A, reified B, reified C, reified D> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -114,6 +123,7 @@ suspend fun <A, B, C, D> forAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -123,6 +133,7 @@ suspend fun <A, B, C, D> forAll(
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = proptest<A, B, C, D>(genA, genB, genC, genD, config) { a, b, c, d -> property(a, b, c, d) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -132,6 +143,7 @@ suspend fun <A, B, C, D> forAll(
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = forAll<A, B, C, D>(iterations, PropTestConfig(), genA, genB, genC, genD, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -142,10 +154,12 @@ suspend fun <A, B, C, D> forAll(
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = forAll(config.copy(iterations = iterations), genA, genB, genC, genD, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
 ): PropertyContext = forAll(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
@@ -157,17 +171,20 @@ suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    config
 ) { a, b, c, d -> property(a, b, c, d) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
 ) = forAll(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forAll(
    iterations: Int,
    config: PropTestConfig,
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
 ) = forAll(config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forNone(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -183,6 +200,7 @@ suspend fun <A, B, C, D> forNone(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -192,6 +210,7 @@ suspend fun <A, B, C, D> forNone(
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = proptest<A, B, C, D>(genA, genB, genC, genD, config) { a, b, c, d -> property(a, b, c, d) shouldBe false }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -201,6 +220,7 @@ suspend fun <A, B, C, D> forNone(
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = forNone<A, B, C, D>(iterations, PropTestConfig(), genA, genB, genC, genD, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -211,10 +231,12 @@ suspend fun <A, B, C, D> forNone(
    property: suspend PropertyContext.(A, B, C, D) -> Boolean
 ) = forNone<A, B, C, D>(config.copy(iterations = iterations), genA, genB, genC, genD, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
@@ -226,11 +248,13 @@ suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    config
 ) { a, b, c, d -> property(a, b, c, d) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D) -> Boolean
 ) = forNone(iterations, PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D> forNone(
    iterations: Int,
    config: PropTestConfig,

--- a/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest5.kt
+++ b/kotest-property/src/commonMain/kotlin/io/kotest/property/propertyTest5.kt
@@ -7,6 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.property.internal.proptest
 import io.kotest.property.resolution.default
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> checkAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -24,6 +25,7 @@ suspend fun <A, B, C, D, E> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> checkAll(
    config: PropTestConfig,
    genA: Gen<A>,
@@ -42,6 +44,7 @@ suspend fun <A, B, C, D, E> checkAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> checkAll(
    iterations: Int,
    genA: Gen<A>,
@@ -52,6 +55,7 @@ suspend fun <A, B, C, D, E> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -63,6 +67,7 @@ suspend fun <A, B, C, D, E> checkAll(
    property: suspend PropertyContext.(A, B, C, D, E) -> Unit
 ): PropertyContext = proptest(genA, genB, genC, genD, genE, config.copy(iterations = iterations), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> checkAll(
    noinline property: suspend PropertyContext.(A, B, C, D, E) -> Unit
 ) = proptest(
@@ -75,6 +80,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> check
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> checkAll(
    config: PropTestConfig,
    noinline property: suspend PropertyContext.(A, B, C, D, E) -> Unit
@@ -88,6 +94,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> check
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> checkAll(
    iterations: Int,
    noinline property: suspend PropertyContext.(A, B, C, D, E) -> Unit
@@ -101,6 +108,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> check
    property
 )
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> checkAll(
    iterations: Int,
    config: PropTestConfig,
@@ -115,6 +123,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> check
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forAll(
    genA: Gen<A>,
    genB: Gen<B>,
@@ -132,6 +141,7 @@ suspend fun <A, B, C, D, E> forAll(
    property
 )
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forAll(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -150,6 +160,7 @@ suspend fun <A, B, C, D, E> forAll(
    ) shouldBe true
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forAll(
    iterations: Int,
    genA: Gen<A>,
@@ -160,6 +171,7 @@ suspend fun <A, B, C, D, E> forAll(
    property: suspend PropertyContext.(A, B, C, D, E) -> Boolean
 ) = forAll<A, B, C, D, E>(PropTestConfig(constraints = Constraints.iterations(iterations)), genA, genB, genC, genD, genE, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -171,10 +183,12 @@ suspend fun <A, B, C, D, E> forAll(
    property: suspend PropertyContext.(A, B, C, D, E) -> Boolean
 ) = forAll<A, B, C, D, E>(config.copy(iterations = iterations), genA, genB, genC, genD, genE, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forAll(
    crossinline property: PropertyContext.(A, B, C, D, E) -> Boolean
 ): PropertyContext = forAll<A, B, C, D, E>(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forAll(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E) -> Boolean
@@ -187,11 +201,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> forAl
    config
 ) { a, b, c, d, e -> property(a, b, c, d, e) shouldBe true }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forAll(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E) -> Boolean
 ) = forAll(PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forAll(
    iterations: Int,
    config: PropTestConfig,
@@ -205,6 +221,7 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> forAl
    config.copy(iterations = iterations),
 ) { a, b, c, d, e -> property(a, b, c, d, e) shouldBe true }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forNone(
    config: PropTestConfig = PropTestConfig(),
    genA: Gen<A>,
@@ -223,6 +240,7 @@ suspend fun <A, B, C, D, E> forNone(
    ) shouldBe false
 }
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forNone(
    iterations: Int,
    genA: Gen<A>,
@@ -233,6 +251,7 @@ suspend fun <A, B, C, D, E> forNone(
    property: suspend PropertyContext.(A, B, C, D, E) -> Boolean
 ): PropertyContext = forNone<A, B, C, D, E>(PropTestConfig(constraints = Constraints.iterations(iterations)), genA, genB, genC, genD, genE, property)
 
+@IgnorableReturnValue
 suspend fun <A, B, C, D, E> forNone(
    iterations: Int,
    config: PropTestConfig,
@@ -244,10 +263,12 @@ suspend fun <A, B, C, D, E> forNone(
    property: suspend PropertyContext.(A, B, C, D, E) -> Boolean
 ) = forNone<A, B, C, D, E>(config.copy(iterations = iterations), genA, genB, genC, genD, genE, property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forNone(
    crossinline property: PropertyContext.(A, B, C, D, E) -> Boolean
 ): PropertyContext = forNone<A, B, C, D, E>(PropTestConfig(), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forNone(
    config: PropTestConfig = PropTestConfig(),
    crossinline property: PropertyContext.(A, B, C, D, E) -> Boolean
@@ -261,11 +282,13 @@ suspend inline fun <reified A, reified B, reified C, reified D, reified E> forNo
       config
    ) { a, b, c, d, e -> property(a, b, c, d, e) shouldBe false }
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forNone(
    iterations: Int,
    crossinline property: PropertyContext.(A, B, C, D, E) -> Boolean
 ): PropertyContext = forNone(PropTestConfig(constraints = Constraints.iterations(iterations)), property)
 
+@IgnorableReturnValue
 suspend inline fun <reified A, reified B, reified C, reified D, reified E> forNone(
    iterations: Int,
    config: PropTestConfig,


### PR DESCRIPTION
## Why

Kotest is compiled with `-Xreturn-value-checker=full`, which marks every declaration in the module as `@MustUseReturnValue`. Because matchers return their receiver to allow chaining, consumers who enable the checker get a warning for every assertion written as a statement:

```kotlin
test("doc-index txt exists and lists files") {
   docIndex shouldHaveAtLeastSize 1
   // warning: unused return value of 'shouldHaveAtLeastSize'
}
```

This was reported on Slack after upgrading 6.1.1 → 6.2.x ("my project's warning list literally explodes"). 6.2.2 worked around it by disabling the checker for release builds. This PR does the real fix, so the checker can be turned back on.

## What

`kotlin.IgnorableReturnValue` opts a declaration out of the check. It targets `FUNCTION` only — there is no file- or class-level escape hatch — so each declaration is annotated individually (2,514 of them).

Annotated:

- every `should*` / `shouldNot*` matcher across all `kotest-assertions-*` modules
- the inspectors (`forAll`, `forNone`, `forExactly`, `forAtLeastOne`, the map aliases, …)
- `assertSoftly`, `withClue`, `asClue`, `invokeMatcher`
- the nondeterministic helpers (`eventually`, `continually`, `until`, `retry`)
- the property entry points (`checkAll`, `forAll`, `proptest`, `permutations`, `checkCoverage`)
- the spec DSL helpers that are written as bare statements (`extension`, `autoClose`, `install`, `register`)
- the scoped-resource helpers (`withSystemProperty`, `withEnvironment`)

**Matcher factories (`beEmpty()`, `haveSize()`, …) are deliberately left unannotated** — their result is the `Matcher` itself, and discarding it is always a mistake, so the checker should keep flagging those.

The annotation is a no-op on a `Unit`-returning function, so matchers are annotated uniformly rather than depending on whether a given overload happens to return its receiver. That keeps the rule auditable ("every matcher has it") and stays correct if a matcher later gains a chaining return.

The second commit re-enables the checker for release builds, which was the point of the exercise.

## Verification

Compiling an **external consumer** against the built jar with `-Xreturn-value-checker=full`:

```kotlin
docIndex shouldHaveAtLeastSize 1   // no warning
content shouldStartWith "# Alpha"  // no warning
beEmpty<String>()                  // still warns — factory result must be used
```

The control line matters: it confirms the checker really is active in that compile, and that factories were not over-annotated.

- `Unused return value` warnings across kotest's own build: **10,909 → 493**. Every remaining one is Kotlin stdlib (`apply`/`let`/`invoke`), a test-local helper, or `internal` engine code — none reach consumers.
- `apiCheck` passes; force-regenerated `.api` dumps are **byte-identical** (BCV does not record annotations), so this is not a binary-compatibility change.
- Full `check`: **22,301 tests** pass across JVM, JVM-max-JDK, wasmJs (browser + node), wasmWasi, linuxX64 and Android-host.

## Note for reviewers

Re-enabling the checker for releases (commit 2) means *all* public non-Unit kotest API becomes must-use for consumers who opt in, not just matchers. I covered the statement-style APIs that kotest's own test suite actually discards, but a consumer could use one that kotest never does. If that feels too broad, commit 2 can be dropped and landed separately — commit 1 stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)