### PR TITLE
introduce a TeamCity renderer that allows tree view and force it for our legacy IJ plugin

### DIFF
--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/listener/TeamCityTestEngineListener.kt
@@ -33,13 +33,23 @@ import kotlin.reflect.KClass
  *
  * Decisions:
  *
- * Intermediate containers will only be output if configured
- * All tests will be output as root tests under the spec as a suite, with the path flattened.
+ * By default, intermediate containers are not output as suites: all tests are output as root
+ * tests under the spec as a suite, with the path flattened. This is because some TeamCity
+ * consumers (e.g. Native and JS) ignore containers without direct tests, so flattening guarantees
+ * every test remains visible.
+ *
+ * When [nestContainers] is enabled, containers are instead reported as nested
+ * testSuiteStarted/testSuiteFinished messages, and test names are not flattened. This gives a
+ * consumer capable of rendering nested suites (e.g. IntelliJ parsing these messages directly from
+ * a forked JVM, as our IJ plugin does for non-Gradle run configurations) a real tree instead of one flattened
+ * leaf per test. This is opt-in so that existing consumers relying on the flattened format are
+ * unaffected.
  *
  */
 @KotestInternal
 class TeamCityTestEngineListener(
    private val prefix: String = TeamCityMessage.TEAM_CITY_PREFIX,
+   private val nestContainers: Boolean = false,
 ) : TestEngineListener {
 
    private val logger = Logger(TeamCityTestEngineListener::class)
@@ -75,8 +85,10 @@ class TeamCityTestEngineListener(
       // if the spec itself has an error, we must insert a placeholder test
       when (val t = result.errorOrNull) {
          null -> Unit
-         is MultipleExceptions -> t.causes.forEach { insertPlaceholderTest(renderer.testPath(ref, it), it) }
-         else -> insertPlaceholderTest(renderer.testPath(ref, t), t)
+         is MultipleExceptions -> t.causes.forEach {
+            insertPlaceholderTest(if (nestContainers) it::class.simpleName ?: "Error" else renderer.testPath(ref, it), it)
+         }
+         else -> insertPlaceholderTest(if (nestContainers) t::class.simpleName ?: "Error" else renderer.testPath(ref, t), t)
       }
 
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_SUITE_FINISHED) {
@@ -88,16 +100,23 @@ class TeamCityTestEngineListener(
 
    override suspend fun testStarted(testCase: TestCase) {
       logger.log { Pair(testCase.name.name, "testStarted $testCase") }
-      if (testCase.type == TestType.Test)
-         TeamCityMessage(prefix, TeamCityMessage.Types.TEST_STARTED) {
-            name(renderer.testPath(testCase))
-            locationHint(Locations.location(testCase.source))
-         }.output()
+      when {
+         nestContainers && testCase.type == TestType.Container ->
+            TeamCityMessage(prefix, TeamCityMessage.Types.TEST_SUITE_STARTED) {
+               name(renderer.localName(testCase))
+               locationHint(Locations.location(testCase.source))
+            }.output()
+         testCase.type == TestType.Test ->
+            TeamCityMessage(prefix, TeamCityMessage.Types.TEST_STARTED) {
+               name(if (nestContainers) renderer.localName(testCase) else renderer.testPath(testCase))
+               locationHint(Locations.location(testCase.source))
+            }.output()
+      }
    }
 
    override suspend fun testIgnored(testCase: TestCase, reason: String?) {
       TeamCityMessage(prefix, TeamCityMessage.Types.TEST_IGNORED) {
-         name(renderer.testPath(testCase))
+         name(if (nestContainers) renderer.localName(testCase) else renderer.testPath(testCase))
          locationHint(Locations.location(testCase.source))
          message(reason)
          result(TestResult.Ignored(reason))
@@ -108,19 +127,25 @@ class TeamCityTestEngineListener(
       logger.log { Pair(testCase.name.name, "testFinished $testCase") }
       results[testCase.descriptor] = result
 
-      if (testCase.type == TestType.Container)
+      if (testCase.type == TestType.Container) {
          failTestSuiteIfError(testCase, result)
-      else {
+         if (nestContainers)
+            TeamCityMessage(prefix, TeamCityMessage.Types.TEST_SUITE_FINISHED) {
+               name(renderer.localName(testCase))
+            }.output()
+      } else {
+         val testName = if (nestContainers) renderer.localName(testCase) else renderer.testPath(testCase)
+
          if (result.isErrorOrFailure) {
             TeamCityMessage(prefix, TeamCityMessage.Types.TEST_FAILED) {
-               name(renderer.testPath(testCase))
+               name(testName)
                exception(result.errorOrNull)
                result(result)
             }.output()
          }
 
          TeamCityMessage(prefix, TeamCityMessage.Types.TEST_FINISHED) {
-            name(renderer.testPath(testCase))
+            name(testName)
             duration(result.duration)
             result(result)
          }.output()
@@ -132,8 +157,10 @@ class TeamCityTestEngineListener(
       // test suites cannot be in a failed state, so we must insert a placeholder to hold any error
       when (val t = result.errorOrNull) {
          null -> Unit
-         is MultipleExceptions -> t.causes.forEach { insertPlaceholderTest(renderer.testPath(testCase, it), it) }
-         else -> insertPlaceholderTest(renderer.testPath(testCase, t), t)
+         is MultipleExceptions -> t.causes.forEach {
+            insertPlaceholderTest(if (nestContainers) it::class.simpleName ?: "Error" else renderer.testPath(testCase, it), it)
+         }
+         else -> insertPlaceholderTest(if (nestContainers) t::class.simpleName ?: "Error" else renderer.testPath(testCase, t), t)
       }
    }
 

--- a/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityPathRenderer.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonMain/kotlin/io/kotest/engine/teamcity/TeamCityPathRenderer.kt
@@ -49,4 +49,14 @@ internal class TeamCityPathRenderer(private val formatting: DisplayNameFormattin
    fun testPath(testCase: TestCase, t: Throwable): String {
       return testPath(testCase) + DELIMITER + t::class.simpleName
    }
+
+   /**
+    * Builds the display name for a single test case, without any ancestor context.
+    * Used when [io.kotest.engine.listener.TeamCityTestEngineListener] is configured to nest
+    * suites, so ancestry is conveyed by nesting testSuiteStarted/testSuiteFinished messages
+    * around this name, rather than by concatenating it with ancestor names.
+    */
+   fun localName(testCase: TestCase): String {
+      return TeamCityTestNameEscaper.escape(formatting.format(testCase))
+   }
 }

--- a/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/teamcity/TeamCityPathRendererTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/commonTest/kotlin/com/sksamuel/kotest/engine/teamcity/TeamCityPathRendererTest.kt
@@ -80,5 +80,27 @@ class TeamCityPathRendererTest : FreeSpec() {
          renderer.testPath(SpecRef.Reference(TeamCityPathRendererTest::class))
          renderer.testPath(tc) shouldBe "$fqn.foo bar ⇢ boo far"
       }
+      "localName should render only the test's own name, ignoring ancestors" {
+         val parent = TestCase(
+            TeamCityPathRendererTest::class.toDescriptor().append("foo"),
+            TestNameBuilder.builder("foo").build(),
+            TeamCityPathRendererTest(),
+            {},
+            SourceRef.None,
+            TestType.Test,
+            parent = null
+         )
+         val tc = TestCase(
+            parent.descriptor.append("boo.far"),
+            TestNameBuilder.builder("boo.far").build(),
+            TeamCityPathRendererTest(),
+            {},
+            SourceRef.None,
+            TestType.Test,
+            parent = parent
+         )
+         val renderer = TeamCityPathRenderer(DisplayNameFormatting(null))
+         renderer.localName(tc) shouldBe "boo far"
+      }
    }
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/TestEngineListenerBuilder.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmMain/kotlin/io/kotest/engine/launcher/TestEngineListenerBuilder.kt
@@ -22,6 +22,12 @@ data class TestEngineListenerBuilder(
 
       internal const val IDEA_PROP = "idea.active"
 
+      // set only by the IntelliJ plugin's non-Gradle (e.g. Maven) run configuration launcher,
+      // so that IntelliJ can render a real nested test tree when it is parsing these TeamCity
+      // messages directly from a forked JVM, without changing the flattened format relied on
+      // by other TeamCity consumers (JS/Native etc).
+      internal const val NEST_CONTAINERS_PROP = "kotest.engine.listener.teamcity.nestContainers"
+
       fun builder(): TestEngineListenerBuilder = TestEngineListenerBuilder(null)
    }
 
@@ -29,14 +35,16 @@ data class TestEngineListenerBuilder(
 
    fun build(): TestEngineListener {
       return when (type) {
-         LISTENER_TC -> TeamCityTestEngineListener()
+         LISTENER_TC -> TeamCityTestEngineListener(nestContainers = nestContainers())
          LISTENER_CONSOLE -> ConsoleTestEngineListener()
          // if not speciifed, we'll try to detect instead
-         else if isIntellij() -> TeamCityTestEngineListener()
+         else if isIntellij() -> TeamCityTestEngineListener(nestContainers = nestContainers())
          else -> ConsoleTestEngineListener()
       }
    }
 
    // this system property is added by intellij itself when running tasks
    private fun isIntellij() = System.getProperty(IDEA_PROP) != null
+
+   private fun nestContainers() = System.getProperty(NEST_CONTAINERS_PROP) == "true"
 }

--- a/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
+++ b/kotest-framework/kotest-framework-engine/src/jvmTest/kotlin/com/sksamuel/kotest/engine/listener/TeamCityTestEngineListenerTest.kt
@@ -351,5 +351,66 @@ a[testFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListe
 a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
 """
       }
+
+      test("nestContainers should report nested containers as nested suites") {
+         val output = captureStandardOut {
+            val listener = TeamCityTestEngineListener("a", nestContainers = true)
+            listener.engineStarted()
+            listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
+            listener.testStarted(a)
+            listener.testStarted(b)
+            listener.testStarted(c)
+            listener.testFinished(c, TestResult.Success(123.milliseconds))
+            listener.testFinished(b, TestResult.Success(324.milliseconds))
+            listener.testFinished(a, TestResult.Success(653.milliseconds))
+            listener.specFinished(
+               SpecRef.Reference(TeamCityTestEngineListenerTest::class),
+               TestResult.Success(0.seconds)
+            )
+            listener.engineFinished(emptyList())
+         }
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='a' locationHint='kotest://foo.bar.Test:12']
+a[testSuiteStarted name='b' locationHint='kotest://foo.bar.Test:17']
+a[testStarted name='c' locationHint='kotest://foo.bar.Test:33']
+a[testFinished name='c' duration='123' result_status='Success']
+a[testSuiteFinished name='b']
+a[testSuiteFinished name='a']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+"""
+      }
+
+      test("nestContainers should insert a placeholder test within the failing container's suite") {
+         val output = captureStandardOut {
+            val listener = TeamCityTestEngineListener("a", nestContainers = true)
+            listener.engineStarted()
+            listener.specStarted(SpecRef.Reference(TeamCityTestEngineListenerTest::class))
+            listener.testStarted(a)
+            listener.testStarted(b)
+            listener.testStarted(c)
+            listener.testFinished(c, TestResult.Success(123.milliseconds))
+            listener.testFinished(b, TestResult.Error(653.milliseconds, Exception("boom")))
+            listener.testFinished(a, TestResult.Success(324.milliseconds))
+            listener.specFinished(
+               SpecRef.Reference(TeamCityTestEngineListenerTest::class),
+               TestResult.Success(0.seconds)
+            )
+            listener.engineFinished(emptyList())
+         }
+         stripDetails(output) shouldBe """a[enteredTheMatrix]
+a[testSuiteStarted name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest' locationHint='kotest://com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest:1']
+a[testSuiteStarted name='a' locationHint='kotest://foo.bar.Test:12']
+a[testSuiteStarted name='b' locationHint='kotest://foo.bar.Test:17']
+a[testStarted name='c' locationHint='kotest://foo.bar.Test:33']
+a[testFinished name='c' duration='123' result_status='Success']
+a[testStarted name='Exception']
+a[testFailed name='Exception' message='boom']
+a[testFinished name='Exception']
+a[testSuiteFinished name='b']
+a[testSuiteFinished name='a']
+a[testSuiteFinished name='com.sksamuel.kotest.engine.listener.TeamCityTestEngineListenerTest']
+"""
+      }
    }
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/KotestRunnableState.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/KotestRunnableState.kt
@@ -34,6 +34,12 @@ class KotestRunnableState(
       // it is a main function that will launch the KotestConsoleRunner
       params.mainClass = launcherConfig.mainClass
 
+      // this run configuration parses TeamCity service messages directly from the forked JVM's
+      // stdout (unlike Gradle runs, where IntelliJ reads the test tree from real JUnit Platform
+      // events), so it can render nested suites. Opt in to a nested tree instead of the flattened
+      // format other TeamCity consumers rely on.
+      params.vmParametersList.addProperty("kotest.engine.listener.teamcity.nestContainers", "true")
+
       val packageName = configuration.getPackageName()
       if (!packageName.isNullOrBlank())
          params.programParametersList.add("--package", packageName)


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
For https://github.com/kotest/kotest/issues/5925
- introduce a TeamCity renderer that allows tree view (nested tests) when prompted
- force this flag to be on when the IJ plugin runs tests in legacy mode