### PR TITLE
Alex/same time offset date time  (#6180)

### DIFF
--- a/documentation/docs/assertions/core.md
+++ b/documentation/docs/assertions/core.md
@@ -288,11 +288,12 @@ Collections: also see [inspectors](inspectors.md) which are useful ways to test 
 | `date.shouldHaveNano(nao)`                    | Asserts that the date have correct nano second.                                         |
 | `date.shouldBe(value plusOrMinus(tolerance))` | Asserts that the date is equal to the given value within a tolerance range of duration. |
 
-| ZonedDateTime                                                 |                                                                                                         |
-|---------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| `zonedDateTime.shouldBeToday()`                               | Asserts that the ZonedDateTime has the same day as the today.                                           |
-| `zonedDateTime.shouldHaveSameInstantAs(other: ZonedDateTime)` | Asserts that the ZonedDateTime is equal to other ZonedDateTime using ```ChronoZonedDateTime.isEqual```. |
-| `zonedDateTime.shouldBe(other plusOrMinus 1.minutes)`         | Asserts that the ZonedDateTime is within 1 minute of `other` ZonedDateTime.                             |
+| ZonedDateTime                                                                |                                                                                                         |
+|------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| `zonedDateTime.shouldBeToday()`                                              | Asserts that the ZonedDateTime has the same day as the today.                                           |
+| `zonedDateTime.shouldHaveSameInstantAs(other: ZonedDateTime)`                | Asserts that the ZonedDateTime is equal to other ZonedDateTime using ```ChronoZonedDateTime.isEqual```. |
+| `zonedDateTime.shouldHaveSameInstantAsOffsetDateTime(other: OffsetDateTime)` | Asserts that the ZonedDateTime is equal to other OffsetDateTime converting both to ```Instant```.       |
+| `zonedDateTime.shouldBe(other plusOrMinus 1.minutes)`                        | Asserts that the ZonedDateTime is within 1 minute of `other` ZonedDateTime.                             |
 
 | OffsetDateTime                                                              |                                                                                                      |
 |-----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|

--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -2368,9 +2368,12 @@ public final class io/kotest/matchers/date/ZonedDateTimeToleranceMatcher : io/ko
 public final class io/kotest/matchers/date/ZoneddatetimeKt {
 	public static final fun atSameZone (Ljava/time/ZonedDateTime;)Lio/kotest/matchers/Matcher;
 	public static final fun beInTodayZDT ()Lio/kotest/matchers/Matcher;
+	public static final fun haveSameInstantAsOffsetDateTime (Ljava/time/OffsetDateTime;)Lio/kotest/matchers/Matcher;
 	public static final fun plusOrMinus-HG0u8IE (Ljava/time/ZonedDateTime;J)Lio/kotest/matchers/date/ZonedDateTimeToleranceMatcher;
 	public static final fun shouldBeToday (Ljava/time/ZonedDateTime;)V
+	public static final fun shouldHaveSameInstantAsOffsetDateTime (Ljava/time/ZonedDateTime;Ljava/time/OffsetDateTime;)V
 	public static final fun shouldNotBeToday (Ljava/time/ZonedDateTime;)V
+	public static final fun shouldNotHaveSameInstantAsOffsetDateTime (Ljava/time/ZonedDateTime;Ljava/time/OffsetDateTime;)V
 }
 
 public final class io/kotest/matchers/doubles/BetweenKt {

--- a/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/zoneddatetime.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmMain/kotlin/io/kotest/matchers/date/zoneddatetime.kt
@@ -3,8 +3,11 @@ package io.kotest.matchers.date
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.be
+import io.kotest.matchers.date.shouldHaveSameInstantAsZonedDateTime
+import io.kotest.matchers.date.shouldNotHaveSameInstantAsZonedDateTime
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
+import java.time.OffsetDateTime
 import java.time.ZonedDateTime
 import kotlin.time.Duration
 
@@ -87,4 +90,69 @@ class ZonedDateTimeToleranceMatcher(
 
    infix fun plusOrMinus(tolerance: Duration): ZonedDateTimeToleranceMatcher =
       ZonedDateTimeToleranceMatcher(expected, tolerance)
+}
+
+/**
+ * Asserts that ZonedDateTime is at the same Instant as an OffsetDateTime
+ *
+ * ```
+ *         val date = ZonedDateTime.of(2026, 7, 14, 8, 0, 0, 0, ZoneId.of("America/New_York"))
+ *         val other = OffsetDateTime.of(2026, 7, 14, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *         date should haveSameInstantAsOffsetDateTime(other)
+ *         shouldThrow<AssertionError> {
+ *            date shouldNot haveSameInstantAsOffsetDateTime(other)
+ *         }
+ *         date.plusSeconds(1L) shouldNot haveSameInstantAsOffsetDateTime(other)
+ *         shouldThrow<AssertionError> {
+ *            date.plusSeconds(1L) should haveSameInstantAsOffsetDateTime(other)
+ *         }
+ * ```
+ */
+infix fun ZonedDateTime.shouldHaveSameInstantAsOffsetDateTime(other: OffsetDateTime) = this should haveSameInstantAsOffsetDateTime(other)
+
+/**
+ * Asserts that ZonedDateTime is at the same Instant as a OffsetDateTime
+ *
+ * ```
+ *         val date = ZonedDateTime.of(2026, 7, 14, 8, 0, 0, 0, ZoneId.of("America/New_York"))
+ *         val other = OffsetDateTime.of(2026, 7, 14, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *         date should haveSameInstantAsOffsetDateTime(other)
+ *         shouldThrow<AssertionError> {
+ *            date shouldNot haveSameInstantAsOffsetDateTime(other)
+ *         }
+ *         date.plusSeconds(1L) shouldNot haveSameInstantAsOffsetDateTime(other)
+ *         shouldThrow<AssertionError> {
+ *            date.plusSeconds(1L) should haveSameInstantAsOffsetDateTime(other)
+ *         }
+ * ```
+ */
+infix fun ZonedDateTime.shouldNotHaveSameInstantAsOffsetDateTime(other: OffsetDateTime) = this shouldNot haveSameInstantAsOffsetDateTime(other)
+
+/**
+ * Matcher that checks if OffsetDateTime is at the same Instant as a ZonedDateTime
+ *
+ * ```
+ *         val date = ZonedDateTime.of(2026, 7, 14, 8, 0, 0, 0, ZoneId.of("America/New_York"))
+ *         val other = OffsetDateTime.of(2026, 7, 14, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+ *         date should haveSameInstantAsOffsetDateTime(other)
+ *         shouldThrow<AssertionError> {
+ *            date shouldNot haveSameInstantAsOffsetDateTime(other)
+ *         }
+ *         date.plusSeconds(1L) shouldNot haveSameInstantAsOffsetDateTime(other)
+ *         shouldThrow<AssertionError> {
+ *            date.plusSeconds(1L) should haveSameInstantAsOffsetDateTime(other)
+ *         }
+ * ```
+ *
+ * @see ZonedDateTime.shouldHaveSameInstantAsOffsetDateTime
+ * @see ZonedDateTime.shouldNotHaveSameInstantAsOffsetDateTime
+ */
+fun haveSameInstantAsOffsetDateTime(other: OffsetDateTime) = object : Matcher<ZonedDateTime> {
+   override fun test(value: ZonedDateTime): MatcherResult =
+      MatcherResult(
+         passed = value.toInstant() == other.toInstant(),
+         failureMessageFn = { "$value should be equal to $other" },
+         negatedFailureMessageFn = {
+            "$value should not be equal to $other"
+         })
 }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/date/DateMatchersTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.date.before
 import io.kotest.matchers.date.haveSameDay
 import io.kotest.matchers.date.haveSameHours
 import io.kotest.matchers.date.haveSameInstantAs
+import io.kotest.matchers.date.haveSameInstantAsOffsetDateTime
 import io.kotest.matchers.date.haveSameMinutes
 import io.kotest.matchers.date.haveSameMonth
 import io.kotest.matchers.date.haveSameNanos
@@ -438,6 +439,19 @@ class DateMatchersTest : StringSpec() {
         date.plusSeconds(1L) shouldNot haveSameInstantAsZonedDateTime(other)
         shouldThrow<AssertionError> {
            date.plusSeconds(1L) should haveSameInstantAsZonedDateTime(other)
+        }
+     }
+
+     "haveSameInstantAsOffsetDateTime should match OffsetDateTime and ZonedDateTime" {
+        val date = ZonedDateTime.of(2026, 7, 14, 8, 0, 0, 0, ZoneId.of("America/New_York"))
+        val other = OffsetDateTime.of(2026, 7, 14, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
+        date should haveSameInstantAsOffsetDateTime(other)
+        shouldThrow<AssertionError> {
+           date shouldNot haveSameInstantAsOffsetDateTime(other)
+        }
+        date.plusSeconds(1L) shouldNot haveSameInstantAsOffsetDateTime(other)
+        shouldThrow<AssertionError> {
+           date.plusSeconds(1L) should haveSameInstantAsOffsetDateTime(other)
         }
      }
   }


### PR DESCRIPTION
add matcher:

```
        val date = ZonedDateTime.of(2026, 7, 14, 8, 0, 0, 0, ZoneId.of("America/New_York"))
        val other = OffsetDateTime.of(2026, 7, 14, 11, 0, 0, 0, ZoneOffset.ofHours(-1))
        date should haveSameInstantAsOffsetDateTime(other)
```