### PR TITLE
chore: route a few hardcoded dependency/plugin versions through the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,8 @@ classgraph = "4.8.184"
 commons-lang3 = "3.20.0"
 gradle-test-logger-plugin = "4.0.0"
 
+intellij-platform-gradle-plugin = "2.13.1"
+
 jaxbApi = "2.3.1"
 java-diff-utils = "4.16"
 jedis = "7.4.1"
@@ -51,6 +53,8 @@ kotlin-poet = "2.3.0"
 kotlinx-io-core = "0.8.2" # 0.9.0 requires Kotlin 2.3.x KLIB ABI; 0.8.2 is the last 2.2.x-compiled release
 ksp = "2.3.9"
 ktor = "3.3.1" # 3.4.0+ requires Kotlin 2.3.x KLIB ABI; 3.3.1 is the last 2.2.x-compiled release
+
+node-gradle-plugin = "7.1.0"
 
 mockk = "1.14.11"
 mordant = "3.0.2"
@@ -249,3 +253,5 @@ android-library = { id = "com.android.library", version.ref = "agp" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-compile-version" }
 jetbrains-kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin-compile-version" }
+jetbrains-intellij-platform = { id = "org.jetbrains.intellij.platform", version.ref = "intellij-platform-gradle-plugin" }
+node-gradle = { id = "com.github.node-gradle.node", version.ref = "node-gradle-plugin" }

--- a/kotest-framework/kotest-framework-plugin-gradle/build.gradle.kts
+++ b/kotest-framework/kotest-framework-plugin-gradle/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
    `kotlin-dsl`
    id("kotest-publishing-conventions")
    alias(libs.plugins.gradle.plugin.publish)
-   id("com.github.node-gradle.node") version "7.1.0"
+   alias(libs.plugins.node.gradle)
 }
 
 group = "io.kotest"

--- a/kotest-intellij-plugin/build.gradle.kts
+++ b/kotest-intellij-plugin/build.gradle.kts
@@ -83,7 +83,7 @@ val descriptor: PluginDescriptor = descriptors.first { it.sourceFolder == produc
 val jvmTargetVersion: String = System.getenv("JVM_TARGET") ?: descriptor.jdkTarget.majorVersion
 
 plugins {
-   id("org.jetbrains.intellij.platform") version "2.13.1"
+   alias(libs.plugins.jetbrains.intellij.platform)
    kotlin("jvm")
 }
 
@@ -192,7 +192,7 @@ dependencies {
       testFramework(TestFrameworkType.Plugin.Java)
    }
 
-   implementation("org.jetbrains:annotations:26.1.0")
+   implementation(libs.jetbrainsAnnotations)
 
    // https://youtrack.jetbrains.com/issue/IJPL-159134/JUnit5-Test-Framework-refers-to-JUnit4-java.lang.NoClassDefFoundError-junit-framework-TestCase
    testImplementation(libs.junit4)

--- a/kotest-runner/kotest-runner-junit-platform/build.gradle.kts
+++ b/kotest-runner/kotest-runner-junit-platform/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
             implementation(projects.kotestAssertions.kotestAssertionsCore)
             implementation(libs.junit.platform5.testkit)
             implementation(libs.mockk)
-            implementation("dev.gradleplugins:gradle-api:8.11.1")
+            implementation(libs.gradle.api)
          }
       }
 


### PR DESCRIPTION
## What

A few modules were declaring dependency/plugin versions as hardcoded string literals instead of going through `gradle/libs.versions.toml`:

- `kotest-runner-junit-platform`: `dev.gradleplugins:gradle-api:8.11.1`
- `kotest-intellij-plugin`: `org.jetbrains:annotations:26.1.0` (a catalog
  entry for this already exists and is used elsewhere, e.g.
  `kotest-assertions-json`)
- `kotest-intellij-plugin`: the `org.jetbrains.intellij.platform` plugin version
- `kotest-framework-plugin-gradle`: the `com.github.node-gradle.node` plugin version

This PR points all four at the catalog instead, adding entries for the two plugin versions that weren't catalogued yet.

## Why I think this is worth doing

I couldn't find a structural reason these needed to be managed separately from the rest of the catalog. There's no comment, doc, or CI logic tying them to a different lifecycle, and sibling modules already use the catalog for the same dependencies/plugins (e.g. `kotest-runner-junit5` already uses `libs.gradle.api`). It looks like a simple leftover mistake rather than something intentional.

If there is a reason to keep some of these on an independent update cadence (I could easily be missing context here, especially around the IntelliJ plugin's release process), I'd guess the better fix would still be a separate version catalog for that group rather than plain string literals. Happy to change approach if that's the case.

This seemed small enough that I skipped opening a separate issue first. Apologies if I should have opened one, and happy to do things differently for future contributions.