### PR TITLE
make-DefaultExtensionRegistry-thread-safe (#6196)

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/extensions/ExtensionRegistry.kt
@@ -44,6 +44,8 @@ class DefaultExtensionRegistry : ExtensionRegistry {
 
    private val extensions = mutableListOf<Pair<Extension, KClass<*>?>>()
 
+   private val lock = Lock()
+
    // get(kClass) is invoked twice per spec instantiation (once for constructor extensions, once
    // for post-instantiation extensions), which was previously an O(n) filter/allocation over every
    // registered extension on each call. Under IsolationMode.SingleInstance each spec class is only
@@ -57,33 +59,47 @@ class DefaultExtensionRegistry : ExtensionRegistry {
    @Volatile
    private var byClass: Map<KClass<*>?, List<Extension>> = emptyMap()
 
-   override fun all(): List<Extension> = extensions.map { it.first }
+   override fun all(): List<Extension> = synchronized(lock) {
+      extensions.map { it.first }
+   }
 
-   override fun get(kClass: KClass<*>): List<Extension> = byClass[kClass] ?: emptyList()
+   override fun get(kClass: KClass<*>): List<Extension> = synchronized(lock) {
+      byClass[kClass] ?: emptyList()
+   }
 
    override fun add(extension: Extension) {
-      extensions.add(Pair(extension, null))
-      rebuild()
+      synchronized(lock) {
+         extensions.add(Pair(extension, null))
+         rebuild()
+      }
    }
 
    override fun add(extension: Extension, kclass: KClass<*>) {
-      extensions.add(Pair(extension, kclass))
-      rebuild()
+      synchronized(lock) {
+         extensions.add(Pair(extension, kclass))
+         rebuild()
+      }
    }
 
    override fun remove(extension: Extension) {
-      extensions.remove(Pair(extension, null))
-      rebuild()
+      synchronized(lock) {
+         extensions.remove(Pair(extension, null))
+         rebuild()
+      }
    }
 
    override fun remove(extension: Extension, kclass: KClass<*>) {
-      extensions.remove(Pair(extension, kclass))
-      rebuild()
+      synchronized(lock) {
+         extensions.remove(Pair(extension, kclass))
+         rebuild()
+      }
    }
 
    override fun clear() {
-      extensions.clear()
-      rebuild()
+      synchronized(lock) {
+         extensions.clear()
+         rebuild()
+      }
    }
 
    private fun rebuild() {
@@ -92,6 +108,8 @@ class DefaultExtensionRegistry : ExtensionRegistry {
 
    override fun isEmpty(): Boolean = extensions.isEmpty()
    override fun isNotEmpty(): Boolean = extensions.isNotEmpty()
+
+   private class Lock
 }
 
 object EmptyExtensionRegistry : ExtensionRegistry {


### PR DESCRIPTION
because `Volatile` does not guarantee atomicity, `synchronized` does.
