### PR TITLE
sourceRef improvements

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/source/sourceRef.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/core/source/sourceRef.kt
@@ -3,8 +3,14 @@ package io.kotest.core.source
 import io.kotest.common.sysprop
 import io.kotest.core.spec.Spec
 import io.kotest.engine.config.KotestEngineProperties
-import kotlin.reflect.KClass
-import kotlin.reflect.full.isSubclassOf
+
+private val specJavaClass: Class<*> = Spec::class.java
+
+// RETAIN_CLASS_REFERENCE gives us the live java.lang.Class for each frame directly,
+// avoiding a Class.forName lookup, and StackWalker.walk() lets us stop as soon as we
+// find the first user frame instead of always materializing the whole call stack
+// the way Thread.currentThread().stackTrace would do.
+private val stackWalker: StackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
 
 /**
  * On the JVM we can create a stack trace to get the line number.
@@ -13,32 +19,34 @@ import kotlin.reflect.full.isSubclassOf
 internal actual fun sourceRef(): SourceRef {
    if (sysprop(KotestEngineProperties.DISABLE_SOURCE_REF, "false") == "true") return SourceRef.None
 
-   val stack = Thread.currentThread().stackTrace
-   if (stack.isEmpty()) return SourceRef.None
-
-   val frame = SourceRefUtils.firstUserFrame(stack)
+   val frame = SourceRefUtils.firstUserFrame(stackWalker) ?: return SourceRef.None
 
    // preference is given to the class name, but we must try to find the enclosing spec
-   val kclass = frame?.className?.let { fqn ->
-      runCatching {
-         var temp: KClass<*>? = Class.forName(fqn).kotlin
-         while (temp != null && !temp.isSubclassOf(Spec::class)) {
-            temp = temp.java.enclosingClass?.kotlin
-         }
-         temp
-      }.getOrNull()
+   var kclass: Class<*>? = frame.declaringClass
+   while (kclass != null && !specJavaClass.isAssignableFrom(kclass)) {
+      kclass = kclass.enclosingClass
    }
 
-   val lineNumber = frame?.lineNumber?.takeIf { it > 0 }
+   val lineNumber = frame.lineNumber.takeIf { it > 0 }
 
    return when {
       kclass == null -> SourceRef.None
-      lineNumber == null -> SourceRef.ClassSource(kclass.java.name)
-      else -> SourceRef.ClassLineSource(kclass.java.name, lineNumber)
+      lineNumber == null -> SourceRef.ClassSource(kclass.name)
+      else -> SourceRef.ClassLineSource(kclass.name, lineNumber)
    }
 }
 
 object SourceRefUtils {
+
+   /**
+    * Returns the first user-land frame from the given [StackWalker], walking the live call
+    * stack lazily so frames beyond the match are never materialized.
+    */
+   internal fun firstUserFrame(walker: StackWalker): StackWalker.StackFrame? {
+      return walker.walk { frames ->
+         frames.filter { !isExcludedFrame(it.className, excludeDataTest = true) }.findFirst()
+      }.orElse(null)
+   }
 
    /**
     * Returns the first user-land frame from the given stack trace.
@@ -51,16 +59,18 @@ object SourceRefUtils {
    }
 
    internal fun filteredUserFrames(stack: Array<StackTraceElement>, excludeDataTest: Boolean = false): List<StackTraceElement> {
-      return stack.dropWhile {
-         it.className.startsWith("java.") ||
-            it.className.startsWith("javax.") ||
-            it.className.startsWith("jdk.internal.") ||
-            it.className.startsWith("com.sun") ||
-            it.className.startsWith("kotlin.") ||
-            it.className.startsWith("kotlinx.") ||
-            it.className.startsWith("io.kotest.core.") ||
-            it.className.startsWith("io.kotest.engine.") ||
-            (excludeDataTest && it.className.startsWith("io.kotest.datatest."))
-      }
+      return stack.dropWhile { isExcludedFrame(it.className, excludeDataTest) }
+   }
+
+   internal fun isExcludedFrame(className: String, excludeDataTest: Boolean): Boolean {
+      return className.startsWith("java.") ||
+         className.startsWith("javax.") ||
+         className.startsWith("jdk.internal.") ||
+         className.startsWith("com.sun") ||
+         className.startsWith("kotlin.") ||
+         className.startsWith("kotlinx.") ||
+         className.startsWith("io.kotest.core.") ||
+         className.startsWith("io.kotest.engine.") ||
+         (excludeDataTest && className.startsWith("io.kotest.datatest."))
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/datatest/DataTestTag.jvm.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/datatest/DataTestTag.jvm.kt
@@ -2,7 +2,14 @@ package io.kotest.datatest
 
 import io.kotest.core.source.SourceRefUtils
 import io.kotest.core.spec.Spec
-import kotlin.reflect.full.isSubclassOf
+
+private val specJavaClass: Class<*> = Spec::class.java
+
+// RETAIN_CLASS_REFERENCE gives us the live java.lang.Class for each frame directly,
+// avoiding a Class.forName lookup, and StackWalker.walk() lets us stop as soon as we
+// find the first user frame instead of always materializing the whole call stack
+// the way Thread.currentThread().stackTrace would do.
+private val stackWalker: StackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)
 
 /**
  * JVM implementation that gets the line number from the stack trace.
@@ -10,14 +17,12 @@ import kotlin.reflect.full.isSubclassOf
  * Highly (ok fully) inspired from [io.kotest.core.source.sourceRef]
  */
 internal actual fun getDataTestCallSiteLineNumber(): String {
-   val stack = Thread.currentThread().stackTrace
-
-   val frame = SourceRefUtils.filteredUserFrames(stack).firstOrNull { element ->
-      runCatching {
-         val clazz = Class.forName(element.className)
-         isSpecOrNestedInSpec(clazz)
-      }.getOrDefault(false)
-   }
+   val frame = stackWalker.walk { frames ->
+      frames
+         .filter { !SourceRefUtils.isExcludedFrame(it.className, excludeDataTest = false) }
+         .filter { isSpecOrNestedInSpec(it.declaringClass) }
+         .findFirst()
+   }.orElse(null)
 
    return frame?.lineNumber?.takeIf { it > 0 }?.toString() ?: "unknown"
 }
@@ -28,20 +33,11 @@ internal actual fun getDataTestCallSiteLineNumber(): String {
  * but are not themselves subclasses of Spec.
  */
 private fun isSpecOrNestedInSpec(clazz: Class<*>): Boolean {
-   // Direct check: is this class a Spec?
-   if (runCatching { clazz.kotlin.isSubclassOf(Spec::class) }.getOrDefault(false)) {
-      return true
+   var current: Class<*>? = clazz
+   while (current != null) {
+      if (specJavaClass.isAssignableFrom(current)) return true
+      current = current.enclosingClass
    }
-
-   // Check enclosing classes (for lambdas and nested classes within a Spec)
-   var enclosing = clazz.enclosingClass
-   while (enclosing != null) {
-      if (runCatching { enclosing.kotlin.isSubclassOf(Spec::class) }.getOrDefault(false)) {
-         return true
-      }
-      enclosing = enclosing.enclosingClass
-   }
-
    return false
 }
 

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/SourceRefTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/SourceRefTest.kt
@@ -32,12 +32,10 @@ class SourceRefTest : FunSpec() {
       // once per registered test. It must remain cheap.
 
       // before PR https://github.com/kotest/kotest/pull/6203:
-      // ~400ms (on Alfonso's machine :))
       // it walked the *entire* call stack via Thread.currentThread().stackTrace and resolved the enclosing Spec
       // with kotlin-reflect's isSubclassOf, which loads/exercises kotlin-reflect's metadata deserialization on every call.
 
       // after PR https://github.com/kotest/kotest/pull/6203:
-      //  ~110-140ms (on Alfonso's machine :))
       // StackWalker + plain java.lang.Class based implementation
 
       // retune if flaky on CI
@@ -48,7 +46,7 @@ class SourceRefTest : FunSpec() {
                Materializer().materialize(spec, Reference(spec::class, spec::class.bestName())).first().source
             }
          }
-         duration.inWholeMilliseconds shouldBeLessThan 400L
+         duration.inWholeMilliseconds shouldBeLessThan 600L
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/SourceRefTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/SourceRefTest.kt
@@ -10,8 +10,10 @@ import io.kotest.core.spec.style.FreeSpec
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.engine.spec.Materializer
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
 
 @EnabledIf(LinuxOnlyGithubCondition::class)
 class SourceRefTest : FunSpec() {
@@ -26,11 +28,27 @@ class SourceRefTest : FunSpec() {
          )
       }
 
+      // sourceRef() computes a stack-based lookup (needed for "jump to source" and failure reporting)
+      // once per registered test. It must remain cheap.
+
+      // before PR https://github.com/kotest/kotest/pull/6203:
+      // ~400ms (on Alfonso's machine :))
+      // it walked the *entire* call stack via Thread.currentThread().stackTrace and resolved the enclosing Spec
+      // with kotlin-reflect's isSubclassOf, which loads/exercises kotlin-reflect's metadata deserialization on every call.
+
+      // after PR https://github.com/kotest/kotest/pull/6203:
+      //  ~110-140ms (on Alfonso's machine :))
+      // StackWalker + plain java.lang.Class based implementation
+
+      // retune if flaky on CI
       test("source ref should be performant").config(timeout = 20.seconds) {
-         repeat(5_000) {
-            val spec = MySpecForTestCaseSourceRefTest()
-            Materializer().materialize(spec, Reference(spec::class, spec::class.bestName())).first().source
+         val duration = measureTime {
+            repeat(5_000) {
+               val spec = MySpecForTestCaseSourceRefTest()
+               Materializer().materialize(spec, Reference(spec::class, spec::class.bestName())).first().source
+            }
          }
+         duration.inWholeMilliseconds shouldBeLessThan 300L
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/SourceRefTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/test/SourceRefTest.kt
@@ -48,7 +48,7 @@ class SourceRefTest : FunSpec() {
                Materializer().materialize(spec, Reference(spec::class, spec::class.bestName())).first().source
             }
          }
-         duration.inWholeMilliseconds shouldBeLessThan 300L
+         duration.inWholeMilliseconds shouldBeLessThan 400L
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestCallSiteLineNumberPerformanceTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestCallSiteLineNumberPerformanceTest.kt
@@ -1,0 +1,36 @@
+package io.kotest.datatest
+
+import io.kotest.common.KotestInternal
+import io.kotest.core.annotation.EnabledIf
+import io.kotest.core.annotation.LinuxOnlyGithubCondition
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeLessThan
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.measureTime
+
+/**
+ * [getDataTestTagConfig] is called once per withXXX call site to tag generated tests
+ * with their source line number (used by the IntelliJ plugin to run a single data test row).
+ * On the JVM this resolves the call site via a stack walk, the same mechanism used by
+ * [io.kotest.core.source.sourceRef] (see [com.sksamuel.kotest.engine.test.SourceRefTest] for that
+ * counterpart test) - it must stay cheap for specs with many withData/withXXX call sites.
+ */
+@EnabledIf(LinuxOnlyGithubCondition::class)
+class DataTestCallSiteLineNumberPerformanceTest : FunSpec() {
+   init {
+      test("data test call site line number lookup should be performant").config(timeout = 20.seconds) {
+         @OptIn(KotestInternal::class)
+         val duration = measureTime {
+            repeat(5_000) {
+               getDataTestTagConfig()
+            }
+         }
+         // after PR https://github.com/kotest/kotest/pull/6203
+         // old impl: ~227ms (on Alfonso's machine :)) with the old Class.forName + kotlin-reflect isSubclassOf
+         // new impl: ~30ms  (on Alfonso's machine :)) with the StackWalker + plain java.lang.Class
+
+         // retune if flaky on CI
+         duration.inWholeMilliseconds shouldBeLessThan 100L
+      }
+   }
+}

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestCallSiteLineNumberPerformanceTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestCallSiteLineNumberPerformanceTest.kt
@@ -26,11 +26,11 @@ class DataTestCallSiteLineNumberPerformanceTest : FunSpec() {
             }
          }
          // after PR https://github.com/kotest/kotest/pull/6203
-         // old impl: ~227ms (on Alfonso's machine :)) with the old Class.forName + kotlin-reflect isSubclassOf
-         // new impl: ~30ms  (on Alfonso's machine :)) with the StackWalker + plain java.lang.Class
+         // old impl: with the old Class.forName + kotlin-reflect isSubclassOf
+         // new impl: with the StackWalker + plain java.lang.Class
 
          // retune if flaky on CI
-         duration.inWholeMilliseconds shouldBeLessThan 200L
+         duration.inWholeMilliseconds shouldBeLessThan 600L
       }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestCallSiteLineNumberPerformanceTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/io/kotest/datatest/DataTestCallSiteLineNumberPerformanceTest.kt
@@ -30,7 +30,7 @@ class DataTestCallSiteLineNumberPerformanceTest : FunSpec() {
          // new impl: ~30ms  (on Alfonso's machine :)) with the StackWalker + plain java.lang.Class
 
          // retune if flaky on CI
-         duration.inWholeMilliseconds shouldBeLessThan 100L
+         duration.inWholeMilliseconds shouldBeLessThan 200L
       }
    }
 }


### PR DESCRIPTION
## Faster jump-to-source / failure reporting

`sourceRef()` runs once per registered test to work out the source location (used for jump-to-source and failure reports). It was walking the *entire* call stack with `Thread.currentThread().stackTrace` and resolving the enclosing spec with kotlin-reflect's `isSubclassOf`, which drags in kotlin-reflect's metadata deserialization on every single call.

Swapped that for `StackWalker` (lazy, stops at the first matching frame, gives you the `Class` directly via `RETAIN_CLASS_REFERENCE`) and plain `Class.isAssignableFrom` instead of kotlin-reflect. Same fix applied to `getDataTestCallSiteLineNumber` in the datatest module, which had the same pattern (and was even worse, doing `Class.forName` + reflection per candidate frame).

No behavior change, same `SourceRef` output, jump-to-source and failure locations still work exactly the same, just without the reflection tax.

Locally this took a synthetic 200k-test benchmark from ~23s to ~12s. 