### PR TITLE
Force commons-beanutils to 1.11.0 (CVE-2025-48734)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ byte-buddy = "1.18.8"
 classgraph = "4.8.184"
 
 commons-lang3 = "3.20.0"
+commons-beanutils = "1.11.0" # CVE-2025-48734 fix; pulled transitively by mockserver via json-path
 gradle-test-logger-plugin = "4.0.0"
 
 jaxbApi = "2.3.1"
@@ -126,6 +127,7 @@ arrow-functions = { module = "io.arrow-kt:arrow-functions", version.ref = "arrow
 
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 apache-commons-lang = { module = "org.apache.commons:commons-lang3", version.ref = "commons-lang3" }
+apache-commons-beanutils = { module = "commons-beanutils:commons-beanutils", version.ref = "commons-beanutils" }
 
 blockhound = { module = "io.projectreactor.tools:blockhound", version.ref = "blockhound" }
 byte-buddy = { group = "net.bytebuddy", name = "byte-buddy", version.ref = "byte-buddy" }

--- a/kotest-extensions/kotest-extensions-mockserver/build.gradle.kts
+++ b/kotest-extensions/kotest-extensions-mockserver/build.gradle.kts
@@ -10,6 +10,13 @@ kotlin {
             implementation(projects.kotestFramework.kotestFrameworkEngine)
             api(libs.mockserver.netty)
             api(libs.mockserver.client.java)
+
+            // mockserver pulls commons-beanutils 1.9.4 transitively (via json-path), which is
+            // affected by CVE-2025-48734. Pull 1.11.0 explicitly to override it: it fixes the
+            // vulnerability and is still Java 8+ compatible. (The fixed version otherwise only
+            // arrives via json-path 3.0.0, which requires Java 17 and would break Kotest's Java 11
+            // baseline.) See #6139.
+            api(libs.apache.commons.beanutils)
          }
       }
       jvmTest {


### PR DESCRIPTION
Addresses the vulnerable `commons-beanutils` dependency reported in #6139 (CVE-2025-48734, CVSS 8.8).

### Root cause

The `kotest-extensions-mockserver` module pulls **`commons-beanutils:1.9.4`** transitively:

```
mockserver-netty -> mockserver-core -> json-path:2.10.0 -> commons-beanutils:1.9.4
```

### Why not just bump mockserver?

The fixed `commons-beanutils:1.11.0` only arrives transitively via `json-path:3.0.0`, which is only pulled by mockserver **7.2.0+**. However `json-path:3.0.0` requires **Java 17**, and even mockserver 7.0.0 (`json-path:3.0.0`) still resolves `commons-beanutils:1.9.4`. Kotest's baseline is `jvmMinTarget = 11`, so upgrading mockserver would break the Java 11 build without cleanly fixing the CVE.

`commons-beanutils:1.11.0` is itself still Java 8+ compatible, so the fix here pulls it explicitly in the mockserver extension, overriding the vulnerable transitive `1.9.4` (Gradle's highest-version-wins) while keeping mockserver on its current, Java-11-compatible release.

### Result

```
commons-beanutils:commons-beanutils:1.9.4 -> 1.11.0
```

The declared `api` dependency also propagates the fixed floor to downstream consumers of the extension.

### Verification

- `jvmTest` for `kotest-extensions-mockserver` passes on the Java 11 target.
- `dependencies` confirms `commons-beanutils` now resolves to `1.11.0`.

Fixes #6139

🤖 Generated with [Claude Code](https://claude.com/claude-code)