### PR TITLE
Use `withEdtSafeAnalysis` to improve safe analysis for spec and style…

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
@@ -26,10 +26,12 @@ abstract class NavigateToTestAction(private val direction: Direction) : AnAction
       val element = file.findElementAt(offset) ?: return
 
       // gets the spec that the element is located in
-      val (spec, style) = AnalysisUtils.withEdtSafeAnalysis {
+      val sst = AnalysisUtils.withEdtSafeAnalysis {
          val spec = element.enclosingSpec()
          Pair(spec, spec.specStyle())
-      }
+      } ?: return null
+
+      val (spec, style) = sst
 
       if (spec == null || style == null) return
 

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
@@ -5,11 +5,11 @@ import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.NavigatablePsiElement
 import com.intellij.psi.PsiDocumentManager
-import io.kotest.plugin.intellij.psi.enclosingSpec
-import io.kotest.plugin.intellij.psi.specStyle
 import io.kotest.plugin.intellij.Test
 import io.kotest.plugin.intellij.TestElement
 import io.kotest.plugin.intellij.psi.AnalysisUtils
+import io.kotest.plugin.intellij.psi.enclosingSpec
+import io.kotest.plugin.intellij.psi.specStyle
 
 enum class Direction {
    Previous, Next
@@ -28,12 +28,11 @@ abstract class NavigateToTestAction(private val direction: Direction) : AnAction
       // gets the spec that the element is located in
       val sst = AnalysisUtils.withEdtSafeAnalysis {
          val spec = element.enclosingSpec()
-         Pair(spec, spec.specStyle())
-      } ?: return null
+         if (spec == null) null else Pair(spec, spec.specStyle())
+      } ?: return
 
       val (spec, style) = sst
-
-      if (spec == null || style == null) return
+      if (style == null) return
 
       // gets the test that contains the element where the action occurred.
       val test = style.findAssociatedTest(element) ?: return

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/actions/NavigateToTestAction.kt
@@ -9,6 +9,7 @@ import io.kotest.plugin.intellij.psi.enclosingSpec
 import io.kotest.plugin.intellij.psi.specStyle
 import io.kotest.plugin.intellij.Test
 import io.kotest.plugin.intellij.TestElement
+import io.kotest.plugin.intellij.psi.AnalysisUtils
 
 enum class Direction {
    Previous, Next
@@ -25,14 +26,18 @@ abstract class NavigateToTestAction(private val direction: Direction) : AnAction
       val element = file.findElementAt(offset) ?: return
 
       // gets the spec that the element is located in
-      val spec = element.enclosingSpec() ?: return
-      val style = spec.specStyle() ?: return
+      val (spec, style) = AnalysisUtils.withEdtSafeAnalysis {
+         val spec = element.enclosingSpec()
+         Pair(spec, spec.specStyle())
+      }
+
+      if (spec == null || style == null) return
 
       // gets the test that contains the element where the action occurred.
       val test = style.findAssociatedTest(element) ?: return
       val alltests = style.tests(spec, false)
 
-      fun flatten(tests:List<TestElement>): List<Test> {
+      fun flatten(tests: List<TestElement>): List<Test> {
          return tests.flatMap { listOf(it.test) + flatten(it.nestedTests) }
       }
 


### PR DESCRIPTION
… extraction

<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
