### PR TITLE
fix(assertions): state the containExactCopies lower bound as at least 1

### DIFF
--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/ContainExactCopies.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/collections/ContainExactCopies.kt
@@ -82,7 +82,7 @@ fun <T> Array<T>.shouldContainExactCopies(element: T, copies: Int): Array<T> = a
 }
 fun <T, C : Collection<T>> containExactCopies(element: T, copies: Int) = object : Matcher<C> {
    override fun test(value: C) : MatcherResult {
-      require(copies > 0) { "Copies should be positive, was $copies" }
+      require(copies > 0) { "Copies must be at least 1, was $copies." }
       val passedAtIndexes = value.mapIndexedNotNull {
             index, it -> if(it == element) index else null
       }

--- a/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/containExactCopies.kt
+++ b/kotest-assertions/kotest-assertions-core/src/commonMain/kotlin/io/kotest/matchers/string/containExactCopies.kt
@@ -64,7 +64,7 @@ fun String.containExactCopies(
    ) = object : Matcher<String> {
    override fun test(value: String) : MatcherResult {
       require(substring.isNotEmpty()) { "Element should not be empty" }
-      require(copies > 0) { "Copies should be positive, was $copies" }
+      require(copies > 0) { "Copies must be at least 1, was $copies." }
       val containsAtIndexes = substringFoundAtIndexes(
          value,
          substring,

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ContainExactCopiesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/collections/ContainExactCopiesTest.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldContainExactCopies
 import io.kotest.matchers.collections.shouldNotContainExactCopies
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldContainInOrder
 
@@ -31,6 +32,11 @@ class ContainExactCopiesTest : WordSpec() {
                "Collection should contain 1 copies of element 3",
                "but contained 2 copies at index(es) [2, 3]"
             )
+         }
+         "reject zero copies with a clear boundary message" {
+            shouldThrow<IllegalArgumentException> {
+               listOf(1, 2, 3).shouldContainExactCopies(element = 4, copies = 0)
+            }.message shouldBe "Copies must be at least 1, was 0."
          }
          "find similar element" {
             shouldThrow<AssertionError> {

--- a/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainExactCopiesTest.kt
+++ b/kotest-assertions/kotest-assertions-core/src/jvmTest/kotlin/com/sksamuel/kotest/matchers/string/ContainExactCopiesTest.kt
@@ -2,6 +2,7 @@ package com.sksamuel.kotest.matchers.string
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContainExactCopies
 import io.kotest.matchers.string.shouldContainInOrder
 import io.kotest.matchers.string.shouldNotContainExactCopies
@@ -33,6 +34,11 @@ class ContainExactCopiesTest : WordSpec() {
                "String should contain 2 copies of element \"1212\"",
                "but contained 1 copies at index(es) [0]"
             )
+         }
+         "reject zero copies with a clear boundary message" {
+            shouldThrow<IllegalArgumentException> {
+               "Mayday".shouldContainExactCopies("ay", copies = 0, allowOverlaps = false)
+            }.message shouldBe "Copies must be at least 1, was 0."
          }
       }
       "shouldNotContainExactCopies" should {


### PR DESCRIPTION
## Summary

Fixes #6182.

`shouldContainExactCopies` / `shouldNotContainExactCopies` reject `copies = 0`
with `IllegalArgumentException: Copies should be positive, was 0`. Per the
discussion on the issue the rejection itself is intentional - `copies` was
designed so that zero is impossible, and a zero-count assertion belongs in
`shouldContain` / `shouldNotContain`. So this keeps the behaviour and only makes
the boundary explicit.

## Why this matters

The current message says "should be positive", which does not tell the caller
what the accepted range actually is. On the issue, `copies = 0` was read as a
matcher bug rather than an out-of-range argument, precisely because the message
describes a property instead of a bound - the reporter's first assumption was
that `listOf(1, 2, 3).shouldContainExactCopies(element = 4, copies = 0)` should
pass, since the list does contain exactly zero copies of `4`.

Nothing in the test suite pinned the boundary either: the existing specs cover
`copies = 1` and mismatched counts, so the `require` could have been loosened or
tightened without a failing test. Both halves are addressed here - the message
names the bound, and a test asserts it - so the intended contract ("the edge is
1, not 0") is documented in the code and enforced by CI rather than living only
in the issue thread.

## Changes

- `require(copies > 0)` in both
  `kotest-assertions-core/.../matchers/collections/ContainExactCopies.kt` and
  `.../matchers/string/containExactCopies.kt` now reads
  `"Copies must be at least 1, was $copies."`
- Both existing `ContainExactCopiesTest` specs gain a case asserting that exact
  message for `copies = 0`.

No behaviour change: the same inputs are accepted and rejected as before, and
the matchers' pass/fail logic is untouched.

## Testing

```
./gradlew :kotest-assertions:kotest-assertions-core:jvmTest \
  --tests "com.sksamuel.kotest.matchers.collections.ContainExactCopiesTest" \
  --tests "com.sksamuel.kotest.matchers.string.ContainExactCopiesTest"

BUILD SUCCESSFUL
collections ContainExactCopiesTest: tests=5 failures=0 errors=0 skipped=0
string      ContainExactCopiesTest: tests=6 failures=0 errors=0 skipped=0
```

Both new cases fail on `master` (the message assertion does not match) and pass
with this change.

## Notes

The issue also raised documenting the boundary. That is left out here to keep
the diff to code + test; happy to follow up with a docs pass across
`documentation/docs` and the versioned docs if you would like it folded in.

AI was used for assistance.
