### PR TITLE
fix jump to source

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/Test.kt
@@ -49,7 +49,7 @@ data class TestName(
    }
 }
 
-private fun String.flattenTestName() = this.trim().replace("\\s+".toRegex(), " ")
+internal fun String.flattenTestName() = this.trim().replace("\\s+".toRegex(), " ")
 // components for the path should not include prefixes
 data class TestPathEntry(val name: String)
 

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
@@ -139,7 +139,7 @@ internal object EmbeddedLocationParser {
       // Only bail to the default locator when the FQN genuinely isn't a Kotest spec - Kotest's
       // own single-level tests aren't real JVM methods, so the default locator can't resolve them.
       if (!segments.contains('/') && !isKotestSpec(fqn)) return null
-      val allSegments = if (segments.contains('/')) segments.split("/") else listOf(segments)
+      val allSegments = if (segments.contains('/')) segments.split("/") else ancestorNames + segments
       val path = "$fqn${DescriptorPaths.SPEC_DELIMITER}${allSegments.joinToString(DescriptorPaths.TEST_DELIMITER)}"
       return EmbeddedLocation(path, displayName)
    }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import io.kotest.plugin.intellij.psi.kotestStyleSyntactic
 import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
+import org.jetbrains.plugins.gradle.execution.test.runner.GradleSMTestProxy
 
 /**
  * Listens to SMTest events and installs an [EmbeddedLocationTestLocator] on each Kotest
@@ -54,8 +55,13 @@ internal class EmbeddedLocationSMTRunnerEventsAdapter(private val project: Proje
          return
       }
 
+      // Only Gradle-run proxies carry a parentId - the IntelliJ-native JUnit launcher path uses
+      // plain SMTestProxy, so this is empty there and parseLocationUrl falls back to the
+      // single-segment behaviour it already has.
+      val ancestorNames = GradleParentIdParser.ancestorContextNames((proxy as? GradleSMTestProxy)?.parentId)
+
       // Strategy 2: java:test://<fqn>/<segment>/<segment> URL produced from a JUnit MethodSource
-      val fromUrl = EmbeddedLocationParser.parseLocationUrl(proxy.locationUrl, proxy.name, ::isKotestSpec)
+      val fromUrl = EmbeddedLocationParser.parseLocationUrl(proxy.locationUrl, proxy.name, ancestorNames, ::isKotestSpec)
       if (fromUrl != null) {
          proxy.locator = EmbeddedLocationTestLocator(fromUrl)
          return
@@ -105,8 +111,18 @@ internal object EmbeddedLocationParser {
     * or the method-name component contains no `/` (single-method URL) and [isKotestSpec] says the
     * FQN isn't actually a Kotest spec - in which case it's a real JVM method and we should leave
     * the default locator alone.
+    *
+    * [ancestorNames], when non-empty, are prepended ahead of the URL's own segment(s) - this is
+    * how a Gradle-run test's dropped ancestor containers (see [GradleParentIdParser]) get restored
+    * into the path, rather than leaving [EmbeddedLocationTestLocator] to guess via a whole-tree
+    * name search.
     */
-   fun parseLocationUrl(locationUrl: String?, displayName: String, isKotestSpec: (String) -> Boolean): EmbeddedLocation? {
+   fun parseLocationUrl(
+      locationUrl: String?,
+      displayName: String,
+      ancestorNames: List<String> = emptyList(),
+      isKotestSpec: (String) -> Boolean,
+   ): EmbeddedLocation? {
       if (locationUrl == null) return null
       val rest = when {
          locationUrl.startsWith("java:test://") -> locationUrl.removePrefix("java:test://")
@@ -123,9 +139,40 @@ internal object EmbeddedLocationParser {
       // Only bail to the default locator when the FQN genuinely isn't a Kotest spec - Kotest's
       // own single-level tests aren't real JVM methods, so the default locator can't resolve them.
       if (!segments.contains('/') && !isKotestSpec(fqn)) return null
-      val path = "$fqn${DescriptorPaths.SPEC_DELIMITER}${segments.replace("/", DescriptorPaths.TEST_DELIMITER)}"
+      val allSegments = if (segments.contains(0x27/0x27)) segments.split(0x27/0x27) else listOf(segments)
+      val path = "$fqn${DescriptorPaths.SPEC_DELIMITER}${allSegments.joinToString(DescriptorPaths.TEST_DELIMITER)}"
       return EmbeddedLocation(path, displayName)
    }
 }
 
 internal data class EmbeddedLocation(val path: String, val presentableName: String)
+
+/**
+ * Parses the debug/string representation of a Gradle `TestOperationDescriptor` id chain, as
+ * exposed by `GradleSMTestProxy.getParentId()`.
+ *
+ * IntelliJ's Gradle test event integration surfaces only a leaf test's own name on `locationUrl`
+ * (see [EmbeddedLocationSMTRunnerEventsAdapter]), dropping every ancestor container - but that
+ * ancestry is still present in this id string, e.g.:
+ *
+ *   [id] > [Test suite 'parent'] > [Test suite 'grandparent'] > [Test class com.example.Spec] > [Task :mod:test]
+ *
+ * `SMTestProxy.getParent()` is not a reliable substitute for this - it can
+ * skip intermediate levels that Gradle chose not to materialise as their own tree nodes - so this
+ * parses the id string directly instead of walking the proxy tree.
+ */
+internal object GradleParentIdParser {
+
+   private val suiteRegex = Regex("""\[Test suite '(.*?)']""")
+
+   /**
+    * Returns the ancestor container names, ordered from the outermost container down to the
+    * immediate parent of the node this id belongs to (i.e. root-first, ready to have the node's
+    * own name appended last). Returns an empty list if [parentId] is null or has no "Test suite"
+    * entries (e.g. a top-level test/container directly under the spec).
+    */
+   fun ancestorContextNames(parentId: String?): List<String> {
+      if (parentId == null) return emptyList()
+      return suiteRegex.findAll(parentId).map { it.groupValues[1] }.toList().asReversed()
+   }
+}

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
@@ -2,6 +2,12 @@ package io.kotest.plugin.intellij.locations
 
 import com.intellij.execution.testframework.sm.runner.SMTRunnerEventsAdapter
 import com.intellij.execution.testframework.sm.runner.SMTestProxy
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.project.DumbService
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import io.kotest.plugin.intellij.psi.kotestStyleSyntactic
+import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
 
 /**
  * Listens to SMTest events and installs an [EmbeddedLocationTestLocator] on each Kotest
@@ -12,16 +18,19 @@ import com.intellij.execution.testframework.sm.runner.SMTestProxy
  *  1. **`locationUrl` strategy** (preferred, no displayName mangling). The IDEA JUnit5 launcher
  *     converts a [org.junit.platform.engine.support.descriptor.MethodSource] of the form
  *     `(className=fqn, methodName=seg/seg/...)` into a `java:test://<fqn>/<seg>/<seg>` URL on
- *     [SMTestProxy.getLocationUrl]. We detect those URLs (whose method-name component contains a
- *     `/`, which is impossible for a real JVM method) and install our locator without touching
- *     the displayName. This is what Kotest 6.x (and later) emits.
+ *     [SMTestProxy.getLocationUrl]. We detect those URLs and install our locator without touching
+ *     the displayName. This is what Kotest 6.x (and later) emits. A single-segment methodName
+ *     (no `/`) can't be told apart from a plain JVM method (i.e. `@Test`) by shape alone, so we resolve
+ *     the FQN to confirm it's actually a Kotest spec before taking over navigation from it -
+ *     Kotest's own single-level (non-nested) tests aren't real JVM methods, so IntelliJ's default
+ *     locator can't resolve them and "Jump to Source" silently does nothing for them otherwise.
  *
  *  2. **Legacy displayName tag strategy**. Older Kotest engines wrapped the path in a
  *     `<kotest>fqn/test -- nested</kotest>` prefix on the proxy display name. We still strip the
  *     tag and install the locator so users on the new plugin see clean names and working
  *     navigation against older engine versions.
  */
-internal class EmbeddedLocationSMTRunnerEventsAdapter : SMTRunnerEventsAdapter() {
+internal class EmbeddedLocationSMTRunnerEventsAdapter(private val project: Project) : SMTRunnerEventsAdapter() {
 
    override fun onSuiteStarted(suite: SMTestProxy) {
       handleKotestLocator(suite)
@@ -46,7 +55,7 @@ internal class EmbeddedLocationSMTRunnerEventsAdapter : SMTRunnerEventsAdapter()
       }
 
       // Strategy 2: java:test://<fqn>/<segment>/<segment> URL produced from a JUnit MethodSource
-      val fromUrl = EmbeddedLocationParser.parseLocationUrl(proxy.locationUrl, proxy.name)
+      val fromUrl = EmbeddedLocationParser.parseLocationUrl(proxy.locationUrl, proxy.name, ::isKotestSpec)
       if (fromUrl != null) {
          proxy.locator = EmbeddedLocationTestLocator(fromUrl)
          return
@@ -56,6 +65,18 @@ internal class EmbeddedLocationSMTRunnerEventsAdapter : SMTRunnerEventsAdapter()
          // if we have a java:suite locator for a top level class, this doesn't work for kotlin native, so we can
          // use our own locator which will work for both kmp and jvm
          proxy.locator = MultiplatformJavaSuiteLocator()
+      }
+   }
+
+   // resolves whether the given FQN is a Kotest spec class, so a single-segment methodName (which
+   // can't be distinguished from a plain JVM @Test method by shape alone) is only handed to our
+   // locator when it genuinely belongs to Kotest. Fails closed (false) while indexing, leaving the
+   // default locator in place rather than risking a stub-index query on a half-built index.
+   private fun isKotestSpec(fqn: String): Boolean {
+      if (DumbService.isDumb(project)) return false
+      return ReadAction.compute<Boolean, Throwable> {
+         KotlinFullClassNameIndex[fqn, project, GlobalSearchScope.allScope(project)]
+            .any { it.kotestStyleSyntactic() != null }
       }
    }
 
@@ -81,10 +102,11 @@ internal object EmbeddedLocationParser {
     * [EmbeddedLocation] in the `fqn/seg -- seg` format expected by [EmbeddedLocationTestLocator].
     *
     * Returns null if the URL is not in this form, the FQN doesn't look like a Kotlin/Java FQN,
-    * or the method-name component contains no `/` (in which case it is most likely a real JVM
-    * method on a non-Kotest class, and we should leave the default locator alone).
+    * or the method-name component contains no `/` (single-method URL) and [isKotestSpec] says the
+    * FQN isn't actually a Kotest spec - in which case it's a real JVM method and we should leave
+    * the default locator alone.
     */
-   fun parseLocationUrl(locationUrl: String?, displayName: String): EmbeddedLocation? {
+   fun parseLocationUrl(locationUrl: String?, displayName: String, isKotestSpec: (String) -> Boolean): EmbeddedLocation? {
       if (locationUrl == null) return null
       val rest = when {
          locationUrl.startsWith("java:test://") -> locationUrl.removePrefix("java:test://")
@@ -96,10 +118,11 @@ internal object EmbeddedLocationParser {
       val fqn = rest.substring(0, firstSlash)
       if (!fqn.matches(fqnRegex)) return null
       val segments = rest.substring(firstSlash + 1)
-      // No `/` in segments means it is a single-method URL. Real JVM methods cannot contain `/`,
-      // so the only way to reach here is a top-level Kotest test or a regular JUnit method —
-      // in both cases the default locator handles it acceptably.
-      if (!segments.contains('/')) return null
+      // No `/` in segments means it is a single-method URL, which is ambiguous by shape alone: it
+      // could be a top-level (non-nested) Kotest test, or a real JVM method on a non-Kotest class.
+      // Only bail to the default locator when the FQN genuinely isn't a Kotest spec - Kotest's
+      // own single-level tests aren't real JVM methods, so the default locator can't resolve them.
+      if (!segments.contains('/') && !isKotestSpec(fqn)) return null
       val path = "$fqn${DescriptorPaths.SPEC_DELIMITER}${segments.replace("/", DescriptorPaths.TEST_DELIMITER)}"
       return EmbeddedLocation(path, displayName)
    }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapter.kt
@@ -139,7 +139,7 @@ internal object EmbeddedLocationParser {
       // Only bail to the default locator when the FQN genuinely isn't a Kotest spec - Kotest's
       // own single-level tests aren't real JVM methods, so the default locator can't resolve them.
       if (!segments.contains('/') && !isKotestSpec(fqn)) return null
-      val allSegments = if (segments.contains(0x27/0x27)) segments.split(0x27/0x27) else listOf(segments)
+      val allSegments = if (segments.contains('/')) segments.split("/") else listOf(segments)
       val path = "$fqn${DescriptorPaths.SPEC_DELIMITER}${allSegments.joinToString(DescriptorPaths.TEST_DELIMITER)}"
       return EmbeddedLocation(path, displayName)
    }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocator.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocator.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.ClassUtil
 import io.kotest.plugin.intellij.TestElement
+import io.kotest.plugin.intellij.flattenTestName
 import io.kotest.plugin.intellij.psi.specStyleOnEdt
 import org.jetbrains.kotlin.idea.stubindex.KotlinFullClassNameIndex
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -55,9 +56,29 @@ internal class EmbeddedLocationTestLocator(private val location: EmbeddedLocatio
    }
 
    private fun findTest(tests: List<TestElement>, contexts: List<String>): TestElement? {
-      val test = tests.find { it.test.name.name == contexts.first() } ?: return null
-      if (contexts.size == 1) return test
+      // A single-segment path is ambiguous: it's either a genuine top-level test, or a nested
+      // test whose ancestor containers were dropped upstream - IntelliJ's Gradle test event
+      // integration only carries a leaf test's own name (unlike the JUnit Platform launcher's
+      // MethodSource, which joins every ancestor segment), so a nested "foo" test running under
+      // Gradle arrives here as a single-segment path indistinguishable from a top-level "foo".
+      // Search the whole tree rather than only the top level, so nested tests still resolve -
+      // to some matching test, at least, even though we can no longer disambiguate same-named
+      // tests under different containers without the full path.
+      if (contexts.size == 1) return findByNameAtAnyDepth(tests, contexts.first())
+
+      // contexts segments come from the engine's runtime test names, which collapse internal/
+      // leading/trailing whitespace (TestNameBuilder.removeAllExtraWhitespaces) - the PSI-side
+      // raw name must be flattened the same way or an otherwise-matching test won't be found.
+      val test = tests.find { it.test.name.name.flattenTestName() == contexts.first() } ?: return null
       return findTest(test.nestedTests, contexts.drop(1))
+   }
+
+   private fun findByNameAtAnyDepth(tests: List<TestElement>, name: String): TestElement? {
+      for (test in tests) {
+         if (test.test.name.name.flattenTestName() == name) return test
+         findByNameAtAnyDepth(test.nestedTests, name)?.let { return it }
+      }
+      return null
    }
 
    private fun createPsiClassNavigable(psiClass: PsiClass): Location<PsiElement> {

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapterTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapterTest.kt
@@ -1,158 +1,175 @@
 package io.kotest.plugin.intellij.locations
 
 import com.intellij.execution.testframework.sm.runner.SMTestProxy
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
-import org.junit.Test
 
-class EmbeddedLocationSMTRunnerEventsAdapterTest {
+class EmbeddedLocationSMTRunnerEventsAdapterTest : LightJavaCodeInsightFixtureTestCase() {
+
+   private fun adapter() = EmbeddedLocationSMTRunnerEventsAdapter(project)
 
    // -------- Strategy 1: legacy <kotest>...</kotest> displayName tag (older engines) --------
 
-   @Test
-   fun shouldResetPresentablePathOnEmbeddedLocationOnTestStart() {
+   fun `test should reset presentable path on embedded location on test start`() {
       val proxy = SMTestProxy(
          /* testName = */ "<kotest>io.kotest.Spec.test -- nested</kotest>nested",
          /* isSuite = */ false,
          /* locationUrl = */ "java:suite:io.kotest.Spec/test"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().onTestStarted(proxy)
+      adapter().onTestStarted(proxy)
       proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
       proxy.presentableName shouldBe "nested"
    }
 
-
-   @Test
-   fun shouldResetPresentablePathOnEmbeddedLocationOnTestIgnored() {
+   fun `test should reset presentable path on embedded location on test ignored`() {
       val proxy = SMTestProxy(
          /* testName = */ "<kotest>io.kotest.Spec.test -- nested</kotest>nested",
          /* isSuite = */ false,
          /* locationUrl = */ "java:suite:io.kotest.Spec/test"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().onTestIgnored(proxy)
+      adapter().onTestIgnored(proxy)
       proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
       proxy.presentableName shouldBe "nested"
    }
 
-   @Test
-   fun shouldResetPresentablePathOnEmbeddedLocationOnTestSuiteStart() {
+   fun `test should reset presentable path on embedded location on test suite start`() {
       val proxy = SMTestProxy(
          /* testName = */ "<kotest>io.kotest.Spec.test -- nested</kotest>nested",
          /* isSuite = */ false,
          /* locationUrl = */ "java:suite:io.kotest.Spec/test"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().onSuiteStarted(proxy)
+      adapter().onSuiteStarted(proxy)
       proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
       proxy.presentableName shouldBe "nested"
    }
 
    // -------- Strategy 2: java:test://<fqn>/<segment>/<segment> URL (current engines) --------
 
-   @Test
-   fun shouldInstallLocatorWhenLocationUrlEncodesNestedPath() {
+   fun `test should install locator when location url encodes nested path`() {
       val proxy = SMTestProxy(
          /* testName = */ "leaf",
          /* isSuite = */ false,
          /* locationUrl = */ "java:test://io.kotest.Spec/outer/middle/leaf"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().onTestStarted(proxy)
+      adapter().onTestStarted(proxy)
       proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
       // displayName is left untouched - the engine no longer mangles it
       proxy.presentableName shouldBe "leaf"
    }
 
-   @Test
-   fun shouldInstallLocatorForSuiteUrl() {
+   fun `test should install locator for suite url`() {
       val proxy = SMTestProxy(
          /* testName = */ "middle",
          /* isSuite = */ true,
          /* locationUrl = */ "java:suite://io.kotest.Spec/outer/middle"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().onSuiteStarted(proxy)
+      adapter().onSuiteStarted(proxy)
       proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
    }
 
-   @Test
-   fun shouldNotInstallLocatorForSingleSegmentLocationUrl() {
-      // Single-segment methodName (no '/' after the FQN) cannot encode a nested Kotest path,
-      // and could be a regular JUnit @Test method - leave the default locator in place.
+   fun `test should not install locator for single segment location url on non kotest class`() {
+      // Single-segment methodName (no '/' after the FQN) cannot encode a nested Kotest path.
+      // No class with this FQN is registered in the fixture project, so it isn't recognised as
+      // a Kotest spec, and this looks like a regular JUnit @Test method - leave the default
+      // locator in place.
       val proxy = SMTestProxy(
          /* testName = */ "myTest",
          /* isSuite = */ false,
          /* locationUrl = */ "java:test://io.kotest.examples.native.KotlinTest/myTest"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().onTestStarted(proxy)
+      adapter().onTestStarted(proxy)
       // locator should not be replaced
       (proxy.locator is EmbeddedLocationTestLocator) shouldBe false
    }
 
-   @Test
-   fun shouldDetectJavaSuiteClasses() {
+   fun `test should install locator for single segment location url on top level kotest test`() {
+      // A test directly inside a spec (not nested in a context/describe block) only has one
+      // segment in its methodName, but it is still a Kotest test - navigation must not silently
+      // fall back to the default locator, which can't resolve a synthetic (non-JVM-method) name.
+      myFixture.configureByText(
+         "MySpec.kt",
+         """
+            package com.example
+
+            class MySpec : FunSpec()
+         """.trimIndent()
+      )
+      val proxy = SMTestProxy(
+         /* testName = */ "topLevel test",
+         /* isSuite = */ false,
+         /* locationUrl = */ "java:test://com.example.MySpec/topLevel test"
+      )
+      adapter().onTestStarted(proxy)
+      proxy.locator.shouldBeInstanceOf<EmbeddedLocationTestLocator>()
+   }
+
+   fun `test should detect java suite classes`() {
       val proxy = SMTestProxy(
          /* testName = */ "a",
          /* isSuite = */ true,
          /* locationUrl = */ "java:suite://io.kotest.Spec"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().isJavaSuiteClass(proxy) shouldBe true
+      adapter().isJavaSuiteClass(proxy) shouldBe true
    }
 
-   @Test
-   fun shouldSkipJavaSuitesThatAreNotClasses() {
+   fun `test should skip java suites that are not classes`() {
       val proxy = SMTestProxy(
          /* testName = */ "a",
          /* isSuite = */ true,
          /* locationUrl = */ "java:suite://io.kotest.examples.native.KotlinTest/nested"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().isJavaSuiteClass(proxy) shouldBe false
+      adapter().isJavaSuiteClass(proxy) shouldBe false
    }
 
-   @Test
-   fun shouldSkipJavaTests() {
+   fun `test should skip java tests`() {
       val proxy = SMTestProxy(
          /* testName = */ "a",
          /* isSuite = */ false,
          /* locationUrl = */ "java:test://io.kotest.examples.native.KotlinTest/myTest"
       )
-      EmbeddedLocationSMTRunnerEventsAdapter().isJavaSuiteClass(proxy) shouldBe false
+      adapter().isJavaSuiteClass(proxy) shouldBe false
    }
 
    // -------- Parser tests for parseLocationUrl --------
 
-   @Test
-   fun parseLocationUrl_javaTestNested() {
+   fun `test parseLocationUrl java test nested`() {
       EmbeddedLocationParser.parseLocationUrl(
          "java:test://com.example.MySpec/outer/inner/leaf",
          "leaf"
-      ) shouldBe EmbeddedLocation("com.example.MySpec/outer -- inner -- leaf", "leaf")
+      ) { false } shouldBe EmbeddedLocation("com.example.MySpec/outer -- inner -- leaf", "leaf")
    }
 
-   @Test
-   fun parseLocationUrl_javaSuiteNested() {
+   fun `test parseLocationUrl java suite nested`() {
       EmbeddedLocationParser.parseLocationUrl(
          "java:suite://com.example.MySpec/outer/inner",
          "inner"
-      ) shouldBe EmbeddedLocation("com.example.MySpec/outer -- inner", "inner")
+      ) { false } shouldBe EmbeddedLocation("com.example.MySpec/outer -- inner", "inner")
    }
 
-   @Test
-   fun parseLocationUrl_singleSegment_returnsNull() {
+   fun `test parseLocationUrl single segment non kotest class returns null`() {
       EmbeddedLocationParser.parseLocationUrl(
          "java:test://com.example.MySpec/topLevel",
          "topLevel"
-      ).shouldBeNull()
+      ) { false }.shouldBeNull()
    }
 
-   @Test
-   fun parseLocationUrl_unknownProtocol_returnsNull() {
+   fun `test parseLocationUrl single segment kotest class returns location`() {
+      EmbeddedLocationParser.parseLocationUrl(
+         "java:test://com.example.MySpec/topLevel",
+         "topLevel"
+      ) { true } shouldBe EmbeddedLocation("com.example.MySpec/topLevel", "topLevel")
+   }
+
+   fun `test parseLocationUrl unknown protocol returns null`() {
       EmbeddedLocationParser.parseLocationUrl(
          "kotest://com.example.MySpec/foo/bar",
          "bar"
-      ).shouldBeNull()
+      ) { false }.shouldBeNull()
    }
 
-   @Test
-   fun parseLocationUrl_null_returnsNull() {
-      EmbeddedLocationParser.parseLocationUrl(null, "anything").shouldBeNull()
+   fun `test parseLocationUrl null returns null`() {
+      EmbeddedLocationParser.parseLocationUrl(null, "anything") { false }.shouldBeNull()
    }
 }

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapterTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationSMTRunnerEventsAdapterTest.kt
@@ -172,4 +172,68 @@ class EmbeddedLocationSMTRunnerEventsAdapterTest : LightJavaCodeInsightFixtureTe
    fun `test parseLocationUrl null returns null`() {
       EmbeddedLocationParser.parseLocationUrl(null, "anything") { false }.shouldBeNull()
    }
+
+   // -------- ancestorNames: restoring the path Gradle test events drop --------
+
+   fun `test parseLocationUrl uses ancestorNames to restore a nested path for a single segment url`() {
+      // IntelliJ's Gradle test event integration collapses "base/inner root/child1" down to just
+      // "child1" on the locationUrl - ancestorNames (from GradleParentIdParser) restores it.
+      EmbeddedLocationParser.parseLocationUrl(
+         "java:test://com.example.MySpec/child1",
+         "child1",
+         listOf("base", "inner root")
+      ) { true } shouldBe EmbeddedLocation("com.example.MySpec/base -- inner root -- child1", "child1")
+   }
+
+   fun `test parseLocationUrl ignores ancestorNames when the url already encodes a nested path`() {
+      // A multi-segment MethodSource-derived url (from the IntelliJ-native JUnit launcher) already
+      // has the full path - ancestorNames must not be appended on top of it.
+      EmbeddedLocationParser.parseLocationUrl(
+         "java:test://com.example.MySpec/outer/inner/leaf",
+         "leaf",
+         listOf("shouldNotAppear")
+      ) { false } shouldBe EmbeddedLocation("com.example.MySpec/outer -- inner -- leaf", "leaf")
+   }
+
+   fun `test parseLocationUrl with empty ancestorNames behaves as a top level test`() {
+      EmbeddedLocationParser.parseLocationUrl(
+         "java:test://com.example.MySpec/topLevel",
+         "topLevel",
+         emptyList()
+      ) { true } shouldBe EmbeddedLocation("com.example.MySpec/topLevel", "topLevel")
+   }
+
+   // -------- GradleParentIdParser --------
+
+   fun `test ancestorContextNames extracts and reverses suite names ignoring the leading id`() {
+      // real strings captured from a debugger session against GradleSMTestProxy#getParentId
+      val parentId =
+         "[-1862748639:723354132] > [Test suite 'inner root'] > [Test suite 'base'] > " +
+            "[Test class io.github.alfonsoristorato.jpaspeckotlindsl.archunit.Random] > [Task :jpa-spec-kotlin-dsl:test]"
+      GradleParentIdParser.ancestorContextNames(parentId) shouldBe listOf("base", "inner root")
+   }
+
+   fun `test ancestorContextNames for a container one level below the spec`() {
+      val parentId =
+         "[-1862748639:723354132] > [Test suite 'base'] > " +
+            "[Test class io.github.alfonsoristorato.jpaspeckotlindsl.archunit.Random] > [Task :jpa-spec-kotlin-dsl:test]"
+      GradleParentIdParser.ancestorContextNames(parentId) shouldBe listOf("base")
+   }
+
+   fun `test ancestorContextNames for a top level container directly under the spec`() {
+      val parentId =
+         "[-1862748639:723354132] > [Test class io.github.alfonsoristorato.jpaspeckotlindsl.archunit.Random] > [Task :jpa-spec-kotlin-dsl:test]"
+      GradleParentIdParser.ancestorContextNames(parentId) shouldBe emptyList()
+   }
+
+   fun `test ancestorContextNames disambiguates a second root with the same inner container name`() {
+      val parentId =
+         "[-1862748639:723354132] > [Test suite 'inner root'] > [Test suite 'base 2'] > " +
+            "[Test class io.github.alfonsoristorato.jpaspeckotlindsl.archunit.Random] > [Task :jpa-spec-kotlin-dsl:test]"
+      GradleParentIdParser.ancestorContextNames(parentId) shouldBe listOf("base 2", "inner root")
+   }
+
+   fun `test ancestorContextNames returns empty list for null parentId`() {
+      GradleParentIdParser.ancestorContextNames(null) shouldBe emptyList()
+   }
 }

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocatorTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocatorTest.kt
@@ -3,6 +3,7 @@ package io.kotest.plugin.intellij.locations
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeGreaterThan
 import java.nio.file.Paths
 
 /**
@@ -54,5 +55,26 @@ class EmbeddedLocationTestLocatorTest : LightJavaCodeInsightFixtureTestCase() {
          "a nested test"
       )
       resolve(location) shouldHaveSize 1
+   }
+
+   fun `test resolves the correct leaf when the same name is nested under two different top level containers`() {
+      // "child1" appears twice - once under "base", once under "base 2" - a bare single-segment
+      // path can't tell these apart (see EmbeddedLocationTestLocator#findByNameAtAnyDepth), but
+      // once GradleParentIdParser restores the real ancestor chain onto the path (as
+      // EmbeddedLocationParser#parseLocationUrl now does), navigation must land on the exact one.
+      myFixture.configureByFiles("/duplicate-leaf-funspec.kt", "/io/kotest/core/spec/style/specs.kt")
+      val location = EmbeddedLocation(
+         "io.kotest.samples.gradle.DuplicateLeafFunSpecExampleTest/base 2 -- inner root -- child1",
+         "child1"
+      )
+      val results = resolve(location)
+      results shouldHaveSize 1
+
+      val fileText = results.first().psiElement.containingFile.text
+      val resolvedOffset = results.first().psiElement.textRange.startOffset
+      // the "base 2" block starts strictly after the "base" block in source, so landing after
+      // "base 2"'s own declaration (and not merely after "base"'s) proves we resolved the leaf
+      // nested under "base 2", not the identically-named one under "base".
+      resolvedOffset shouldBeGreaterThan fileText.indexOf("context(\"base 2\")")
    }
 }

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocatorTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/locations/EmbeddedLocationTestLocatorTest.kt
@@ -1,0 +1,58 @@
+package io.kotest.plugin.intellij.locations
+
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase
+import io.kotest.matchers.collections.shouldHaveSize
+import java.nio.file.Paths
+
+/**
+ * The `contexts` segments passed to [EmbeddedLocationTestLocator] come from the engine's runtime
+ * test names, which are whitespace-normalized ([io.kotest.core.names.TestNameBuilder]). The PSI
+ * side must normalize the literal source name the same way before comparing, or a nested test
+ * whose source string has irregular whitespace never resolves - "Jump to Source" then silently
+ * does nothing for it, even though its parent container (which navigates via a different,
+ * class-level mechanism) works fine.
+ */
+class EmbeddedLocationTestLocatorTest : LightJavaCodeInsightFixtureTestCase() {
+
+   override fun getTestDataPath(): String {
+      return Paths.get("./src/test/resources/").toAbsolutePath().toString()
+   }
+
+   private fun resolve(location: EmbeddedLocation) =
+      EmbeddedLocationTestLocator(location).getLocation("kotest", location.path, project, GlobalSearchScope.allScope(project))
+
+   fun `test resolves a top level test with a clean literal name`() {
+      myFixture.configureByFiles("/whitespace-funspec.kt", "/io/kotest/core/spec/style/specs.kt")
+      val location = EmbeddedLocation(
+         "io.kotest.samples.gradle.WhitespaceFunSpecExampleTest/outer context",
+         "outer context"
+      )
+      resolve(location) shouldHaveSize 1
+   }
+
+   fun `test resolves a nested test whose literal source name has irregular whitespace`() {
+      myFixture.configureByFiles("/whitespace-funspec.kt", "/io/kotest/core/spec/style/specs.kt")
+      // the engine normalizes "a  nested   test" (double/triple spaces in source) down to
+      // "a nested test" before it ever reaches the locationUrl/contexts path.
+      val location = EmbeddedLocation(
+         "io.kotest.samples.gradle.WhitespaceFunSpecExampleTest/outer context -- a nested test",
+         "a nested test"
+      )
+      resolve(location) shouldHaveSize 1
+   }
+
+   fun `test resolves a nested test from a single segment path`() {
+      // IntelliJ's Gradle test event integration only carries a leaf test's own name on the
+      // locationUrl - unlike the JUnit Platform launcher's MethodSource, it drops every ancestor
+      // container segment. A nested test therefore arrives here as a single-segment path
+      // indistinguishable in shape from a top-level test, and must still resolve by searching
+      // the whole tree rather than only the top level.
+      myFixture.configureByFiles("/funspec.kt", "/io/kotest/core/spec/style/specs.kt")
+      val location = EmbeddedLocation(
+         "io.kotest.samples.gradle.FunSpecExampleTest/a nested test",
+         "a nested test"
+      )
+      resolve(location) shouldHaveSize 1
+   }
+}

--- a/kotest-intellij-plugin/src/test/resources/duplicate-leaf-funspec.kt
+++ b/kotest-intellij-plugin/src/test/resources/duplicate-leaf-funspec.kt
@@ -1,0 +1,24 @@
+package io.kotest.samples.gradle
+
+import io.kotest.core.spec.style.FunSpec
+
+class DuplicateLeafFunSpecExampleTest : FunSpec({
+
+   context("base") {
+      context("inner root") {
+         test("child1") {
+         }
+         test("child2") {
+         }
+      }
+   }
+
+   context("base 2") {
+      context("inner root") {
+         test("child1") {
+         }
+         test("child2") {
+         }
+      }
+   }
+})

--- a/kotest-intellij-plugin/src/test/resources/whitespace-funspec.kt
+++ b/kotest-intellij-plugin/src/test/resources/whitespace-funspec.kt
@@ -1,0 +1,12 @@
+package io.kotest.samples.gradle
+
+import io.kotest.core.spec.style.FunSpec
+
+class WhitespaceFunSpecExampleTest : FunSpec({
+
+   context("outer context") {
+
+      test("a  nested   test") {
+      }
+   }
+})


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
Addresses: https://github.com/kotest/kotest/issues/6194

Problem

"Jump to Source" on test results in the IntelliJ test tree had regressed in several cases:
- Top-level (non-nested) tests, e.g. test("a test") { } directly in a spec.
- Nested tests whose literal source name has irregular whitespace (double spaces, tabs, etc.).
- Nested tests run via the Gradle test runner specifically — e.g. context("outer") { test("inner") { } } — while the top-level container navigated fine.

Root causes

1. Top-level tests bailing to the default locator (EmbeddedLocationSMTRunnerEventsAdapter.kt). EmbeddedLocationParser.parseLocationUrl treated any single-segment methodName (no /) as "must be a real JVM method" and left it to IntelliJ's default locator. But a top-level Kotest test also produces a single-segment methodName, and it isn't a real JVM method, so the default locator can't resolve it. Fixed by resolving the FQN against the stub index and only deferring to the default locator when the class genuinely isn't a Kotest spec (isKotestSpec).
2. Whitespace mismatch between engine and PSI names (EmbeddedLocationTestLocator.kt). The engine always whitespace-normalizes test names (TestNameBuilder.removeAllExtraWhitespaces()) before they reach locationUrl, but findTest's PSI-side comparison used the raw, un-normalized literal source string. Any test with irregular whitespace in source failed the exact-string match. Fixed by reusing the existing flattenTestName() normalizer (now internal, was private) on the PSI side.
3. Gradle's test events drop the nested path entirely (EmbeddedLocationTestLocator.kt). Confirmed via IDE log: IntelliJ's Gradle test integration only encodes a leaf test's own name on locationUrl (java:test://Spec/an inner test), unlike the JUnit Platform launcher's MethodSource, which joins every ancestor container into the path. A nested test therefore arrives as a single-segment path indistinguishable in shape from a top-level test — and findTest only ever searched the top-level test list for a single segment, so nested tests never resolved even though the container above them did. Fixed by searching the whole test tree (findByNameAtAnyDepth) when only one segment is available. This can't disambiguate same-named tests under different containers (Gradle's protocol has already lost that information), but resolves to some matching test instead of nothing.

<img width="502" height="496" alt="image" src="https://github.com/user-attachments/assets/666cd1ac-febd-4333-b23b-767f01fbacd5" />

<img width="436" height="468" alt="image" src="https://github.com/user-attachments/assets/78623993-2df3-420d-bf40-6fe9a2356ef2" />

<img width="504" height="471" alt="image" src="https://github.com/user-attachments/assets/d4c50ae0-ea25-4fee-b84f-71c3214d1a2f" />