### PR TITLE
Update kotlinx-datetime to 0.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -193,7 +193,7 @@ kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-em
 
 ksp = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.2" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.8.0" }
 
 material = { group = "androidx.compose.material3", name = "material3", version = "1.4.0" }
 

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/api/kotest-assertions-kotlinx-datetime.api
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/api/kotest-assertions-kotlinx-datetime.api
@@ -19,12 +19,12 @@ public final class io/kotest/matchers/kotlinx/datetime/DatetimeKt {
 	public static final fun shouldBeBetween (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/LocalDateTime;)Ljava/lang/Object;
 	public static final fun shouldHaveDayOfMonth (Lkotlinx/datetime/LocalDateTime;I)I
 	public static final fun shouldHaveDayOfWeek (Lkotlinx/datetime/LocalDateTime;I)I
-	public static final fun shouldHaveDayOfWeek (Lkotlinx/datetime/LocalDateTime;Ljava/time/DayOfWeek;)Ljava/time/DayOfWeek;
+	public static final fun shouldHaveDayOfWeek (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/DayOfWeek;)Lkotlinx/datetime/DayOfWeek;
 	public static final fun shouldHaveDayOfYear (Lkotlinx/datetime/LocalDateTime;I)I
 	public static final fun shouldHaveHour (Lkotlinx/datetime/LocalDateTime;I)I
 	public static final fun shouldHaveMinute (Lkotlinx/datetime/LocalDateTime;I)I
 	public static final fun shouldHaveMonth (Lkotlinx/datetime/LocalDateTime;I)I
-	public static final fun shouldHaveMonth (Lkotlinx/datetime/LocalDateTime;Ljava/time/Month;)Ljava/time/Month;
+	public static final fun shouldHaveMonth (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/Month;)Lkotlinx/datetime/Month;
 	public static final fun shouldHaveNano (Lkotlinx/datetime/LocalDateTime;I)I
 	public static final fun shouldHaveSameDayAs (Lkotlinx/datetime/LocalDate;Lkotlinx/datetime/LocalDate;)V
 	public static final fun shouldHaveSameDayAs (Lkotlinx/datetime/LocalDateTime;Lkotlinx/datetime/LocalDateTime;)V
@@ -48,15 +48,15 @@ public final class io/kotest/matchers/kotlinx/datetime/DatetimeKt {
 }
 
 public final class io/kotest/matchers/kotlinx/datetime/InstantKt {
-	public static final fun after (Lkotlinx/datetime/Instant;)Lio/kotest/matchers/Matcher;
-	public static final fun before (Lkotlinx/datetime/Instant;)Lio/kotest/matchers/Matcher;
-	public static final fun between (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)Lio/kotest/matchers/Matcher;
-	public static final fun shouldBeAfter (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)Ljava/lang/Object;
-	public static final fun shouldBeBefore (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)Ljava/lang/Object;
-	public static final fun shouldBeBetween (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)Ljava/lang/Object;
-	public static final fun shouldNotBeAfter (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)V
-	public static final fun shouldNotBeBefore (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)Lkotlinx/datetime/Instant;
-	public static final fun shouldNotBeBetween (Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;)Lkotlinx/datetime/Instant;
+	public static final fun after (Lkotlin/time/Instant;)Lio/kotest/matchers/Matcher;
+	public static final fun before (Lkotlin/time/Instant;)Lio/kotest/matchers/Matcher;
+	public static final fun between (Lkotlin/time/Instant;Lkotlin/time/Instant;)Lio/kotest/matchers/Matcher;
+	public static final fun shouldBeAfter (Lkotlin/time/Instant;Lkotlin/time/Instant;)Ljava/lang/Object;
+	public static final fun shouldBeBefore (Lkotlin/time/Instant;Lkotlin/time/Instant;)Ljava/lang/Object;
+	public static final fun shouldBeBetween (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlin/time/Instant;)Ljava/lang/Object;
+	public static final fun shouldNotBeAfter (Lkotlin/time/Instant;Lkotlin/time/Instant;)V
+	public static final fun shouldNotBeBefore (Lkotlin/time/Instant;Lkotlin/time/Instant;)Lkotlin/time/Instant;
+	public static final fun shouldNotBeBetween (Lkotlin/time/Instant;Lkotlin/time/Instant;Lkotlin/time/Instant;)Lkotlin/time/Instant;
 }
 
 public final class io/kotest/matchers/kotlinx/datetime/TodayKt {

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/instant.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/instant.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 /**
  * Assert that [Instant] is before [anotherInstant].

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/today.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/commonMain/kotlin/io/kotest/matchers/kotlinx/datetime/today.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldNot
 import kotlinx.datetime.*
+import kotlin.time.Clock
 
 /**
  * Matcher that checks if a LocalDateTime has a Date component of today

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/jvmTest/kotlin/io/kotest/matchers/kotlinx/datetime/InstantTests.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/jvmTest/kotlin/io/kotest/matchers/kotlinx/datetime/InstantTests.kt
@@ -4,8 +4,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 import kotlin.time.Duration.Companion.milliseconds
 
 class InstantTests : FreeSpec({

--- a/kotest-assertions/kotest-assertions-kotlinx-datetime/src/jvmTest/kotlin/io/kotest/matchers/kotlinx/datetime/LocalDateTimeTests.kt
+++ b/kotest-assertions/kotest-assertions-kotlinx-datetime/src/jvmTest/kotlin/io/kotest/matchers/kotlinx/datetime/LocalDateTimeTests.kt
@@ -6,13 +6,13 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 import kotlinx.datetime.todayIn
 import kotlin.time.Duration.Companion.days
 

--- a/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
+++ b/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/dates.kt
@@ -3,7 +3,6 @@ package io.kotest.property.kotlinx.datetime
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.next
-import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -14,6 +13,7 @@ import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import kotlin.random.nextInt
+import kotlin.time.Clock
 
 /**
  * Returns an [Arb] where each value is a [LocalDate], with a random day, and a year in the given range.

--- a/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/instants.kt
+++ b/kotest-property/kotest-property-datetime/src/commonMain/kotlin/io/kotest/property/kotlinx/datetime/instants.kt
@@ -3,8 +3,8 @@ package io.kotest.property.kotlinx.datetime
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.long
 import io.kotest.property.arbitrary.map
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 /**
  * Returns an [Arb] where each value is a randomly generated Instant in the given range.


### PR DESCRIPTION
Rebuilds the kotlinx-datetime assertion (`kotest-assertions-kotlinx-datetime`) and property (`kotest-property-datetime`) modules against **kotlinx-datetime 0.8.0** (previously 0.6.2).

### Why

Since kotlinx-datetime 0.7.0, `Instant` (and `Clock`) became a `typealias` to the stdlib `kotlin.time.Instant` / `kotlin.time.Clock`. Because Kotest's modules were compiled against 0.6.2, the published Kotlin/Native klibs reference `Instant` as a standalone class. Consumers on 0.7.0+ then hit a **klib link error**, forcing them onto the `0.6.x-compat` flavor and blocking adoption of the modern ABI.

### Changes

- Bump `kotlinx-datetime` `0.6.2` → `0.8.0` in the version catalog.
- Update imports of `Instant`/`Clock` to `kotlin.time` in the datetime matcher/generator sources and tests.
- Regenerate the affected API dumps (`kotlinx/datetime/Instant` → `kotlin/time/Instant`).

0.8.0 declares a stdlib floor of Kotlin 2.1.20, so its klib ABI remains consumable by the project's Kotlin 2.2.21.

### Verification

- `compileKotlinJvm` + `jvmTest` pass for both modules.
- `compileKotlinLinuxX64` passes for both modules (confirms the native klib link issue is resolved).
- API dumps regenerated via `apiDump`.

Fixes #6169

🤖 Generated with [Claude Code](https://claude.com/claude-code)