### PR TITLE
General improvements - framework

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/logger.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/core/logger.kt
@@ -11,8 +11,10 @@ import kotlin.time.TimeSource
 @KotestInternal
 val start by lazy { TimeSource.Monotonic.markNow() }
 
+// Cached once per process: KOTEST_DEBUG is not expected to change mid-run, and this check
+// otherwise re-read a sysprop/env var on every single log call across the whole engine.
 @PublishedApi
-internal fun isLoggingEnabled(): Boolean = syspropOrEnv("KOTEST_DEBUG")?.uppercase() == "TRUE"
+internal val isLoggingEnabled: Boolean by lazy { syspropOrEnv("KOTEST_DEBUG")?.uppercase() == "TRUE" }
 
 @KotestInternal
 /**
@@ -30,38 +32,42 @@ class Logger(private val kclass: KClass<*>) {
       inline operator fun <reified T> invoke() = Logger(T::class)
    }
 
+   // inline so f() is never invoked, and no lambda is allocated, when logging is disabled
    @OverloadResolutionByLambdaReturnType
    @JvmName("logpair")
-   fun log(f: () -> Pair<String?, String>) {
-      log {
+   inline fun log(f: () -> Pair<String?, String>) {
+      if (isLoggingEnabled) {
          val (context, message) = f()
-         LogLine(context, message)
+         outputLog(LogLine(context, message))
       }
    }
 
+   // inline so f() is never invoked, and no lambda is allocated, when logging is disabled
    @OverloadResolutionByLambdaReturnType
-   fun log(f: () -> LogLine) {
-      outputLog {
-         val (context, message) = f()
-         listOf(
-            (kclass.simpleName ?: "").padEnd(60, ' '),
-            (context ?: "").padEnd(70, ' ').take(70),
-            message
-         ).joinToString("  ")
+   inline fun log(f: () -> LogLine) {
+      if (isLoggingEnabled) {
+         outputLog(f())
       }
    }
 
    @OverloadResolutionByLambdaReturnType
    @JvmName("logsimple")
-   fun log(f: () -> String) {
-      log { LogLine(null, f()) }
+   // inline so f() is never invoked, and no lambda is allocated, when logging is disabled
+   inline fun log(f: () -> String) {
+      if (isLoggingEnabled) {
+         outputLog(LogLine(null, f()))
+      }
    }
 
-   private fun outputLog(f: () -> String) {
-      if (isLoggingEnabled()) {
-         writeLog(start, null, f) // writes to file where possible e.g., jvm
-         println(start.elapsedNow().inWholeMilliseconds.toString().padStart(6, ' ') + "  " + f())
-      }
+   @PublishedApi
+   internal fun outputLog(line: LogLine) {
+      val message = listOf(
+         (kclass.simpleName ?: "").padEnd(60, ' '),
+         (line.context ?: "").padEnd(70, ' ').take(70),
+         line.message
+      ).joinToString("  ")
+      writeLog(start, null) { message } // writes to file where possible e.g., jvm
+      println(start.elapsedNow().inWholeMilliseconds.toString().padStart(6, ' ') + "  " + message)
    }
 }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
@@ -1,6 +1,7 @@
 package io.kotest.engine.extensions
 
 import io.kotest.core.extensions.Extension
+import kotlin.concurrent.Volatile
 import kotlin.reflect.KClass
 
 /**
@@ -43,30 +44,50 @@ class DefaultExtensionRegistry : ExtensionRegistry {
 
    private val extensions = mutableListOf<Pair<Extension, KClass<*>?>>()
 
+   // get(kClass) is invoked twice per spec instantiation (once for constructor extensions, once
+   // for post-instantiation extensions), which was previously an O(n) filter/allocation over every
+   // registered extension on each call. Under IsolationMode.SingleInstance each spec class is only
+   // instantiated once, so this doesn't matter there, but under InstancePerTest/InstancePerLeaf/
+   // InstancePerRoot the same spec class is instantiated fresh per test/leaf/root, so without this
+   // cache the same class's extension list would be re-filtered from scratch on every single test.
+   // Extensions are normally all registered up front, before specs start executing, so we rebuild
+   // this snapshot on every mutation and let get() do a plain O(1) read. That also keeps get() safe
+   // to call concurrently (e.g. under SpecExecutionMode.Concurrent) without needing to synchronize
+   // reads, since add/remove are not expected to race with spec execution.
+   @Volatile
+   private var byClass: Map<KClass<*>?, List<Extension>> = emptyMap()
+
    override fun all(): List<Extension> = extensions.map { it.first }
 
-   override fun get(kClass: KClass<*>): List<Extension> {
-      return extensions.filter { it.second == kClass }.map { it.first }
-   }
+   override fun get(kClass: KClass<*>): List<Extension> = byClass[kClass] ?: emptyList()
 
    override fun add(extension: Extension) {
       extensions.add(Pair(extension, null))
+      rebuild()
    }
 
    override fun add(extension: Extension, kclass: KClass<*>) {
       extensions.add(Pair(extension, kclass))
+      rebuild()
    }
 
    override fun remove(extension: Extension) {
       extensions.remove(Pair(extension, null))
+      rebuild()
    }
 
    override fun remove(extension: Extension, kclass: KClass<*>) {
       extensions.remove(Pair(extension, kclass))
+      rebuild()
    }
 
    override fun clear() {
       extensions.clear()
+      rebuild()
+   }
+
+   private fun rebuild() {
+      byClass = extensions.groupBy({ it.second }, { it.first })
    }
 
    override fun isEmpty(): Boolean = extensions.isEmpty()

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/instantiate.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/instantiate.kt
@@ -2,8 +2,17 @@
 
 package io.kotest.engine
 
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
 import kotlin.reflect.jvm.isAccessible
+
+// resolving the zero-arg constructor via kclass.constructors.find { ... } is a reflective scan.
+// Under IsolationMode.SingleInstance each spec class is only instantiated once, so this cache
+// doesn't matter there, but under InstancePerTest/InstancePerLeaf/InstancePerRoot the same spec
+// class is instantiated fresh per test/leaf/root, so without this cache the same class's
+// constructor would be re-resolved from scratch on every single test in that spec.
+private val constructorCache = ConcurrentHashMap<KClass<*>, KFunction<*>>()
 
 /**
  * Instantiates an instance of the given class, or if it is an object, returns that object instance
@@ -14,9 +23,10 @@ internal fun <T : Any> instantiateOrObject(kclass: KClass<T>): Result<T> {
    if (obj != null) return Result.success(obj)
 
    return runCatching {
-      val zeroArgsConstructor = kclass.constructors.find { it.parameters.isEmpty() }
-         ?: throw IllegalArgumentException("Class ${kclass.simpleName} should have a zero-arg constructor")
-      zeroArgsConstructor.isAccessible = true
+      val zeroArgsConstructor = (constructorCache.getOrPut(kclass) {
+         kclass.constructors.find { it.parameters.isEmpty() }
+            ?: throw IllegalArgumentException("Class ${kclass.simpleName} should have a zero-arg constructor")
+      } as KFunction<T>).also { it.isAccessible = true }
       zeroArgsConstructor.call()
    }.onFailure {
       it.printStackTrace()


### PR DESCRIPTION
[avoid checking if log is enabled on every call and inline log methods](https://github.com/kotest/kotest/commit/f550ed5efd1591ba1c5bd9eefeb6d928fa437a5b)

made the Logger.log(...) overloads inline (no lambda allocation when logging is off) and cached isLoggingEnabled behind a by lazy instead of re-reading KOTEST_DEBUG via sysprop/env on every single call.

[cache per-spec constructor and extension lookups in the engine](https://github.com/kotest/kotest/pull/6190/commits/4129a7246e1b9d4df73461f5baf070609c63eda0)

instantiateOrObject resolved the zero-arg constructor via `kclass.constructors.find { ... }` on every call, with no cache across calls for the same class. `DefaultExtensionRegistry.get(kClass)` had the same shape: an O(n) filter + allocation over every registered extension, run twice per spec instantiation (once for constructor extensions, once for post-instantiation extensions).

Under `IsolationMode.SingleInstance` (the default) each spec class is only instantiated once, so neither of these costs repeats. But under `IsolationMode.InstancePerTest`, `InstancePerLeaf`, and `InstancePerRoot`, the engine deliberately creates a fresh instance of the same spec class per test/leaf/root to isolate mutable state between tests,
which means the same class's constructor and extension list were being re-resolved from scratch on every single test in that spec.
