### PR TITLE
make ai skill available to users via claude marketplace and tie versioning to kotest releases

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "kotest",
+  "owner": {
+    "name": "Kotest Team",
+    "url": "https://github.com/kotest"
+  },
+  "metadata": {
+    "description": "Official marketplace for Kotest agent skills.",
+    "version": "6.2.3"
+  },
+  "plugins": [
+    {
+      "name": "kotest-skills",
+      "source": "./",
+      "description": "Agent skills for writing, migrating, and debugging Kotlin tests with Kotest."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "kotest-skills",
+  "version": "6.2.3",
+  "description": "Agent skills for writing, migrating, and debugging Kotlin tests with Kotest.",
+  "author": {
+    "name": "Kotest Team"
+  },
+  "homepage": "https://kotest.io",
+  "repository": "https://github.com/kotest/kotest",
+  "license": "Apache-2.0",
+  "keywords": ["kotest", "kotlin", "testing"]
+}

--- a/.github/workflows/release_all.yml
+++ b/.github/workflows/release_all.yml
@@ -110,3 +110,21 @@ jobs:
                  git tag -a "${TAG}" -m "Release ${TAG}"
                  git push origin "refs/tags/${TAG}"
                fi
+         -  name: Bump kotest-skills plugin version
+            shell: bash
+            run: |
+               set -euo pipefail
+               VERSION="${{ inputs.version }}"
+               jq --arg v "$VERSION" '.version = $v' .claude-plugin/plugin.json > /tmp/plugin.json
+               mv /tmp/plugin.json .claude-plugin/plugin.json
+               jq --arg v "$VERSION" '.metadata.version = $v' .claude-plugin/marketplace.json > /tmp/marketplace.json
+               mv /tmp/marketplace.json .claude-plugin/marketplace.json
+               git config --global user.email "sam@sksamuel.com"
+               git config --global user.name "Kotest Release Bot"
+               git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+               if git diff --cached --quiet; then
+                 echo "kotest-skills plugin already at ${VERSION}; nothing to commit."
+               else
+                 git commit -m "Bump kotest-skills plugin version to ${VERSION}"
+                 git push origin "${{ inputs.branch }}"
+               fi

--- a/documentation/docs/ai/index.md
+++ b/documentation/docs/ai/index.md
@@ -1,0 +1,44 @@
+---
+id: index
+title: AI Agent Skills
+slug: ai-skills.html
+sidebar_label: Introduction
+---
+
+Kotest ships an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that teaches AI
+coding assistants like Claude Code how to write, migrate, and debug Kotlin tests with Kotest. The skill
+covers spec styles, assertions, property-based testing, lifecycle hooks, extensions, multiplatform
+setup, and common troubleshooting steps -- the same knowledge in this documentation site, packaged for
+an agent to use directly while it edits your code.
+
+The skill source lives in the [`skills/`](https://github.com/kotest/kotest/tree/master/skills) directory
+of the main Kotest repository.
+
+## Installing with Claude Code
+
+The skill is distributed as a [plugin](https://docs.claude.com/en/docs/claude-code/plugins) through a
+marketplace hosted in the Kotest repository. Add the marketplace once, then install the plugin:
+
+```
+/plugin marketplace add kotest/kotest
+/plugin install kotest-skills
+```
+
+Claude Code will pick up the skill automatically whenever you're working on Kotest-related code -- no
+further configuration needed.
+
+## Installing manually
+
+If you use a different tool, or don't want to use the plugin marketplace, you can copy the skill
+directory directly into any location your tool loads skills from, for example:
+
+```bash
+git clone --depth 1 https://github.com/kotest/kotest.git /tmp/kotest-skill-src
+cp -r /tmp/kotest-skill-src/skills/kotest .claude/skills/kotest
+```
+
+## Keeping up to date
+
+The skill is versioned alongside the rest of the Kotest repository. Re-running
+`/plugin marketplace update kotest` (or re-copying the directory for manual installs) will pick up the
+latest content.

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -80,6 +80,12 @@ module.exports = {
                position: 'left'
             },
             {
+               type: 'doc',
+               docId: 'ai/index',
+               label: 'AI',
+               position: 'left'
+            },
+            {
                type:'search',
                position: 'right'
             },

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -4,6 +4,9 @@ module.exports = {
     "release6",
     "blogs"
   ],
+  "ai": [
+    "ai/index"
+  ],
   "proptest": [
     "proptest/index",
     "proptest/testfunctions",

--- a/documentation/versioned_docs/version-6.2/ai/index.md
+++ b/documentation/versioned_docs/version-6.2/ai/index.md
@@ -1,0 +1,44 @@
+---
+id: index
+title: AI Agent Skills
+slug: ai-skills.html
+sidebar_label: Introduction
+---
+
+Kotest ships an [Agent Skill](https://docs.claude.com/en/docs/claude-code/skills) that teaches AI
+coding assistants like Claude Code how to write, migrate, and debug Kotlin tests with Kotest. The skill
+covers spec styles, assertions, property-based testing, lifecycle hooks, extensions, multiplatform
+setup, and common troubleshooting steps -- the same knowledge in this documentation site, packaged for
+an agent to use directly while it edits your code.
+
+The skill source lives in the [`skills/`](https://github.com/kotest/kotest/tree/master/skills) directory
+of the main Kotest repository.
+
+## Installing with Claude Code
+
+The skill is distributed as a [plugin](https://docs.claude.com/en/docs/claude-code/plugins) through a
+marketplace hosted in the Kotest repository. Add the marketplace once, then install the plugin:
+
+```
+/plugin marketplace add kotest/kotest
+/plugin install kotest-skills
+```
+
+Claude Code will pick up the skill automatically whenever you're working on Kotest-related code -- no
+further configuration needed.
+
+## Installing manually
+
+If you use a different tool, or don't want to use the plugin marketplace, you can copy the skill
+directory directly into any location your tool loads skills from, for example:
+
+```bash
+git clone --depth 1 https://github.com/kotest/kotest.git /tmp/kotest-skill-src
+cp -r /tmp/kotest-skill-src/skills/kotest .claude/skills/kotest
+```
+
+## Keeping up to date
+
+The skill is versioned alongside the rest of the Kotest repository. Re-running
+`/plugin marketplace update kotest` (or re-copying the directory for manual installs) will pick up the
+latest content.

--- a/documentation/versioned_sidebars/version-6.2-sidebars.json
+++ b/documentation/versioned_sidebars/version-6.2-sidebars.json
@@ -4,6 +4,9 @@
     "release6",
     "blogs"
   ],
+  "ai": [
+    "ai/index"
+  ],
   "proptest": [
     "proptest/index",
     "proptest/testfunctions",

--- a/skills/kotlin-tooling-kotest/SKILL.md
+++ b/skills/kotlin-tooling-kotest/SKILL.md
@@ -1,9 +1,0 @@
----
-name: kotest
-description: >
-
-license:
-metadata:
-  author: Kotest Team
-  version: "1.0.0"
----


### PR DESCRIPTION
somehow addressing https://github.com/kotest/kotest/issues/5901

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
Somehow the skill we have should be made available to users and installable in something they are used to already (claude marketplace is quite common)
This PR introduces a way for claude users to install the skill we have created + adds a new section in the navbar of our docs

Do let me know if AI in the navbar is a bit too much :) 

<img width="2234" height="1136" alt="image" src="https://github.com/user-attachments/assets/7d422a61-ada1-420d-98a1-9e1fa98508ad" />
