### PR TITLE
match fields of data classes that are data objects

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
@@ -113,7 +113,7 @@ internal object DataClassEq : Eq<Any> {
                if (isDataClassInstance(actualPropertyValue) && isDataClassInstance(expectedPropertyValue)) {
                   dataClassDiff(actualPropertyValue, expectedPropertyValue, depth + 1, context)?.let { diff ->
                      Pair(prop, diff)
-                  }
+                  } ?: Pair(prop, StandardDifference(result.error()))
                }
                else {
                   val error = result.error()

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/assertions/eq/DataClassEq.kt
@@ -98,6 +98,10 @@ internal object DataClassEq : Eq<Any> {
       }
    }
 
+   internal fun dataClassFieldCount(value: Any?): Int = value?.let {
+      reflection.primaryConstructorMembers(it::class).size
+   } ?: 0
+
    private fun computeMemberDifferences(
       expected: Any,
       actual: Any,
@@ -111,9 +115,13 @@ internal object DataClassEq : Eq<Any> {
          when (result) {
             is EqResult.Failure -> {
                if (isDataClassInstance(actualPropertyValue) && isDataClassInstance(expectedPropertyValue)) {
-                  dataClassDiff(actualPropertyValue, expectedPropertyValue, depth + 1, context)?.let { diff ->
-                     Pair(prop, diff)
-                  } ?: Pair(prop, StandardDifference(result.error()))
+                  if(dataClassFieldCount(actualPropertyValue) > 0 || dataClassFieldCount(expectedPropertyValue) > 0) {
+                     dataClassDiff(actualPropertyValue, expectedPropertyValue, depth + 1, context)?.let { diff ->
+                        Pair(prop, diff)
+                     }
+                  } else {
+                     Pair(prop, StandardDifference(result.error()))
+                  }
                }
                else {
                   val error = result.error()

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.kotest.eq
 
 import io.kotest.assertions.AssertionErrorBuilder
+import io.kotest.assertions.eq.DataClassEq.dataClassFieldCount
 import io.kotest.assertions.eq.DefaultEqResolver
 import io.kotest.assertions.eq.Eq
 import io.kotest.assertions.eq.EqContext
@@ -239,5 +240,15 @@ class `DataClassEq AssertionConfig Tests` : StringSpec({
       val throwable = shouldThrowAny { DataClass1(1, 3.4F) shouldBe DataClass1(2, 3.5F) }
 
       throwable.message shouldBe "expected:<DataClass1(a=2, b=3.5)> but was:<DataClass1(a=1, b=3.4)>"
+   }
+
+   "dataClassFieldCount counts fields for data class" {
+      dataClassFieldCount(IntRatio(3, 4)) shouldBe 2
+   }
+   "dataClassFieldCount returns 0 for data object" {
+      dataClassFieldCount(Status.Active) shouldBe 0
+   }
+   "dataClassFieldCount handles null" {
+      dataClassFieldCount(null) shouldBe 0
    }
 })

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/eq/DataClassEqTest.kt
@@ -7,6 +7,7 @@ import io.kotest.assertions.eq.EqContext
 import io.kotest.assertions.eq.EqResult
 import io.kotest.assertions.eq.isDataClassInstance
 import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -62,6 +63,13 @@ sealed class BoolState(val bytes: ByteArray?) {
    data object False : BoolState(byteArrayOf(0))
    data object Unknown : BoolState(null)
 }
+
+sealed class Status {
+   data object Active : Status()
+   data object Inactive : Status()
+}
+
+data class User(val name: String, val status: Status)
 
 class DataClassEqTest : StringSpec({
 
@@ -205,6 +213,18 @@ class DataClassEqTest : StringSpec({
 
       throwable.message shouldNotStartWith "data class diff"
    }
+
+   "should detect difference in one data object field" {
+      val user1 = User("John", Status.Active)
+      val user2 = User("John", Status.Inactive)
+
+      withClue("Guardian assumption - field status is different") {
+         user1.status shouldNotBe user2.status
+      }
+
+      user1 shouldNotBe user2
+   }
+
 })
 
 class `DataClassEq AssertionConfig Tests` : StringSpec({


### PR DESCRIPTION
fix for https://github.com/kotest/kotest/issues/6171 - correctly match fields of data classes that are data objects