### PR TITLE
use a singleton strategy for getConfigurationFactory of Kotest legacy producers + ensure the same config is reused for gradle producers

### DIFF
--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducer.kt
@@ -120,12 +120,17 @@ class GradleMultiplatformJvmTestTaskRunProducer : GradleTestRunConfigurationProd
       val filter = GradleTestFilterBuilder.builder()
          .withSpec(testref.spec)
          .withTest(testref.test)
+         .withDataTestAncestorPath(testref.test?.dataTestInfoMaybe()?.ancestorTestPath)
          .build(false)
 
+      // onFirstRun stores the filter as a single combined task element, e.g. "--tests 'Foo.bar'",
+      // not as two separate elements ("--tests", "'Foo.bar'"). Find that element and strip the
+      // "--tests" prefix to recover the raw filter value for comparison.
       val existingFilter = configuration.settings.taskNames
-         .dropWhile { !it.startsWith("--tests") } // find the --tests filter, drop it, take whatever is after it
-         .drop(1)
-         .take(1).joinToString(" ")
+         .firstOrNull { it.startsWith("--tests") }
+         ?.removePrefix("--tests")
+         ?.trim()
+         ?: ""
       logger.info("Checking config filter [${existingFilter}] against selected test [${filter}]")
 
       return existingFilter == filter

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/KotestConfigurationType.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/KotestConfigurationType.kt
@@ -2,9 +2,17 @@ package io.kotest.plugin.intellij.run.idea
 
 import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.configurations.ConfigurationType
+import com.intellij.execution.configurations.ConfigurationTypeUtil
 import io.kotest.plugin.intellij.Constants
 import io.kotest.plugin.intellij.Icons
 import javax.swing.Icon
+
+// Producers must fetch the platform-registered singleton (rather than instantiating
+// KotestConfigurationType themselves) so that run configurations created from different
+// contexts are seen by IntelliJ as belonging to the same configuration type/factory. Without
+// this, RunManager's lookup of existing configurations for a given factory never matches, and
+// a new run configuration is created on every run instead of reusing the existing one.
+fun getKotestConfigurationType(): KotestConfigurationType = ConfigurationTypeUtil.findConfigurationType(KotestConfigurationType::class.java)
 
 @Deprecated("Starting with Kotest 6 the preferred method is to run via gradle")
 class KotestConfigurationType : ConfigurationType {
@@ -20,4 +28,6 @@ class KotestConfigurationType : ConfigurationType {
    override fun getDisplayName(): String = Constants.FRAMEWORK_NAME
 
    override fun getConfigurationFactories(): Array<ConfigurationFactory> = arrayOf(factory)
+
+   fun getFactory(): ConfigurationFactory = factory
 }

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/PackageRunConfigurationProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/PackageRunConfigurationProducer.kt
@@ -36,7 +36,7 @@ class PackageRunConfigurationProducer : LazyRunConfigurationProducer<KotestRunCo
    /**
     * Returns the [KotestConfigurationFactory] used to create [KotestRunConfiguration]s.
     */
-   override fun getConfigurationFactory(): ConfigurationFactory = KotestConfigurationFactory(KotestConfigurationType())
+   override fun getConfigurationFactory(): ConfigurationFactory = getKotestConfigurationType().getFactory()
 
    /**
     * When two configurations are created from the same context by two different producers, checks if the
@@ -91,7 +91,18 @@ class PackageRunConfigurationProducer : LazyRunConfigurationProducer<KotestRunCo
    override fun isConfigurationFromContext(
       configuration: KotestRunConfiguration,
       context: ConfigurationContext
-   ): Boolean = false
+   ): Boolean {
+
+      if (RunnerModes.mode(context.module) != RunnerMode.LEGACY) return false
+
+      val psiDirectory = context.psiLocation as? PsiJavaDirectoryImpl ?: return false
+      val index = ProjectRootManager.getInstance(context.project).fileIndex
+      if (!index.isInTestSourceContent(psiDirectory.virtualFile)) return false
+
+      val psiPackage = JavaDirectoryService.getInstance().getPackage(psiDirectory) ?: return false
+      return configuration.getPackageName() == psiPackage.qualifiedName
+         && configuration.configurationModule.module == context.module
+   }
 
    override fun setupConfigurationFromContext(
       configuration: KotestRunConfiguration,

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/SpecPlatformRunConfigurationProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/SpecPlatformRunConfigurationProducer.kt
@@ -30,7 +30,7 @@ class SpecPlatformRunConfigurationProducer : LazyRunConfigurationProducer<Kotest
 
    private val logger = logger<SpecPlatformRunConfigurationProducer>()
 
-   override fun getConfigurationFactory(): ConfigurationFactory = KotestConfigurationFactory(KotestConfigurationType())
+   override fun getConfigurationFactory(): ConfigurationFactory = getKotestConfigurationType().getFactory()
 
    /**
     * When two configurations are created from the same context by two different producers, checks if the

--- a/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/TestPlatformRunConfigurationProducer.kt
+++ b/kotest-intellij-plugin/src/main/kotlin/io/kotest/plugin/intellij/run/idea/TestPlatformRunConfigurationProducer.kt
@@ -34,7 +34,7 @@ class TestPlatformRunConfigurationProducer : LazyRunConfigurationProducer<Kotest
    /**
     * Returns the [KotestConfigurationFactory] used to create [KotestRunConfiguration]s.
     */
-   override fun getConfigurationFactory(): ConfigurationFactory = KotestConfigurationFactory(KotestConfigurationType())
+   override fun getConfigurationFactory(): ConfigurationFactory = getKotestConfigurationType().getFactory()
 
    /**
     * In an IntelliJ custom plugin, the [shouldReplace] method in a RunConfigurationProducer is used to

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducerTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/gradle/GradleMultiplatformJvmTestTaskRunProducerTest.kt
@@ -103,6 +103,99 @@ class GradleMultiplatformJvmTestTaskRunProducerTest : BasePlatformTestCase() {
    }
 
    /**
+    * Calls the protected [GradleMultiplatformJvmTestTaskRunProducer.doIsConfigurationFromContext]
+    * via reflection so that the class need not be made `open` just for testing.
+    */
+   private fun callDoIsConfigurationFromContext(
+      producer: GradleMultiplatformJvmTestTaskRunProducer,
+      configuration: GradleRunConfiguration,
+      context: ConfigurationContext
+   ): Boolean {
+      val method = GradleMultiplatformJvmTestTaskRunProducer::class.java.getDeclaredMethod(
+         "doIsConfigurationFromContext",
+         GradleRunConfiguration::class.java,
+         ConfigurationContext::class.java
+      )
+      method.isAccessible = true
+      return method.invoke(producer, configuration, context) as Boolean
+   }
+
+   /**
+    * Regression test: [GradleMultiplatformJvmTestTaskRunProducer.doIsConfigurationFromContext] must
+    * recognize an existing configuration for the same test so that clicking the gutter icon again
+    * reuses it instead of creating a duplicate.
+    *
+    * The `--tests` filter is stored by `onFirstRun` as a single combined task element, e.g.
+    * `"--tests 'Foo.bar'"`, not as two separate elements (`"--tests"`, `"'Foo.bar'"`). A prior bug in
+    * the matching logic assumed the latter, so it never matched an existing configuration and a new
+    * one was created on every run. See https://github.com/kotest/kotest/issues/6214.
+    */
+   fun testReusesExistingConfigurationForSameTest() {
+      setupGradleTestTaskMode()
+
+      val psiFiles = myFixture.configureByFiles(
+         "/funspec.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      // Line 22 is `test("a nested test")` — an individual test context
+      val psiElement = psiFiles[0].elementAtLine(22) ?: error("Could not find PSI element at line 22")
+      val context = ConfigurationContext.createEmptyContextForLocation(
+         PsiLocation(project, myFixture.module, psiElement)
+      )
+
+      val producer = GradleMultiplatformJvmTestTaskRunProducer()
+      val configuration = producer.configurationFactory.createTemplateConfiguration(project) as GradleRunConfiguration
+      val ref = Ref.create<PsiElement?>(psiElement)
+
+      callDoSetup(producer, configuration, context, ref) shouldBe true
+
+      // Simulate what onFirstRun stores once the task chooser resolves — a single combined
+      // "--tests '...'" element alongside the actual gradle task.
+      val testref = io.kotest.plugin.intellij.psi.ElementUtils.findTestReference(psiElement)
+         ?: error("Could not resolve test reference for psiElement")
+      val filter = GradleTestFilterBuilder.builder()
+         .withSpec(testref.spec)
+         .withTest(testref.test)
+         .build(true)
+      configuration.settings.taskNames = listOf(":jvmTest", filter)
+
+      callDoIsConfigurationFromContext(producer, configuration, context) shouldBe true
+   }
+
+   /**
+    * A configuration created for a different test must not be treated as a match, even though both
+    * contain a `--tests` filter.
+    */
+   fun testDoesNotReuseConfigurationForDifferentTest() {
+      setupGradleTestTaskMode()
+
+      val psiFiles = myFixture.configureByFiles(
+         "/funspec.kt",
+         "/io/kotest/core/spec/style/specs.kt"
+      )
+
+      val clickedElement = psiFiles[0].elementAtLine(22) ?: error("Could not find PSI element at line 22")
+      val otherElement = psiFiles[0].elementAtLine(8) ?: error("Could not find PSI element at line 8")
+      val context = ConfigurationContext.createEmptyContextForLocation(
+         PsiLocation(project, myFixture.module, clickedElement)
+      )
+
+      val producer = GradleMultiplatformJvmTestTaskRunProducer()
+      val configuration = producer.configurationFactory.createTemplateConfiguration(project) as GradleRunConfiguration
+
+      val otherTestref = io.kotest.plugin.intellij.psi.ElementUtils.findTestReference(otherElement)
+         ?: error("Could not resolve test reference for otherElement")
+      val otherFilter = GradleTestFilterBuilder.builder()
+         .withSpec(otherTestref.spec)
+         .withTest(otherTestref.test)
+         .build(true)
+      configuration.settings.taskNames = listOf(":jvmTest", otherFilter)
+
+      callDoIsConfigurationFromContext(producer, configuration, context) shouldBe false
+   }
+
+   /**
     * Configures the test fixture so that [io.kotest.plugin.intellij.run.RunnerModes.mode] returns
     * [io.kotest.plugin.intellij.run.RunnerMode.GRADLE_TEST_TASK].
     *

--- a/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/idea/KotestConfigurationTypeTest.kt
+++ b/kotest-intellij-plugin/src/test/kotlin/io/kotest/plugin/intellij/run/idea/KotestConfigurationTypeTest.kt
@@ -1,0 +1,47 @@
+@file:Suppress("DEPRECATION")
+
+package io.kotest.plugin.intellij.run.idea
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldNotBeSameInstanceAs
+
+/**
+ * Regression tests for https://github.com/kotest/kotest/issues/6214.
+ *
+ * The three legacy ("idea") run configuration producers used to build their [getKotestConfigurationType]
+ * factory by instantiating `KotestConfigurationType()` directly, e.g.
+ * `KotestConfigurationFactory(KotestConfigurationType())`. Since [KotestConfigurationType] has no
+ * `equals`/`hashCode`, every such instance was only reference-equal to itself — distinct from the
+ * singleton IntelliJ registers via the `<configurationType>` extension point in plugin.xml.
+ * `RunManager`'s lookup of existing configurations for a given factory relies on that registered
+ * singleton, so a fresh instance on every producer call meant existing configurations were never
+ * found, and a new run configuration was created on every gutter run.
+ */
+class KotestConfigurationTypeTest : BasePlatformTestCase() {
+
+   /** [getKotestConfigurationType] must always return the same, platform-registered instance. */
+   fun testGetKotestConfigurationTypeReturnsSameSingletonAcrossCalls() {
+      val first = getKotestConfigurationType()
+      val second = getKotestConfigurationType()
+      first shouldBe second
+   }
+
+   /** A directly-instantiated [KotestConfigurationType] must NOT be treated as the same type. */
+   fun testDirectlyInstantiatedTypeIsNotTheRegisteredSingleton() {
+      val rogue = KotestConfigurationType()
+      val registered = getKotestConfigurationType()
+      rogue shouldNotBeSameInstanceAs registered
+   }
+
+   /** All three legacy producers must share the exact same [getConfigurationFactory] instance. */
+   fun testLegacyProducersShareTheSameConfigurationFactory() {
+      val specFactory = SpecPlatformRunConfigurationProducer().configurationFactory
+      val testFactory = TestPlatformRunConfigurationProducer().configurationFactory
+      val packageFactory = PackageRunConfigurationProducer().configurationFactory
+
+      specFactory shouldBe testFactory
+      testFactory shouldBe packageFactory
+      specFactory shouldBe getKotestConfigurationType().getFactory()
+   }
+}


### PR DESCRIPTION
<!-- 
If this PR updates documentation, please update all relevant versions of the docs, see: https://github.com/kotest/kotest/tree/master/documentation/versioned_docs
The documentation at https://github.com/kotest/kotest/tree/master/documentation/docs is the documentation for the next minor or major version _TO BE RELEASED_
-->
for https://github.com/kotest/kotest/issues/6214

Running tests via the gutter icon was creating a new config every time it was run, both on Legacy runners and on Gradle runners
