### PR TITLE
Alex/range intersect details  (#6183)

### DIFF
--- a/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
+++ b/kotest-assertions/kotest-assertions-core/api/kotest-assertions-core.api
@@ -3218,6 +3218,16 @@ public final class io/kotest/matchers/ranges/IntersectKt {
 	public static final fun shouldNotIntersect (Lkotlin/ranges/OpenEndRange;Lkotlin/ranges/OpenEndRange;)Lkotlin/ranges/OpenEndRange;
 }
 
+public final class io/kotest/matchers/ranges/IntersectResult : java/lang/Enum {
+	public static final field GREATER_THAN_OTHER Lio/kotest/matchers/ranges/IntersectResult;
+	public static final field INTERSECT Lio/kotest/matchers/ranges/IntersectResult;
+	public static final field LESS_THAN_OTHER Lio/kotest/matchers/ranges/IntersectResult;
+	public final fun getDescription ()Ljava/lang/String;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/kotest/matchers/ranges/IntersectResult;
+	public static fun values ()[Lio/kotest/matchers/ranges/IntersectResult;
+}
+
 public final class io/kotest/matchers/ranges/RangeKt {
 	public static final fun closedClosed (Lio/kotest/matchers/ranges/Range$Companion;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lio/kotest/matchers/ranges/Range;
 	public static final fun closedOpen (Lio/kotest/matchers/ranges/Range$Companion;Ljava/lang/Comparable;Ljava/lang/Comparable;)Lio/kotest/matchers/ranges/Range;

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/Range.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/Range.kt
@@ -19,7 +19,11 @@ internal data class Range<T : Comparable<T>>(
          end.edgeType == RangeEdgeType.EXCLUSIVE
       )
 
-   fun intersect(other: Range<T>): Boolean = !this.lessThan(other) && !other.lessThan(this)
+   fun intersect(other: Range<T>): IntersectResult = when {
+      this.lessThan(other) -> IntersectResult.LESS_THAN_OTHER
+      this.greaterThan(other) -> IntersectResult.GREATER_THAN_OTHER
+      else -> IntersectResult.INTERSECT
+   }
 
    fun lessThan(other: Range<T>): Boolean {
       val endOfThis: T = this.end.value
@@ -47,6 +51,14 @@ internal data class Range<T : Comparable<T>>(
    }
 
    companion object
+}
+
+enum class IntersectResult(
+   val description: String,
+) {
+   INTERSECT("Intersected"),
+   LESS_THAN_OTHER("less than other"),
+   GREATER_THAN_OTHER("greater than other"),
 }
 
 @PublishedApi

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/intersect.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/ranges/intersect.kt
@@ -129,11 +129,11 @@ internal fun <T : Comparable<T>> intersect(range: Range<T>) = object : Matcher<R
    override fun test(value: Range<T>): MatcherResult {
       if (range.isEmpty()) throw AssertionError("Asserting content on empty range. Use Iterable.shouldBeEmpty() instead.")
 
-      val match = range.intersect(value)
+      val match = value.intersect(range)
 
       return MatcherResult(
-         match,
-         { "Range ${value.print().value} should intersect ${range.print().value}, but doesn't" },
+         match == IntersectResult.INTERSECT,
+         { "Range ${value.print().value} should intersect ${range.print().value}, but doesn't, it was ${match.description}" },
          { "Range ${value.print().value} should not intersect ${range.print().value}, but does" }
       )
    }

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectClosedTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectClosedTest.kt
@@ -14,10 +14,16 @@ class ClosedIntersectClosedTest : WordSpec() {
 
    init {
       "should" should {
-         "fail" {
+         "fail because less than other" {
             shouldThrowAny {
                oneThree shouldIntersect fourSix
-            }.message shouldBe "Range [1, 3] should intersect [4, 6], but doesn't"
+            }.message shouldBe "Range [1, 3] should intersect [4, 6], but doesn't, it was less than other"
+         }
+
+         "fail because greater than other" {
+            shouldThrowAny {
+               fourSix shouldIntersect oneThree
+            }.message shouldBe "Range [4, 6] should intersect [1, 3], but doesn't, it was greater than other"
          }
 
          "pass" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectOpenEndTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/ClosedIntersectOpenEndTest.kt
@@ -14,12 +14,20 @@ class ClosedIntersectOpenEndTest : WordSpec() {
 
    init {
       "should" should {
-         "fail" {
+         "fail, less than other" {
             shouldThrowAny {
                val openEndRange = oneThree.toOpenEndRange()
                println(openEndRange)
                openEndRange shouldIntersect fourSix
-            }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0], but doesn't"
+            }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0], but doesn't, it was less than other"
+         }
+
+         "fail, greater than other" {
+            shouldThrowAny {
+               val openEndRange = fourSix.toOpenEndRange()
+               println(openEndRange)
+               openEndRange shouldIntersect oneThree
+            }.message shouldBe "Range [4.0, 6.0) should intersect [1.0, 3.0], but doesn't, it was greater than other"
          }
 
          "pass" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/OpenEndIntersectOpenEndTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/OpenEndIntersectOpenEndTest.kt
@@ -15,12 +15,20 @@ class OpenEndIntersectOpenEndTest : WordSpec() {
 
    init {
       "should" should {
-         "fail" {
+         "fail, less than other" {
             shouldThrowAny {
                val openEndRange = oneThree
                println(openEndRange)
                openEndRange shouldIntersect fourSix
-            }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0), but doesn't"
+            }.message shouldBe "Range [1.0, 3.0) should intersect [4.0, 6.0), but doesn't, it was less than other"
+         }
+
+         "fail, greater than other" {
+            shouldThrowAny {
+               val openEndRange = fourSix
+               println(openEndRange)
+               openEndRange shouldIntersect oneThree
+            }.message shouldBe "Range [4.0, 6.0) should intersect [1.0, 3.0), but doesn't, it was greater than other"
          }
 
          "pass" {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/RangeTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/ranges/RangeTest.kt
@@ -7,6 +7,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.data.row
 import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.ranges.IntersectResult
 import io.kotest.matchers.ranges.Range
 import io.kotest.matchers.ranges.RangeEdge
 import io.kotest.matchers.ranges.RangeEdgeType
@@ -192,7 +193,7 @@ class RangeTest : WordSpec() {
             ) { rangeStart, rangeLength, otherStart, otherLength ->
                val range = rangeStart..(rangeStart + rangeLength)
                val other = otherStart..(otherStart + otherLength)
-               Range.ofClosedRange(range).intersect(Range.ofClosedRange(other)) == range.toSet()
+               (Range.ofClosedRange(range).intersect(Range.ofClosedRange(other)) == IntersectResult.INTERSECT) == range.toSet()
                   .intersect(other.toSet()).isNotEmpty()
             }
          }
@@ -203,7 +204,7 @@ class RangeTest : WordSpec() {
             ) { rangeStart, rangeLength, otherStart, otherLength ->
                val range = rangeStart..<(rangeStart + rangeLength)
                val other = otherStart..<(otherStart + otherLength)
-               Range.ofOpenEndRange(range).intersect(Range.ofOpenEndRange(other)) == range.toSet()
+               (Range.ofOpenEndRange(range).intersect(Range.ofOpenEndRange(other)) == IntersectResult.INTERSECT) == range.toSet()
                   .intersect(other.toSet()).isNotEmpty()
             }
          }
@@ -214,10 +215,10 @@ class RangeTest : WordSpec() {
             ) { rangeStart, rangeLength, otherStart, otherLength ->
                val range = rangeStart..(rangeStart + rangeLength)
                val other = otherStart..<(otherStart + otherLength)
-               (Range.ofClosedRange(range).intersect(Range.ofOpenEndRange(other)) == range.toSet()
+               ((Range.ofClosedRange(range).intersect(Range.ofOpenEndRange(other)) == IntersectResult.INTERSECT) == range.toSet()
                   .intersect(other.toSet()).isNotEmpty())
                   &&
-                  (Range.ofOpenEndRange(other).intersect(Range.ofClosedRange(range)) == range.toSet()
+                  ((Range.ofOpenEndRange(other).intersect(Range.ofClosedRange(range)) == IntersectResult.INTERSECT) == range.toSet()
                      .intersect(other.toSet()).isNotEmpty())
             }
          }


### PR DESCRIPTION
describe why shouldIntersect failed:

```
            shouldThrowAny {
               fourSix shouldIntersect oneThree
            }.message shouldBe "Range [4, 6] should intersect [1, 3], but doesn't, it was greater than other"
```